### PR TITLE
fix(relayer): Set fallback deposit confirmation defaults

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -115,7 +115,7 @@ export class Relayer {
 
     const { minConfirmations } = minDepositConfirmations[originChainId].find(({ usdThreshold }) =>
       usdThreshold.gte(fillAmountUsd)
-    ) ?? { minConfirmations: Number.MAX_SAFE_INTEGER };
+    );
     const { latestBlockSearched } = spokePoolClients[originChainId];
     if (latestBlockSearched - blockNumber < minConfirmations) {
       this.logger.debug({

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -115,7 +115,7 @@ export class Relayer {
 
     const { minConfirmations } = minDepositConfirmations[originChainId].find(({ usdThreshold }) =>
       usdThreshold.gte(fillAmountUsd)
-    );
+    ) ?? { minConfirmations: Number.MAX_SAFE_INTEGER };
     const { latestBlockSearched } = spokePoolClients[originChainId];
     if (latestBlockSearched - blockNumber < minConfirmations) {
       this.logger.debug({

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -285,10 +285,11 @@ export class RelayerConfig extends CommonConfig {
       // Append default thresholds as a safe upper-bound.
       Object.keys(this.minDepositConfirmations).forEach((chainId) => {
         const depositConfirmations = this.minDepositConfirmations[chainId];
-        if (depositConfirmations.at(-1).minConfirmations < Number.MAX_SAFE_INTEGER) {
+        const prevMDC = depositConfirmations.at(-1).minConfirmations;
+        if (prevMDC < Number.MAX_SAFE_INTEGER) {
           depositConfirmations.push({
             usdThreshold: bnUint256Max,
-            minConfirmations: Number.MAX_SAFE_INTEGER,
+            minConfirmations: prevMDC + 1,
           });
         }
       });

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -285,11 +285,11 @@ export class RelayerConfig extends CommonConfig {
       // Append default thresholds as a safe upper-bound.
       Object.keys(this.minDepositConfirmations).forEach((chainId) => {
         const depositConfirmations = this.minDepositConfirmations[chainId];
-        const prevMDC = depositConfirmations.at(-1).minConfirmations;
-        if (prevMDC < Number.MAX_SAFE_INTEGER) {
+        const { usdThreshold: threshold, minConfirmations: mdc } = depositConfirmations.at(-1);
+        if (threshold.lt(bnUint256Max)) {
           depositConfirmations.push({
             usdThreshold: bnUint256Max,
-            minConfirmations: prevMDC + 1,
+            minConfirmations: Math.max(mdc + 1, Number.MAX_SAFE_INTEGER),
           });
         }
       });

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -282,14 +282,13 @@ export class RelayerConfig extends CommonConfig {
           });
         });
 
-      // Append default thresholds as a safe upper-bound.
-      Object.keys(this.minDepositConfirmations).forEach((chainId) => {
-        const depositConfirmations = this.minDepositConfirmations[chainId];
-        const { usdThreshold: threshold, minConfirmations: mdc } = depositConfirmations.at(-1);
-        if (threshold.lt(bnUint256Max)) {
+      // Ensure that there is always a deposit confirmation config for the maximum theoretical value of a fill.
+      Object.values(this.minDepositConfirmations).forEach((depositConfirmations) => {
+        const { usdThreshold: maxThreshold, minConfirmations: maxConfirmations } = depositConfirmations.at(-1);
+        if (maxThreshold.lt(bnUint256Max)) {
           depositConfirmations.push({
             usdThreshold: bnUint256Max,
-            minConfirmations: Math.max(mdc + 1, Number.MAX_SAFE_INTEGER),
+            minConfirmations: Math.max(maxConfirmations + 1, Number.MAX_SAFE_INTEGER),
           });
         }
       });


### PR DESCRIPTION
Number.MAX_SAFE_INTEGER had a special meaning in the config code, so if
the operator incidentally used it as the actual configured MDC for a
threshold any given chain, the safe upper-limit would not be applied.