### PR TITLE
fix(finalizer): define contract addresses required for Lisk finalizations

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -1,4 +1,5 @@
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP, ethers } from "../utils";
+import { DEFAULT_L2_CONTRACT_ADDRESSES } from "@eth-optimism/sdk";
 
 // Maximum supported version of the configuration loaded into the Across ConfigStore.
 // It protects bots from running outdated code against newer version of the on-chain config store.
@@ -347,3 +348,24 @@ export const EXPECTED_L1_TO_L2_MESSAGE_TIME = {
   [CHAIN_IDs.BASE]: 20 * 60,
   [CHAIN_IDs.MODE]: 20 * 60,
 };
+
+export const OPSTACK_CONTRACT_OVERRIDES = {
+    [CHAIN_IDs.LISK]: {
+        l1: {
+          AddressManager: '0x2dF7057d3F25212E51aFEA8dA628668229Ea423f' as const,
+          L1CrossDomainMessenger:
+            '0x31B72D76FB666844C41EdF08dF0254875Dbb7edB' as const,
+          L1StandardBridge: '0x2658723Bf70c7667De6B25F99fcce13A16D25d08' as const,
+          StateCommitmentChain:
+            '0x0000000000000000000000000000000000000000' as const,
+          CanonicalTransactionChain:
+            '0x0000000000000000000000000000000000000000' as const,
+          BondManager: '0x0000000000000000000000000000000000000000' as const,
+          OptimismPortal: '0x26dB93F8b8b4f7016240af62F7730979d353f9A7' as const,
+          L2OutputOracle: '0x113cB99283AF242Da0A0C54347667edF531Aa7d6' as const,
+          OptimismPortal2: '0x0000000000000000000000000000000000000000' as const,
+          DisputeGameFactory: '0x0000000000000000000000000000000000000000' as const,
+        },
+        l2: DEFAULT_L2_CONTRACT_ADDRESSES,
+    },
+}

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -350,22 +350,19 @@ export const EXPECTED_L1_TO_L2_MESSAGE_TIME = {
 };
 
 export const OPSTACK_CONTRACT_OVERRIDES = {
-    [CHAIN_IDs.LISK]: {
-        l1: {
-          AddressManager: '0x2dF7057d3F25212E51aFEA8dA628668229Ea423f' as const,
-          L1CrossDomainMessenger:
-            '0x31B72D76FB666844C41EdF08dF0254875Dbb7edB' as const,
-          L1StandardBridge: '0x2658723Bf70c7667De6B25F99fcce13A16D25d08' as const,
-          StateCommitmentChain:
-            '0x0000000000000000000000000000000000000000' as const,
-          CanonicalTransactionChain:
-            '0x0000000000000000000000000000000000000000' as const,
-          BondManager: '0x0000000000000000000000000000000000000000' as const,
-          OptimismPortal: '0x26dB93F8b8b4f7016240af62F7730979d353f9A7' as const,
-          L2OutputOracle: '0x113cB99283AF242Da0A0C54347667edF531Aa7d6' as const,
-          OptimismPortal2: '0x0000000000000000000000000000000000000000' as const,
-          DisputeGameFactory: '0x0000000000000000000000000000000000000000' as const,
-        },
-        l2: DEFAULT_L2_CONTRACT_ADDRESSES,
+  [CHAIN_IDs.LISK]: {
+    l1: {
+      AddressManager: "0x2dF7057d3F25212E51aFEA8dA628668229Ea423f",
+      L1CrossDomainMessenger: "0x31B72D76FB666844C41EdF08dF0254875Dbb7edB",
+      L1StandardBridge: "0x2658723Bf70c7667De6B25F99fcce13A16D25d08",
+      StateCommitmentChain: "0x0000000000000000000000000000000000000000",
+      CanonicalTransactionChain: "0x0000000000000000000000000000000000000000",
+      BondManager: "0x0000000000000000000000000000000000000000",
+      OptimismPortal: "0x26dB93F8b8b4f7016240af62F7730979d353f9A7",
+      L2OutputOracle: "0x113cB99283AF242Da0A0C54347667edF531Aa7d6",
+      OptimismPortal2: "0x0000000000000000000000000000000000000000",
+      DisputeGameFactory: "0x0000000000000000000000000000000000000000",
     },
-}
+    l2: DEFAULT_L2_CONTRACT_ADDRESSES,
+  },
+};

--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -22,7 +22,7 @@ import {
   winston,
   chainIsProd,
 } from "../../utils";
-import { Multicall2Call } from "../../common";
+import { Multicall2Call, OPSTACK_CONTRACT_OVERRIDES } from "../../common";
 import { FinalizerPromise, CrossChainMessage } from "../types";
 
 interface CrossChainMessageWithEvent {
@@ -117,12 +117,14 @@ export async function opStackFinalizer(
 
 function getOptimismClient(chainId: OVM_CHAIN_ID, hubSigner: Signer): OVM_CROSS_CHAIN_MESSENGER {
   const hubChainId = chainIsProd(chainId) ? CHAIN_IDs.MAINNET : CHAIN_IDs.SEPOLIA;
+  const contractOverrides = OPSTACK_CONTRACT_OVERRIDES[chainId];
   return new optimismSDK.CrossChainMessenger({
     bedrock: true,
     l1ChainId: hubChainId,
     l2ChainId: chainId,
     l1SignerOrProvider: hubSigner.connect(getCachedProvider(hubChainId, true)),
     l2SignerOrProvider: hubSigner.connect(getCachedProvider(chainId, true)),
+    contracts: contractOverrides,
   });
 }
 


### PR DESCRIPTION
The eth-optimism SDK does not have predefined contract addresses for Lisk like it does for all of our other OP Stack chains. This causes finalizations to throw undefined errors. This commit adds in the necessary contract addresses which we then pass into the optimismSDK's `CrossChainMessenger`. We will also need to do something similar for Blast.