### PR TITLE
improve(relayer): Conditionally update cross chain transfers

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -1112,11 +1112,12 @@ export class InventoryClient {
     await this.adapterManager.wrapEthIfAboveThreshold(this.inventoryConfig, this.simMode);
   }
 
-  async update(): Promise<void> {
+  update(chainIds?: number[]): Promise<void> {
     if (!this.isInventoryManagementEnabled()) {
       return;
     }
-    await this.crossChainTransferClient.update(this.getL1Tokens());
+
+    return this.crossChainTransferClient.update(this.getL1Tokens(), chainIds);
   }
 
   isInventoryManagementEnabled(): boolean {

--- a/src/clients/bridges/CrossChainTransferClient.ts
+++ b/src/clients/bridges/CrossChainTransferClient.ts
@@ -79,12 +79,13 @@ export class CrossChainTransferClient {
     ).add(rebalance);
   }
 
-  async update(l1Tokens: string[]): Promise<void> {
-    const monitoredChains = this.getEnabledL2Chains(); // Use all chainIds except L1.
-    this.log("Updating cross chain transfers", { monitoredChains });
+  async update(l1Tokens: string[], chainIds = this.getEnabledL2Chains()): Promise<void> {
+    const enabledChainIds = this.getEnabledL2Chains();
+    chainIds = chainIds.filter((chainId) => enabledChainIds.includes(chainId));
+    this.log("Updating cross chain transfers", { chainIds });
 
     const outstandingTransfersPerChain = await Promise.all(
-      monitoredChains.map(async (chainId) => [
+      chainIds.map(async (chainId) => [
         chainId,
         await this.adapterManager.getOutstandingCrossChainTokenTransferAmount(chainId, l1Tokens),
       ])

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -198,9 +198,12 @@ export async function updateRelayerClients(clients: RelayerClients, config: Rela
   await clients.tokenClient.update();
 
   // We can update the inventory client at the same time as checking for eth wrapping as these do not depend on each other.
+  const inventoryChainIds = Object.values(spokePoolClients)
+    .filter(({ latestBlockSearched, deploymentBlock }) => latestBlockSearched > deploymentBlock)
+    .map(({ chainId }) => chainId);
   await Promise.all([
     clients.acrossApiClient.update(config.ignoreLimits),
-    clients.inventoryClient.update(),
+    clients.inventoryClient.update(inventoryChainIds),
     clients.inventoryClient.wrapL2EthIfAboveThreshold(),
     clients.inventoryClient.setL1TokenApprovals(),
     config.sendingRelaysEnabled ? clients.tokenClient.setOriginTokenApprovals() : Promise.resolve(),


### PR DESCRIPTION
When inventory management is enabled, make cross-chain transfer querying for each chain conditional on the corresponding SpokePoolClient having been updated. This addresses a constraint that exists the various bridge adapters, whereby they rely on the SpokePoolClient having been updated first in order to piggyback on its event search config.