### PR TITLE
improve(SpokePoolClient): Log on failed listener

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -88,6 +88,7 @@ export class IndexedSpokePoolClient extends clients.SpokePoolClient {
       stdio: ["ignore", "inherit", "inherit", "ipc"],
     });
 
+    this.worker.on("exit", (code, signal) => this.childExit(code, signal));
     this.worker.on("message", (message) => this.indexerUpdate(message));
     this.logger.debug({
       at: "SpokePoolClient#startWorker",
@@ -116,6 +117,26 @@ export class IndexedSpokePoolClient extends clients.SpokePoolClient {
         exitCode,
       });
     }
+  }
+
+  /**
+   * The worker process has exited. Future: Optionally restart it based on the exit code.
+   * See also: https://nodejs.org/api/child_process.html#event-exit
+   * @param code Optional exit code.
+   * @param signal Optional signal resulting in termination.
+   * @returns void
+   */
+  protected childExit(code?: number, signal?: string): void {
+    if (code === 0) {
+      return;
+    }
+
+    this.logger.warn({
+      at: "SpokePoolClient#childExit",
+      message: `${this.chain} SpokePool listener exited.`,
+      code,
+      signal,
+    });
   }
 
   /**


### PR DESCRIPTION
In the event that a child process terminates improperly, ensure that it is logged by the relayer. This will be extended in future to support restarting the listener process.