### PR TITLE
fix(ProfitClient): Reduce log level for unexpected output token

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -400,7 +400,7 @@ export class ProfitClient {
     try {
       l1Token = this.hubPoolClient.getL1TokenInfoForL2Token(outputToken, destinationChainId);
     } catch {
-      this.logger.info({
+      this.logger.debug({
         at: "ProfitClient#getFillAmountInUsd",
         message: `Cannot resolve output token ${outputToken} on ${getNetworkName(destinationChainId)}.`,
       });


### PR DESCRIPTION
Integrators who are using Across settlement for in-protocal swaps are specifying unknown output tokens and it's causing quite a bit of noise in the logs.