### PR TITLE
feat(Dataworker): Move persistence of bundle data step to Disputer instead of Proposer

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -479,6 +479,18 @@ export class Dataworker {
     const timerStart = Date.now();
     const { bundleDepositsV3, bundleFillsV3, bundleSlowFillsV3, unexecutableSlowFills, expiredDepositsToRefundV3 } =
       await this.clients.bundleDataClient.loadData(blockRangesForProposal, spokePoolClients, loadDataFromArweave);
+    // Prepare information about what we need to store to
+    // Arweave for the bundle. We will be doing this at a
+    // later point so that we can confirm that this data is
+    // worth storing.
+    const dataToPersistToDALayer = {
+      bundleBlockRanges: blockRangesForProposal,
+      bundleDepositsV3,
+      expiredDepositsToRefundV3,
+      bundleFillsV3,
+      unexecutableSlowFills,
+      bundleSlowFillsV3,
+    };
     const [, mainnetBundleEndBlock] = blockRangesForProposal[0];
 
     const poolRebalanceRoot = await this._getPoolRebalanceRoot(
@@ -533,6 +545,7 @@ export class Dataworker {
       relayerRefundTree: relayerRefundRoot.tree,
       slowFillLeaves: slowRelayRoot.leaves,
       slowFillTree: slowRelayRoot.tree,
+      dataToPersistToDALayer
     };
   }
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -353,12 +353,15 @@ export class Dataworker {
     );
   }
 
+  /**
+   * @returns bundle data if new proposal transaction is enqueued, else undefined
+   */
   async proposeRootBundle(
     spokePoolClients: { [chainId: number]: SpokePoolClient },
     usdThresholdToSubmitNewBundle?: BigNumber,
     submitProposals = true,
     earliestBlocksInSpokePoolClients: { [chainId: number]: number } = {}
-  ): Promise<void> {
+  ): Promise<BundleDataToPersistToDALayerType> {
     // TODO: Handle the case where we can't get event data or even blockchain data from any chain. This will require
     // some changes to override the bundle block range here, and loadData to skip chains with zero block ranges.
     // For now, we assume that if one blockchain fails to return data, then this entire function will fail. This is a
@@ -467,6 +470,7 @@ export class Dataworker {
         rootBundleData.slowFillTree.getHexRoot()
       );
     }
