### PR TITLE
improve(adapters): centralize chain supported tokens

### DIFF
--- a/src/clients/bridges/ArbitrumAdapter.ts
+++ b/src/clients/bridges/ArbitrumAdapter.ts
@@ -18,7 +18,7 @@ import {
 } from "../../utils";
 import { SpokePoolClient } from "../../clients";
 import { SortableEvent, OutstandingTransfers } from "../../interfaces";
-import { CONTRACT_ADDRESSES } from "../../common";
+import { CONTRACT_ADDRESSES, SUPPORTED_TOKENS } from "../../common";
 import { CCTPAdapter } from "./CCTPAdapter";
 
 // TODO: Move to ../../common/ContractAddresses.ts
@@ -67,18 +67,7 @@ export class ArbitrumAdapter extends CCTPAdapter {
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
     monitoredAddresses: string[]
   ) {
-    super(spokePoolClients, 42161, monitoredAddresses, logger, [
-      "USDC",
-      "USDT",
-      "WETH",
-      "DAI",
-      "WBTC",
-      "UMA",
-      "BADGER",
-      "BAL",
-      "ACX",
-      "POOL",
-    ]);
+    super(spokePoolClients, 42161, monitoredAddresses, logger, SUPPORTED_TOKENS[CHAIN_IDs.ARBITRUM]);
   }
 
   async getOutstandingCrossChainTransfers(l1Tokens: string[]): Promise<OutstandingTransfers> {

--- a/src/clients/bridges/ArbitrumAdapter.ts
+++ b/src/clients/bridges/ArbitrumAdapter.ts
@@ -67,7 +67,8 @@ export class ArbitrumAdapter extends CCTPAdapter {
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
     monitoredAddresses: string[]
   ) {
-    super(spokePoolClients, 42161, monitoredAddresses, logger, SUPPORTED_TOKENS[CHAIN_IDs.ARBITRUM]);
+    const { ARBITRUM } = CHAIN_IDs;
+    super(spokePoolClients, ARBITRUM, monitoredAddresses, logger, SUPPORTED_TOKENS[ARBITRUM]);
   }
 
   async getOutstandingCrossChainTransfers(l1Tokens: string[]): Promise<OutstandingTransfers> {

--- a/src/clients/bridges/LineaAdapter.ts
+++ b/src/clients/bridges/LineaAdapter.ts
@@ -1,5 +1,5 @@
 import * as sdk from "@across-protocol/sdk";
-import { CONTRACT_ADDRESSES } from "../../common";
+import { CONTRACT_ADDRESSES, SUPPORTED_TOKENS } from "../../common";
 import { OutstandingTransfers } from "../../interfaces";
 import {
   BigNumber,
@@ -28,7 +28,7 @@ export class LineaAdapter extends BaseAdapter {
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
     monitoredAddresses: string[]
   ) {
-    super(spokePoolClients, CHAIN_IDs.LINEA, monitoredAddresses, logger, ["USDC", "USDT", "WETH", "WBTC", "DAI"]);
+    super(spokePoolClients, CHAIN_IDs.LINEA, monitoredAddresses, logger, SUPPORTED_TOKENS[CHAIN_IDs.LINEA]);
   }
   async checkTokenApprovals(address: string, l1Tokens: string[]): Promise<void> {
     // Note: Linea has two bridges: one for

--- a/src/clients/bridges/LineaAdapter.ts
+++ b/src/clients/bridges/LineaAdapter.ts
@@ -28,7 +28,8 @@ export class LineaAdapter extends BaseAdapter {
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
     monitoredAddresses: string[]
   ) {
-    super(spokePoolClients, CHAIN_IDs.LINEA, monitoredAddresses, logger, SUPPORTED_TOKENS[CHAIN_IDs.LINEA]);
+    const { LINEA } = CHAIN_IDs;
+    super(spokePoolClients, LINEA, monitoredAddresses, logger, SUPPORTED_TOKENS[LINEA]);
   }
   async checkTokenApprovals(address: string, l1Tokens: string[]): Promise<void> {
     // Note: Linea has two bridges: one for

--- a/src/clients/bridges/PolygonAdapter.ts
+++ b/src/clients/bridges/PolygonAdapter.ts
@@ -18,7 +18,7 @@ import {
 } from "../../utils";
 import { SpokePoolClient } from "../../clients";
 import { SortableEvent, OutstandingTransfers } from "../../interfaces";
-import { CONTRACT_ADDRESSES } from "../../common";
+import { CONTRACT_ADDRESSES, SUPPORTED_TOKENS } from "../../common";
 import { CCTPAdapter } from "./CCTPAdapter";
 
 // ether bridge = 0x8484Ef722627bf18ca5Ae6BcF031c23E6e922B30
@@ -117,19 +117,7 @@ export class PolygonAdapter extends CCTPAdapter {
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
     monitoredAddresses: string[]
   ) {
-    super(spokePoolClients, 137, monitoredAddresses, logger, [
-      "USDC",
-      "USDT",
-      "WETH",
-      "DAI",
-      "WBTC",
-      "UMA",
-      "BAL",
-      "ACX",
-      "BADGER",
-      "POOL",
-      "MATIC",
-    ]);
+    super(spokePoolClients, 137, monitoredAddresses, logger, SUPPORTED_TOKENS[CHAIN_IDs.POLYGON]);
   }
 
   // On polygon a bridge transaction looks like a transfer from address(0) to the target.

--- a/src/clients/bridges/PolygonAdapter.ts
+++ b/src/clients/bridges/PolygonAdapter.ts
@@ -117,7 +117,8 @@ export class PolygonAdapter extends CCTPAdapter {
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
     monitoredAddresses: string[]
   ) {
-    super(spokePoolClients, 137, monitoredAddresses, logger, SUPPORTED_TOKENS[CHAIN_IDs.POLYGON]);
+    const { POLYGON } = CHAIN_IDs;
+    super(spokePoolClients, POLYGON, monitoredAddresses, logger, SUPPORTED_TOKENS[POLYGON]);
   }
 
   // On polygon a bridge transaction looks like a transfer from address(0) to the target.

--- a/src/clients/bridges/ZKSyncAdapter.ts
+++ b/src/clients/bridges/ZKSyncAdapter.ts
@@ -32,7 +32,8 @@ export class ZKSyncAdapter extends BaseAdapter {
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
     monitoredAddresses: string[]
   ) {
-    super(spokePoolClients, 324, monitoredAddresses, logger, SUPPORTED_TOKENS[CHAIN_IDs.ZK_SYNC]);
+    const { ZK_SYNC } = CHAIN_IDs;
+    super(spokePoolClients, ZK_SYNC, monitoredAddresses, logger, SUPPORTED_TOKENS[ZK_SYNC]);
   }
 
   async getOutstandingCrossChainTransfers(l1Tokens: string[]): Promise<OutstandingTransfers> {

--- a/src/clients/bridges/ZKSyncAdapter.ts
+++ b/src/clients/bridges/ZKSyncAdapter.ts
@@ -11,11 +11,12 @@ import {
   ZERO_ADDRESS,
   TOKEN_SYMBOLS_MAP,
   bnZero,
+  CHAIN_IDs,
 } from "../../utils";
 import { SpokePoolClient } from "../.";
 import assert from "assert";
 import * as zksync from "zksync-web3";
-import { CONTRACT_ADDRESSES } from "../../common";
+import { CONTRACT_ADDRESSES, SUPPORTED_TOKENS } from "../../common";
 import { isDefined } from "../../utils/TypeGuards";
 import { gasPriceOracle, utils } from "@across-protocol/sdk";
 import { zkSync as zkSyncUtils } from "../../utils/chains";
@@ -31,7 +32,7 @@ export class ZKSyncAdapter extends BaseAdapter {
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
     monitoredAddresses: string[]
   ) {
-    super(spokePoolClients, 324, monitoredAddresses, logger, ["USDC", "USDT", "WETH", "WBTC", "DAI"]);
+    super(spokePoolClients, 324, monitoredAddresses, logger, SUPPORTED_TOKENS[CHAIN_IDs.ZK_SYNC]);
   }
 
   async getOutstandingCrossChainTransfers(l1Tokens: string[]): Promise<OutstandingTransfers> {

--- a/src/clients/bridges/op-stack/base/BaseChainAdapter.ts
+++ b/src/clients/bridges/op-stack/base/BaseChainAdapter.ts
@@ -1,6 +1,7 @@
-import { winston } from "../../../../utils";
+import { winston, CHAIN_IDs } from "../../../../utils";
 import { SpokePoolClient } from "../../..";
 import { OpStackAdapter } from "../OpStackAdapter";
+import { SUPPORTED_TOKENS } from "../../../../common";
 
 // Note: this is called BaseChainAdapter because BaseAdapter is the name of the base class.
 export class BaseChainAdapter extends OpStackAdapter {
@@ -14,7 +15,7 @@ export class BaseChainAdapter extends OpStackAdapter {
       // Custom Bridges
       {},
       logger,
-      ["BAL", "DAI", "ETH", "WETH", "USDC", "POOL"],
+      SUPPORTED_TOKENS[CHAIN_IDs.BASE], 
       spokePoolClients,
       monitoredAddresses
     );

--- a/src/clients/bridges/op-stack/base/BaseChainAdapter.ts
+++ b/src/clients/bridges/op-stack/base/BaseChainAdapter.ts
@@ -15,7 +15,7 @@ export class BaseChainAdapter extends OpStackAdapter {
       // Custom Bridges
       {},
       logger,
-      SUPPORTED_TOKENS[CHAIN_IDs.BASE], 
+      SUPPORTED_TOKENS[CHAIN_IDs.BASE],
       spokePoolClients,
       monitoredAddresses
     );

--- a/src/clients/bridges/op-stack/mode/ModeAdapter.ts
+++ b/src/clients/bridges/op-stack/mode/ModeAdapter.ts
@@ -1,6 +1,7 @@
-import { winston } from "../../../../utils";
+import { winston, CHAIN_IDs } from "../../../../utils";
 import { SpokePoolClient } from "../../..";
 import { OpStackAdapter } from "../OpStackAdapter";
+import { SUPPORTED_TOKENS } from "../../../../common";
 
 export class ModeAdapter extends OpStackAdapter {
   constructor(
@@ -13,7 +14,7 @@ export class ModeAdapter extends OpStackAdapter {
       // Custom Bridges
       {},
       logger,
-      ["ETH", "WETH", "USDC", "USDT", "WBTC"],
+      SUPPORTED_TOKENS[CHAIN_IDs.MODE],
       spokePoolClients,
       monitoredAddresses
     );

--- a/src/clients/bridges/op-stack/optimism/OptimismAdapter.ts
+++ b/src/clients/bridges/op-stack/optimism/OptimismAdapter.ts
@@ -1,6 +1,7 @@
-import { winston, TOKEN_SYMBOLS_MAP } from "../../../../utils";
+import { winston, TOKEN_SYMBOLS_MAP, CHAIN_IDs } from "../../../../utils";
 import { SpokePoolClient } from "../../..";
 import { BaseAdapter } from "../..";
+import { SUPPORTED_TOKENS } from "../../../../common";
 import { OpStackAdapter } from "../OpStackAdapter";
 import { DaiOptimismBridge } from "./DaiOptimismBridge";
 import { SnxOptimismBridge } from "./SnxOptimismBridge";
@@ -24,7 +25,7 @@ export class OptimismAdapter extends OpStackAdapter {
         [TOKEN_SYMBOLS_MAP.SNX.addresses[hubChainId]]: snxBridge,
       },
       logger,
-      ["DAI", "SNX", "USDC", "USDT", "WETH", "WBTC", "UMA", "BAL", "ACX", "POOL"],
+      SUPPORTED_TOKENS[CHAIN_IDs.OPTIMISM],
       spokePoolClients,
       monitoredAddresses
     );

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -313,6 +313,22 @@ export const chainIdsToCctpDomains: { [chainId: number]: number } = {
   80001: 7, // Polygon PoS Mumbai
 };
 
+export const SUPPORTED_TOKENS: { [chainId: number]: string[] } = {
+  10: ["DAI", "SNX", "BAL", "ETH", "WETH", "USDC", "POOL", "USDT", "WBTC", "UMA", "ACX"],
+  137: ["USDC", "USDT", "WETH", "DAI", "WBTC", "UMA", "BAL", "ACX", "POOL"],
+  324: ["USDC", "USDT", "WETH", "WBTC", "DAI"],
+  8453: ["BAL", "DAI", "ETH", "WETH", "USDC", "POOL"],
+  34443: ["ETH", "WETH", "USDC", "USDT", "WBTC"],
+  42161: ["USDC", "USDT", "WETH", "DAI", "WBTC", "UMA", "BAL", "ACX", "POOL"],
+  59144: ["USDC", "USDT", "WETH", "WBTC", "DAI"],
+
+  // Testnets:
+  919: ["ETH", "WETH", "USDC", "USDT", "WBTC"],
+  59141: ["USDC", "USDT", "WETH", "WBTC", "DAI"],
+  84532: ["BAL", "DAI", "ETH", "WETH", "USDC"],
+  421614: ["USDC", "USDT", "WETH", "DAI", "WBTC", "UMA", "ACX"],
+  11155420: ["DAI", "SNX", "BAL", "ETH", "WETH", "USDC", "USDT", "WBTC", "UMA", "ACX"],
+};
 /**
  * A mapping of chain IDs to tokens on that chain which need their allowance
  * to first be zeroed before setting a new allowance. This is useful for

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -314,7 +314,7 @@ export const chainIdsToCctpDomains: { [chainId: number]: number } = {
 };
 
 export const SUPPORTED_TOKENS: { [chainId: number]: string[] } = {
-  10: ["DAI", "SNX", "BAL", "ETH", "WETH", "USDC", "POOL", "USDT", "WBTC", "UMA", "ACX"],
+  10: ["DAI", "SNX", "BAL", "WETH", "USDC", "POOL", "USDT", "WBTC", "UMA", "ACX"],
   137: ["USDC", "USDT", "WETH", "DAI", "WBTC", "UMA", "BAL", "ACX", "POOL"],
   324: ["USDC", "USDT", "WETH", "WBTC", "DAI"],
   8453: ["BAL", "DAI", "ETH", "WETH", "USDC", "POOL"],


### PR DESCRIPTION
We want to be able to modify a small number of files (e.g. those in `src/common`) in order to support a new chain. A low-hanging fruit which also shrinks the diff in this PR: https://github.com/across-protocol/relayer/pull/1524 will move the tokens supported by a specific route to our constants. 

The motivation for this is to eventually be able to construct a generic adapter which can fetch all of its configuration directly when all it knows is its chain ID.