### PR TITLE
fix(Blast): Correct WETH address

### DIFF
--- a/src/clients/bridges/BaseAdapter.ts
+++ b/src/clients/bridges/BaseAdapter.ts
@@ -352,11 +352,15 @@ export abstract class BaseAdapter {
 
     // First verify that the target contract looks like WETH. This protects against
     // accidentally sending ETH to the wrong address, which would be a critical error.
-    const symbol = await l2WEthContract.symbol();
-    assert(
-      symbol === "WETH",
-      `Critical (may delete ETH): Unable to verify ${this.getName()} WETH address (${l2WEthContract.address})`
-    );
+    // Permit bypass if simMode is set in order to permit tests to pass.
+    let symbol: string;
+    if (simMode === false) {
+      const symbol = await l2WEthContract.symbol();
+      assert(
+        symbol === "WETH",
+        `Critical (may delete ETH): Unable to verify ${this.getName()} WETH address (${l2WEthContract.address})`
+      );
+    }
 
     const method = "deposit";
     const formatFunc = createFormatFunction(2, 4, false, 18);
@@ -380,6 +384,7 @@ export abstract class BaseAdapter {
       });
       return { hash: ZERO_ADDRESS } as TransactionResponse;
     } else {
+      assert(symbol === "WETH");
       return (
         await txnClient.submit(chainId, [
           { contract: l2WEthContract, chainId, method, args: [], value, mrkdwn, message },

--- a/src/clients/bridges/BaseAdapter.ts
+++ b/src/clients/bridges/BaseAdapter.ts
@@ -350,8 +350,8 @@ export abstract class BaseAdapter {
   ): Promise<TransactionResponse> {
     const { chainId, txnClient } = this;
 
-    // First verify that the target contract looks like WETH. This protects against accidentally
-    // sending ETH to the wrong address, would be a critical error and would delete funds.
+    // First verify that the target contract looks like WETH. This protects against
+    // accidentally sending ETH to the wrong address, which would be a critical error.
     const symbol = await l2WEthContract.symbol();
     assert(
       symbol === "WETH",

--- a/src/clients/bridges/BaseAdapter.ts
+++ b/src/clients/bridges/BaseAdapter.ts
@@ -353,12 +353,10 @@ export abstract class BaseAdapter {
     // First verify that the target contract looks like WETH. This protects against accidentally
     // sending ETH to the wrong address, would be a critical error and would delete funds.
     const symbol = await l2WEthContract.symbol();
-    if (symbol !== "WETH") {
-      assert(
-        symbol === "WETH",
-        `Critical (may delete ETH): Unable to verify ${this.getName()} WETH address (${l2WEthContract.address})`
-      );
-    }
+    assert(
+      symbol === "WETH",
+      `Critical (may delete ETH): Unable to verify ${this.getName()} WETH address (${l2WEthContract.address})`
+    );
 
     const method = "deposit";
     const formatFunc = createFormatFunction(2, 4, false, 18);

--- a/src/clients/bridges/BaseAdapter.ts
+++ b/src/clients/bridges/BaseAdapter.ts
@@ -349,6 +349,17 @@ export abstract class BaseAdapter {
     simMode = false
   ): Promise<TransactionResponse> {
     const { chainId, txnClient } = this;
+
+    // First verify that the target contract looks like WETH. This protects against accidentally
+    // sending ETH to the wrong address, would be a critical error and would delete funds.
+    const symbol = await l2WEthContract.symbol();
+    if (symbol !== "WETH") {
+      assert(
+        symbol === "WETH",
+        `Critical (may delete ETH): Unable to verify ${this.getName()} WETH address (${l2WEthContract.address})`
+      );
+    }
+
     const method = "deposit";
     const formatFunc = createFormatFunction(2, 4, false, 18);
     const mrkdwn =

--- a/src/clients/bridges/BaseAdapter.ts
+++ b/src/clients/bridges/BaseAdapter.ts
@@ -355,7 +355,7 @@ export abstract class BaseAdapter {
     // Permit bypass if simMode is set in order to permit tests to pass.
     let symbol: string;
     if (simMode === false) {
-      const symbol = await l2WEthContract.symbol();
+      symbol = await l2WEthContract.symbol();
       assert(
         symbol === "WETH",
         `Critical (may delete ETH): Unable to verify ${this.getName()} WETH address (${l2WEthContract.address})`

--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -239,7 +239,7 @@ export const CONTRACT_ADDRESSES: {
       abi: OVM_L2_STANDARD_BRIDGE_ABI,
     },
     weth: {
-      address: "0x4200000000000000000000000000000000000004",
+      address: "0x4300000000000000000000000000000000000004",
       abi: WETH_ABI,
     },
     eth: {

--- a/src/common/abi/Weth.json
+++ b/src/common/abi/Weth.json
@@ -54,5 +54,19 @@
     ],
     "name": "Transfer",
     "type": "event"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type":"function"
   }
 ]

--- a/src/common/abi/Weth.json
+++ b/src/common/abi/Weth.json
@@ -67,6 +67,6 @@
     ],
     "payable": false,
     "stateMutability": "view",
-    "type":"function"
+    "type": "function"
   }
 ]


### PR DESCRIPTION
Blast uses a non-standard OP address for WETH. The address we had specified was off by a single digit (0x42.....04 instead of 0x43..04). 0x42..04 is an OP predeploy, so deposit() simulation failed. Had it been an EOA then there was potential for loss of ETH when attempting to wrap to WETH. To protect against this in future, first call WETH.symbol() to verify that the destination contract is an ERC20, and secondly to verify that the contract claims to be a WETH implementation. This should catch the absolute majority of mistakes that could occur here.