### PR TITLE
feat(Dataworker): Split l2 and l1 executors

### DIFF
--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -10,7 +10,8 @@ export class DataworkerConfig extends CommonConfig {
   // These variables can be toggled to choose whether the bot will go through the dataworker logic.
   readonly disputerEnabled: boolean;
   readonly proposerEnabled: boolean;
-  readonly executorEnabled: boolean;
+  readonly l2ExecutorEnabled: boolean;
+  readonly l1ExecutorEnabled: boolean;
   readonly finalizerEnabled: boolean;
 
   // This variable can be toggled to bypass the proposer logic and always attempt to propose
@@ -49,7 +50,8 @@ export class DataworkerConfig extends CommonConfig {
       MAX_RELAYER_REPAYMENT_LEAF_SIZE_OVERRIDE,
       DISPUTER_ENABLED,
       PROPOSER_ENABLED,
-      EXECUTOR_ENABLED,
+      L2_EXECUTOR_ENABLED,
+      L1_EXECUTOR_ENABLED,
       SPOKE_ROOTS_LOOKBACK_COUNT,
       SEND_DISPUTES,
       SEND_PROPOSALS,
@@ -85,8 +87,9 @@ export class DataworkerConfig extends CommonConfig {
       : toBNWei("500000");
     this.disputerEnabled = DISPUTER_ENABLED === "true";
     this.proposerEnabled = PROPOSER_ENABLED === "true";
-    this.executorEnabled = EXECUTOR_ENABLED === "true";
-    if (this.executorEnabled) {
+    this.l2ExecutorEnabled = L2_EXECUTOR_ENABLED === "true";
+    this.l1ExecutorEnabled = L1_EXECUTOR_ENABLED === "true";
+    if (this.l2ExecutorEnabled || this.l1ExecutorEnabled) {
       assert(this.spokeRootsLookbackCount > 0, "must set spokeRootsLookbackCount > 0 if executor enabled");
     } else if (this.disputerEnabled || this.proposerEnabled) {
       // should set spokeRootsLookbackCount == 0 if executor disabled and proposer/disputer enabled

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -89,8 +89,8 @@ export class DataworkerConfig extends CommonConfig {
     this.proposerEnabled = PROPOSER_ENABLED === "true";
     this.l2ExecutorEnabled = L2_EXECUTOR_ENABLED === "true";
     this.l1ExecutorEnabled = L1_EXECUTOR_ENABLED === "true";
-    if (this.l2ExecutorEnabled || this.l1ExecutorEnabled) {
-      assert(this.spokeRootsLookbackCount > 0, "must set spokeRootsLookbackCount > 0 if executor enabled");
+    if (this.l2ExecutorEnabled) {
+      assert(this.spokeRootsLookbackCount > 0, "must set spokeRootsLookbackCount > 0 if L2 executor enabled");
     } else if (this.disputerEnabled || this.proposerEnabled) {
       // should set spokeRootsLookbackCount == 0 if executor disabled and proposer/disputer enabled
       this.spokeRootsLookbackCount = 0;


### PR DESCRIPTION
We can run the pool rebalance leaf executor separately from the refund leaf executor to speed up both bots. It takes ~3 minutes to reconstruct a bundle, so executing the pool rebalance leaf + 2 refund leaf bundles into the past leads to 9 mins of run time just to execute pool rebalance leaves.
