### PR TITLE
fix(relayer): Protect against unresolved limit idx

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -290,13 +290,13 @@ export class Relayer {
     const limits = this.fillLimits[originChainId];
 
     // Find the uppermost USD threshold compatible with the age of the origin chain deposit.
-    // If no config applies to the blockNumber (i.e. because it's too old), just return the uppermost limit.
     // @todo: Swap out for Array.findLastIndex() when available.
     let idx = 0;
     while (idx < limits.length && limits[idx].fromBlock <= blockNumber) {
       ++idx;
     }
 
+    // If no config applies to the blockNumber (i.e. because it's too old), just return the uppermost limit.
     return Math.min(idx, limits.length - 1);
   }
 

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -293,10 +293,11 @@ export class Relayer {
     // If no config applies to the blockNumber (i.e. because it's too old), just return the uppermost limit.
     // @todo: Swap out for Array.findLastIndex() when available.
     let idx = 0;
-    while (idx < limits.length && limits[idx].fromBlock <= blockNumber) {
+    while (limits[idx].fromBlock <= blockNumber && idx < limits.length) {
       ++idx;
     }
-    return idx;
+
+    return Math.min(idx, limits.length - 1);
   }
 
   /**

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -288,10 +288,15 @@ export class Relayer {
    */
   findOriginChainLimitIdx(originChainId: number, blockNumber: number): number {
     const limits = this.fillLimits[originChainId];
-    const idx = limits.findIndex(({ fromBlock }) => fromBlock <= blockNumber);
 
+    // Find the uppermost USD threshold compatible with the age of the origin chain deposit.
     // If no config applies to the blockNumber (i.e. because it's too old), just return the uppermost limit.
-    return idx !== -1 ? idx : limits.length - 1;
+    // @todo: Swap out for Array.findLastIndex() when available.
+    let idx = 0;
+    while (idx < limits.length && limits[idx].fromBlock <= blockNumber) {
+      ++idx;
+    }
+    return idx;
   }
 
   /**

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -297,7 +297,7 @@ export class Relayer {
     }
 
     // If no config applies to the blockNumber (i.e. because it's too old), just return the uppermost limit.
-    return Math.min(idx, limits.length - 1);
+    return Math.max(0, idx - 1);
   }
 
   /**

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -293,7 +293,7 @@ export class Relayer {
     // If no config applies to the blockNumber (i.e. because it's too old), just return the uppermost limit.
     // @todo: Swap out for Array.findLastIndex() when available.
     let idx = 0;
-    while (limits[idx].fromBlock <= blockNumber && idx < limits.length) {
+    while (idx < limits.length && limits[idx].fromBlock <= blockNumber) {
       ++idx;
     }
 

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -297,7 +297,7 @@ export class Relayer {
     }
 
     // If no config applies to the blockNumber (i.e. because it's too old), just return the uppermost limit.
-    return Math.max(0, idx - 1);
+    return Math.min(idx, limits.length - 1);
   }
 
   /**

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -287,7 +287,11 @@ export class Relayer {
    * @returns An index into the limits array.
    */
   findOriginChainLimitIdx(originChainId: number, blockNumber: number): number {
-    return this.fillLimits[originChainId].findIndex(({ fromBlock }) => fromBlock <= blockNumber);
+    const limits = this.fillLimits[originChainId];
+    const idx = limits.findIndex(({ fromBlock }) => fromBlock <= blockNumber);
+
+    // If no config applies to the blockNumber (i.e. because it's too old), just return the uppermost limit.
+    return idx !== -1 ? idx : limits.length - 1;
   }
 
   /**

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -292,7 +292,7 @@ export class Relayer {
     // Find the uppermost USD threshold compatible with the age of the origin chain deposit.
     // @todo: Swap out for Array.findLastIndex() when available.
     let idx = 0;
-    while (idx < limits.length && limits[idx].fromBlock <= blockNumber) {
+    while (idx < limits.length && limits[idx].fromBlock > blockNumber) {
       ++idx;
     }
 


### PR DESCRIPTION
In cases where the age of the deposit exceeds the uppermost configured deposit confirmation limit, just revert to the uppermost limit. This protects against resolving an index of -1, which causes a subsequent blowup when we try to reduce the limits for that index.