### PR TITLE
feat(monitor): Add logs about stuck root bundle relays

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -353,3 +353,14 @@ export const DEFAULT_ARWEAVE_GATEWAY = { url: "arweave.net", port: 443, protocol
 // Chains with slow (> 2 day liveness) canonical L2-->L1 bridges that we prioritize taking repayment on.
 // This does not include all  7-day withdrawal chains because we don't necessarily prefer being repaid on some of these 7-day chains, like Mode.
 export const SLOW_WITHDRAWAL_CHAINS = [CHAIN_IDs.BASE, CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM];
+
+// Expected worst-case time for message from L1 to propogate to L2 in seconds
+export const EXPECTED_L1_TO_L2_MESSAGE_TIME = {
+  59144: 60 * 60,
+  42161: 20 * 60,
+  10: 20 * 60,
+  137: 60 * 60,
+  324: 60 * 60,
+  8453: 20 * 60,
+  34443: 20 * 60,
+};

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -1,5 +1,5 @@
 import { BalanceAllocator } from "../clients";
-import { spokePoolClientsToProviders } from "../common";
+import { EXPECTED_L1_TO_L2_MESSAGE_TIME, spokePoolClientsToProviders } from "../common";
 import {
   BalanceType,
   BundleAction,
@@ -569,28 +569,46 @@ export class Monitor {
     if (lastFullyExecutedBundle === undefined) {
       return;
     }
-    // If we're still within the grace period, skip looking for any stuck rebalances.
-    // Again, this would give false negatives for transfers that have been stuck for longer than one bundle if the
-    // current time is within the grace period of last executed bundle. But this is a good trade off for simpler code.
-    const lastFullyExecutedBundleTime = lastFullyExecutedBundle.challengePeriodEndTimestamp;
-    const currentTime = Number(await this.clients.hubPoolClient.hubPool.getCurrentTime());
-    if (lastFullyExecutedBundleTime + REBALANCE_FINALIZE_GRACE_PERIOD > currentTime) {
-      this.logger.debug({
-        at: "Monitor#checkStuckRebalances",
-        message: `Within ${REBALANCE_FINALIZE_GRACE_PERIOD / 60}min grace period of last bundle execution`,
-        lastFullyExecutedBundleTime,
-        currentTime,
-      });
-      return;
-    }
 
     const allL1Tokens = this.clients.hubPoolClient.getL1Tokens();
     for (const chainId of this.crossChainAdapterSupportedChains) {
+      const gracePeriod = EXPECTED_L1_TO_L2_MESSAGE_TIME[chainId] ?? REBALANCE_FINALIZE_GRACE_PERIOD;
+      // If we're still within the grace period, skip looking for any stuck rebalances.
+      // Again, this would give false negatives for transfers that have been stuck for longer than one bundle if the
+      // current time is within the grace period of last executed bundle. But this is a good trade off for simpler code.
+      const lastFullyExecutedBundleTime = lastFullyExecutedBundle.challengePeriodEndTimestamp;
+      const currentTime = Number(await this.clients.hubPoolClient.hubPool.getCurrentTime());
+      if (lastFullyExecutedBundleTime + gracePeriod > currentTime) {
+        this.logger.debug({
+          at: "Monitor#checkStuckRebalances",
+          message: `Within ${gracePeriod / 60}min grace period of last bundle execution for ${getNetworkName(chainId)}`,
+          lastFullyExecutedBundleTime,
+          currentTime,
+        });
+        return;
+      }
+
       // If chain wasn't active in latest bundle, then skip it.
       const chainIndex = this.clients.hubPoolClient.configStoreClient.getChainIdIndicesForBlock().indexOf(chainId);
       if (chainIndex >= lastFullyExecutedBundle.bundleEvaluationBlockNumbers.length) {
         continue;
       }
+
+      // First, log if the root bundle never relayed to the spoke pool.
+      const rootBundleRelay = this.clients.spokePoolClients[chainId].getRootBundleRelays().find((relay) => {
+        return (
+          relay.relayerRefundRoot === lastFullyExecutedBundle.relayerRefundRoot &&
+          relay.slowRelayRoot === lastFullyExecutedBundle.slowRelayRoot
+        );
+      });
+      if (!rootBundleRelay) {
+        this.logger.warn({
+          at: "Monitor#checkStuckRebalances",
+          message: `HubPool -> ${getNetworkName(chainId)} SpokePool root bundle relay stuck 👨🏻‍🦽‍➡️`,
+          lastFullyExecutedBundle,
+        });
+      }
+
       const spokePoolAddress = this.clients.spokePoolClients[chainId].spokePool.address;
       for (const l1Token of allL1Tokens) {
         // Outstanding transfers are mapped to either the spoke pool or the hub pool, depending on which

--- a/test/Monitor.ts
+++ b/test/Monitor.ts
@@ -375,11 +375,10 @@ describe("Monitor", async function () {
     await monitorInstance.update();
     await monitorInstance.checkStuckRebalances();
 
-    expect(lastSpyLogIncludes(spy, "HubPool -> SpokePool rebalances stuck 🦴")).to.be.true;
-    const log = spy.lastCall;
-    expect(log.lastArg.mrkdwn).to.contains(
-      `Rebalances of ${await l1Token.symbol()} to ${getNetworkName(originChainId)} is stuck`
-    );
+    const stuckTransfer = spy.getCalls().find((call) => call.lastArg.message.includes("rebalances stuck"));
+    const stuckRootRelay = spy.getCalls().find((call) => call.lastArg.message.includes("root bundle relay stuck"));
+    expect(stuckTransfer).to.not.be.undefined;
+    expect(stuckRootRelay).to.not.be.undefined;
   });
 
   it("Monitor should report unfilled deposits", async function () {


### PR DESCRIPTION
Even if root bundle relay from L1 to L2 doesn't contain token transfers, we should still warn if something is stuck
