### PR TITLE
improve(InventoryClient): 1x overage on lite chains

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -476,15 +476,17 @@ export class InventoryClient {
       chainsToEvaluate.push(originChainId);
     }
 
+    const liteChainIds = this.hubPoolClient.configStoreClient.getLiteChainIdIndicesForBlock();
+
     const eligibleRefundChains: number[] = [];
     // At this point, all chains to evaluate have defined token configs and are sorted in order of
     // highest priority to take repayment on, assuming the chain is under-allocated.
-    for (const _chain of chainsToEvaluate) {
-      assert(this._l1TokenEnabledForChain(l1Token, _chain), `Token ${l1Token} not enabled for chain ${_chain}`);
+    for (const chainId of chainsToEvaluate) {
+      assert(this._l1TokenEnabledForChain(l1Token, chainId), `Token ${l1Token} not enabled for chain ${chainId}`);
       // Destination chain:
-      const repaymentToken = this.getRepaymentTokenForL1Token(l1Token, _chain);
-      const chainShortfall = this.tokenClient.getShortfallTotalRequirement(_chain, repaymentToken);
-      const chainVirtualBalance = this.getBalanceOnChain(_chain, l1Token, repaymentToken);
+      const repaymentToken = this.getRepaymentTokenForL1Token(l1Token, chainId);
+      const chainShortfall = this.tokenClient.getShortfallTotalRequirement(chainId, repaymentToken);
+      const chainVirtualBalance = this.getBalanceOnChain(chainId, l1Token, repaymentToken);
       const chainVirtualBalanceWithShortfall = chainVirtualBalance.sub(chainShortfall);
       let cumulativeVirtualBalanceWithShortfall = cumulativeVirtualBalance.sub(chainShortfall);
       // @dev No need to factor in outputAmount when computing origin chain balance since funds only leave relayer
@@ -493,14 +495,14 @@ export class InventoryClient {
       // This is possible when the output token is USDC.e and the input token is USDC which would still cause
       // validateOutputToken() to return true above.
       let chainVirtualBalanceWithShortfallPostRelay =
-        _chain === destinationChainId &&
+        chainId === destinationChainId &&
         this.hubPoolClient.areTokensEquivalent(inputToken, originChainId, outputToken, destinationChainId)
           ? chainVirtualBalanceWithShortfall.sub(outputAmount)
           : chainVirtualBalanceWithShortfall;
 
       // Add upcoming refunds:
       chainVirtualBalanceWithShortfallPostRelay = chainVirtualBalanceWithShortfallPostRelay.add(
-        totalRefundsPerChain[_chain] ?? bnZero
+        totalRefundsPerChain[chainId] ?? bnZero
       );
       // To correctly compute the allocation % for this destination chain, we need to add all upcoming refunds for the
       // equivalents of l1Token on all chains.
@@ -514,18 +516,19 @@ export class InventoryClient {
         .div(cumulativeVirtualBalanceWithShortfallPostRelay);
 
       // Consider configured buffer for target to allow relayer to support slight overages.
-      const tokenConfig = this.getTokenConfig(l1Token, _chain, repaymentToken);
+      const tokenConfig = this.getTokenConfig(l1Token, chainId, repaymentToken);
       assert(
         isDefined(tokenConfig),
-        `No ${outputToken} tokenConfig in the Inventory Config for ${l1Token} on ${_chain} with a repaymentToken of ${repaymentToken}.`
+        `No ${outputToken} tokenConfig for ${l1Token} on ${chainId} with a repaymentToken ${repaymentToken}.`
       );
-      const thresholdPct = toBN(tokenConfig.targetPct)
-        .mul(tokenConfig.targetOverageBuffer ?? toBNWei("1"))
-        .div(fixedPointAdjustment);
+      const targetOverage =
+        tokenConfig.targetOverageBuffer ?? liteChainIds.includes(chainId) ? toBNWei("1") : toBNWei("1.5");
+      const thresholdPct = toBN(tokenConfig.targetPct).mul(targetOverage).div(fixedPointAdjustment);
+
       this.log(
         `Evaluated taking repayment on ${
-          _chain === originChainId ? "origin" : _chain === destinationChainId ? "destination" : "slow withdrawal"
-        } chain ${_chain} for deposit ${deposit.depositId}: ${
+          chainId === originChainId ? "origin" : chainId === destinationChainId ? "destination" : "slow withdrawal"
+        } chain ${chainId} for deposit ${deposit.depositId}: ${
           expectedPostRelayAllocation.lte(thresholdPct) ? "UNDERALLOCATED ✅" : "OVERALLOCATED ❌"
         }`,
         {
@@ -546,7 +549,7 @@ export class InventoryClient {
         }
       );
       if (expectedPostRelayAllocation.lte(thresholdPct)) {
-        eligibleRefundChains.push(_chain);
+        eligibleRefundChains.push(chainId);
       }
     }
 


### PR DESCRIPTION
Lite chains will have a tendency to creep over target and require manual rebalancing. Try to limit this by clamping the default overage buffer on lite chains to 1x, instead of the existing default 1.5x.