### PR TITLE
fix: Bump SDK for dataworker fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.13",
     "@across-protocol/contracts": "^3.0.10",
-    "@across-protocol/sdk": "^3.1.20",
-    "@across-protocol/sdk": "^3.1.21",
+    "@across-protocol/sdk": "^3.1.22",
     "@arbitrum/sdk": "^3.1.3",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",


### PR DESCRIPTION
To permit the dataworker to resolve deposits for invalid fills.