### PR TITLE
feat(scroll): Add Scroll adapter

### DIFF
--- a/src/clients/bridges/AdapterManager.ts
+++ b/src/clients/bridges/AdapterManager.ts
@@ -3,7 +3,7 @@ import { spokesThatHoldEthAndWeth, SUPPORTED_TOKENS } from "../../common/Constan
 import { InventoryConfig, OutstandingTransfers } from "../../interfaces";
 import { BigNumber, isDefined, winston, Signer, getL2TokenAddresses, TransactionResponse, assert } from "../../utils";
 import { SpokePoolClient, HubPoolClient } from "../";
-import { ArbitrumAdapter, PolygonAdapter, ZKSyncAdapter, LineaAdapter, OpStackAdapter } from "./";
+import { ArbitrumAdapter, PolygonAdapter, ZKSyncAdapter, LineaAdapter, OpStackAdapter, ScrollAdapter } from "./";
 import { CHAIN_IDs } from "@across-protocol/constants";
 
 import { BaseChainAdapter } from "../../adapter";
@@ -39,7 +39,7 @@ export class AdapterManager {
       );
     };
 
-    const { OPTIMISM, ARBITRUM, POLYGON, ZK_SYNC, BASE, MODE, LINEA, LISK, BLAST } = CHAIN_IDs;
+    const { OPTIMISM, ARBITRUM, POLYGON, ZK_SYNC, BASE, MODE, LINEA, LISK, BLAST, SCROLL } = CHAIN_IDs;
     if (this.spokePoolClients[OPTIMISM] !== undefined) {
       this.adapters[OPTIMISM] = new OpStackAdapter(
         OPTIMISM,
@@ -96,6 +96,9 @@ export class AdapterManager {
         spokePoolClients,
         filterMonitoredAddresses(BLAST)
       );
+    }
+    if (this.spokePoolClients[SCROLL] !== undefined) {
+      this.adapters[SCROLL] = new ScrollAdapter(logger, spokePoolClients, filterMonitoredAddresses(SCROLL));
     }
 
     logger.debug({

--- a/src/clients/bridges/ScrollAdapter.ts
+++ b/src/clients/bridges/ScrollAdapter.ts
@@ -1,0 +1,32 @@
+import { SUPPORTED_TOKENS, CUSTOM_BRIDGE, CANONICAL_BRIDGE, DEFAULT_GAS_MULTIPLIER } from "../../common";
+import { CHAIN_IDs, TOKEN_SYMBOLS_MAP, winston } from "../../utils";
+import { SpokePoolClient } from "../SpokePoolClient";
+import { BaseChainAdapter } from "../../adapter/BaseChainAdapter";
+
+export class ScrollAdapter extends BaseChainAdapter {
+  constructor(
+    logger: winston.Logger,
+    readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
+    monitoredAddresses: string[]
+  ) {
+    const { SCROLL, MAINNET } = CHAIN_IDs;
+    const bridges = {};
+    const l2Signer = spokePoolClients[SCROLL].spokePool.signer;
+    const l1Signer = spokePoolClients[MAINNET].spokePool.signer;
+    SUPPORTED_TOKENS[SCROLL]?.map((symbol) => {
+      const l1Token = TOKEN_SYMBOLS_MAP[symbol].addresses[MAINNET];
+      const bridgeConstructor = CUSTOM_BRIDGE[SCROLL][l1Token] ?? CANONICAL_BRIDGE[SCROLL];
+      bridges[l1Token] = new bridgeConstructor(SCROLL, MAINNET, l1Signer, l2Signer, l1Token);
+    });
+    super(
+      spokePoolClients,
+      SCROLL,
+      MAINNET,
+      monitoredAddresses,
+      logger,
+      SUPPORTED_TOKENS[SCROLL],
+      bridges,
+      DEFAULT_GAS_MULTIPLIER[SCROLL] ?? 1
+    );
+  }
+}

--- a/src/clients/bridges/index.ts
+++ b/src/clients/bridges/index.ts
@@ -6,3 +6,4 @@ export * from "./PolygonAdapter";
 export * from "./CrossChainTransferClient";
 export * from "./ZKSyncAdapter";
 export * from "./LineaAdapter";
+export * from "./ScrollAdapter";


### PR DESCRIPTION
This instantiates a Scroll Adapter based off of the new generic adapter code. This is a smaller fix since I did not want to modify the Inventory/CrossChainTransfer clients when we would have to revert them back as soon as the generic code replaces the current. 