### PR TITLE
improve(relayer): Avoid friendly fire when new chains are added

### DIFF
--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -357,9 +357,9 @@ export async function constructClients(
 
 // @dev The HubPoolClient is dependent on the state of the ConfigStoreClient,
 //      so update the ConfigStoreClient first.
-export async function updateClients(clients: Clients, config: CommonConfig): Promise<void> {
+export async function updateClients(clients: Clients, config: CommonConfig, logger?: winston.Logger): Promise<void> {
   await clients.configStoreClient.update();
-  config.loadAndValidateConfigForChains(clients.configStoreClient.getChainIdIndicesForBlock());
+  config.validate(clients.configStoreClient.getChainIdIndicesForBlock(), logger);
 }
 
 export function spokePoolClientsToProviders(spokePoolClients: { [chainId: number]: SpokePoolClient }): {

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -92,7 +92,7 @@ export class CommonConfig {
    * @param chainIdIndices All expected chain ID's that could be supported by this config.
    */
   validate(chainIds: number[], logger: winston.Logger): void {
-    const { maxBlockLookBack } = this;
+    const { blockRangeEndBlockBuffer, maxBlockLookBack } = this;
 
     // Warn about any missing MAX_BLOCK_LOOK_BACK config.
     if (Object.keys(maxBlockLookBack).length > 0) {
@@ -106,8 +106,8 @@ export class CommonConfig {
     }
 
     // BLOCK_RANGE_END_BLOCK_BUFFER is important for the dataworker, so assert on it.
-    if (Object.keys(this.blockRangeEndBlockBuffer).length > 0) {
-      const buffer = Object.keys(maxBlockLookBack).map(Number);
+    if (Object.keys(blockRangeEndBlockBuffer).length > 0) {
+      const buffer = Object.keys(blockRangeEndBlockBuffer).map(Number);
       const missing = chainIds.find((chainId) => !buffer.includes(chainId));
       assert(!missing, `Missing BLOCK_RANGE_END_BLOCK_BUFFER configuration for chainId ${missing}`);
     }

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -119,8 +119,7 @@ export class CommonConfig {
         process.env[`MULTICALL_CHUNK_SIZE_CHAIN_${chainId}`]
           ?? process.env.MULTICALL_CHUNK_SIZE
           ?? DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE[chainId]
-          ?? DEFAULT_MULTICALL_CHUNK_SIZE
-      );
+      ) || DEFAULT_MULTICALL_CHUNK_SIZE;
       assert(chunkSize > 0, `Chain ${chainId} multicall chunk size (${chunkSize}) must be greater than 0`);
       this.multiCallChunkSize[chainId] = chunkSize;
 

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -92,23 +92,21 @@ export class CommonConfig {
    * @param chainIdIndices All expected chain ID's that could be supported by this config.
    */
   validate(chainIds: number[], logger: winston.Logger): void {
-    const { blockRangeEndBlockBuffer, maxBlockLookBack } = this;
-
     // Warn about any missing MAX_BLOCK_LOOK_BACK config.
-    if (Object.keys(maxBlockLookBack).length > 0) {
-      const lookback = Object.keys(maxBlockLookBack).map(Number);
-      const missing = chainIds.find((chainId) => !lookback.includes(chainId));
+    const lookbackKeys = Object.keys(this.maxBlockLookBack).map(Number);
+    if (lookbackKeys.length > 0) {
+      const missing = chainIds.find((chainId) => !lookbackKeys.includes(chainId));
       if (missing) {
         const message = `Missing MAX_BLOCK_LOOK_BACK configuration for chainId ${missing}`;
         logger.warn({ at: "RelayerConfig::validate", message });
-        maxBlockLookBack[missing] = 5000; // Revert to a safe default.
+        this.maxBlockLookBack[missing] = 5000; // Revert to a safe default.
       }
     }
 
     // BLOCK_RANGE_END_BLOCK_BUFFER is important for the dataworker, so assert on it.
-    if (Object.keys(blockRangeEndBlockBuffer).length > 0) {
-      const buffer = Object.keys(blockRangeEndBlockBuffer).map(Number);
-      const missing = chainIds.find((chainId) => !buffer.includes(chainId));
+    const bufferKeys = Object.keys(this.blockRangeEndBlockBuffer).map(Number);
+    if (bufferKeys.length > 0) {
+      const missing = chainIds.find((chainId) => !bufferKeys.includes(chainId));
       assert(!missing, `Missing BLOCK_RANGE_END_BLOCK_BUFFER configuration for chainId ${missing}`);
     }
 

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -1,7 +1,7 @@
 import winston from "winston";
 import { DEFAULT_MULTICALL_CHUNK_SIZE, DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE, DEFAULT_ARWEAVE_GATEWAY } from "../common";
 import { ArweaveGatewayInterface, ArweaveGatewayInterfaceSS } from "../interfaces";
-import { assert, CHAIN_IDs, ethers, getNetworkName, isDefined } from "../utils";
+import { assert, CHAIN_IDs, ethers, isDefined } from "../utils";
 import * as Constants from "./Constants";
 
 export interface ProcessEnv {
@@ -91,7 +91,7 @@ export class CommonConfig {
    * @throws If overridden TO_BLOCK_OVERRIDE_${chainId} isn't greater than 0
    * @param chainIdIndices All expected chain ID's that could be supported by this config.
    */
-  validate(chainIds: number[], logger?: winston.Logger): void {
+  validate(chainIds: number[], logger: winston.Logger): void {
     const { maxBlockLookBack } = this;
 
     // Warn about any missing MAX_BLOCK_LOOK_BACK config.
@@ -99,9 +99,7 @@ export class CommonConfig {
       const lookback = Object.keys(maxBlockLookBack).map(Number);
       const missing = chainIds.find((chainId) => !lookback.includes(chainId));
       if (missing) {
-        const message = `Missing ${getNetworkName(missing)} MAX_BLOCK_LOOK_BACK configuration`;
-        assert(!missing || logger, message);
-
+        const message = `Missing MAX_BLOCK_LOOK_BACK configuration for chainId ${missing}`;
         logger.warn({ at: "RelayerConfig::validate", message });
         maxBlockLookBack[missing] = 5000; // Revert to a safe default.
       }
@@ -111,7 +109,7 @@ export class CommonConfig {
     if (Object.keys(this.blockRangeEndBlockBuffer).length > 0) {
       const buffer = Object.keys(maxBlockLookBack).map(Number);
       const missing = chainIds.find((chainId) => !buffer.includes(chainId));
-      assert(!missing, `Missing ${getNetworkName(missing)} BLOCK_RANGE_END_BLOCK_BUFFER configuration`);
+      assert(!missing, `Missing BLOCK_RANGE_END_BLOCK_BUFFER configuration for chainId ${missing}`);
     }
 
     for (const chainId of chainIds) {

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -116,10 +116,10 @@ export class CommonConfig {
       // Multicall chunk size precedence: Environment, chain-specific config, global default.
       // prettier-ignore
       const chunkSize = Number(
-      process.env[`MULTICALL_CHUNK_SIZE_CHAIN_${chainId}`]
-        ?? process.env.MULTICALL_CHUNK_SIZE
-        ?? DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE[chainId]
-        ?? DEFAULT_MULTICALL_CHUNK_SIZE
+        process.env[`MULTICALL_CHUNK_SIZE_CHAIN_${chainId}`]
+          ?? process.env.MULTICALL_CHUNK_SIZE
+          ?? DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE[chainId]
+          ?? DEFAULT_MULTICALL_CHUNK_SIZE
       );
       assert(chunkSize > 0, `Chain ${chainId} multicall chunk size (${chunkSize}) must be greater than 0`);
       this.multiCallChunkSize[chainId] = chunkSize;

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -30,7 +30,7 @@ export async function constructDataworkerClients(
   const commonClients = await constructClients(logger, config, baseSigner);
   const { hubPoolClient, configStoreClient } = commonClients;
 
-  await updateClients(commonClients, config);
+  await updateClients(commonClients, config, logger);
   await hubPoolClient.update();
 
   // We don't pass any spoke pool clients to token client since data worker doesn't need to set approvals for L2 tokens.
@@ -111,7 +111,7 @@ export async function constructSpokePoolClientsForFastDataworker(
 }
 
 export function getSpokePoolClientEventSearchConfigsForFastDataworker(
-  config: Omit<DataworkerConfig, "loadAndValidateConfigForChains">,
+  config: Omit<DataworkerConfig, "validate">,
   clients: DataworkerClients,
   dataworker: Dataworker
 ): {

--- a/src/monitor/MonitorClientHelper.ts
+++ b/src/monitor/MonitorClientHelper.ts
@@ -28,7 +28,7 @@ export async function constructMonitorClients(
   const commonClients = await constructClients(logger, config, baseSigner);
   const { hubPoolClient, configStoreClient } = commonClients;
 
-  await updateClients(commonClients, config);
+  await updateClients(commonClients, config, logger);
   await hubPoolClient.update();
 
   // Construct spoke pool clients for all chains that are not *currently* disabled. Caller can override

--- a/src/monitor/MonitorConfig.ts
+++ b/src/monitor/MonitorConfig.ts
@@ -161,7 +161,7 @@ export class MonitorConfig extends CommonConfig {
     }
   }
 
-  override validate(chainIds: number[], logger?: winston.Logger): void {
+  override validate(chainIds: number[], logger: winston.Logger): void {
     super.validate(chainIds, logger);
 
     // Min deposit confirmations seems like the most likely constant to have all possible chain IDs listed.

--- a/src/monitor/MonitorConfig.ts
+++ b/src/monitor/MonitorConfig.ts
@@ -1,3 +1,4 @@
+import winston from "winston";
 import { CommonConfig, ProcessEnv } from "../common";
 import { ethers, getEthAddressForChain } from "../utils";
 
@@ -160,19 +161,16 @@ export class MonitorConfig extends CommonConfig {
     }
   }
 
-  loadAndValidateConfigForChains(chainIdIndices: number[]): void {
+  override validate(chainIds: number[], logger?: winston.Logger): void {
+    super.validate(chainIds, logger);
+
     // Min deposit confirmations seems like the most likely constant to have all possible chain IDs listed.
-    chainIdIndices.forEach((chainId) => {
+    chainIds.forEach((chainId) => {
       this.spokePoolsBlocks[chainId] = {
-        startingBlock: process.env[`STARTING_BLOCK_NUMBER_${chainId}`]
-          ? Number(process.env[`STARTING_BLOCK_NUMBER_${chainId}`])
-          : undefined,
-        endingBlock: process.env[`ENDING_BLOCK_NUMBER_${chainId}`]
-          ? Number(process.env[`ENDING_BLOCK_NUMBER_${chainId}`])
-          : undefined,
+        startingBlock: Number(process.env[`STARTING_BLOCK_NUMBER_${chainId}`]) || undefined,
+        endingBlock: Number(process.env[`ENDING_BLOCK_NUMBER_${chainId}`]) || undefined,
       };
     });
-    super.loadAndValidateConfigForChains(chainIdIndices);
   }
 }
 

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -74,7 +74,7 @@ export async function constructRelayerClients(
   const hubPoolLookBack = sdkUtils.chainIsProd(config.hubPoolChainId) ? 3600 * 8 : Number.POSITIVE_INFINITY;
   const commonClients = await constructClients(logger, config, baseSigner, hubPoolLookBack);
   const { configStoreClient, hubPoolClient } = commonClients;
-  await updateClients(commonClients, config);
+  await updateClients(commonClients, config, logger);
   await hubPoolClient.update();
 
   // If both origin and destination chains are configured, then limit the SpokePoolClients instantiated to the

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -1,8 +1,11 @@
 import { utils as ethersUtils } from "ethers";
+import winston from "winston";
 import { typeguards } from "@across-protocol/sdk";
 import {
   BigNumber,
   bnUint256Max,
+  CHAIN_IDs,
+  dedupArray,
   toBNWei,
   assert,
   getNetworkName,
@@ -276,5 +279,32 @@ export class RelayerConfig extends CommonConfig {
     );
 
     this.ignoreLimits = RELAYER_IGNORE_LIMITS === "true";
+  }
+
+  /**
+   * @notice Loads additional configuration state that can only be known after we know all chains that we're going to
+   * support. Warns or throws if any of the configurations are not valid.
+   * @param chainIdIndices All expected chain ID's that could be supported by this config.
+   * @param logger Optional logger object.
+   */
+  override validate(chainIds: number[], logger?: winston.Logger): void {
+    const { relayerOriginChains, relayerDestinationChains } = this;
+    const relayerChainIds =
+      relayerOriginChains.length > 0 && relayerDestinationChains.length > 0
+        ? dedupArray([...relayerOriginChains, ...relayerDestinationChains])
+        : chainIds;
+
+    const ignoredChainIds = chainIds
+      .filter((chainId) => !relayerChainIds.includes(chainId) && chainId !== CHAIN_IDs.BOBA);
+    if (ignoredChainIds.length > 0 && logger) {
+      logger.debug({
+        at: "RelayerConfig::validate",
+        message: `Ignoring ${ignoredChainIds.length} chains.`,
+        ignoredChainIds
+      });
+    }
+
+    // Only validate config for chains that the relayer cares about.
+    super.validate(relayerChainIds, logger);
   }
 }

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -294,13 +294,14 @@ export class RelayerConfig extends CommonConfig {
         ? dedupArray([...relayerOriginChains, ...relayerDestinationChains])
         : chainIds;
 
-    const ignoredChainIds = chainIds
-      .filter((chainId) => !relayerChainIds.includes(chainId) && chainId !== CHAIN_IDs.BOBA);
+    const ignoredChainIds = chainIds.filter(
+      (chainId) => !relayerChainIds.includes(chainId) && chainId !== CHAIN_IDs.BOBA
+    );
     if (ignoredChainIds.length > 0 && logger) {
       logger.debug({
         at: "RelayerConfig::validate",
         message: `Ignoring ${ignoredChainIds.length} chains.`,
-        ignoredChainIds
+        ignoredChainIds,
       });
     }
 

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -287,7 +287,7 @@ export class RelayerConfig extends CommonConfig {
    * @param chainIdIndices All expected chain ID's that could be supported by this config.
    * @param logger Optional logger object.
    */
-  override validate(chainIds: number[], logger?: winston.Logger): void {
+  override validate(chainIds: number[], logger: winston.Logger): void {
     const { relayerOriginChains, relayerDestinationChains } = this;
     const relayerChainIds =
       relayerOriginChains.length > 0 && relayerDestinationChains.length > 0


### PR DESCRIPTION
The relayer currently has an annoying constraint that it needs to be updated each time a new chain is added to the config store. This is because the post-update configuration validation is unnecesarily strict. In cases where the relayer has a custom set of origin and destination chains, it actually doesn't make sense to require that configuration is defined for any new chain that has been added.

So:
- When the relayer does not rely on a new chain, don't verify configuration for that chain.
- When the relayer does rely on a new chain, warn about missing config and revert to a conservative default of 5k blocks for eth_getLogs() calls. The warnings should prompt the operator to update their bot or define the necessary config in their environment.