### PR TITLE
improve(bridges): pass through USDCTokenSplitterBridge for native USDC

### DIFF
--- a/src/adapter/bridges/BaseBridgeAdapter.ts
+++ b/src/adapter/bridges/BaseBridgeAdapter.ts
@@ -64,9 +64,7 @@ export abstract class BaseBridgeAdapter {
     // @todo: Fix call to `getTranslatedTokenAddress()` such that it does not require
     // ifDefined(...). This is incompatible with remote chains where both native and
     // bridged USDC are defined.
-    const isNativeUSDC =
-      this.l2chainId === CHAIN_IDs.SCROLL && isDefined(TOKEN_SYMBOLS_MAP.USDC.addresses[this.l2chainId]);
-    return getTranslatedTokenAddress(l1Token, this.hubChainId, this.l2chainId, isNativeUSDC);
+    return getTranslatedTokenAddress(l1Token, this.hubChainId, this.l2chainId, false);
   }
 
   protected getL1Bridge(): Contract {

--- a/src/adapter/bridges/UsdcTokenSplitterBridge.ts
+++ b/src/adapter/bridges/UsdcTokenSplitterBridge.ts
@@ -5,7 +5,7 @@ import { BridgeTransactionDetails, BaseBridgeAdapter, BridgeEvents } from "./Bas
 import { EventSearchConfig, Provider, TOKEN_SYMBOLS_MAP, compareAddressesSimple, assert } from "../../utils";
 
 export class UsdcTokenSplitterBridge extends BaseBridgeAdapter {
-  protected cctpBridge: BaseBridgeAdapter;
+  protected cctpBridge: UsdcCCTPBridge;
   protected canonicalBridge: BaseBridgeAdapter;
 
   constructor(
@@ -33,7 +33,7 @@ export class UsdcTokenSplitterBridge extends BaseBridgeAdapter {
   }
 
   private getRouteForL2Token(l2Token: string): BaseBridgeAdapter {
-    return compareAddressesSimple(l2Token, TOKEN_SYMBOLS_MAP.USDC.addresses[this.l2chainId])
+    return (compareAddressesSimple(l2Token, TOKEN_SYMBOLS_MAP.USDC.addresses[this.l2chainId]) && this.cctpBridge.isCCTPEnabled())
       ? this.cctpBridge
       : this.canonicalBridge;
   }
@@ -86,5 +86,9 @@ export class UsdcTokenSplitterBridge extends BaseBridgeAdapter {
       });
       return acc;
     }, {});
+  }
+
+  protected override resolveL2TokenAddress(l1Token: string) {
+    return this.cctpBridge.resolveL2TokenAddress(l1Token);
   }
 }

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -375,6 +375,8 @@ export const CANONICAL_BRIDGE: {
 
 // Custom Bridges are all bridges between chains which only support a small number (typically one) of tokens.
 // In addition to mapping a chain to the custom bridges, we also need to specify which token the bridge supports.
+// Note: All chains which have a native USDC entry should have a UsdcTokenSplitterBridge defined, as this bridge 
+// will then route USDC through the canonical or, if available, CCTP routes.
 export const CUSTOM_BRIDGE: {
   [chainId: number]: {
     [tokenAddress: string]: {
@@ -417,6 +419,9 @@ export const CUSTOM_BRIDGE: {
   },
   [CHAIN_IDs.POLYGON]: {
     [TOKEN_SYMBOLS_MAP.WETH.addresses[CHAIN_IDs.MAINNET]]: PolygonWethBridge,
+    [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: UsdcTokenSplitterBridge,
+  },
+  [CHAIN_IDs.SCROLL]: {
     [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: UsdcTokenSplitterBridge,
   },
   [CHAIN_IDs.ZK_SYNC]: {


### PR DESCRIPTION
As introduced in this PR https://github.com/across-protocol/relayer/pull/1708, we have a special case for resolving L2 token addresses for Scroll USDC. Scroll's USDC is "native" in the sense that it can be upgraded to fit Circle CCTP. This PR instantiates a USDCTokenSplitter bridge as a custom bridge for Scroll USDC, so that we can properly resolve L2 token addresses. Note this can be done for any L2 on which there exists native USDC, as the TokenSplitterBridge will only use CCTP if there is a defined message transmitter on L2. 

This is nice since there can exist native USDC without CCTP support, and if/when those chains _do_ support CCTP, the only change we will have to make is to add the contract address to `src/common/ContractAddresses`. On the other end, if we don't want to go this route, we can move the USDC entry for Scroll in the constants repository to USDC.e.