### PR TITLE
fix(relayer): Don't log noisily on 0 limits if limits are disabled

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -74,7 +74,7 @@ export class Relayer {
   filterDeposit({ deposit, version: depositVersion, invalidFills }: RelayerUnfilledDeposit): boolean {
     const { depositId, originChainId, destinationChainId, depositor, recipient, inputToken, blockNumber } = deposit;
     const { acrossApiClient, configStoreClient, hubPoolClient, profitClient, spokePoolClients } = this.clients;
-    const { ignoredAddresses, relayerTokens, acceptInvalidFills, minDepositConfirmations } = this.config;
+    const { ignoredAddresses, ignoreLimits, relayerTokens, acceptInvalidFills, minDepositConfirmations } = this.config;
     const [srcChain, dstChain] = [getNetworkName(originChainId), getNetworkName(destinationChainId)];
 
     // If we don't have the latest code to support this deposit, skip it.
@@ -203,21 +203,23 @@ export class Relayer {
     // The relayer should *not* be filling deposits that the HubPool doesn't have liquidity for otherwise the relayer's
     // refund will be stuck for potentially 7 days. Note: Filter for supported tokens first, since the relayer only
     // queries for limits on supported tokens.
-    const { inputAmount } = deposit;
-    const limit = acrossApiClient.getLimit(originChainId, l1Token.address);
-    if (acrossApiClient.updatedLimits && inputAmount.gt(limit)) {
-      this.logger.warn({
-        at: "Relayer::filterDeposit",
-        message: "😱 Skipping deposit with greater unfilled amount than API suggested limit",
-        limit,
-        l1Token: l1Token.address,
-        depositId,
-        inputToken,
-        inputAmount,
-        originChainId,
-        transactionHash: deposit.transactionHash,
-      });
-      return false;
+    if (!ignoreLimits) {
+      const { inputAmount } = deposit;
+      const limit = acrossApiClient.getLimit(originChainId, l1Token.address);
+      if (acrossApiClient.updatedLimits && inputAmount.gt(limit)) {
+        this.logger.warn({
+          at: "Relayer::filterDeposit",
+          message: "😱 Skipping deposit with greater unfilled amount than API suggested limit",
+          limit,
+          l1Token: l1Token.address,
+          depositId,
+          inputToken,
+          inputAmount,
+          originChainId,
+          transactionHash: deposit.transactionHash,
+        });
+        return false;
+      }
     }
 
     // The deposit passed all checks, so we can include it in the list of unfilled deposits.


### PR DESCRIPTION
The existing behaviour is misleading and confusing.