### PR TITLE
refactor(constants): Use symbolic chain labels

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -12,15 +12,15 @@ export const MAX_RELAYER_DEPOSIT_LOOK_BACK = 4 * 60 * 60;
 
 // Target ~4 days per chain. Should cover all events needed to construct pending bundle.
 export const DATAWORKER_FAST_LOOKBACK: { [chainId: number]: number } = {
-  1: 28800,
-  10: 172800, // 1 block every 2 seconds after bedrock
-  137: 138240,
-  288: 11520,
-  324: 4 * 24 * 60 * 60,
-  8453: 172800, // Same as Optimism.
-  34443: 172800, // Same as Optimism.
-  42161: 1382400,
-  59144: 115200, // 1 block every 3 seconds
+  [CHAIN_IDs.MAINNET]: 28800,
+  [CHAIN_IDs.OPTIMISM]: 172800, // 1 block every 2 seconds after bedrock
+  [CHAIN_IDs.POLYGON]: 138240,
+  [CHAIN_IDs.BOBA]: 11520,
+  [CHAIN_IDs.ZK_SYNC]: 4 * 24 * 60 * 60,
+  [CHAIN_IDs.BASE]: 172800, // Same as Optimism.
+  [CHAIN_IDs.MODE]: 172800, // Same as Optimism.
+  [CHAIN_IDs.ARBITRUM]: 1382400,
+  [CHAIN_IDs.LINEA]: 115200, // 1 block every 3 seconds
 };
 
 // Target ~14 days per chain. Should cover all events that could be finalized, so 2x the optimistic
@@ -49,69 +49,55 @@ export const FINALIZER_TOKENBRIDGE_LOOKBACK = 14 * 24 * 60 * 60;
 // ORU will not be finalized until after 7 days, so there is little difference in following behind 0 blocks versus
 // anything under 7 days.
 export const DEFAULT_MIN_DEPOSIT_CONFIRMATIONS = {
-  1: 64, // Finalized block: https://www.alchemy.com/overviews/ethereum-commitment-levels
-  10: 120,
-  137: 128, // Commonly used finality level for CEX's that accept Polygon deposits
-  288: 0,
-  324: 120,
-  8453: 120,
-  34443: 120,
-  42161: 0,
-  59144: 30,
+  [CHAIN_IDs.MAINNET]: 64, // Finalized block: https://www.alchemy.com/overviews/ethereum-commitment-levels
+  [CHAIN_IDs.OPTIMISM]: 120,
+  [CHAIN_IDs.POLYGON]: 128, // Commonly used finality level for CEX's that accept Polygon deposits
+  [CHAIN_IDs.BOBA]: 0,
+  [CHAIN_IDs.ZK_SYNC]: 120,
+  [CHAIN_IDs.BASE]: 120,
+  [CHAIN_IDs.MODE]: 120,
+  [CHAIN_IDs.ARBITRUM]: 0,
+  [CHAIN_IDs.LINEA]: 30,
   // Testnets:
-  5: 0,
-  280: 0,
-  420: 0,
-  919: 0,
-  59140: 0,
-  80001: 0,
-  84531: 0,
-  84532: 0,
-  421613: 0,
-  421614: 0,
-  11155111: 0,
-  11155420: 0,
+  [CHAIN_IDs.MODE_SEPOLIA]: 0,
+  [CHAIN_IDs.POLYGON_AMOY]: 0,
+  [CHAIN_IDs.BASE_SEPOLIA]: 0,
+  [CHAIN_IDs.ARBITRUM_SEPOLIA]: 0,
+  [CHAIN_IDs.SEPOLIA]: 0,
+  [CHAIN_IDs.OPTIMISM_SEPOLIA]: 0,
 };
 export const MIN_DEPOSIT_CONFIRMATIONS: { [threshold: number | string]: { [chainId: number]: number } } = {
   1000: {
-    1: 32, // Justified block
-    10: 60,
-    137: 100, // Probabilistically safe level based on historic Polygon reorgs
-    288: 0,
-    324: 0,
-    8453: 60,
-    34443: 60,
-    42161: 0,
-    59144: 1,
+    [CHAIN_IDs.MAINNET]: 32, // Justified block
+    [CHAIN_IDs.OPTIMISM]: 60,
+    [CHAIN_IDs.POLYGON]: 100, // Probabilistically safe level based on historic Polygon reorgs
+    [CHAIN_IDs.BOBA]: 0,
+    [CHAIN_IDs.ZK_SYNC]: 0,
+    [CHAIN_IDs.BASE]: 60,
+    [CHAIN_IDs.MODE]: 60,
+    [CHAIN_IDs.ARBITRUM]: 0,
+    [CHAIN_IDs.LINEA]: 1,
     // Testnets:
-    5: 0,
-    280: 0,
-    420: 0,
-    919: 0,
-    59140: 0,
-    80001: 0,
-    84531: 0,
-    421613: 0,
+    [CHAIN_IDs.MODE_SEPOLIA]: 0,
+    [CHAIN_IDs.POLYGON_AMOY]: 0,
+    [CHAIN_IDs.BASE_SEPOLIA]: 0,
+    [CHAIN_IDs.OPTIMISM_SEPOLIA]: 0,
   },
   100: {
-    1: 16, // Mainnet reorgs are rarely > 4 blocks in depth so this is a very safe buffer
-    10: 60,
-    137: 80,
-    288: 0,
-    324: 0,
-    8453: 60,
-    34443: 60,
-    42161: 0,
-    59144: 1,
+    [CHAIN_IDs.MAINNET]: 16, // Mainnet reorgs are rarely > 4 blocks in depth so this is a very safe buffer
+    [CHAIN_IDs.OPTIMISM]: 60,
+    [CHAIN_IDs.POLYGON]: 80,
+    [CHAIN_IDs.BOBA]: 0,
+    [CHAIN_IDs.ZK_SYNC]: 0,
+    [CHAIN_IDs.BASE]: 60,
+    [CHAIN_IDs.MODE]: 60,
+    [CHAIN_IDs.ARBITRUM]: 0,
+    [CHAIN_IDs.LINEA]: 1,
     // Testnets:
-    5: 0,
-    280: 0,
-    420: 0,
-    919: 0,
-    59140: 0,
-    80001: 0,
-    84531: 0,
-    421613: 0,
+    [CHAIN_IDs.MODE_SEPOLIA]: 0,
+    [CHAIN_IDs.POLYGON_AMOY]: 0,
+    [CHAIN_IDs.BASE_SEPOLIA]: 0,
+    [CHAIN_IDs.ARBITRUM_SEPOLIA]: 0,
   },
 };
 
