### PR TITLE
fix(relayer): Skip cross-chain transfer tracking when looping

### DIFF
--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -199,9 +199,8 @@ export async function updateRelayerClients(clients: RelayerClients, config: Rela
 
   // We can update the inventory client at the same time as checking for eth wrapping as these do not depend on each other.
   // Cross-chain deposit tracking produces duplicates in looping mode, so in that case don't attempt it.
-  const inventoryChainIds = config.pollingDelay === 0
-    ? Object.values(spokePoolClients).map(({ chainId }) => chainId)
-    : [];
+  const inventoryChainIds =
+    config.pollingDelay === 0 ? Object.values(spokePoolClients).map(({ chainId }) => chainId) : [];
   await Promise.all([
     clients.acrossApiClient.update(config.ignoreLimits),
     clients.inventoryClient.update(inventoryChainIds),

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -198,9 +198,10 @@ export async function updateRelayerClients(clients: RelayerClients, config: Rela
   await clients.tokenClient.update();
 
   // We can update the inventory client at the same time as checking for eth wrapping as these do not depend on each other.
-  const inventoryChainIds = Object.values(spokePoolClients)
-    .filter(({ latestBlockSearched, deploymentBlock }) => latestBlockSearched > deploymentBlock)
-    .map(({ chainId }) => chainId);
+  // Cross-chain deposit tracking produces duplicates in looping mode, so in that case don't attempt it.
+  const inventoryChainIds = config.pollingDelay === 0
+    ? Object.values(spokePoolClients).map(({ chainId }) => chainId)
+    : [];
   await Promise.all([
     clients.acrossApiClient.update(config.ignoreLimits),
     clients.inventoryClient.update(inventoryChainIds),

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -197,8 +197,11 @@ export async function updateRelayerClients(clients: RelayerClients, config: Rela
   // Update the token client first so that inventory client has latest balances.
   await clients.tokenClient.update();
 
-  // We can update the inventory client at the same time as checking for eth wrapping as these do not depend on each other.
-  // Cross-chain deposit tracking produces duplicates in looping mode, so in that case don't attempt it.
+  // We can update the inventory client in parallel with checking for eth wrapping as these do not depend on each other.
+  // Cross-chain deposit tracking produces duplicates in looping mode, so in that case don't attempt it. This does not
+  // disable inventory management, but does make it ignorant of in-flight cross-chain transfers. The rebalancer is
+  // assumed to run separately from the relayer and with pollingDelay 0, so it doesn't loop and will track transfers
+  // correctly to avoid repeat rebalances.
   const inventoryChainIds =
     config.pollingDelay === 0 ? Object.values(spokePoolClients).map(({ chainId }) => chainId) : [];
   await Promise.all([


### PR DESCRIPTION
Checking the logs more closely, it's obvious that some chain adapters repeatedly produce the same copies of deposit hashes. This creates duplicates and will result in delays and odd results in balance projections. A proper fix is needed in the adapters, but this is deferred for now because of the ongoing new-chain automation work.