### PR TITLE
fix(relayer): Hard stop child process on exit

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -88,6 +88,9 @@ export class IndexedSpokePoolClient extends clients.SpokePoolClient {
       stdio: ["ignore", "inherit", "inherit", "ipc"],
     });
 
+    // Don't permit the worker to keep the parent alive.
+    this.worker.unref();
+
     this.worker.on("message", (message) => this.indexerUpdate(message));
     this.logger.debug({
       at: "SpokePoolClient#startWorker",

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -88,15 +88,17 @@ export class IndexedSpokePoolClient extends clients.SpokePoolClient {
       stdio: ["ignore", "inherit", "inherit", "ipc"],
     });
 
-    // Don't permit the worker to keep the parent alive.
-    this.worker.unref();
-
     this.worker.on("message", (message) => this.indexerUpdate(message));
     this.logger.debug({
       at: "SpokePoolClient#startWorker",
       message: `Spawned ${this.chain} SpokePool indexer.`,
       args: this.worker.spawnargs,
     });
+  }
+
+  bonkWorker(): void {
+    this.worker.disconnect();
+    this.worker.kill("SIGKILL");
   }
 
   /**

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -96,7 +96,7 @@ export class IndexedSpokePoolClient extends clients.SpokePoolClient {
     });
   }
 
-  bonkWorker(): void {
+  stopWorker(): void {
     this.worker.disconnect();
     this.worker.kill("SIGKILL");
   }

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -107,6 +107,10 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
     }
   } finally {
     await disconnectRedisClients(logger);
+
+    if (config.externalIndexer) {
+      Object.values(relayerClients.spokePoolClients).map((spokePoolClient) => spokePoolClient.stopWorker());
+    }
   }
 
   const runtime = getCurrentTime() - startTime;


### PR DESCRIPTION
Websocket errors can sporadically cause a child listener process to hang, such that it doesn't respond properly to a channel disconnect or HUP from the parent. 