### PR TITLE
refactor(TokenClient): Cleanup USDC symbol aliases

### DIFF
--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -191,7 +191,7 @@ export class TokenClient {
 
         // If the HubPool token is USDC then it might map to multiple tokens on the destination chain.
         if (symbol === "USDC") {
-          const usdcAliases = ["USDC", "USDC.e", "USDbC"];
+          const usdcAliases = ["USDC.e", "USDbC"];
           usdcAliases
             .map((symbol) => TOKEN_SYMBOLS_MAP[symbol]?.addresses[chainId])
             .filter(isDefined)

--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -191,8 +191,7 @@ export class TokenClient {
 
         // If the HubPool token is USDC then it might map to multiple tokens on the destination chain.
         if (symbol === "USDC") {
-          const usdcAliases = ["USDC.e", "USDbC"];
-          usdcAliases
+          ["USDC.e", "USDbC"]
             .map((symbol) => TOKEN_SYMBOLS_MAP[symbol]?.addresses[chainId])
             .filter(isDefined)
             .forEach((address) => tokenAddrs.push(address));


### PR DESCRIPTION
USDC was required back when constants defined _USDC, but now it's just a duplicate.