### PR TITLE
fix(config): Limit Linea multicalls to 50 transactions

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -184,6 +184,7 @@ export const DEFAULT_MULTICALL_CHUNK_SIZE = 100;
 export const DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE: { [chainId: number]: number } = {
   10: 75,
   8453: 75,
+  59144: 50,
 };
 
 // List of proposal block numbers to ignore. This should be ignored because they are administrative bundle proposals


### PR DESCRIPTION
Linea has a frustrating failure mode where some large multicall transactions will be accepted by their RPC, but will hang forever without confirmation. Subsequent transactions are rejected with REPLACEMENT_FEE_TOO_LOW. This has caused problems in the executor when trying to execute a lot of slow fills, and external intervention is needed.