### PR TITLE
improve(relayer): Persist fillStatus across loops

### DIFF
--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -62,8 +62,7 @@ export function getUnfilledDeposits(
   // Iterate over each chainId and check for unfilled deposits.
   const deposits = Object.values(spokePoolClients)
     .filter(({ chainId, isUpdated }) => isUpdated && chainId !== destinationChainId)
-    .map((spokePoolClient) => spokePoolClient.getDepositsForDestinationChain(destinationChainId))
-    .flat()
+    .flatMap((spokePoolClient) => spokePoolClient.getDepositsForDestinationChain(destinationChainId))
     .filter((deposit) => {
       const depositHash = spokePoolClients[deposit.originChainId].getDepositHash(deposit);
       return (fillStatus[depositHash] ?? FillStatus.Unfilled) !== FillStatus.Filled;

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -62,7 +62,8 @@ export function getUnfilledDeposits(
   // Iterate over each chainId and check for unfilled deposits.
   const deposits = Object.values(spokePoolClients)
     .filter(({ chainId, isUpdated }) => isUpdated && chainId !== destinationChainId)
-    .flatMap((spokePoolClient) => spokePoolClient.getDepositsForDestinationChain(destinationChainId))
+    .map((spokePoolClient) => spokePoolClient.getDepositsForDestinationChain(destinationChainId))
+    .flat()
     .filter((deposit) => {
       const depositHash = spokePoolClients[deposit.originChainId].getDepositHash(deposit);
       return (fillStatus[depositHash] ?? FillStatus.Unfilled) !== FillStatus.Filled;

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -1,6 +1,6 @@
 import { utils as sdkUtils } from "@across-protocol/sdk";
 import { HubPoolClient } from "../clients";
-import { Fill, SpokePoolClientsByChain, V3DepositWithBlock } from "../interfaces";
+import { Fill, FillStatus, SpokePoolClientsByChain, V3DepositWithBlock } from "../interfaces";
 import { bnZero } from "../utils";
 import { getBlockRangeForChain } from "../dataworker/DataworkerUtils";
 
@@ -54,7 +54,8 @@ export type RelayerUnfilledDeposit = {
 export function getUnfilledDeposits(
   destinationChainId: number,
   spokePoolClients: SpokePoolClientsByChain,
-  hubPoolClient: HubPoolClient
+  hubPoolClient: HubPoolClient,
+  fillStatus: { [deposit: string]: number } = {}
 ): RelayerUnfilledDeposit[] {
   const destinationClient = spokePoolClients[destinationChainId];
 
@@ -62,7 +63,11 @@ export function getUnfilledDeposits(
   const deposits = Object.values(spokePoolClients)
     .filter(({ chainId, isUpdated }) => isUpdated && chainId !== destinationChainId)
     .map((spokePoolClient) => spokePoolClient.getDepositsForDestinationChain(destinationChainId))
-    .flat();
+    .flat()
+    .filter((deposit) => {
+      const depositHash = spokePoolClients[deposit.originChainId].getDepositHash(deposit);
+      return (fillStatus[depositHash] ?? FillStatus.Unfilled) !== FillStatus.Filled;
+    });
 
   return deposits
     .map((deposit) => {


### PR DESCRIPTION
The looping relayer is forced to drink from the fire hose when determining the set of unfilled deposits. In times of high demand this can lead to a lot of unnecessary looping to filter out deposits that have already been filled. This change adds tracking of fill status across loops in order to permit already-filled deposits to be filtered out as early as possible.