### PR TITLE
improve(bridges): add special USDC case for the ScrollBridge.

### DIFF
--- a/src/adapter/bridges/BaseBridgeAdapter.ts
+++ b/src/adapter/bridges/BaseBridgeAdapter.ts
@@ -1,5 +1,4 @@
 import {
-  CHAIN_IDs,
   Contract,
   BigNumber,
   EventSearchConfig,
@@ -8,7 +7,6 @@ import {
   getTranslatedTokenAddress,
   assert,
   isDefined,
-  TOKEN_SYMBOLS_MAP,
 } from "../../utils";
 import { SortableEvent } from "../../interfaces";
 
@@ -61,12 +59,7 @@ export abstract class BaseBridgeAdapter {
   ): Promise<BridgeEvents>;
 
   protected resolveL2TokenAddress(l1Token: string): string {
-    // @todo: Fix call to `getTranslatedTokenAddress()` such that it does not require
-    // ifDefined(...). This is incompatible with remote chains where both native and
-    // bridged USDC are defined.
-    const isNativeUSDC =
-      this.l2chainId === CHAIN_IDs.SCROLL && isDefined(TOKEN_SYMBOLS_MAP.USDC.addresses[this.l2chainId]);
-    return getTranslatedTokenAddress(l1Token, this.hubChainId, this.l2chainId, isNativeUSDC);
+    return getTranslatedTokenAddress(l1Token, this.hubChainId, this.l2chainId, false);
   }
 
   protected getL1Bridge(): Contract {

--- a/src/adapter/bridges/ScrollERC20Bridge.ts
+++ b/src/adapter/bridges/ScrollERC20Bridge.ts
@@ -9,6 +9,8 @@ import {
   fixedPointAdjustment,
   isContractDeployedToAddress,
   bnZero,
+  compareAddressesSimple,
+  TOKEN_SYMBOLS_MAP,
 } from "../../utils";
 import { CONTRACT_ADDRESSES, SCROLL_CUSTOM_GATEWAY } from "../../common";
 import { BaseBridgeAdapter, BridgeTransactionDetails, BridgeEvents } from "./BaseBridgeAdapter";
@@ -126,5 +128,12 @@ export class ScrollERC20Bridge extends BaseBridgeAdapter {
 
   protected getScrollGatewayRouter(): Contract {
     return this.scrollGatewayRouter;
+  }
+
+  protected override resolveL2TokenAddress(l1Token: string): string {
+    if (compareAddressesSimple(TOKEN_SYMBOLS_MAP.USDC.addresses[this.hubChainId], l1Token)) {
+      return TOKEN_SYMBOLS_MAP.USDC.addresses[this.l2chainId]; // Scroll only has one USDC token type.
+    }
+    return super.resolveL2TokenAddress(l1Token);
   }
 }


### PR DESCRIPTION
This is a simple fix to the issue we had for resolving a USDC address for scroll, whereby we would include a special case in `resolveL2TokenAddress` in BaseBridgeAdapter. This moves this logic to the Scroll bridge so this conditional won't be triggered by all bridges.