### PR TITLE
fix(AcrossAPIClient): Support liquid-reserves query

### DIFF
--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -143,11 +143,7 @@ export class AcrossApiClient {
       const baseTtl = 300;
       // Apply a random margin to spread expiry over a larger time window.
       const ttl = baseTtl + Math.ceil(_.random(-0.5, 0.5, true) * baseTtl);
-      await redis.set(
-        this.getLimitsCacheKey(l1Tokens),
-        liquidReserves.map((n) => n.toString()).join(","),
-        ttl
-      );
+      await redis.set(this.getLimitsCacheKey(l1Tokens), liquidReserves.map((n) => n.toString()).join(","), ttl);
     }
 
     return liquidReserves;

--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -69,7 +69,7 @@ export class AcrossApiClient {
 
     // /liquid-reserves
     // Store the max available HubPool liquidity (less API-imposed cushioning) for each L1 token.
-    const liquidReserves = await this.callLimits(enabledTokens);
+    const liquidReserves = await this.callLimits(tokens);
     tokens.forEach((token, i) => (this.limits[token] = liquidReserves[i]));
 
     this.logger.debug({

--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -145,7 +145,7 @@ export class AcrossApiClient {
       const ttl = baseTtl + Math.ceil(_.random(-0.5, 0.5, true) * baseTtl);
       await redis.set(
         this.getLimitsCacheKey(l1Tokens),
-        liquidReserves.map((n) => n.toString()),
+        liquidReserves.map((n) => n.toString()).join(","),
         ttl
       );
     }

--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -67,7 +67,7 @@ export class AcrossApiClient {
     });
     this.updatedLimits = false;
 
-    // /liquidReserves
+    // /liquid-reserves
     // Store the max available HubPool liquidity (less API-imposed cushioning) for each L1 token.
     const liquidReserves = await this.callLimits(enabledTokens);
     tokens.forEach((token, i) => (this.limits[token] = liquidReserves[i]));

--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -60,7 +60,7 @@ export class AcrossApiClient {
     const tokens = this.tokensQuery.filter((token) => enabledTokens.includes(token));
     this.logger.debug({
       at: "AcrossAPIClient",
-      message: "Querying /liquidReserves",
+      message: "Querying /liquid-reserves",
       timeout: this.timeout,
       tokens,
       endpoint: this.endpoint,


### PR DESCRIPTION
The API was recently updated to return a modified definition of maxDeposit, such that it is capped at the largest desirable deposit amount (but not necessarily the largest deposit that Across can support). This change also added a destinationChainId-dependent aspect, which is incompatible with the relayer's existing use of the API where it tries to only query from anywhere -> mainnet to determine limits. This caused flow-on effects in the relayer where it would refuse to make fills that were perfectly OK to fill. This change restores the ability of the relayer to accurately fill based on configured limits.