### PR TITLE
feat: Log unprofitable fills in separate channel

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1190,6 +1190,7 @@ export class Relayer {
         at: "Relayer::handleUnprofitableFill",
         message: "Not relaying unprofitable deposits 🙅‍♂️!",
         mrkdwn,
+        notificationPath: "across-unprofitable-fills",
       });
     }
   }


### PR DESCRIPTION
The relayer channel should ideally only show successful fills
