### PR TITLE
improve(relayer): Don't log ignored addresses on startup

### DIFF
--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -34,7 +34,9 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
     stop = true;
   });
 
-  logger[startupLogLevel(config)]({ at: "Relayer#run", message: "Relayer started 🏃‍♂️", config, relayerRun });
+  // Explicitly don't log ignoredAddresses because it can be huge and can overwhelm log transports.
+  const { ignoredAddresses: _ignoredConfig, ...loggedConfig } = config;
+  logger[startupLogLevel(config)]({ at: "Relayer#run", message: "Relayer started 🏃‍♂️", loggedConfig, relayerRun });
   const relayerClients = await constructRelayerClients(logger, config, baseSigner);
   const relayer = new Relayer(await baseSigner.getAddress(), logger, relayerClients, config);
 


### PR DESCRIPTION
These log messages can be very large and can kill the log transport.