### PR TITLE
fix(zkSyncWethBridge): enable hub pool tracking

### DIFF
--- a/src/adapter/bridges/ZKSyncWethBridge.ts
+++ b/src/adapter/bridges/ZKSyncWethBridge.ts
@@ -9,6 +9,7 @@ import {
   ZERO_ADDRESS,
   TOKEN_SYMBOLS_MAP,
   assert,
+  compareAddressesSimple,
 } from "../../utils";
 import { CONTRACT_ADDRESSES } from "../../common";
 import { isDefined } from "../../utils/TypeGuards";
@@ -92,7 +93,7 @@ export class ZKSyncWethBridge extends BaseBridgeAdapter {
     eventConfig: EventSearchConfig
   ): Promise<BridgeEvents> {
     const hubPool = this.getHubPool();
-    if (fromAddress === hubPool.address) {
+    if (compareAddressesSimple(fromAddress, hubPool.address)) {
       return Promise.resolve({});
     }
     const wethAddress = TOKEN_SYMBOLS_MAP.WETH.addresses[this.hubChainId];
@@ -111,7 +112,9 @@ export class ZKSyncWethBridge extends BaseBridgeAdapter {
     );
     if (isL2Contract) {
       // The TokensRelayed event does not distinguish between chain or l1Token, so we filter it here.
-      events = events.filter((e) => e.args.to === toAddress && e.args.l1Token === wethAddress);
+      events = events.filter(
+        (e) => compareAddressesSimple(e.args.to, toAddress) && compareAddressesSimple(e.args.l1Token, wethAddress)
+      );
     }
     const processedEvents = events.map((event) =>
       isL2Contract ? processEvent(event, "amount", "to", "to") : processEvent(event, "_amount", "_to", "from")
@@ -131,7 +134,7 @@ export class ZKSyncWethBridge extends BaseBridgeAdapter {
     eventConfig: EventSearchConfig
   ): Promise<BridgeEvents> {
     const hubPool = this.getHubPool();
-    if (fromAddress === hubPool.address) {
+    if (compareAddressesSimple(fromAddress, hubPool.address)) {
       return Promise.resolve({});
     }
 

--- a/src/adapter/bridges/ZKSyncWethBridge.ts
+++ b/src/adapter/bridges/ZKSyncWethBridge.ts
@@ -113,8 +113,8 @@ export class ZKSyncWethBridge extends BaseBridgeAdapter {
         .map((e) => {
           return {
             ...processEvent(e, "amount", "to", "to"),
-            from: hubPool.address
-          }
+            from: hubPool.address,
+          };
         });
     } else {
       events = await paginatedEventQuery(

--- a/src/adapter/bridges/ZKSyncWethBridge.ts
+++ b/src/adapter/bridges/ZKSyncWethBridge.ts
@@ -110,8 +110,12 @@ export class ZKSyncWethBridge extends BaseBridgeAdapter {
         .filter(
           (e) => compareAddressesSimple(e.args.to, toAddress) && compareAddressesSimple(e.args.l1Token, wethAddress)
         )
-        .map((e) => processEvent(e, "amount", "to", "to"));
-      processedEvents.forEach((e) => (e.from = hubPool.address));
+        .map((e) => {
+          return {
+            ...processEvent(e, "amount", "to", "to"),
+            from: hubPool.address
+          }
+        });
     } else {
       events = await paginatedEventQuery(
         this.atomicDepositor,

--- a/test/generic-adapters/zkSync.ts
+++ b/test/generic-adapters/zkSync.ts
@@ -178,7 +178,7 @@ describe("Cross Chain Adapter: zkSync", async function () {
       const result = await adapter.bridges[l1Weth].queryL2BridgeFinalizationEvents(
         l1Weth,
         monitoredEoa,
-        null,
+        monitoredEoa,
         searchConfig
       );
       expect(Object.keys(result).length).to.equal(1);
@@ -220,7 +220,7 @@ describe("Cross Chain Adapter: zkSync", async function () {
       await atomicDepositor.bridgeWethToZkSync(monitoredEoa, depositAmount, 0, 0, ZERO_ADDRESS);
       const deposits = await adapter.bridges[l1Weth].queryL1BridgeInitiationEvents(
         l1Weth,
-        null,
+        monitoredEoa,
         monitoredEoa,
         searchConfig
       );
@@ -229,7 +229,7 @@ describe("Cross Chain Adapter: zkSync", async function () {
 
       let receipts = await adapter.bridges[l1Weth].queryL2BridgeFinalizationEvents(
         l1Weth,
-        null,
+        monitoredEoa,
         monitoredEoa,
         searchConfig
       );
@@ -263,7 +263,7 @@ describe("Cross Chain Adapter: zkSync", async function () {
       await l2Weth.transfer(ZERO_ADDRESS, monitoredEoa, depositAmount); // Simulate subsequent WETH deposit.
       receipts = await adapter.bridges[l1Weth].queryL2BridgeFinalizationEvents(
         l1Weth,
-        null,
+        monitoredEoa,
         monitoredEoa,
         searchConfig
       );
@@ -298,7 +298,7 @@ describe("Cross Chain Adapter: zkSync", async function () {
 
       const result = await adapter.bridges[l1Weth].queryL1BridgeInitiationEvents(
         l1Weth,
-        null,
+        spokePool.address,
         spokePool.address,
         searchConfig
       );
@@ -318,7 +318,7 @@ describe("Cross Chain Adapter: zkSync", async function () {
 
       const result = await adapter.bridges[l1Weth].queryL2BridgeFinalizationEvents(
         l1Weth,
-        null,
+        spokePool.address,
         spokePool.address,
         searchConfig
       );
@@ -359,7 +359,7 @@ describe("Cross Chain Adapter: zkSync", async function () {
       await hubPool.relayTokens(l1Weth, l2Weth.address, depositAmount, spokePool.address);
       const deposits = await adapter.bridges[l1Weth].queryL1BridgeInitiationEvents(
         l1Weth,
-        null,
+        spokePool.address,
         spokePool.address,
         searchConfig
       );
@@ -368,7 +368,7 @@ describe("Cross Chain Adapter: zkSync", async function () {
 
       let receipts = await adapter.bridges[l1Weth].queryL2BridgeFinalizationEvents(
         l1Weth,
-        null,
+        spokePool.address,
         spokePool.address,
         searchConfig
       );
@@ -401,7 +401,7 @@ describe("Cross Chain Adapter: zkSync", async function () {
       await l2Eth.transfer(zksync.utils.applyL1ToL2Alias(hubPool.address), spokePool.address, depositAmount);
       receipts = await adapter.bridges[l1Weth].queryL2BridgeFinalizationEvents(
         l1Weth,
-        null,
+        spokePool.address,
         spokePool.address,
         searchConfig
       );
@@ -458,7 +458,7 @@ describe("Cross Chain Adapter: zkSync", async function () {
       await adapter.sendTokenToTargetChain(monitoredEoa, l1Weth, l2Token, depositAmount);
       const deposits = await adapter.bridges[l1Weth].queryL1BridgeInitiationEvents(
         l1Weth,
-        null,
+        monitoredEoa,
         monitoredEoa,
         searchConfig
       );

--- a/test/generic-adapters/zkSync.ts
+++ b/test/generic-adapters/zkSync.ts
@@ -214,14 +214,6 @@ describe("Cross Chain Adapter: zkSync", async function () {
             },
           },
         },
-        [hubPool.address]: {
-          [l1Weth]: {
-            [l2Weth.address]: {
-              depositTxHashes: [],
-              totalAmount: BigNumber.from(0),
-            },
-          },
-        },
       });
 
       // Make a single l1 -> l2 deposit.
@@ -264,14 +256,6 @@ describe("Cross Chain Adapter: zkSync", async function () {
             },
           },
         },
-        [hubPool.address]: {
-          [l1Weth]: {
-            [l2Weth.address]: {
-              depositTxHashes: [],
-              totalAmount: BigNumber.from(0),
-            },
-          },
-        },
       });
 
       // Finalise the ongoing deposit on the destination chain.
@@ -299,14 +283,6 @@ describe("Cross Chain Adapter: zkSync", async function () {
           },
         },
         [spokePool.address]: {
-          [l1Weth]: {
-            [l2Weth.address]: {
-              depositTxHashes: [],
-              totalAmount: BigNumber.from(0),
-            },
-          },
-        },
-        [hubPool.address]: {
           [l1Weth]: {
             [l2Weth.address]: {
               depositTxHashes: [],
@@ -377,14 +353,6 @@ describe("Cross Chain Adapter: zkSync", async function () {
             },
           },
         },
-        [hubPool.address]: {
-          [l1Weth]: {
-            [l2Weth.address]: {
-              depositTxHashes: [],
-              totalAmount: BigNumber.from(0),
-            },
-          },
-        },
       });
 
       // Make a single l1 -> l2 deposit.
@@ -427,14 +395,6 @@ describe("Cross Chain Adapter: zkSync", async function () {
             },
           },
         },
-        [hubPool.address]: {
-          [l1Weth]: {
-            [l2Weth.address]: {
-              depositTxHashes: [deposits[l2Weth.address][0].transactionHash],
-              totalAmount: deposits[l2Weth.address][0].amount,
-            },
-          },
-        },
       });
 
       // Finalise the ongoing deposit on the destination chain.
@@ -468,14 +428,6 @@ describe("Cross Chain Adapter: zkSync", async function () {
             },
           },
         },
-        [hubPool.address]: {
-          [l1Weth]: {
-            [l2Weth.address]: {
-              depositTxHashes: [],
-              totalAmount: BigNumber.from(0),
-            },
-          },
-        },
       });
     });
 
@@ -493,14 +445,6 @@ describe("Cross Chain Adapter: zkSync", async function () {
           },
         },
         [spokePool.address]: {
-          [l1Weth]: {
-            [l2Weth.address]: {
-              depositTxHashes: [],
-              totalAmount: BigNumber.from(0),
-            },
-          },
-        },
-        [hubPool.address]: {
           [l1Weth]: {
             [l2Weth.address]: {
               depositTxHashes: [],
@@ -534,14 +478,6 @@ describe("Cross Chain Adapter: zkSync", async function () {
           },
         },
         [spokePool.address]: {
-          [l1Weth]: {
-            [l2Weth.address]: {
-              depositTxHashes: [],
-              totalAmount: BigNumber.from(0),
-            },
-          },
-        },
-        [hubPool.address]: {
           [l1Weth]: {
             [l2Weth.address]: {
               depositTxHashes: [],

--- a/test/generic-adapters/zkSync.ts
+++ b/test/generic-adapters/zkSync.ts
@@ -214,6 +214,14 @@ describe("Cross Chain Adapter: zkSync", async function () {
             },
           },
         },
+        [hubPool.address]: {
+          [l1Weth]: {
+            [l2Weth.address]: {
+              depositTxHashes: [],
+              totalAmount: BigNumber.from(0),
+            },
+          },
+        },
       });
 
       // Make a single l1 -> l2 deposit.
@@ -256,6 +264,14 @@ describe("Cross Chain Adapter: zkSync", async function () {
             },
           },
         },
+        [hubPool.address]: {
+          [l1Weth]: {
+            [l2Weth.address]: {
+              depositTxHashes: [],
+              totalAmount: BigNumber.from(0),
+            },
+          },
+        },
       });
 
       // Finalise the ongoing deposit on the destination chain.
@@ -283,6 +299,14 @@ describe("Cross Chain Adapter: zkSync", async function () {
           },
         },
         [spokePool.address]: {
+          [l1Weth]: {
+            [l2Weth.address]: {
+              depositTxHashes: [],
+              totalAmount: BigNumber.from(0),
+            },
+          },
+        },
+        [hubPool.address]: {
           [l1Weth]: {
             [l2Weth.address]: {
               depositTxHashes: [],
@@ -353,6 +377,14 @@ describe("Cross Chain Adapter: zkSync", async function () {
             },
           },
         },
+        [hubPool.address]: {
+          [l1Weth]: {
+            [l2Weth.address]: {
+              depositTxHashes: [],
+              totalAmount: BigNumber.from(0),
+            },
+          },
+        },
       });
 
       // Make a single l1 -> l2 deposit.
@@ -395,6 +427,14 @@ describe("Cross Chain Adapter: zkSync", async function () {
             },
           },
         },
+        [hubPool.address]: {
+          [l1Weth]: {
+            [l2Weth.address]: {
+              depositTxHashes: [deposits[l2Weth.address][0].transactionHash],
+              totalAmount: deposits[l2Weth.address][0].amount,
+            },
+          },
+        },
       });
 
       // Finalise the ongoing deposit on the destination chain.
@@ -428,6 +468,14 @@ describe("Cross Chain Adapter: zkSync", async function () {
             },
           },
         },
+        [hubPool.address]: {
+          [l1Weth]: {
+            [l2Weth.address]: {
+              depositTxHashes: [],
+              totalAmount: BigNumber.from(0),
+            },
+          },
+        },
       });
     });
 
@@ -445,6 +493,14 @@ describe("Cross Chain Adapter: zkSync", async function () {
           },
         },
         [spokePool.address]: {
+          [l1Weth]: {
+            [l2Weth.address]: {
+              depositTxHashes: [],
+              totalAmount: BigNumber.from(0),
+            },
+          },
+        },
+        [hubPool.address]: {
           [l1Weth]: {
             [l2Weth.address]: {
               depositTxHashes: [],
@@ -478,6 +534,14 @@ describe("Cross Chain Adapter: zkSync", async function () {
           },
         },
         [spokePool.address]: {
+          [l1Weth]: {
+            [l2Weth.address]: {
+              depositTxHashes: [],
+              totalAmount: BigNumber.from(0),
+            },
+          },
+        },
+        [hubPool.address]: {
           [l1Weth]: {
             [l2Weth.address]: {
               depositTxHashes: [],


### PR DESCRIPTION
The monitor thought there were stuck rebalance roots for zkSync since the `ZkSyncWethBridge` was unable to track HubPool transfers. This is because the code was based off of an older version [here](https://github.com/across-protocol/relayer/blob/c2f847c90b024d6970b0306654e68968479348ab/src/clients/bridges/ZKSyncAdapter.ts#L74) which has since been updated. This PR makes the changes to allow the monitor to use the hubPool as a monitored address. 