+    return rootBundleData.dataToPersistToDALayer;
   }
 
   async _proposeRootBundle(

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -622,7 +622,7 @@ export class Dataworker {
     if (persistBundleData && isDefined(bundleData)) {
       await persistDataToArweave(
         this.clients.arweaveClient,
-        bundleData as unknown as Record<string, unknown>,
+        bundleData,
         this.logger,
         `bundles-${bundleData.bundleBlockRanges}`
       );

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -554,7 +554,7 @@ export class Dataworker {
     spokePoolClients: { [chainId: number]: SpokePoolClient },
     submitDisputes = true,
     earliestBlocksInSpokePoolClients: { [chainId: number]: number } = {},
-    persistBundleData = false,
+    persistBundleData = false
   ): Promise<void> {
     if (!this.clients.hubPoolClient.isUpdated || this.clients.hubPoolClient.currentTime === undefined) {
       throw new Error("HubPoolClient not updated");

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -545,7 +545,7 @@ export class Dataworker {
       relayerRefundTree: relayerRefundRoot.tree,
       slowFillLeaves: slowRelayRoot.leaves,
       slowFillTree: slowRelayRoot.tree,
-      dataToPersistToDALayer
+      dataToPersistToDALayer,
     };
   }
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -83,7 +83,6 @@ type ProposeRootBundleReturnType = {
   relayerRefundTree: MerkleTree<RelayerRefundLeaf>;
   slowFillLeaves: V3SlowFillLeaf[];
   slowFillTree: MerkleTree<V3SlowFillLeaf>;
-  dataToPersistToDALayer: BundleDataToPersistToDALayerType;
 };
 
 export type PoolRebalanceRoot = {
@@ -358,7 +357,7 @@ export class Dataworker {
     usdThresholdToSubmitNewBundle?: BigNumber,
     submitProposals = true,
     earliestBlocksInSpokePoolClients: { [chainId: number]: number } = {}
-  ): Promise<BundleDataToPersistToDALayerType> {
+  ): Promise<void> {
     // TODO: Handle the case where we can't get event data or even blockchain data from any chain. This will require
     // some changes to override the bundle block range here, and loadData to skip chains with zero block ranges.
     // For now, we assume that if one blockchain fails to return data, then this entire function will fail. This is a
@@ -467,7 +466,6 @@ export class Dataworker {
         rootBundleData.slowFillTree.getHexRoot()
       );
     }
-    return rootBundleData.dataToPersistToDALayer;
   }
 
   async _proposeRootBundle(
@@ -480,18 +478,6 @@ export class Dataworker {
     const timerStart = Date.now();
     const { bundleDepositsV3, bundleFillsV3, bundleSlowFillsV3, unexecutableSlowFills, expiredDepositsToRefundV3 } =
       await this.clients.bundleDataClient.loadData(blockRangesForProposal, spokePoolClients, loadDataFromArweave);
-    // Prepare information about what we need to store to
-    // Arweave for the bundle. We will be doing this at a
-    // later point so that we can confirm that this data is
-    // worth storing.
-    const dataToPersistToDALayer = {
-      bundleBlockRanges: blockRangesForProposal,
-      bundleDepositsV3,
-      expiredDepositsToRefundV3,
-      bundleFillsV3,
-      unexecutableSlowFills,
-      bundleSlowFillsV3,
-    };
     const [, mainnetBundleEndBlock] = blockRangesForProposal[0];
 
     const poolRebalanceRoot = await this._getPoolRebalanceRoot(
@@ -546,7 +532,6 @@ export class Dataworker {
       relayerRefundTree: relayerRefundRoot.tree,
       slowFillLeaves: slowRelayRoot.leaves,
       slowFillTree: slowRelayRoot.tree,
-      dataToPersistToDALayer,
     };
   }
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -83,6 +83,7 @@ type ProposeRootBundleReturnType = {
   relayerRefundTree: MerkleTree<RelayerRefundLeaf>;
   slowFillLeaves: V3SlowFillLeaf[];
   slowFillTree: MerkleTree<V3SlowFillLeaf>;
+  dataToPersistToDALayer: BundleDataToPersistToDALayerType;
 };
 
 export type PoolRebalanceRoot = {

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -591,8 +591,8 @@ export async function persistDataToArweave(
   // If so, we don't need to persist it again.
   const matchingTxns = await client.getByTopic(tag, any());
   if (matchingTxns.length > 0) {
-    logger.info({
-      at: "Dataworker#index",
+    logger.debug({
+      at: "DataworkerUtils#persistDataToArweave",
       message: `Data already exists on Arweave with tag: ${tag}`,
       hash: matchingTxns.map((txn) => txn.hash),
     });
@@ -603,17 +603,17 @@ export async function persistDataToArweave(
       client.getBalance(),
     ]);
     logger.info({
-      at: "Dataworker#index",
+      at: "DataworkerUtils#persistDataToArweave",
       message: "Persisted data to Arweave! 💾",
       receipt: `https://arweave.app/tx/${hashTxn}`,
       rawData: `https://arweave.net/${hashTxn}`,
       address,
       balance,
     });
+    const endTime = performance.now();
+    logger.debug({
+      at: "Dataworker#index",
+      message: `Time to persist data to Arweave: ${endTime - startTime}ms`,
+    });
   }
-  const endTime = performance.now();
-  logger.debug({
-    at: "Dataworker#index",
-    message: `Time to persist data to Arweave: ${endTime - startTime}ms`,
-  });
 }

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -112,7 +112,12 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
       const dataworkerFunctionLoopTimerStart = performance.now();
       // Validate and dispute pending proposal before proposing a new one
       if (config.disputerEnabled) {
-        await dataworker.validatePendingRootBundle(spokePoolClients, config.sendingDisputesEnabled, fromBlocks, config.persistingBundleData);
+        await dataworker.validatePendingRootBundle(
+          spokePoolClients,
+          config.sendingDisputesEnabled,
+          fromBlocks,
+          config.persistingBundleData
+        );
       } else {
         logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Disputer disabled" });
       }

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -1,14 +1,6 @@
-import {
-  processEndPollingLoop,
-  winston,
-  config,
-  startupLogLevel,
-  Signer,
-  disconnectRedisClients,
-  isDefined,
-} from "../utils";
+import { processEndPollingLoop, winston, config, startupLogLevel, Signer, disconnectRedisClients } from "../utils";
 import { spokePoolClientsToProviders } from "../common";
-import { BundleDataToPersistToDALayerType, Dataworker } from "./Dataworker";
+import { Dataworker } from "./Dataworker";
 import { DataworkerConfig } from "./DataworkerConfig";
 import {
   constructDataworkerClients,
@@ -17,7 +9,6 @@ import {
   DataworkerClients,
 } from "./DataworkerClientHelper";
 import { BalanceAllocator } from "../clients/BalanceAllocator";
-import { persistDataToArweave } from "./DataworkerUtils";
 import { PendingRootBundle } from "../interfaces";
 
 config();
@@ -62,7 +53,6 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
     message: `Time to update non-spoke clients: ${(performance.now() - loopStart) / 1000}s`,
   });
   loopStart = performance.now();
-  let bundleDataToPersist: BundleDataToPersistToDALayerType | undefined = undefined;
   let poolRebalanceLeafExecutionCount = 0;
   try {
     logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Dataworker started 👩‍🔬", config });
@@ -116,6 +106,8 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
           spokePoolClients,
           config.sendingDisputesEnabled,
           fromBlocks,
+          // @dev Opportunistically publish bundle data to external storage layer since we're reconstructing it in this
+          // process, if user has configured it so.
           config.persistingBundleData
         );
       } else {
@@ -123,7 +115,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
       }
 
       if (config.proposerEnabled) {
-        bundleDataToPersist = await dataworker.proposeRootBundle(
+        await dataworker.proposeRootBundle(
           spokePoolClients,
           config.rootBundleExecutionThreshold,
           config.sendingProposalsEnabled,
@@ -169,62 +161,25 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
       // leaves to be executed but the proposed bundle was already executed, then exit early.
       const pendingProposal: PendingRootBundle = await clients.hubPoolClient.hubPool.rootBundleProposal();
 
-      // Define a helper function to persist the bundle data to the DALayer.
-      const persistBundle = async () => {
-        // Submit the bundle data to persist to the DALayer if persistingBundleData is enabled.
-        // Note: The check for `bundleDataToPersist` is necessary for TSC to be happy.
-        if (
-          config.persistingBundleData &&
-          isDefined(bundleDataToPersist) &&
-          pendingProposal.unclaimedPoolRebalanceLeafCount === 0
-        ) {
-          await persistDataToArweave(
-            clients.arweaveClient,
-            bundleDataToPersist,
-            logger,
-            `bundles-${bundleDataToPersist.bundleBlockRanges}`
-          );
-        }
-      };
-
-      const executeDataworkerTransactions = async () => {
-        const proposalCollision = isDefined(bundleDataToPersist) && pendingProposal.unclaimedPoolRebalanceLeafCount > 0;
-        // The pending root bundle that we want to execute has already been executed if its unclaimed leaf count
-        // does not match the number of leaves the executor wants to execute, or the pending root bundle's
-        // challenge period timestamp is in the future. This latter case is rarer but it can
-        // happen if a proposal in addition to the root bundle execution happens in the middle of this executor run.
-        const executorCollision =
-          poolRebalanceLeafExecutionCount > 0 &&
-          (pendingProposal.unclaimedPoolRebalanceLeafCount !== poolRebalanceLeafExecutionCount ||
-            pendingProposal.challengePeriodEndTimestamp > clients.hubPoolClient.currentTime);
-        if (proposalCollision || executorCollision) {
-          logger[startupLogLevel(config)]({
-            at: "Dataworker#index",
-            message: "Exiting early due to dataworker function collision",
-            proposalCollision,
-            executorCollision,
-            pendingProposal,
-          });
-        } else {
-          await clients.multiCallerClient.executeTxnQueues();
-        }
-      };
-
-      // We want to persist the bundle data to the DALayer *AND* execute the multiCall transaction queue
-      // in parallel. We want to have both of these operations complete, even if one of them fails.
-      const [persistResult, multiCallResult] = await Promise.allSettled([
-        persistBundle(),
-        executeDataworkerTransactions(),
-      ]);
-
-      // If either of the operations failed, log the error.
-      if (persistResult.status === "rejected" || multiCallResult.status === "rejected") {
-        logger.error({
+      const proposalCollision = pendingProposal.unclaimedPoolRebalanceLeafCount > 0;
+      // The pending root bundle that we want to execute has already been executed if its unclaimed leaf count
+      // does not match the number of leaves the executor wants to execute, or the pending root bundle's
+      // challenge period timestamp is in the future. This latter case is rarer but it can
+      // happen if a proposal in addition to the root bundle execution happens in the middle of this executor run.
+      const executorCollision =
+        poolRebalanceLeafExecutionCount > 0 &&
+        (pendingProposal.unclaimedPoolRebalanceLeafCount !== poolRebalanceLeafExecutionCount ||
+          pendingProposal.challengePeriodEndTimestamp > clients.hubPoolClient.currentTime);
+      if (proposalCollision || executorCollision) {
+        logger[startupLogLevel(config)]({
           at: "Dataworker#index",
-          message: "Failed to persist bundle data to the DALayer or execute the multiCall transaction queue",
-          persistResult: persistResult.status === "rejected" ? persistResult.reason : undefined,
-          multiCallResult: multiCallResult.status === "rejected" ? multiCallResult.reason : undefined,
+          message: "Exiting early due to dataworker function collision",
+          proposalCollision,
+          executorCollision,
+          pendingProposal,
         });
+      } else {
+        await clients.multiCallerClient.executeTxnQueues();
       }
 
       const dataworkerFunctionLoopTimerEnd = performance.now();

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -112,7 +112,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
       const dataworkerFunctionLoopTimerStart = performance.now();
       // Validate and dispute pending proposal before proposing a new one
       if (config.disputerEnabled) {
-        await dataworker.validatePendingRootBundle(spokePoolClients, config.sendingDisputesEnabled, fromBlocks);
+        await dataworker.validatePendingRootBundle(spokePoolClients, config.sendingDisputesEnabled, fromBlocks, config.persistingBundleData);
       } else {
         logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Disputer disabled" });
       }

--- a/src/interfaces/BundleData.ts
+++ b/src/interfaces/BundleData.ts
@@ -45,3 +45,7 @@ export type LoadDataReturnValue = {
   unexecutableSlowFills: BundleExcessSlowFills;
   bundleSlowFillsV3: BundleSlowFills;
 };
+
+export interface BundleData extends LoadDataReturnValue {
+  bundleBlockRanges: number[][];
+}

--- a/src/interfaces/BundleData.ts
+++ b/src/interfaces/BundleData.ts
@@ -46,6 +46,6 @@ export type LoadDataReturnValue = {
   bundleSlowFillsV3: BundleSlowFills;
 };
 
-export interface BundleData extends LoadDataReturnValue {
+export type BundleData = LoadDataReturnValue & {
   bundleBlockRanges: number[][];
-}
+};

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -7,6 +7,7 @@ export * from "./Token";
 export * from "./Error";
 export * from "./Report";
 export * from "./Arweave";
+export * from "./BundleData";
 
 // Bridge interfaces
 export interface OutstandingTransfers {


### PR DESCRIPTION
This PR adds a feature to the disputer which allows it repersist data to arweave in the event the pending bundle is valid, since it also reconstructs valid bundle data from scratch.

This way the disputer can have multiple chances throughout the bundle's challenge period to repersist to arweave.

A future PR would add this ability to the executor
