### PR TITLE
improve(sdk): use sdk types/utils/hub

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.14",
     "@across-protocol/contracts": "^3.0.10",
-    "@across-protocol/sdk": "^3.1.23",
+    "@across-protocol/sdk": "^3.1.26",
     "@arbitrum/sdk": "^3.1.3",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -1,9 +1,8 @@
 import { clients, interfaces } from "@across-protocol/sdk";
 import { Contract } from "ethers";
 import winston from "winston";
-import { CHAIN_IDs, MakeOptional, EventSearchConfig, getTokenInfo, getL1TokenInfo, getUsdcSymbol } from "../utils";
+import { CHAIN_IDs, MakeOptional, EventSearchConfig } from "../utils";
 import { IGNORED_HUB_EXECUTED_BUNDLES, IGNORED_HUB_PROPOSED_BUNDLES } from "../common";
-import { L1Token } from "../interfaces";
 
 export type LpFeeRequest = clients.LpFeeRequest;
 
@@ -32,33 +31,6 @@ export class HubPoolClient extends clients.HubPoolClient {
       },
       cachingMechanism
     );
-  }
-
-  /**
-   * @dev If tokenAddress + chain do not exist in TOKEN_SYMBOLS_MAP then this will throw.
-   * @param tokenAddress Token address on `chain`
-   * @param chain Chain where the `tokenAddress` exists in TOKEN_SYMBOLS_MAP.
-   * @returns Token info for the given token address on the L2 chain including symbol and decimal.
-   */
-  getTokenInfoForAddress(tokenAddress: string, chain: number): L1Token {
-    const tokenInfo = getTokenInfo(tokenAddress, chain);
-    // @dev Temporarily handle case where an L2 token for chain ID can map to more than one TOKEN_SYMBOLS_MAP
-    // entry. For example, L2 Bridged USDC maps to both the USDC and USDC.e/USDbC entries in TOKEN_SYMBOLS_MAP.
-    if (tokenInfo.symbol.toLowerCase() === "usdc" && chain !== this.chainId) {
-      tokenInfo.symbol = getUsdcSymbol(tokenAddress, chain) ?? "UNKNOWN";
-    }
-    return tokenInfo;
-  }
-
-  /**
-   * @dev If tokenAddress + chain do not exist in TOKEN_SYMBOLS_MAP then this will throw.
-   * @dev if the token matched in TOKEN_SYMBOLS_MAP does not have an L1 token address then this will throw.
-   * @param tokenAddress Token address on `chain`
-   * @param chain Chain where the `tokenAddress` exists in TOKEN_SYMBOLS_MAP.
-   * @returns Token info for the given token address on the Hub chain including symbol and decimal and L1 address.
-   */
-  getL1TokenInfoForAddress(tokenAddress: string, chain: number): L1Token {
-    return getL1TokenInfo(tokenAddress, chain);
   }
 
   async computeRealizedLpFeePct(deposit: LpFeeRequest): Promise<interfaces.RealizedLpFee> {

--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -1,5 +1,5 @@
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
-import { BigNumber, ethers, isDefined } from ".";
+import { BigNumber, compareAddressesSimple, ethers, isDefined } from ".";
 
 export function compareAddresses(addressA: string, addressB: string): 1 | -1 | 0 {
   // Convert address strings to BigNumbers and then sort numerical value of the BigNumber, which sorts the addresses
@@ -13,13 +13,6 @@ export function compareAddresses(addressA: string, addressB: string): 1 | -1 | 0
   } else {
     return 0;
   }
-}
-
-export function compareAddressesSimple(addressA?: string, addressB?: string): boolean {
-  if (addressA === undefined || addressB === undefined) {
-    return false;
-  }
-  return addressA.toLowerCase() === addressB.toLowerCase();
 }
 
 export function includesAddressSimple(address: string | undefined, list: string[]): boolean {
@@ -104,17 +97,6 @@ export function getTranslatedTokenAddress(
   }
 
   return getTokenAddress(l1Token, hubChainId, l2ChainId);
-}
-
-/**
- * Get the USDC symbol for the given token address and chain ID.
- * @param l2Token A Web3 token address (not case sensitive)
- * @param chainId A chain Id to reference
- * @returns Either USDC (if native) or USDbC/USDC.e (if bridged) or undefined if the token address is not recognized.
- */
-export function getUsdcSymbol(l2Token: string, chainId: number): string | undefined {
-  const compareToken = (token?: string) => isDefined(token) && compareAddressesSimple(l2Token, token);
-  return ["USDC", "USDbC", "USDC.e"].find((token) => compareToken(TOKEN_SYMBOLS_MAP[token]?.addresses?.[chainId]));
 }
 
 export function checkAddressChecksum(tokenAddress: string): boolean {

--- a/src/utils/CCTPUtils.ts
+++ b/src/utils/CCTPUtils.ts
@@ -3,9 +3,8 @@ import { TransactionReceipt } from "@ethersproject/abstract-provider";
 import axios from "axios";
 import { BigNumber, ethers } from "ethers";
 import { CONTRACT_ADDRESSES, chainIdsToCctpDomains } from "../common";
-import { compareAddressesSimple } from "./AddressUtils";
 import { EventSearchConfig, paginatedEventQuery } from "./EventUtils";
-import { bnZero } from "./SDKUtils";
+import { bnZero, compareAddressesSimple } from "./SDKUtils";
 import { isDefined } from "./TypeGuards";
 import { getProvider } from "./ProviderUtils";
 

--- a/src/utils/SDKUtils.ts
+++ b/src/utils/SDKUtils.ts
@@ -40,4 +40,8 @@ export const {
   isContractDeployedToAddress,
   blockExplorerLinks,
   createShortHexString: shortenHexString,
+  compareAddressesSimple,
+  getTokenInfo,
+  getL1TokenInfo,
+  getUsdcSymbol,
 } = sdk.utils;

--- a/src/utils/TokenUtils.ts
+++ b/src/utils/TokenUtils.ts
@@ -2,7 +2,6 @@ import { constants, utils } from "@across-protocol/sdk";
 import { CONTRACT_ADDRESSES } from "../common";
 import { BigNumberish, utils as ethersUtils } from "ethers";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
-import { L1Token } from "../interfaces";
 const { ZERO_ADDRESS } = constants;
 
 export const { fetchTokenInfo } = utils;
@@ -15,37 +14,6 @@ export function getL2TokenAddresses(l1TokenAddress: string): { [chainId: number]
 
 export function getNativeTokenAddressForChain(chainId: number): string {
   return CONTRACT_ADDRESSES[chainId]?.eth?.address ?? ZERO_ADDRESS;
-}
-
-export function getTokenInfo(l2TokenAddress: string, chainId: number): L1Token {
-  // @dev This might give false positives if tokens on different networks have the same address. I'm not sure how
-  // to get around this...
-  const tokenObject = Object.values(TOKEN_SYMBOLS_MAP).find(({ addresses }) => addresses[chainId] === l2TokenAddress);
-  if (!tokenObject) {
-    throw new Error(
-      `TokenUtils#getTokenInfo: Unable to resolve token in TOKEN_SYMBOLS_MAP for ${l2TokenAddress} on chain ${chainId}`
-    );
-  }
-  return {
-    address: l2TokenAddress,
-    symbol: tokenObject.symbol,
-    decimals: tokenObject.decimals,
-  };
-}
-
-export function getL1TokenInfo(l2TokenAddress: string, chainId: number): L1Token {
-  const tokenObject = Object.values(TOKEN_SYMBOLS_MAP).find(({ addresses }) => addresses[chainId] === l2TokenAddress);
-  const l1TokenAddress = tokenObject?.addresses[CHAIN_IDs.MAINNET];
-  if (!l1TokenAddress) {
-    throw new Error(
-      `TokenUtils#getL1TokenInfo: Unable to resolve l1 token address in TOKEN_SYMBOLS_MAP for L2 token ${l2TokenAddress} on chain ${chainId}`
-    );
-  }
-  return {
-    address: l1TokenAddress,
-    symbol: tokenObject.symbol,
-    decimals: tokenObject.decimals,
-  };
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,10 +50,10 @@
     axios "^1.6.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.1.23":
-  version "3.1.23"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.1.23.tgz#12db8040dfe0ec4d19ea7262b5cabaa3b18dfad9"
-  integrity sha512-qBGrsYbiMQrKu4zcbOMvmJsVURpUpjLmwKU8hzDHHjGomIzECEtW4pyWmgD3pri8x+X90wh07pw7yw8I5FsClw==
+"@across-protocol/sdk@^3.1.26":
+  version "3.1.26"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.1.26.tgz#5ea04235a79ff26c1fb7a2214b8fb70d13c349da"
+  integrity sha512-NyU7pqUqBwaxBshNwhQVGflG0KtkpyU7/YXZwxrXhk7hDm0UEpuzlpOuyQoc2NVdMBXN8gLx4rD8cXqc1rrhJw==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.14"
@@ -61,7 +61,6 @@
     "@eth-optimism/sdk" "^3.3.1"
     "@pinata/sdk" "^2.1.0"
     "@types/mocha" "^10.0.1"
-    "@uma/logger" "^1.3.0"
     "@uma/sdk" "^0.34.1"
     arweave "^1.14.4"
     async "^3.2.5"


### PR DESCRIPTION
Related to https://github.com/across-protocol/sdk/pull/705 - adds integrated sdk work back into the relayer.