@@ -123,28 +109,22 @@ export const REDIS_URL_DEFAULT = "redis://localhost:6379";
 // if the RPC provider allows it. This is why the user should override these lookbacks if they are not using
 // Quicknode for example.
 export const CHAIN_MAX_BLOCK_LOOKBACK = {
-  1: 10000,
-  10: 10000, // Quick
-  137: 3490,
-  288: 4990,
-  324: 10000,
-  8453: 1500,
-  34443: 1500,
-  42161: 10000,
-  59144: 5000,
+  [CHAIN_IDs.MAINNET]: 10000,
+  [CHAIN_IDs.OPTIMISM]: 10000, // Quick
+  [CHAIN_IDs.POLYGON]: 3490,
+  [CHAIN_IDs.BOBA]: 4990,
+  [CHAIN_IDs.ZK_SYNC]: 10000,
+  [CHAIN_IDs.BASE]: 1500,
+  [CHAIN_IDs.MODE]: 1500,
+  [CHAIN_IDs.ARBITRUM]: 10000,
+  [CHAIN_IDs.LINEA]: 5000,
   // Testnets:
-  5: 10000,
-  280: 10000,
-  420: 10000,
-  919: 10000,
-  59140: 10000,
-  80001: 10000,
-  84531: 10000,
-  84532: 10000,
-  421613: 10000,
-  421614: 10000,
-  11155111: 10000,
-  11155420: 10000,
+  [CHAIN_IDs.MODE_SEPOLIA]: 10000,
+  [CHAIN_IDs.POLYGON_AMOY]: 10000,
+  [CHAIN_IDs.BASE_SEPOLIA]: 10000,
+  [CHAIN_IDs.ARBITRUM_SEPOLIA]: 10000,
+  [CHAIN_IDs.SEPOLIA]: 10000,
+  [CHAIN_IDs.OPTIMISM_SEPOLIA]: 10000,
 };
 
 // These should be safely above the finalization period for the chain and
