### PR TITLE
improve(finalizer): cache transaction receipts

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -251,7 +251,7 @@ class CacheProvider extends RateLimitedProvider {
     }
   }
 
-  private async cacheType(method: string, params: Array<any>, result: Array<any>): Promise<CacheType> {
+  private async cacheType(method: string, params: Array<any>, result: any): Promise<CacheType> {
     // Today, we only cache eth_getLogs and eth_call.
     if (method === "eth_getLogs") {
       const [{ fromBlock, toBlock }] = params;
@@ -289,7 +289,7 @@ class CacheProvider extends RateLimitedProvider {
       // The RPC method `eth_getTransactionReceipt` has no block range in its parameters, so we cannot assign a cache type based off of how far back the request looks. Instead,
       // We look at which block the transaction was mined. This should allow us to not cache a transaction which may be susceptible to a reorg.
       // The only parameter is `hash` which is the transaction hash to get a receipt for.
-      const [{ blockNumber }] = result;
+      const { blockNumber } = result;
       const minedBlock = parseInt(blockNumber, 16);
       return this.cacheTypeForBlock(minedBlock);
     } else {

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -289,7 +289,7 @@ class CacheProvider extends RateLimitedProvider {
       // The RPC method `eth_getTransactionReceipt` has no block range in its parameters, so we cannot assign a cache type based off of how far back the request looks. Instead,
       // We look at which block the transaction was mined. This should allow us to not cache a transaction which may be susceptible to a reorg.
       // The only parameter is `hash` which is the transaction hash to get a receipt for.
-      const { blockNumber } = result;
+      const [{ blockNumber }] = result;
       const minedBlock = parseInt(blockNumber, 16);
       return this.cacheTypeForBlock(minedBlock);
     } else {

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -287,6 +287,7 @@ class CacheProvider extends RateLimitedProvider {
       return this.cacheTypeForBlock(blockNumber);
     } else if (method === "eth_getTransactionReceipt") {
       // The RPC method `eth_getTransactionReceipt` has no block range in its parameters, so we cannot assign a cache type based off of how far back the request looks. Here, we assume that there should be a TTL, which means that we will primarily reap the benefits of caching when this method is called to query recent transactions.
+      // The only parameter is `hash` which is the transaction hash to get a receipt for.
       return CacheType.WITH_TTL;
     } else {
       return CacheType.NONE;

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -286,12 +286,7 @@ class CacheProvider extends RateLimitedProvider {
       // If the block is old enough to cache, cache the call.
       return this.cacheTypeForBlock(blockNumber);
     } else if (method === "eth_getTransactionReceipt") {
-      // It's possible to be rate-limited by RPCs during finalization runs, specifically for chains which require
-      // L1 -> L2 finalizations (e.g. Linea). For those runs, we match a transaction receipt on L1 with their status
-      // on L2. This means eth_getTransactionReceipt is called often, so we should cache the responses over runs to
-      // prevent rate limits. While this method does not have a block number in its parameters, we optimistically return
-      // the WITH_TTL cache type since L1 -> L2 message time is short, and we are caching a data for all L1 -> L2 messages,
-      // which may be a significant amount of data.
+      // The RPC method `eth_getTransactionReceipt` has no block range in its parameters, so we cannot assign a cache type based off of how far back the request looks. Here, we assume that there should be a TTL, which means that we will primarily reap the benefits of caching when this method is called to query recent transactions.
       return CacheType.WITH_TTL;
     } else {
       return CacheType.NONE;


### PR DESCRIPTION
Currently, for some chains such as Linea, the number of requests we make to an RPC scales with how many cross chain transfers we make ([example](https://github.com/across-protocol/relayer/blob/8129687f511dd817dfbc3c7c1d1245eee2bdd4b2/src/finalizer/utils/linea/l2ToL1.ts#L46)). Therefore, for cases when we have a large amount of outstanding transfers at once, we could get rate limited by our RPC providers. This PR caches the `eth_getTransactionReceipt` method, which we observed to be the method called during rate limit errors. This required a "hack" since this method has no block range as input, so we cannot classify whether or not it should be stored with/without a TTL, but since we know the context of which this method is called, specifically for currently outstanding transfers, we can assume the receipt will not have to be stored for a long time and can optimistically assign it to have the standard TTL.