### PR TITLE
lint: add no-misused promises to linter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,6 @@ module.exports = {
     "@typescript-eslint/no-unused-vars": ["error", { ignoreRestSiblings: true }],
     "chai-expect/missing-assertion": 2,
     "no-duplicate-imports": "error",
-    // "require-await": "error",
     "@typescript-eslint/no-floating-promises": ["error"],
     "@typescript-eslint/no-misused-promises": ["error", { checksVoidReturn: false }],
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,8 +36,9 @@ module.exports = {
     "@typescript-eslint/no-unused-vars": ["error", { ignoreRestSiblings: true }],
     "chai-expect/missing-assertion": 2,
     "no-duplicate-imports": "error",
-    //    "require-await": "error",
+    // "require-await": "error",
     "@typescript-eslint/no-floating-promises": ["error"],
+    "@typescript-eslint/no-misused-promises": ["error", { checksVoidReturn: false }],
   },
   settings: {
     node: {

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -569,7 +569,7 @@ export class BundleDataClient {
 
   private async loadArweaveData(blockRangesForChains: number[][]): Promise<LoadDataReturnValue> {
     const arweaveKey = this.getArweaveClientKey(blockRangesForChains);
-    if (!this.arweaveDataCache[arweaveKey]) {
+    if (!(await this.arweaveDataCache[arweaveKey])) {
       this.arweaveDataCache[arweaveKey] = this.loadPersistedDataFromArweave(blockRangesForChains);
     }
     const arweaveData = _.cloneDeep(await this.arweaveDataCache[arweaveKey]);
@@ -585,7 +585,7 @@ export class BundleDataClient {
     attemptArweaveLoad = false
   ): Promise<LoadDataReturnValue> {
     const key = JSON.stringify(blockRangesForChains);
-    if (!this.loadDataCache[key]) {
+    if (!(await this.loadDataCache[key])) {
       let arweaveData;
       if (attemptArweaveLoad) {
         arweaveData = await this.loadArweaveData(blockRangesForChains);

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -570,7 +570,7 @@ export class BundleDataClient {
   private async loadArweaveData(blockRangesForChains: number[][]): Promise<LoadDataReturnValue> {
     const arweaveKey = this.getArweaveClientKey(blockRangesForChains);
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    if (this.arweaveDataCache[arweaveKey]) {
+    if (!this.arweaveDataCache[arweaveKey]) {
       this.arweaveDataCache[arweaveKey] = this.loadPersistedDataFromArweave(blockRangesForChains);
     }
     const arweaveData = _.cloneDeep(await this.arweaveDataCache[arweaveKey]);
@@ -587,7 +587,7 @@ export class BundleDataClient {
   ): Promise<LoadDataReturnValue> {
     const key = JSON.stringify(blockRangesForChains);
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    if (this.loadDataCache[key]) {
+    if (!this.loadDataCache[key]) {
       let arweaveData;
       if (attemptArweaveLoad) {
         arweaveData = await this.loadArweaveData(blockRangesForChains);

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -569,7 +569,8 @@ export class BundleDataClient {
 
   private async loadArweaveData(blockRangesForChains: number[][]): Promise<LoadDataReturnValue> {
     const arweaveKey = this.getArweaveClientKey(blockRangesForChains);
-    if (!(await this.arweaveDataCache[arweaveKey])) {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    if (this.arweaveDataCache[arweaveKey]) {
       this.arweaveDataCache[arweaveKey] = this.loadPersistedDataFromArweave(blockRangesForChains);
     }
     const arweaveData = _.cloneDeep(await this.arweaveDataCache[arweaveKey]);
@@ -585,7 +586,8 @@ export class BundleDataClient {
     attemptArweaveLoad = false
   ): Promise<LoadDataReturnValue> {
     const key = JSON.stringify(blockRangesForChains);
-    if (!(await this.loadDataCache[key])) {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    if (this.loadDataCache[key]) {
       let arweaveData;
       if (attemptArweaveLoad) {
         arweaveData = await this.loadArweaveData(blockRangesForChains);

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2221,7 +2221,7 @@ export class Dataworker {
     // FIXME: Temporary fix to disable root cache rebalancing and to keep the
     //        executor running for tonight (2023-08-28) until we can fix the
     //        root cache rebalancing bug.
-    if (!this.rootCache[key] || process.env.DATAWORKER_DISABLE_REBALANCE_ROOT_CACHE === "true") {
+    if (!(await this.rootCache[key]) || process.env.DATAWORKER_DISABLE_REBALANCE_ROOT_CACHE === "true") {
       this.rootCache[key] = _buildPoolRebalanceRoot(
         latestMainnetBlock,
         mainnetBundleEndBlock,

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2221,7 +2221,8 @@ export class Dataworker {
     // FIXME: Temporary fix to disable root cache rebalancing and to keep the
     //        executor running for tonight (2023-08-28) until we can fix the
     //        root cache rebalancing bug.
-    if (!(await this.rootCache[key]) || process.env.DATAWORKER_DISABLE_REBALANCE_ROOT_CACHE === "true") {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    if (!this.rootCache[key] || process.env.DATAWORKER_DISABLE_REBALANCE_ROOT_CACHE === "true") {
       this.rootCache[key] = _buildPoolRebalanceRoot(
         latestMainnetBlock,
         mainnetBundleEndBlock,


### PR DESCRIPTION
The `no-misused-promises` rule enforces unresolved promises to be resolved before used (e.g. in a boolean conditional or in an object). Adding this in the linter will ideally prevent bugs which occur due to handling promises instead of the resolved value.