### PR TITLE
improve(Relayer): Tune down lite chain repayment logs for rebalancer

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -590,12 +590,8 @@ export class InventoryClient {
     // chain, and the origin chain is not an eligible repayment chain, then we shouldn't fill this deposit otherwise
     // the filler will be forced to be over-allocated on the origin chain, which could be very difficult to withdraw
     // funds from.
+    // @dev The RHS of this conditional is essentially true if eligibleRefundChains does NOT deep equal [originChainid].
     if (deposit.fromLiteChain && (eligibleRefundChains.length !== 1 || !eligibleRefundChains.includes(originChainId))) {
-      this.logger.warn({
-        at: "InventoryClient#determineRefundChainId",
-        message: `Deposit ${deposit.depositId} originated on lite chain ${originChainId} and origin chain is over-allocated. Refusing to fill deposit.`,
-        eligibleRefundChains,
-      });
       return [];
     }
 

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -908,9 +908,12 @@ export class Relayer {
     const start = performance.now();
     const preferredChainIds = await inventoryClient.determineRefundChainId(deposit, hubPoolToken.address);
     if (preferredChainIds.length === 0) {
-      this.logger.info({
+      // @dev If the origin chain is a lite chain and there are no preferred repayment chains, then we can assume
+      // that the origin chain, the only possible repayment chain, is over-allocated. We should log this case because
+      // it is a special edge case the relayer should be aware of.
+      this.logger[this.config.sendingRelaysEnabled ? "warn" : "debug"]({
         at: "Relayer::resolveRepaymentChain",
-        message: `Unable to identify a preferred repayment chain for ${originChain} deposit ${depositId}.`,
+        message: deposit.fromLiteChain ? `Deposit ${depositId} originated from over-allocated lite chain` : `Unable to identify a preferred repayment chain for ${originChain} deposit ${depositId}.`,
         deposit,
       });
       return {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -913,7 +913,9 @@ export class Relayer {
       // it is a special edge case the relayer should be aware of.
       this.logger[this.config.sendingRelaysEnabled ? "warn" : "debug"]({
         at: "Relayer::resolveRepaymentChain",
-        message: deposit.fromLiteChain ? `Deposit ${depositId} originated from over-allocated lite chain` : `Unable to identify a preferred repayment chain for ${originChain} deposit ${depositId}.`,
+        message: deposit.fromLiteChain
+          ? `Deposit ${depositId} originated from over-allocated lite chain`
+          : `Unable to identify a preferred repayment chain for ${originChain} deposit ${depositId}.`,
         deposit,
       });
       return {


### PR DESCRIPTION
If Rebalancer, not Relayer, is running (i.e. config.sendingRelaysEnabled == false), then don't log about not being able to fill a deposit due to over allocation on lite chain.

Moreover, improve the logs by moving the informative log about over allocation from the inventory client to the relayer
