### PR TITLE
improve(Monitor): Unwrap WETH on Ethereum when attempting to refill ETH for configured accounts

### DIFF
--- a/src/clients/BalanceAllocator.ts
+++ b/src/clients/BalanceAllocator.ts
@@ -1,4 +1,4 @@
-import { BigNumber, ERC20, ethers, min, getEthAddressForChain } from "../utils";
+import { BigNumber, ERC20, ethers, min, getNativeTokenAddressForChain } from "../utils";
 
 // This type is used to map used and current balances of different users.
 export interface BalanceMap {
@@ -143,7 +143,7 @@ export class BalanceAllocator {
 
   // This method is primarily here to be overriden for testing purposes.
   protected async _queryBalance(chainId: number, token: string, holder: string): Promise<BigNumber> {
-    return getEthAddressForChain(chainId).toLowerCase() === token.toLowerCase()
+    return getNativeTokenAddressForChain(chainId).toLowerCase() === token.toLowerCase()
       ? await this.providers[chainId].getBalance(holder)
       : await ERC20.connect(token, this.providers[chainId]).balanceOf(holder);
   }

--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -203,6 +203,12 @@ export const CONTRACT_ADDRESSES: {
       address: "0x9daF8c91AEFAE50b9c0E69629D3F6Ca40cA3B3FE",
       abi: CCTP_TOKEN_MESSENGER_ABI,
     },
+    // The "eth" entries in this dictionary should be renamed to gasToken/nativeToken to make it more clear
+    // how they are used in the code. For now, set this address to the MATIC address on Polygon. This address
+    // is used in TokenUtils/getEthAddress() and should be set if the native token address is not 0x0.
+    eth: {
+      address: "0x0000000000000000000000000000000000001010",
+    },
   },
   324: {
     zkSyncDefaultErc20Bridge: {

--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -8,7 +8,7 @@ import {
   convertFromWei,
   getBlockForTimestamp,
   getCurrentTime,
-  getEthAddressForChain,
+  getNativeTokenAddressForChain,
   getL1TokenInfo,
   getRedisCache,
   getUniqueLogIndex,
@@ -204,7 +204,7 @@ async function prepareFinalizations(
 ): Promise<Multicall2Call[]> {
   const l1Mailbox = getMailbox(l1ChainId);
   const l1ERC20Bridge = getL1ERC20Bridge(l1ChainId);
-  const ethAddr = getEthAddressForChain(l2ChainId);
+  const ethAddr = getNativeTokenAddressForChain(l2ChainId);
 
   return await sdkUtils.mapAsync(withdrawalParams, async (withdrawal) =>
     prepareFinalization(withdrawal, ethAddr, l1Mailbox, l1ERC20Bridge)

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -484,7 +484,7 @@ export class Monitor {
           // want to test this in production before rolling it out to all chains.
           if (!canRefill && chainId === CHAIN_IDs.MAINNET && token === getNativeTokenAddressForChain(chainId)) {
             const weth = new Contract(
-              TOKEN_SYMBOLS_MAP["WETH"].addresses[chainId],
+              TOKEN_SYMBOLS_MAP.WETH.addresses[chainId],
               WETH9.abi,
               this.clients.spokePoolClients[chainId].spokePool.signer
             );

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -513,6 +513,7 @@ export class Monitor {
                 token,
                 chainId,
               });
+              return;
             }
           }
           if (canRefill) {

--- a/src/monitor/MonitorConfig.ts
+++ b/src/monitor/MonitorConfig.ts
@@ -1,6 +1,6 @@
 import winston from "winston";
 import { CommonConfig, ProcessEnv } from "../common";
-import { ethers, getEthAddressForChain } from "../utils";
+import { ethers, getNativeTokenAddressForChain } from "../utils";
 
 // Set modes to true that you want to enable in the AcrossMonitor bot.
 export interface BotModes {
@@ -106,7 +106,7 @@ export class MonitorConfig extends CommonConfig {
             // Optional fields that will set to defaults:
             isHubPool: Boolean(isHubPool),
             // Fields that are always set to defaults:
-            token: getEthAddressForChain(chainId),
+            token: getNativeTokenAddressForChain(chainId),
           };
         }
       );
@@ -154,9 +154,9 @@ export class MonitorConfig extends CommonConfig {
             parsedWarnThreshold = Number(warnThreshold);
           }
 
-          const isNativeToken = !token || token === "0x0" || token === getEthAddressForChain(chainId);
+          const isNativeToken = !token || token === getNativeTokenAddressForChain(chainId);
           return {
-            token: isNativeToken ? getEthAddressForChain(chainId) : token,
+            token: isNativeToken ? getNativeTokenAddressForChain(chainId) : token,
             errorThreshold: parsedErrorThreshold,
             warnThreshold: parsedWarnThreshold,
             account: ethers.utils.getAddress(account),

--- a/src/utils/TokenUtils.ts
+++ b/src/utils/TokenUtils.ts
@@ -13,8 +13,6 @@ export function getL2TokenAddresses(l1TokenAddress: string): { [chainId: number]
   })?.addresses;
 }
 
-// TODO: This should be renamed to getNative/GasTokenAddressForChain to align closer with this function's usage.
-// It's typically used to query the native token for a chain.
 export function getNativeTokenAddressForChain(chainId: number): string {
   return CONTRACT_ADDRESSES[chainId]?.eth?.address ?? ZERO_ADDRESS;
 }

--- a/src/utils/TokenUtils.ts
+++ b/src/utils/TokenUtils.ts
@@ -13,7 +13,9 @@ export function getL2TokenAddresses(l1TokenAddress: string): { [chainId: number]
   })?.addresses;
 }
 
-export function getEthAddressForChain(chainId: number): string {
+// TODO: This should be renamed to getNative/GasTokenAddressForChain to align closer with this function's usage.
+// It's typically used to query the native token for a chain.
+export function getNativeTokenAddressForChain(chainId: number): string {
   return CONTRACT_ADDRESSES[chainId]?.eth?.address ?? ZERO_ADDRESS;
 }
 


### PR DESCRIPTION
Motivation:
- Seeing lots of warning when trying to refill ETH from one account to another because the sender has lots of WETH but not enough ETH.

Features:
- Add feature in Monitor to automatically unwrap WETH into ETH when trying to refill ETH on Ethereum
- Refactor/rename functions to better support a future where we have different native tokens per chain.

Details
- Found a bug where we incorrectly assume that the `eth` address on Polygon is 0x0, but the MATIC address seems to be: [0x0000000000000000000000000000000000001010](https://polygonscan.com/token/0x0000000000000000000000000000000000001010)
- This has never really been an issue up until now since we make the correct balance calls (provider.getBalance) anyways even though we make faulty assumptions that the polygon eth token is 0x0
- This could have been an issue when unwrapping WMATIC into MATIC on Polygon but we don't do this anywhere in the code
