### PR TITLE
improve(relayer): Relax future quoteTimestamp constraint

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -482,8 +482,9 @@ export class Relayer {
     const { hubPoolClient, profitClient, spokePoolClients, tokenClient, multiCallerClient } = this.clients;
 
     // Fetch the average block time for mainnet, for later use in evaluating quoteTimestamps.
-    this.hubPoolBlockBuffer ??=
-      HUB_SPOKE_BLOCK_LAG * (await sdkUtils.averageBlockTime(hubPoolClient.hubPool.provider)).average;
+    this.hubPoolBlockBuffer ??= Math.ceil(
+      HUB_SPOKE_BLOCK_LAG * (await sdkUtils.averageBlockTime(hubPoolClient.hubPool.provider)).average
+    );
 
     // Flush any pre-existing enqueued transactions that might not have been executed.
     multiCallerClient.clearTransactionQueue();

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -482,7 +482,8 @@ export class Relayer {
     const { hubPoolClient, profitClient, spokePoolClients, tokenClient, multiCallerClient } = this.clients;
 
     // Fetch the average block time for mainnet, for later use in evaluating quoteTimestamps.
-    this.hubPoolBlockBuffer ??= HUB_SPOKE_BLOCK_LAG * (await sdkUtils.averageBlockTime(hubPoolClient.hubPool.provider)).average;
+    this.hubPoolBlockBuffer ??=
+      HUB_SPOKE_BLOCK_LAG * (await sdkUtils.averageBlockTime(hubPoolClient.hubPool.provider)).average;
 
     // Flush any pre-existing enqueued transactions that might not have been executed.
     multiCallerClient.clearTransactionQueue();

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -126,6 +126,7 @@ export class Relayer {
         message: `Skipping ${srcChain} deposit due to future quoteTimestamp.`,
         currentTime: hubPoolClient.currentTime,
         quoteTimestamp: deposit.quoteTimestamp,
+        buffer: this.hubPoolBlockBuffer,
         transactionHash: deposit.transactionHash,
       });
       return false;

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -116,11 +116,6 @@ export class Relayer {
       return false;
     }
 
-    // Skip deposits with quoteTimestamp in the future (impossible to know HubPool utilization => LP fee cannot be computed).
-    if (deposit.quoteTimestamp > hubPoolClient.currentTime) {
-      return false;
-    }
-
     if (ignoredAddresses?.includes(getAddress(depositor)) || ignoredAddresses?.includes(getAddress(recipient))) {
       this.logger.debug({
         at: "Relayer::filterDeposit",

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -24,6 +24,7 @@ import { RelayerConfig } from "./RelayerConfig";
 const { getAddress } = ethersUtils;
 const { isDepositSpedUp, isMessageEmpty, resolveDepositMessage } = sdkUtils;
 const UNPROFITABLE_DEPOSIT_NOTICE_PERIOD = 60 * 60; // 1 hour
+const HUB_SPOKE_BLOCK_LAG = 2; // Permit SpokePool timestamps to be ahead of the HubPool by 2 HubPool blocks.
 
 type RepaymentFee = { paymentChainId: number; lpFeePct: BigNumber };
 type BatchLPFees = { [depositKey: string]: RepaymentFee[] };
@@ -38,6 +39,8 @@ export class Relayer {
   public readonly relayerAddress: string;
   public readonly fillStatus: { [depositHash: string]: number } = {};
   private pendingTxnReceipts: { [chainId: number]: Promise<TransactionResponse[]> } = {};
+
+  private hubPoolBlockBuffer: number;
 
   constructor(
     relayerAddress: string,
@@ -111,6 +114,18 @@ export class Relayer {
         blockNumber,
         confirmations: latestBlockSearched - blockNumber,
         minConfirmations,
+        transactionHash: deposit.transactionHash,
+      });
+      return false;
+    }
+
+    // Skip deposits with quoteTimestamp in the future (impossible to know HubPool utilization => LP fee cannot be computed).
+    if (deposit.quoteTimestamp - hubPoolClient.currentTime > this.hubPoolBlockBuffer) {
+      this.logger.debug({
+        at: "Relayer::evaluateFill",
+        message: `Skipping ${srcChain} deposit due to future quoteTimestamp.`,
+        currentTime: hubPoolClient.currentTime,
+        quoteTimestamp: deposit.quoteTimestamp,
         transactionHash: deposit.transactionHash,
       });
       return false;
@@ -464,7 +479,10 @@ export class Relayer {
     sendSlowRelays = true,
     simulate = false
   ): Promise<{ [chainId: number]: Promise<string[]> }> {
-    const { profitClient, spokePoolClients, tokenClient, multiCallerClient } = this.clients;
+    const { hubPoolClient, profitClient, spokePoolClients, tokenClient, multiCallerClient } = this.clients;
+
+    // Fetch the average block time for mainnet, for later use in evaluating quoteTimestamps.
+    this.hubPoolBlockBuffer ??= HUB_SPOKE_BLOCK_LAG * (await sdkUtils.averageBlockTime(hubPoolClient.hubPool.provider)).average;
 
     // Flush any pre-existing enqueued transactions that might not have been executed.
     multiCallerClient.clearTransactionQueue();

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -448,15 +448,15 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
 
       // Override hub pool client timestamp to make deposit look like its in the future
       await updateAllClients();
-      hubPoolClient.currentTime = quoteTimestamp - 1;
+      hubPoolClient.currentTime = quoteTimestamp - 100;
       let txnReceipts = await relayerInstance.checkForUnfilledDepositsAndFill();
       for (const receipts of Object.values(txnReceipts)) {
         expect((await receipts).length).to.equal(0);
       }
       expect(lastSpyLogIncludes(spy, "0 unfilled deposits")).to.be.true;
 
-      // If we reset the timestamp, the relayer will fill the deposit:
-      hubPoolClient.currentTime = quoteTimestamp;
+      // If we reset the timestamp to within the block lag buffer, the relayer will fill the deposit:
+      hubPoolClient.currentTime = quoteTimestamp - 1;
       txnReceipts = await relayerInstance.checkForUnfilledDepositsAndFill();
       expect((await txnReceipts[destinationChainId]).length).to.equal(1);
       expect(lastSpyLogIncludes(spy, "Filled v3 deposit")).to.be.true;


### PR DESCRIPTION
Any users of SpokePool.depositV3Now() inherit the origin chain's block.timestamp as their quoteTimestamp. Any integrators who call deposit() or depositV3() and supply block.timestamp for quoteTimestamp will see the same result. On fast L2s this will almost always be ahead of the latest HubPool timestamp. Per current relayer implementation, these deposits are silently ignored until the quoteTimestamp is behind the HubPool timestamp.

The risk of resolving an inaccurate LP utilisation at the quoteTimestamp is significantly reduced in v3, such that it's probably now not worth being strict on. The residual risk of future quoteTimestamps is really only when there are large gaps in which HubPool utilisation could change dramatically, and even then, the effect should be small (relayer repayment is somewhat less than expected). The SpokePools already enforce that the quoteTimestamp cannot be ahead of the origin chain's timestamp, so the risk of this is only present if there is significant clock drift between chains.

To balance this, permit quoteTimestamps to be up to 2 blocks ahead of the current HubPool block. This allows some flexibility where there is 0 or negligible effect, whilst still protecting against weird outcomes in the event of clock drift.