### PR TITLE
fix(ProviderUtils): filter out totalDifficulty from RPC response

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -133,6 +133,7 @@ function compareRpcResults(method: string, rpcResultA: any, rpcResultB: any): bo
         "l1BatchNumber", // zkSync
         "l1BatchTimestamp", // zkSync
         "size", // Alchemy/Arbitrum (temporary)
+        "totalDifficulty", //Quicknode/Alchemy (sometimes)
       ],
       rpcResultA,
       rpcResultB

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -133,7 +133,7 @@ function compareRpcResults(method: string, rpcResultA: any, rpcResultB: any): bo
         "l1BatchNumber", // zkSync
         "l1BatchTimestamp", // zkSync
         "size", // Alchemy/Arbitrum (temporary)
-        "totalDifficulty", //Quicknode/Alchemy (sometimes)
+        "totalDifficulty", // Quicknode/Alchemy (sometimes)
       ],
       rpcResultA,
       rpcResultB


### PR DESCRIPTION
We had an issue where Infura's Optimism RPC provider went down, leading to a large number of quorum disputes for `eth_getBlockByNumber` between Alchemy and Quicknode, particularly in the `totalDifficulty` field. This commit should filter out that field so we won't error if RPCs disagree on it. 