### PR TITLE
fix(InventoryClient): Subtle target overage syntax error

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -50,10 +50,7 @@ export type Rebalance = {
 };
 
 const { CHAIN_IDs } = constants;
-
-// In anticipation of most Lite chains tending to be exit-heavy, define a lower default overage.
-const DEFAULT_CHAIN_OVERAGE = toBNWei("1.5");
-const LITE_CHAIN_OVERAGE = toBNWei("1.1");
+const DEFAULT_TOKEN_OVERAGE = toBNWei("1.5");
 
 export class InventoryClient {
   private logDisabledManagement = false;
@@ -482,8 +479,6 @@ export class InventoryClient {
       chainsToEvaluate.push(originChainId);
     }
 
-    const liteChainIds = this.hubPoolClient.configStoreClient.getLiteChainIdIndicesForBlock();
-
     const eligibleRefundChains: number[] = [];
     // At this point, all chains to evaluate have defined token configs and are sorted in order of
     // highest priority to take repayment on, assuming the chain is under-allocated.
@@ -532,8 +527,7 @@ export class InventoryClient {
 
       // It's undesirable to accrue excess balances on a Lite chain because the relayer relies on additional deposits
       // destined for that chain in order to offload its excess.
-      let { targetOverageBuffer } = tokenConfig;
-      targetOverageBuffer ??= liteChainIds.includes(chainId) ? LITE_CHAIN_OVERAGE : DEFAULT_CHAIN_OVERAGE;
+      const { targetOverageBuffer = DEFAULT_TOKEN_OVERAGE } = tokenConfig;
       const effectiveTargetPct = tokenConfig.targetPct.mul(targetOverageBuffer).div(fixedPointAdjustment);
 
       this.log(

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -534,7 +534,6 @@ export class InventoryClient {
       // destined for that chain in order to offload its excess.
       let { targetOverageBuffer } = tokenConfig;
       targetOverageBuffer ??= liteChainIds.includes(chainId) ? LITE_CHAIN_OVERAGE : DEFAULT_CHAIN_OVERAGE;
-
       const effectiveTargetPct = tokenConfig.targetPct.mul(targetOverageBuffer).div(fixedPointAdjustment);
 
       this.log(

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -51,7 +51,7 @@ export type Rebalance = {
 
 const { CHAIN_IDs } = constants;
 
-// In anticipation of most Lite chains tending to be exit-heavy, drop the default buffer to 1.2x.
+// In anticipation of most Lite chains tending to be exit-heavy, define a lower default overage.
 const DEFAULT_CHAIN_OVERAGE = toBNWei("1.5");
 const LITE_CHAIN_OVERAGE = toBNWei("1.1");
 


### PR DESCRIPTION
The existing one-liner was marginally too clever and resulted in unintuitive behaviour. In the pre-existing code the expression would unconditionally be evaluated via the ternary statement, so any env-defined target overage would be ignored.

It's apparently not valid (...or maybe not wise) to combine a nullish coalescing operator with a ternary statement. It is possible to fix this in a one-liner by wrapping the ternary statement in brackets, but it feels risky to retain that so I've split the expression into two lines.

Having done some additional testing, the conclusion is that lite-chain overrides are tricky unless explicitly specified in the environment. The reason for this is that the existing relayer config parser automatically populates   targetOverageBuffer entries for all tokens if they are otherwise not defined. It does this at a point where the lite chain IDs are not known, and it requires further refactoring in order to relocate that to a post-update config where lite chains are known. Given that there is only one lite chain so far, just revert to requiring an explicit env configuration.