### PR TITLE
improve(relayer): Permit filling above MDC config

### DIFF
--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -288,7 +288,7 @@ export class RelayerConfig extends CommonConfig {
         if (maxThreshold.lt(bnUint256Max)) {
           depositConfirmations.push({
             usdThreshold: bnUint256Max,
-            minConfirmations: Math.max(maxConfirmations + 1, Number.MAX_SAFE_INTEGER),
+            minConfirmations: maxConfirmations + 1
           });
         }
       });

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -288,7 +288,7 @@ export class RelayerConfig extends CommonConfig {
         if (maxThreshold.lt(bnUint256Max)) {
           depositConfirmations.push({
             usdThreshold: bnUint256Max,
-            minConfirmations: maxConfirmations + 1
+            minConfirmations: maxConfirmations + 1,
           });
         }
       });


### PR DESCRIPTION
Once the upper MDC config taps out, permit anything in excess to be filled after the subsequent block. This is an improvement over the current config, because presently the relayer requires Number.MAX_SAFE_INTEGER (...lots) blocks before it'll fill these.