### PR TITLE
improve(Finalizer): Handle Linea SDK errors

### DIFF
--- a/src/finalizer/utils/linea/l1ToL2.ts
+++ b/src/finalizer/utils/linea/l1ToL2.ts
@@ -69,25 +69,40 @@ export async function lineaL1ToL2Finalizer(
     } = event;
     // It's unlikely that our multicall will have multiple transactions to bridge to Linea
     // so we can grab the statuses individually.
-    const messageStatus = await l2MessageServiceContract.getMessageStatus(_messageHash);
-    return {
-      messageSender: _from,
-      destination: _to,
-      fee: _fee,
-      value: _value,
-      messageNonce: _nonce,
-      calldata: _calldata,
-      messageHash: _messageHash,
-      txHash,
-      logIndex,
-      status: messageStatus,
-      messageType: determineMessageType(event, hubPoolClient),
-    };
+    try {
+      // The Linea SDK MessageServiceContract constructs its own Provider without our retry logic so we try-catch
+      // it in order to catch any one-off failures.
+      const messageStatus = await l2MessageServiceContract.getMessageStatus(_messageHash);
+      return {
+        messageSender: _from,
+        destination: _to,
+        fee: _fee,
+        value: _value,
+        messageNonce: _nonce,
+        calldata: _calldata,
+        messageHash: _messageHash,
+        txHash,
+        logIndex,
+        status: messageStatus,
+        messageType: determineMessageType(event, hubPoolClient),
+      };
+    } catch (e) {
+      logger.debug({
+        at: "Finalizer#LineaL1ToL2Finalizer",
+        message: "LineaSDK.getMessageStatus failed",
+        error: e,
+        event,
+      });
+      return {
+        status: "sdkError",
+      };
+    }
   });
   // Group messages by status
   const {
     claimed = [],
     claimable = [],
+    failed = [],
     unknown = [],
   } = groupBy(enrichedMessageSentEvents, (message) => {
     switch (message.status) {
@@ -95,6 +110,8 @@ export async function lineaL1ToL2Finalizer(
         return "claimed";
       case OnChainMessageStatus.CLAIMABLE:
         return "claimable";
+      case "sdkError":
+        return "failed";
       default:
         return "unknown";
     }
@@ -149,6 +166,7 @@ export async function lineaL1ToL2Finalizer(
     statuses: {
       claimed: claimed.length,
       claimable: claimable.length,
+      sdkError: failed.length,
       notReceived: unknown.length,
     },
   });


### PR DESCRIPTION
The Linea SDK MessageServiceContract constructs its own Provider without our retry logic so we try-catch it in order to catch any one-off failures.

An alternative implementation would be to replace the contract object returned by the SDK and create our own but that look a bit more involved, so for now I implement a try-catch to handle these failures
