### PR TITLE
fix(Dataworker): Shallow copy refunds object when constructing RelayerRefundRoot

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -481,16 +481,13 @@ export class Dataworker {
     // Arweave for the bundle. We will be doing this at a
     // later point so that we can confirm that this data is
     // worth storing.
-    // @dev Deep clone all objects to avoid any potential
-    // reference issues when we pass the loadData return values to
-    // the following root-building functions.
     const dataToPersistToDALayer = {
-      bundleBlockRanges: _.cloneDeep(blockRangesForProposal),
-      bundleDepositsV3: _.cloneDeep(bundleDepositsV3),
-      expiredDepositsToRefundV3: _.cloneDeep(expiredDepositsToRefundV3),
-      bundleFillsV3: _.cloneDeep(bundleFillsV3),
-      unexecutableSlowFills: _.cloneDeep(unexecutableSlowFills),
-      bundleSlowFillsV3: _.cloneDeep(bundleSlowFillsV3),
+      bundleBlockRanges: blockRangesForProposal,
+      bundleDepositsV3,
+      expiredDepositsToRefundV3,
+      bundleFillsV3,
+      unexecutableSlowFills,
+      bundleSlowFillsV3,
     };
     const [, mainnetBundleEndBlock] = blockRangesForProposal[0];
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -481,13 +481,16 @@ export class Dataworker {
     // Arweave for the bundle. We will be doing this at a
     // later point so that we can confirm that this data is
     // worth storing.
+    // @dev Deep clone all objects to avoid any potential
+    // reference issues when we pass the loadData return values to
+    // the following root-building functions.
     const dataToPersistToDALayer = {
-      bundleBlockRanges: blockRangesForProposal,
-      bundleDepositsV3,
-      expiredDepositsToRefundV3,
-      bundleFillsV3,
-      unexecutableSlowFills,
-      bundleSlowFillsV3,
+      bundleBlockRanges: [...blockRangesForProposal],
+      bundleDepositsV3: { ...bundleDepositsV3 },
+      expiredDepositsToRefundV3: { ...expiredDepositsToRefundV3 },
+      bundleFillsV3: { ...bundleFillsV3 },
+      unexecutableSlowFills: { ...unexecutableSlowFills },
+      bundleSlowFillsV3: { ...bundleSlowFillsV3 },
     };
     const [, mainnetBundleEndBlock] = blockRangesForProposal[0];
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -485,12 +485,12 @@ export class Dataworker {
     // reference issues when we pass the loadData return values to
     // the following root-building functions.
     const dataToPersistToDALayer = {
-      bundleBlockRanges: [...blockRangesForProposal],
-      bundleDepositsV3: { ...bundleDepositsV3 },
-      expiredDepositsToRefundV3: { ...expiredDepositsToRefundV3 },
-      bundleFillsV3: { ...bundleFillsV3 },
-      unexecutableSlowFills: { ...unexecutableSlowFills },
-      bundleSlowFillsV3: { ...bundleSlowFillsV3 },
+      bundleBlockRanges: _.cloneDeep(blockRangesForProposal),
+      bundleDepositsV3: _.cloneDeep(bundleDepositsV3),
+      expiredDepositsToRefundV3: _.cloneDeep(expiredDepositsToRefundV3),
+      bundleFillsV3: _.cloneDeep(bundleFillsV3),
+      unexecutableSlowFills: _.cloneDeep(unexecutableSlowFills),
+      bundleSlowFillsV3: _.cloneDeep(bundleSlowFillsV3),
     };
     const [, mainnetBundleEndBlock] = blockRangesForProposal[0];
 

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -49,6 +49,7 @@ import {
 } from "../interfaces/BundleData";
 export const { getImpliedBundleBlockRanges, getBlockRangeForChain, getBlockForChain } = utils;
 import { any } from "superstruct";
+import _ from "lodash";
 
 export function getEndBlockBuffers(
   chainIdListForBundleEvaluationBlockNumbers: number[],
@@ -247,7 +248,7 @@ export function getRefundsFromBundle(
         return;
       }
       if (combinedRefunds[repaymentChainId][l2TokenAddress] === undefined) {
-        combinedRefunds[repaymentChainId][l2TokenAddress] = { ...refunds };
+        combinedRefunds[repaymentChainId][l2TokenAddress] = _.cloneDeep(refunds);
       } else {
         // Each refunds object should have a unique refund address so we can add new ones to the
         // existing dictionary.

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -247,7 +247,7 @@ export function getRefundsFromBundle(
         return;
       }
       if (combinedRefunds[repaymentChainId][l2TokenAddress] === undefined) {
-        combinedRefunds[repaymentChainId][l2TokenAddress] = refunds;
+        combinedRefunds[repaymentChainId][l2TokenAddress] = { ...refunds };
       } else {
         // Each refunds object should have a unique refund address so we can add new ones to the
         // existing dictionary.

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -247,14 +247,15 @@ export function getRefundsFromBundle(
       if (refunds === undefined) {
         return;
       }
+      const refundsClone = _.cloneDeep(refunds);
       if (combinedRefunds[repaymentChainId][l2TokenAddress] === undefined) {
-        combinedRefunds[repaymentChainId][l2TokenAddress] = _.cloneDeep(refunds);
+        combinedRefunds[repaymentChainId][l2TokenAddress] = refundsClone;
       } else {
         // Each refunds object should have a unique refund address so we can add new ones to the
         // existing dictionary.
         combinedRefunds[repaymentChainId][l2TokenAddress] = {
           ...combinedRefunds[repaymentChainId][l2TokenAddress],
-          ...refunds,
+          ...refundsClone,
         };
       }
     });

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -255,7 +255,7 @@ export function getRefundsFromBundle(
         // existing dictionary.
         combinedRefunds[repaymentChainId][l2TokenAddress] = {
           ...combinedRefunds[repaymentChainId][l2TokenAddress],
-          ...refundsClone,
+          ...refundsShallowCopy,
         };
       }
     });

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -49,7 +49,6 @@ import {
 } from "../interfaces/BundleData";
 export const { getImpliedBundleBlockRanges, getBlockRangeForChain, getBlockForChain } = utils;
 import { any } from "superstruct";
-import _ from "lodash";
 
 export function getEndBlockBuffers(
   chainIdListForBundleEvaluationBlockNumbers: number[],
@@ -247,9 +246,10 @@ export function getRefundsFromBundle(
       if (refunds === undefined) {
         return;
       }
-      const refundsClone = _.cloneDeep(refunds);
+      // @dev use shallow copy so that modifying combinedRefunds doesn't modify the original refunds object.
+      const refundsShallowCopy = { ...refunds };
       if (combinedRefunds[repaymentChainId][l2TokenAddress] === undefined) {
-        combinedRefunds[repaymentChainId][l2TokenAddress] = refundsClone;
+        combinedRefunds[repaymentChainId][l2TokenAddress] = refundsShallowCopy;
       } else {
         // Each refunds object should have a unique refund address so we can add new ones to the
         // existing dictionary.


### PR DESCRIPTION
## Motivation
We noticed that the Dataworker failed to reconstruct a bundle using Arweave bundle data but could reconstruct the same bundle using fresh data from scratch. This indicated corrupted data posted to Arweave.

When investigating Arweave, we noticed that all the bundleData looked correct except for `bundleFillsV3.refunds` which contained refunds for expired deposits. This is odd and unexpected since refunds should only be filled with fast fill refunds, not expired deposit refunds. This led me to realize that [this function](https://github.com/across-protocol/relayer/blob/13c5f17db14f11789f3fb6322f52183293fdb3cd/src/dataworker/DataworkerUtils.ts#L233) touches both `bundleFillsV3.refunds` and `expiredDeposits`, which led me to then realize that we are mutating the former when examining the latter.

Specifically:
- currently we set `combinedRefunds[repaymentChainId][l2TokenAddress] = refunds` on line 251
- but that's setting to the reference
- so later when we modify `combinedRefunds` on line 267, we set inadvertently `refunds` to contain the expired deposit refunds
- and recall, `refunds` is part of `bundleFillsV3` which is what we post to Arweave
- this explains why the `refunds` object posted to Arweave could contain expired deposit data

## Bug Description
In `DataworkerUtils`, when we construct the `combinedRefunds` object using the `refunds` from `bundleFillsV3` (i.e. the fast fill refunds in a bundle) and the `expiredDepositRefunds` (i.e. refunds for expired deposits), we accidentally modify the former as a reference variable.

This leads to upstream issues in `proposeRootBundle` which returns the bundle data to post to Arweave [here](https://github.com/across-protocol/relayer/blob/13c5f17db14f11789f3fb6322f52183293fdb3cd/src/dataworker/Dataworker.ts#L488). However, the very subtle bug is that the values we save to post to arweave here are the same references we accidentally mutate above.

This bug would only have been possible if we were trying to execute l2 leaves for a bundle containing expired deposit refunds, which only could have happened after #1587 which loads data from Arweave in the Executor, and expired deposits were only included in a bundle recently
