### PR TITLE
improve(relayer): swap priority of origin/destination for Lite chain relayer repayments

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -464,9 +464,9 @@ export class InventoryClient {
     // lite chain deposits force repayment on origin, we end up taking lots of repayment on the lite chain so
     // we should take repayment away from the lite chain where possible.
     if (
+      deposit.toLiteChain &&
       !chainsToEvaluate.includes(originChainId) &&
-      this._l1TokenEnabledForChain(l1Token, Number(originChainId)) &&
-      deposit.toLiteChain
+      this._l1TokenEnabledForChain(l1Token, Number(originChainId))
     ) {
       chainsToEvaluate.push(originChainId);
     }

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -460,23 +460,23 @@ export class InventoryClient {
       chainsToEvaluate.push(...chainsWithExcessSpokeBalances);
     }
     // Add destination and origin chain if they are not already added.
-    // Prioritize destination chain repayment over origin chain repayment but prefer both over
+    // Prioritize origin chain repayment over destination chain repayment but prefer both over
     // hub chain repayment if they are under allocated. We don't include hub chain
     // since its the fallback chain if both destination and origin chain are over allocated.
     // If destination chain is hub chain, we still want to evaluate it before the origin chain.
-    if (
-      !chainsToEvaluate.includes(destinationChainId) &&
-      this._l1TokenEnabledForChain(l1Token, Number(destinationChainId)) &&
-      !deposit.fromLiteChain
-    ) {
-      chainsToEvaluate.push(destinationChainId);
-    }
     if (
       !chainsToEvaluate.includes(originChainId) &&
       originChainId !== hubChainId &&
       this._l1TokenEnabledForChain(l1Token, Number(originChainId))
     ) {
       chainsToEvaluate.push(originChainId);
+    }
+    if (
+      !chainsToEvaluate.includes(destinationChainId) &&
+      this._l1TokenEnabledForChain(l1Token, Number(destinationChainId)) &&
+      !deposit.fromLiteChain
+    ) {
+      chainsToEvaluate.push(destinationChainId);
     }
 
     const eligibleRefundChains: number[] = [];

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -460,7 +460,7 @@ export class InventoryClient {
       chainsToEvaluate.push(...chainsWithExcessSpokeBalances);
     }
     // Add origin chain to take higher priority than destination chain if the destination chain
-    // is a lite chain, which should allow the relayer to take more repayments away from the lite chain. Because 
+    // is a lite chain, which should allow the relayer to take more repayments away from the lite chain. Because
     // lite chain deposits force repayment on origin, we end up taking lots of repayment on the lite chain so
     // we should take repayment away from the lite chain where possible.
     if (

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -460,7 +460,9 @@ export class InventoryClient {
       chainsToEvaluate.push(...chainsWithExcessSpokeBalances);
     }
     // Add origin chain to take higher priority than destination chain if the destination chain
-    // is a lite chain, which should allow the relayer to take more repayments on mainnet.
+    // is a lite chain, which should allow the relayer to take more repayments away from the lite chain. Because 
+    // lite chain deposits force repayment on origin, we end up taking lots of repayment on the lite chain so
+    // we should take repayment away from the lite chain where possible.
     if (
       !chainsToEvaluate.includes(originChainId) &&
       deposit.toLiteChain &&

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -465,8 +465,8 @@ export class InventoryClient {
     // we should take repayment away from the lite chain where possible.
     if (
       !chainsToEvaluate.includes(originChainId) &&
-      deposit.toLiteChain &&
-      this._l1TokenEnabledForChain(l1Token, Number(originChainId))
+      this._l1TokenEnabledForChain(l1Token, Number(originChainId)) &&
+      deposit.toLiteChain
     ) {
       chainsToEvaluate.push(originChainId);
     }


### PR DESCRIPTION
This issue is especially pronounced with Lite chains such as Lisk, where filling a deposit from mainnet to Lisk may result in unwanted repayment on Lisk, causing the relayer's balance to be perpetually above target. In general, Lite chains cause the relayer to end up with a lot of inventory on the lite chain so we should aim to take repayment away from the lite chain when we get the chance.