### PR TITLE
improve(Dataworker): Speed up BundleDataClient.loadDataFromScratch

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -302,7 +302,7 @@ export class BundleDataClient {
           const matchingDeposit = this.spokePoolClients[fill.originChainId].getDeposit(fill.depositId);
           const hasMatchingDeposit =
             matchingDeposit !== undefined &&
-            utils.getRelayHashFromEvent(fill) === utils.getRelayHashFromEvent(matchingDeposit);
+            this.getRelayHashFromEvent(fill) === this.getRelayHashFromEvent(matchingDeposit);
           return hasMatchingDeposit;
         })
         .forEach((fill) => {
@@ -607,7 +607,7 @@ export class BundleDataClient {
     blockRangesForChains: number[][],
     spokePoolClients: SpokePoolClientsByChain
   ): Promise<LoadDataReturnValue> {
-    const start = performance.now();
+    let start = performance.now();
     const key = JSON.stringify(blockRangesForChains);
 
     if (!this.clients.configStoreClient.isUpdated) {
@@ -747,6 +747,7 @@ export class BundleDataClient {
     // - olderDepositHashes: Deposits sent in a prior bundle that newly expired in this bundle
     const olderDepositHashes: Set<string> = new Set<string>();
 
+    let depositCounter = 0;
     for (const originChainId of allChainIds) {
       const originClient = spokePoolClients[originChainId];
       const originChainBlockRange = getBlockRangeForChain(blockRangesForChains, originChainId, chainIds);
@@ -760,7 +761,8 @@ export class BundleDataClient {
           .getDepositsForDestinationChain(destinationChainId)
           .filter((deposit) => deposit.blockNumber <= originChainBlockRange[1])
           .forEach((deposit) => {
-            const relayDataHash = utils.getRelayHashFromEvent(deposit);
+            depositCounter++;
+            const relayDataHash = this.getRelayHashFromEvent(deposit);
             if (v3RelayHashes[relayDataHash]) {
               // If we've seen this deposit before, then skip this deposit. This can happen if our RPC provider
               // gives us bad data.
@@ -794,11 +796,17 @@ export class BundleDataClient {
           });
       }
     }
+    this.logger.debug({
+      at: "BundleDataClient#loadData",
+      message: `Processed ${depositCounter} deposits in ${performance.now() - start}ms.`,
+    });
+    start = performance.now();
 
     // Process fills now that we've populated relay hash dictionary with deposits:
     const validatedBundleV3Fills: (V3FillWithBlock & { quoteTimestamp: number })[] = [];
     const validatedBundleSlowFills: V3DepositWithBlock[] = [];
     const validatedBundleUnexecutableSlowFills: V3DepositWithBlock[] = [];
+    let fillCounter = 0;
     for (const originChainId of allChainIds) {
       const originClient = spokePoolClients[originChainId];
       for (const destinationChainId of allChainIds) {
@@ -817,7 +825,8 @@ export class BundleDataClient {
             .getFillsForOriginChain(originChainId)
             .filter((fill) => fill.blockNumber <= destinationChainBlockRange[1]),
           async (fill) => {
-            const relayDataHash = utils.getRelayHashFromEvent(fill);
+            const relayDataHash = this.getRelayHashFromEvent(fill);
+            fillCounter++;
 
             if (v3RelayHashes[relayDataHash]) {
               if (!v3RelayHashes[relayDataHash].fill) {
@@ -865,7 +874,7 @@ export class BundleDataClient {
                 // object property values against the deposit's, we
                 // sanity check it here by comparing the full relay hashes. If there's an error here then the
                 // historical deposit query is not working as expected.
-                assert(utils.getRelayHashFromEvent(matchedDeposit) === relayDataHash);
+                assert(this.getRelayHashFromEvent(matchedDeposit) === relayDataHash);
                 validatedBundleV3Fills.push({
                   ...fill,
                   quoteTimestamp: matchedDeposit.quoteTimestamp,
@@ -884,7 +893,7 @@ export class BundleDataClient {
             .getSlowFillRequestsForOriginChain(originChainId)
             .filter((request) => request.blockNumber <= destinationChainBlockRange[1]),
           async (slowFillRequest: SlowFillRequestWithBlock) => {
-            const relayDataHash = utils.getRelayHashFromEvent(slowFillRequest);
+            const relayDataHash = this.getRelayHashFromEvent(slowFillRequest);
 
             if (v3RelayHashes[relayDataHash]) {
               if (!v3RelayHashes[relayDataHash].slowFillRequest) {
@@ -952,7 +961,7 @@ export class BundleDataClient {
               // object property values against the deposit's, we
               // sanity check it here by comparing the full relay hashes. If there's an error here then the
               // historical deposit query is not working as expected.
-              assert(utils.getRelayHashFromEvent(matchedDeposit) === relayDataHash);
+              assert(this.getRelayHashFromEvent(matchedDeposit) === relayDataHash);
               v3RelayHashes[relayDataHash].deposit = matchedDeposit;
 
               // Note: we don't need to query for a historical fill at this point because a fill
@@ -1008,6 +1017,11 @@ export class BundleDataClient {
         });
       }
     }
+    this.logger.debug({
+      at: "BundleDataClient#loadData",
+      message: `Processed ${fillCounter} fills in ${performance.now() - start}ms.`,
+    });
+    start = performance.now();
 
     // Go through expired deposits in this bundle and now prune those that we have seen a fill for to construct
     // the list of expired deposits we need to refund in this bundle.
@@ -1090,6 +1104,7 @@ export class BundleDataClient {
     });
 
     // Batch compute V3 lp fees.
+    start = performance.now();
     const promises = [
       validatedBundleV3Fills.length > 0
         ? this.clients.hubPoolClient.batchComputeRealizedLpFeePct(
@@ -1129,6 +1144,10 @@ export class BundleDataClient {
         : [],
     ];
     const [v3FillLpFees, v3SlowFillLpFees, v3UnexecutableSlowFillLpFees] = await Promise.all(promises);
+    this.logger.debug({
+      at: "BundleDataClient#loadData",
+      message: `Computed batch async LP fees in ${performance.now() - start}ms.`,
+    });
     v3FillLpFees.forEach(({ realizedLpFeePct }, idx) => {
       const fill = validatedBundleV3Fills[idx];
       const { chainToSendRefundTo, repaymentToken } = getRefundInformationFromFill(
@@ -1179,6 +1198,14 @@ export class BundleDataClient {
       unexecutableSlowFills,
       bundleSlowFillsV3,
     };
+  }
+
+  // Internal function to uniquely identify a bridge event. This is preferred over `SDK.getRelayDataHash` which returns
+  // keccak256 hash of the relay data, which can be used as input into the on-chain `fillStatuses()` function in the
+  // spoke pool contract. However, this internal function is used to uniquely identify a bridging event
+  // for speed since its easier to build a string from the event data than to hash it.
+  private getRelayHashFromEvent(event: V3DepositWithBlock | V3FillWithBlock | SlowFillRequestWithBlock): string {
+    return `${event.depositor}-${event.recipient}-${event.exclusiveRelayer}-${event.inputToken}-${event.outputToken}-${event.inputAmount}-${event.outputAmount}-${event.originChainId}-${event.depositId}-${event.fillDeadline}-${event.exclusivityDeadline}-${event.message}-${event.destinationChainId}`;
   }
 
   async getBundleBlockTimestamps(

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1044,7 +1044,7 @@ export class Dataworker {
             blockNumberRanges,
             spokePoolClients,
             matchingRootBundle.blockNumber,
-            true, // Load data from arweave when executing for speed.
+            true // Load data from arweave when executing for speed.
           );
 
           const { slowFillLeaves: leaves, slowFillTree: tree } = rootBundleData;
@@ -1337,7 +1337,7 @@ export class Dataworker {
       pendingRootBundle,
       spokePoolClients,
       earliestBlocksInSpokePoolClients,
-      true, // Load data from arweave when executing leaves for speed.
+      true // Load data from arweave when executing leaves for speed.
     );
 
     if (!valid) {
@@ -1979,7 +1979,7 @@ export class Dataworker {
           blockNumberRanges,
           spokePoolClients,
           matchingRootBundle.blockNumber,
-          true, // load data from Arweave for speed purposes
+          true // load data from Arweave for speed purposes
         );
 
         if (tree.getHexRoot() !== rootBundleRelay.relayerRefundRoot) {

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -377,7 +377,7 @@ describe("Dataworker: Load data used in all functions", async function () {
         [originChainId]: spokePoolClient_1,
         [destinationChainId]: spokePoolClient_2,
       });
-      expect(spyLogIncludes(spy, -2, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
+      expect(spyLogIncludes(spy, -3, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
       expect(data1.bundleFillsV3[repaymentChainId][l1Token_1.address].fills.length).to.equal(1);
       expect(data1.bundleDepositsV3).to.deep.equal({});
     });

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -739,7 +739,7 @@ describe("Dataworker: Load data used in all functions", async function () {
         [originChainId]: spokePoolClient_1,
         [destinationChainId]: spokePoolClient_2,
       });
-      expect(spyLogIncludes(spy, -2, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
+      expect(spyLogIncludes(spy, -4, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
       expect(data1.bundleSlowFillsV3[destinationChainId][erc20_2.address].length).to.equal(1);
       expect(data1.bundleDepositsV3).to.deep.equal({});
     });
@@ -880,7 +880,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       });
       // Here we can see that the historical query for the deposit actually succeeds, but the deposit itself
       // was not one eligible to be slow filled.
-      expect(spyLogIncludes(spy, -2, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
+      expect(spyLogIncludes(spy, -4, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
 
       expect(data1.bundleSlowFillsV3).to.deep.equal({});
       expect(data1.bundleDepositsV3).to.deep.equal({});

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -377,7 +377,7 @@ describe("Dataworker: Load data used in all functions", async function () {
         [originChainId]: spokePoolClient_1,
         [destinationChainId]: spokePoolClient_2,
       });
-      expect(spyLogIncludes(spy, -3, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
+      expect(spyLogIncludes(spy, -4, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
       expect(data1.bundleFillsV3[repaymentChainId][l1Token_1.address].fills.length).to.equal(1);
       expect(data1.bundleDepositsV3).to.deep.equal({});
     });


### PR DESCRIPTION
# Motivation

Loading bundle data is now consistently taking 3-5 minutes given increased volume, likely stemming from increase in total bridge events per bundle

I've narrowed down, using timers, the slowdown to the `loadDataFromScratch` and the `SpokePoolClient.update()` calls which together account for most of the vast majority of the total run time for any dataworker function

# Implementation

- Replacing `utils.getRelayHashFromEvent` implementation takes current bundle construction with ~5000 deposits and fills runtime from 160s to 5s within the `loadDataFromScratch` function.
- Fetching bundle data from Arweave instead of from scratch in the Executor saves executor time
- Added timers for loading bundle data to help track regressions