### PR TITLE
fix(Linea): Define BridgingInitiatedV2

### DIFF
--- a/contracts/MockLineaEvents.sol
+++ b/contracts/MockLineaEvents.sol
@@ -42,19 +42,19 @@ contract LineaUsdcBridge {
 }
 
 contract LineaERC20Bridge {
-    event BridgingInitiated(address indexed sender, address recipient, address indexed token, uint256 indexed amount);
-    event BridgingFinalized(
+    event BridgingInitiatedV2(address indexed sender, address indexed recipient, address indexed token, uint256 amount);
+    event BridgingFinalizedV2(
         address indexed nativeToken,
         address indexed bridgedToken,
-        uint256 indexed amount,
-        address recipient
+        uint256 amount,
+        address indexed recipient
     );
 
     function emitBridgingInitiated(address sender, address recipient, address token) external {
-        emit BridgingInitiated(sender, recipient, token, 0);
+        emit BridgingInitiatedV2(sender, recipient, token, 0);
     }
 
     function emitBridgingFinalized(address l1Token, address recipient) external {
-        emit BridgingFinalized(l1Token, address(0), 0, recipient);
+        emit BridgingFinalizedV2(l1Token, address(0), 0, recipient);
     }
 }

--- a/src/clients/bridges/LineaAdapter.ts
+++ b/src/clients/bridges/LineaAdapter.ts
@@ -290,7 +290,7 @@ export class LineaAdapter extends BaseAdapter {
   ): Promise<Event[]> {
     const initiatedQueryResult = await paginatedEventQuery(
       l1Bridge,
-      l1Bridge.filters.BridgingInitiated(null /* sender */, null /* recipient, non-indexed must be null */, l1Token),
+      l1Bridge.filters.BridgingInitiatedV2(null /* sender */, null /* recipient, non-indexed must be null */, l1Token),
       l1SearchConfig
     );
     return initiatedQueryResult.filter(({ args }) => args.recipient === monitoredAddress);

--- a/src/clients/bridges/LineaAdapter.ts
+++ b/src/clients/bridges/LineaAdapter.ts
@@ -304,7 +304,7 @@ export class LineaAdapter extends BaseAdapter {
   ): Promise<Event[]> {
     const finalizedQueryResult = await paginatedEventQuery(
       l2Bridge,
-      l2Bridge.filters.BridgingFinalized(l1Token),
+      l2Bridge.filters.BridgingFinalizedV2(l1Token),
       l2SearchConfig
     );
     return finalizedQueryResult.filter(({ args }) => args.recipient === monitoredAddress);

--- a/src/clients/bridges/LineaAdapter.ts
+++ b/src/clients/bridges/LineaAdapter.ts
@@ -290,7 +290,7 @@ export class LineaAdapter extends BaseAdapter {
   ): Promise<Event[]> {
     const initiatedQueryResult = await paginatedEventQuery(
       l1Bridge,
-      l1Bridge.filters.BridgingInitiatedV2(null /* sender */, null /* recipient, non-indexed must be null */, l1Token),
+      l1Bridge.filters.BridgingInitiatedV2(null /* sender */, monitoredAddress /* recipient */, l1Token),
       l1SearchConfig
     );
     return initiatedQueryResult.filter(({ args }) => args.recipient === monitoredAddress);
@@ -304,7 +304,12 @@ export class LineaAdapter extends BaseAdapter {
   ): Promise<Event[]> {
     const finalizedQueryResult = await paginatedEventQuery(
       l2Bridge,
-      l2Bridge.filters.BridgingFinalizedV2(l1Token),
+      l2Bridge.filters.BridgingFinalizedV2(
+        l1Token,
+        null /* bridgedToken */,
+        null /* bridgedToken */,
+        monitoredAddress /* recipient */
+      ),
       l2SearchConfig
     );
     return finalizedQueryResult.filter(({ args }) => args.recipient === monitoredAddress);

--- a/src/clients/bridges/LineaAdapter.ts
+++ b/src/clients/bridges/LineaAdapter.ts
@@ -293,7 +293,7 @@ export class LineaAdapter extends BaseAdapter {
       l1Bridge.filters.BridgingInitiatedV2(null /* sender */, monitoredAddress /* recipient */, l1Token),
       l1SearchConfig
     );
-    return initiatedQueryResult.filter(({ args }) => args.recipient === monitoredAddress);
+    return initiatedQueryResult;
   }
 
   async getErc20DepositFinalizedEvents(
@@ -312,7 +312,7 @@ export class LineaAdapter extends BaseAdapter {
       ),
       l2SearchConfig
     );
-    return finalizedQueryResult.filter(({ args }) => args.recipient === monitoredAddress);
+    return finalizedQueryResult;
   }
 
   matchErc20DepositEvents(

--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -288,6 +288,37 @@ export const LINEA_TOKEN_BRIDGE_CONTRACT_ABI = [
       {
         indexed: true,
         internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "recipient",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "token",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "BridgingInitiatedV2",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
         name: "nativeToken",
         type: "address",
       },

--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -298,19 +298,19 @@ export const LINEA_TOKEN_BRIDGE_CONTRACT_ABI = [
         type: "address",
       },
       {
-        indexed: true,
+        indexed: false,
         internalType: "uint256",
         name: "amount",
         type: "uint256",
       },
       {
-        indexed: false,
+        indexed: true,
         internalType: "address",
         name: "recipient",
         type: "address",
       },
     ],
-    name: "BridgingFinalized",
+    name: "BridgingFinalizedV2",
     type: "event",
   },
   {

--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -261,37 +261,6 @@ export const LINEA_TOKEN_BRIDGE_CONTRACT_ABI = [
         type: "address",
       },
       {
-        indexed: false,
-        internalType: "address",
-        name: "recipient",
-        type: "address",
-      },
-      {
-        indexed: true,
-        internalType: "address",
-        name: "token",
-        type: "address",
-      },
-      {
-        indexed: true,
-        internalType: "uint256",
-        name: "amount",
-        type: "uint256",
-      },
-    ],
-    name: "BridgingInitiated",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: "address",
-        name: "sender",
-        type: "address",
-      },
-      {
         indexed: true,
         internalType: "address",
         name: "recipient",

--- a/src/finalizer/utils/linea/common.ts
+++ b/src/finalizer/utils/linea/common.ts
@@ -206,7 +206,7 @@ export async function findMessageFromTokenBridge(
 ): Promise<MessageSentEvent[]> {
   const bridgeEvents = await paginatedEventQuery(
     bridgeContract,
-    bridgeContract.filters.BridgingInitiated(l1ToL2AddressesToFinalize),
+    bridgeContract.filters.BridgingInitiatedV2(l1ToL2AddressesToFinalize),
     searchConfig
   );
   const messageSent = messageServiceContract.contract.interface.getEventTopic("MessageSent");


### PR DESCRIPTION
Linea have upgraded their token bridge and emit BridgingInitiatedV2 instead of BridgingInitiated. This allows for filtering on receipient to occur, at the expense of amount.

Required before merge:
- Do we ever rely on filtering by amount?
- Do all ERC20s now emit `BridgingInitiatedV2`, or do some still emit `BridgingInitiated`?
- Is this event emitted in both directions?

Side note: I initially thought we'd need the Linea SDK v0.3.0 and had spent some time struggling to update to it. It causes a lot of things in the current Linea adapter implementation to break, and the fixes seem non-trivial. I suspect we might want to re-architect the Linea finalizer to rely less on type unions, because it's painful when Consensys rug the types we rely on.