@@ -152,28 +132,22 @@ export const CHAIN_MAX_BLOCK_LOOKBACK = {
 // can be matched with a deposit on the origin chain, so something like
 // ~1-2 mins per chain.
 export const BUNDLE_END_BLOCK_BUFFERS = {
-  1: 5, // 12s/block
-  10: 60, // 2s/block
-  137: 128, // 2s/block. Polygon reorgs often so this number is set larger than the largest observed reorg.
-  288: 0, // **UPDATE** 288 is disabled so there should be no buffer.
-  324: 120, // ~1s/block. ZkSync is a centralized sequencer but is relatively unstable so this is kept higher than 0
-  8453: 60, // 2s/block. Same finality profile as Optimism
-  34443: 60, // 2s/block. Same finality profile as Optimism
-  42161: 240, // ~0.25s/block. Arbitrum is a centralized sequencer
-  59144: 40, // At 3s/block, 2 mins = 40 blocks.
+  [CHAIN_IDs.MAINNET]: 5, // 12s/block
+  [CHAIN_IDs.OPTIMISM]: 60, // 2s/block
+  [CHAIN_IDs.POLYGON]: 128, // 2s/block. Polygon reorgs often so this number is set larger than the largest observed reorg.
+  [CHAIN_IDs.BOBA]: 0, // **UPDATE** 288 is disabled so there should be no buffer.
+  [CHAIN_IDs.ZK_SYNC]: 120, // ~1s/block. ZkSync is a centralized sequencer but is relatively unstable so this is kept higher than 0
+  [CHAIN_IDs.BASE]: 60, // 2s/block. Same finality profile as Optimism
+  [CHAIN_IDs.MODE]: 60, // 2s/block. Same finality profile as Optimism
+  [CHAIN_IDs.ARBITRUM]: 240, // ~0.25s/block. Arbitrum is a centralized sequencer
+  [CHAIN_IDs.LINEA]: 40, // At 3s/block, 2 mins = 40 blocks.
   // Testnets:
-  5: 0,
-  280: 0,
-  420: 0,
-  919: 0,
-  59140: 0,
-  80001: 0,
-  84531: 0,
-  84532: 0,
-  421613: 0,
-  421614: 0,
-  11155111: 0,
-  11155420: 0,
+  [CHAIN_IDs.MODE_SEPOLIA]: 0,
+  [CHAIN_IDs.POLYGON_AMOY]: 0,
+  [CHAIN_IDs.BASE_SEPOLIA]: 0,
+  [CHAIN_IDs.ARBITRUM_SEPOLIA]: 0,
+  [CHAIN_IDs.SEPOLIA]: 0,
+  [CHAIN_IDs.OPTIMISM_SEPOLIA]: 0,
 };
 
 export const DEFAULT_RELAYER_GAS_PADDING = ".15"; // Padding on token- and message-based relayer fill gas estimates.
@@ -182,9 +156,9 @@ export const DEFAULT_RELAYER_GAS_MESSAGE_MULTIPLIER = "1.0"; // Multiplier on pr
 
 export const DEFAULT_MULTICALL_CHUNK_SIZE = 100;
 export const DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE: { [chainId: number]: number } = {
-  10: 75,
-  8453: 75,
-  59144: 50,
+  [CHAIN_IDs.OPTIMISM]: 75,
+  [CHAIN_IDs.BASE]: 75,
+  [CHAIN_IDs.LINEA]: 50,
 };
 
 // List of proposal block numbers to ignore. This should be ignored because they are administrative bundle proposals
@@ -200,56 +174,49 @@ export const IGNORED_HUB_EXECUTED_BUNDLES: number[] = [];
 // Provider caching will not be allowed for queries whose responses depend on blocks closer than this many blocks.
 // This is intended to be conservative.
 export const CHAIN_CACHE_FOLLOW_DISTANCE: { [chainId: number]: number } = {
-  1: 128,
-  10: 120,
-  137: 256,
-  288: 0,
-  324: 512,
-  8453: 120,
-  34443: 120,
-  42161: 32,
-  59144: 100, // Linea has a soft-finality of 1 block. This value is padded - but at 3s/block the padding is 5 minutes
-  534352: 0,
+  [CHAIN_IDs.MAINNET]: 128,
+  [CHAIN_IDs.OPTIMISM]: 120,
+  [CHAIN_IDs.POLYGON]: 256,
+  [CHAIN_IDs.BOBA]: 0,
+  [CHAIN_IDs.ZK_SYNC]: 512,
+  [CHAIN_IDs.BASE]: 120,
+  [CHAIN_IDs.MODE]: 120,
+  [CHAIN_IDs.ARBITRUM]: 32,
+  [CHAIN_IDs.LINEA]: 100, // Linea has a soft-finality of 1 block. This value is padded - but at 3s/block the padding is 5 minutes
+  [CHAIN_IDs.SCROLL]: 0,
   // Testnets:
-  5: 0,
-  280: 0,
-  420: 0,
-  919: 0,
-  59140: 0,
-  80001: 0,
-  84531: 0,
-  84532: 0,
-  421613: 0,
-  421614: 0,
-  534351: 0,
-  11155111: 0,
-  11155420: 0,
+  [CHAIN_IDs.MODE_SEPOLIA]: 0,
+  [CHAIN_IDs.POLYGON_AMOY]: 0,
+  [CHAIN_IDs.BASE_SEPOLIA]: 0,
+  [CHAIN_IDs.ARBITRUM_SEPOLIA]: 0,
+  [CHAIN_IDs.SEPOLIA]: 0,
+  [CHAIN_IDs.OPTIMISM_SEPOLIA]: 0,
 };
 
 // This is the block distance at which the bot, by default, stores in redis with no TTL.
 // These are all intended to be roughly 2 days of blocks for each chain.
 // blocks = 172800 / avg_block_time
 export const DEFAULT_NO_TTL_DISTANCE: { [chainId: number]: number } = {
-  1: 14400,
-  10: 86400,
-  137: 86400,
-  288: 86400,
-  324: 172800,
-  8453: 86400,
-  34443: 86400,
-  59144: 57600,
-  42161: 691200,
-  534352: 57600,
+  [CHAIN_IDs.MAINNET]: 14400,
+  [CHAIN_IDs.OPTIMISM]: 86400,
+  [CHAIN_IDs.POLYGON]: 86400,
+  [CHAIN_IDs.BOBA]: 86400,
+  [CHAIN_IDs.ZK_SYNC]: 172800,
+  [CHAIN_IDs.BASE]: 86400,
+  [CHAIN_IDs.MODE]: 86400,
+  [CHAIN_IDs.LINEA]: 57600,
+  [CHAIN_IDs.ARBITRUM]: 691200,
+  [CHAIN_IDs.SCROLL]: 57600,
 };
 
 // Reasonable default maxFeePerGas and maxPriorityFeePerGas scalers for each chain.
 export const DEFAULT_GAS_FEE_SCALERS: {
   [chainId: number]: { maxFeePerGasScaler: number; maxPriorityFeePerGasScaler: number };
 } = {
-  1: { maxFeePerGasScaler: 3, maxPriorityFeePerGasScaler: 1.2 },
-  10: { maxFeePerGasScaler: 2, maxPriorityFeePerGasScaler: 1 },
-  8453: { maxFeePerGasScaler: 2, maxPriorityFeePerGasScaler: 1 },
-  34443: { maxFeePerGasScaler: 2, maxPriorityFeePerGasScaler: 1 },
+  [CHAIN_IDs.MAINNET]: { maxFeePerGasScaler: 3, maxPriorityFeePerGasScaler: 1.2 },
+  [CHAIN_IDs.OPTIMISM]: { maxFeePerGasScaler: 2, maxPriorityFeePerGasScaler: 1 },
+  [CHAIN_IDs.BASE]: { maxFeePerGasScaler: 2, maxPriorityFeePerGasScaler: 1 },
+  [CHAIN_IDs.MODE]: { maxFeePerGasScaler: 2, maxPriorityFeePerGasScaler: 1 },
 };
 
 // This is how many seconds stale the block number can be for us to use it for evaluating the reorg distance in the cache provider.
@@ -261,27 +228,21 @@ export const PROVIDER_CACHE_TTL_MODIFIER = 0.15;
 
 // Multicall3 Constants:
 export const multicall3Addresses = {
-  1: "0xcA11bde05977b3631167028862bE2a173976CA11",
-  10: "0xcA11bde05977b3631167028862bE2a173976CA11",
-  137: "0xcA11bde05977b3631167028862bE2a173976CA11",
-  288: "0xcA11bde05977b3631167028862bE2a173976CA11",
-  324: "0xF9cda624FBC7e059355ce98a31693d299FACd963",
-  8453: "0xcA11bde05977b3631167028862bE2a173976CA11",
-  34443: "0xcA11bde05977b3631167028862bE2a173976CA11",
-  42161: "0xcA11bde05977b3631167028862bE2a173976CA11",
-  59144: "0xcA11bde05977b3631167028862bE2a173976CA11",
-  534352: "0xcA11bde05977b3631167028862bE2a173976CA11",
+  [CHAIN_IDs.MAINNET]: "0xcA11bde05977b3631167028862bE2a173976CA11",
+  [CHAIN_IDs.OPTIMISM]: "0xcA11bde05977b3631167028862bE2a173976CA11",
+  [CHAIN_IDs.POLYGON]: "0xcA11bde05977b3631167028862bE2a173976CA11",
+  [CHAIN_IDs.BOBA]: "0xcA11bde05977b3631167028862bE2a173976CA11",
+  [CHAIN_IDs.ZK_SYNC]: "0xF9cda624FBC7e059355ce98a31693d299FACd963",
+  [CHAIN_IDs.BASE]: "0xcA11bde05977b3631167028862bE2a173976CA11",
+  [CHAIN_IDs.MODE]: "0xcA11bde05977b3631167028862bE2a173976CA11",
+  [CHAIN_IDs.ARBITRUM]: "0xcA11bde05977b3631167028862bE2a173976CA11",
+  [CHAIN_IDs.LINEA]: "0xcA11bde05977b3631167028862bE2a173976CA11",
+  [CHAIN_IDs.SCROLL]: "0xcA11bde05977b3631167028862bE2a173976CA11",
   // testnet
-  5: "0xcA11bde05977b3631167028862bE2a173976CA11",
-  280: "0xF9cda624FBC7e059355ce98a31693d299FACd963",
-  420: "0xcA11bde05977b3631167028862bE2a173976CA11",
-  59140: "0xcA11bde05977b3631167028862bE2a173976CA11",
-  80001: "0xcA11bde05977b3631167028862bE2a173976CA11",
-  84531: "0xcA11bde05977b3631167028862bE2a173976CA11",
-  84532: "0xcA11bde05977b3631167028862bE2a173976CA11",
-  421613: "0xcA11bde05977b3631167028862bE2a173976CA11",
-  534351: "0xcA11bde05977b3631167028862bE2a173976CA11",
-  11155111: "0xcA11bde05977b3631167028862bE2a173976CA11",
+  [CHAIN_IDs.POLYGON_AMOY]: "0xcA11bde05977b3631167028862bE2a173976CA11",
+  [CHAIN_IDs.BASE_SEPOLIA]: "0xcA11bde05977b3631167028862bE2a173976CA11",
+  [CHAIN_IDs.SCROLL_SEPOLIA]: "0xcA11bde05977b3631167028862bE2a173976CA11",
+  [CHAIN_IDs.SEPOLIA]: "0xcA11bde05977b3631167028862bE2a173976CA11",
 };
 export type Multicall2Call = {
   callData: ethers.utils.BytesLike;
@@ -290,7 +251,13 @@ export type Multicall2Call = {
 
 // These are the spokes that can hold both ETH and WETH, so they should be added together when caclulating whether
 // a bundle execution is possible with the funds in the pool.
-export const spokesThatHoldEthAndWeth = [10, 324, 8453, 34443, 59144];
+export const spokesThatHoldEthAndWeth = [
+  CHAIN_IDs.OPTIMISM,
+  CHAIN_IDs.ZK_SYNC,
+  CHAIN_IDs.BASE,
+  CHAIN_IDs.MODE,
+  CHAIN_IDs.LINEA,
+];
 
 /**
  * An official mapping of chain IDs to CCTP domains. This mapping is separate from chain identifiers
@@ -298,36 +265,32 @@ export const spokesThatHoldEthAndWeth = [10, 324, 8453, 34443, 59144];
  * @link https://developers.circle.com/stablecoins/docs/supported-domains
  */
 export const chainIdsToCctpDomains: { [chainId: number]: number } = {
-  // Mainnet
-  1: 0, // Mainnet
-  10: 2, // Optimism
-  42161: 3, // Arbitrum
-  8453: 6, // Base
-  137: 7, // Polygon
-
-  // Testnet
-  11155111: 0, // Eth Sepolia
-  11155420: 2, // Optimism Sepolia
-  421614: 3, // Arbitrum Sepolia
-  84532: 6, // Base Sepolia
-  80001: 7, // Polygon PoS Mumbai
+  [CHAIN_IDs.MAINNET]: 0,
+  [CHAIN_IDs.OPTIMISM]: 2,
+  [CHAIN_IDs.ARBITRUM]: 3,
+  [CHAIN_IDs.BASE]: 6,
+  [CHAIN_IDs.POLYGON]: 7,
+  [CHAIN_IDs.SEPOLIA]: 0,
+  [CHAIN_IDs.OPTIMISM_SEPOLIA]: 2,
+  [CHAIN_IDs.ARBITRUM_SEPOLIA]: 3,
+  [CHAIN_IDs.BASE_SEPOLIA]: 6,
+  [CHAIN_IDs.POLYGON_AMOY]: 7,
 };
 
 export const SUPPORTED_TOKENS: { [chainId: number]: string[] } = {
-  10: ["DAI", "SNX", "BAL", "WETH", "USDC", "POOL", "USDT", "WBTC", "UMA", "ACX"],
-  137: ["USDC", "USDT", "WETH", "DAI", "WBTC", "UMA", "BAL", "ACX", "POOL"],
-  324: ["USDC", "USDT", "WETH", "WBTC", "DAI"],
-  8453: ["BAL", "DAI", "ETH", "WETH", "USDC", "POOL"],
-  34443: ["ETH", "WETH", "USDC", "USDT", "WBTC"],
-  42161: ["USDC", "USDT", "WETH", "DAI", "WBTC", "UMA", "BAL", "ACX", "POOL"],
-  59144: ["USDC", "USDT", "WETH", "WBTC", "DAI"],
+  [CHAIN_IDs.OPTIMISM]: ["DAI", "SNX", "BAL", "WETH", "USDC", "POOL", "USDT", "WBTC", "UMA", "ACX"],
+  [CHAIN_IDs.POLYGON]: ["USDC", "USDT", "WETH", "DAI", "WBTC", "UMA", "BAL", "ACX", "POOL"],
+  [CHAIN_IDs.ZK_SYNC]: ["USDC", "USDT", "WETH", "WBTC", "DAI"],
+  [CHAIN_IDs.BASE]: ["BAL", "DAI", "ETH", "WETH", "USDC", "POOL"],
+  [CHAIN_IDs.MODE]: ["ETH", "WETH", "USDC", "USDT", "WBTC"],
+  [CHAIN_IDs.ARBITRUM]: ["USDC", "USDT", "WETH", "DAI", "WBTC", "UMA", "BAL", "ACX", "POOL"],
+  [CHAIN_IDs.LINEA]: ["USDC", "USDT", "WETH", "WBTC", "DAI"],
 
   // Testnets:
-  919: ["ETH", "WETH", "USDC", "USDT", "WBTC"],
-  59141: ["USDC", "USDT", "WETH", "WBTC", "DAI"],
-  84532: ["BAL", "DAI", "ETH", "WETH", "USDC"],
-  421614: ["USDC", "USDT", "WETH", "DAI", "WBTC", "UMA", "ACX"],
-  11155420: ["DAI", "SNX", "BAL", "ETH", "WETH", "USDC", "USDT", "WBTC", "UMA", "ACX"],
+  [CHAIN_IDs.MODE_SEPOLIA]: ["ETH", "WETH", "USDC", "USDT", "WBTC"],
+  [CHAIN_IDs.BASE_SEPOLIA]: ["BAL", "DAI", "ETH", "WETH", "USDC"],
+  [CHAIN_IDs.ARBITRUM_SEPOLIA]: ["USDC", "USDT", "WETH", "DAI", "WBTC", "UMA", "ACX"],
+  [CHAIN_IDs.OPTIMISM_SEPOLIA]: ["DAI", "SNX", "BAL", "ETH", "WETH", "USDC", "USDT", "WBTC", "UMA", "ACX"],
 };
 /**
  * A mapping of chain IDs to tokens on that chain which need their allowance
@@ -356,11 +319,11 @@ export const SLOW_WITHDRAWAL_CHAINS = [CHAIN_IDs.BASE, CHAIN_IDs.ARBITRUM, CHAIN
 
 // Expected worst-case time for message from L1 to propogate to L2 in seconds
 export const EXPECTED_L1_TO_L2_MESSAGE_TIME = {
-  59144: 60 * 60,
-  42161: 20 * 60,
-  10: 20 * 60,
-  137: 60 * 60,
-  324: 60 * 60,
-  8453: 20 * 60,
-  34443: 20 * 60,
+  [CHAIN_IDs.LINEA]: 60 * 60,
+  [CHAIN_IDs.ARBITRUM]: 20 * 60,
+  [CHAIN_IDs.OPTIMISM]: 20 * 60,
+  [CHAIN_IDs.POLYGON]: 60 * 60,
+  [CHAIN_IDs.ZK_SYNC]: 60 * 60,
+  [CHAIN_IDs.BASE]: 20 * 60,
+  [CHAIN_IDs.MODE]: 20 * 60,
 };

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -54,8 +54,8 @@ export const DEFAULT_MIN_DEPOSIT_CONFIRMATIONS = {
   [CHAIN_IDs.OPTIMISM]: 120,
   [CHAIN_IDs.POLYGON]: 128, // Commonly used finality level for CEX's that accept Polygon deposits
   [CHAIN_IDs.BOBA]: 0,
-  [CHAIN_IDs.LISK]: 120, // Same as other OVM. Hard finality is 1800 blocks
   [CHAIN_IDs.ZK_SYNC]: 120,
+  [CHAIN_IDs.LISK]: 120, // Same as other OVM. Hard finality is 1800 blocks
   [CHAIN_IDs.BASE]: 120,
   [CHAIN_IDs.MODE]: 120,
   [CHAIN_IDs.ARBITRUM]: 0,

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -82,8 +82,8 @@ export const MIN_DEPOSIT_CONFIRMATIONS: { [threshold: number | string]: { [chain
     [CHAIN_IDs.LINEA]: 1,
     // Testnets:
     [CHAIN_IDs.MODE_SEPOLIA]: 0,
-    [CHAIN_IDs.POLYGON_AMOY]: 0,
     [CHAIN_IDs.LISK_SEPOLIA]: 0,
+    [CHAIN_IDs.POLYGON_AMOY]: 0,
     [CHAIN_IDs.BASE_SEPOLIA]: 0,
     [CHAIN_IDs.OPTIMISM_SEPOLIA]: 0,
   },
@@ -100,8 +100,8 @@ export const MIN_DEPOSIT_CONFIRMATIONS: { [threshold: number | string]: { [chain
     [CHAIN_IDs.LINEA]: 1,
     // Testnets:
     [CHAIN_IDs.MODE_SEPOLIA]: 0,
-    [CHAIN_IDs.POLYGON_AMOY]: 0,
     [CHAIN_IDs.LISK_SEPOLIA]: 0,
+    [CHAIN_IDs.POLYGON_AMOY]: 0,
     [CHAIN_IDs.BASE_SEPOLIA]: 0,
     [CHAIN_IDs.ARBITRUM_SEPOLIA]: 0,
   },


### PR DESCRIPTION
Using symbols ensures that chain IDs can't accidentally be mistyped. While here, flush all Görli references because they're not longer needed. The ordering of entries is unchanged here; in a follow-up PR I will reorder alphabetically.