### PR TITLE
improve(finalizer): cache attestation responses from Circle's API

### DIFF
--- a/src/utils/CCTPUtils.ts
+++ b/src/utils/CCTPUtils.ts
@@ -277,7 +277,8 @@ async function generateCCTPAttestationProof(messageHash: string, isMainnet: bool
       `https://iris-api${isMainnet ? "" : "-sandbox"}.circle.com/attestations/${messageHash}`
     );
     attestationResponse = httpResponse.data;
-    await redisCache.set(messageHash, attestationResponse, 60 * 60 * 24); // Key expires after one day.
+    const randomInterval = () => Math.floor(Math.random() * (4 * 86400)) + 4 * 86400; // 60 * 60 * 4 = 86400 = 1 day.
+    await redisCache.set(messageHash, attestationResponse, randomInterval()); // Cache expires at random second anywhere between 4-7 days.
   }
   return attestationResponse;
 }


### PR DESCRIPTION
The finalizer sends too many requests to Circle's attestation API, which sometimes causes it to error out. This update will allow the finalizer to cache attestations which it previously queried, which should reduce the number of total queries the finalizer makes to the API over multiple runs.