### PR TITLE
improve(relayer): take refunds on origin when filling on a lite chain.

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -555,8 +555,7 @@ export class InventoryClient {
       // It's undesirable to accrue excess balances on a Lite chain because the relayer relies on additional deposits
       // destined for that chain in order to offload its excess.
       const { targetOverageBuffer = DEFAULT_TOKEN_OVERAGE } = tokenConfig;
-      const isLiteChain = (deposit.toLiteChain && chainId === destinationChainId) || (deposit.fromLiteChain && chainId === originChainId);
-      const ignoreOverageBuffer = isLiteChain && chainId != originChainId;
+      const ignoreOverageBuffer = (deposit.toLiteChain && chainId === destinationChainId) && chainId != originChainId;
       const effectiveTargetPct = ignoreOverageBuffer ? tokenConfig.targetPct : tokenConfig.targetPct.mul(targetOverageBuffer).div(fixedPointAdjustment);
 
       this.log(

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -555,8 +555,10 @@ export class InventoryClient {
       // It's undesirable to accrue excess balances on a Lite chain because the relayer relies on additional deposits
       // destined for that chain in order to offload its excess.
       const { targetOverageBuffer = DEFAULT_TOKEN_OVERAGE } = tokenConfig;
-      const ignoreOverageBuffer = (deposit.toLiteChain && chainId === destinationChainId) && chainId != originChainId;
-      const effectiveTargetPct = ignoreOverageBuffer ? tokenConfig.targetPct : tokenConfig.targetPct.mul(targetOverageBuffer).div(fixedPointAdjustment);
+      const effectiveTargetPct =
+        deposit.toLiteChain && chainId === destinationChainId
+          ? tokenConfig.targetPct
+          : tokenConfig.targetPct.mul(targetOverageBuffer).div(fixedPointAdjustment);
 
       this.log(
         `Evaluated taking repayment on ${

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -555,7 +555,9 @@ export class InventoryClient {
       // It's undesirable to accrue excess balances on a Lite chain because the relayer relies on additional deposits
       // destined for that chain in order to offload its excess.
       const { targetOverageBuffer = DEFAULT_TOKEN_OVERAGE } = tokenConfig;
-      const effectiveTargetPct = tokenConfig.targetPct.mul(targetOverageBuffer).div(fixedPointAdjustment);
+      const isLiteChain = (deposit.toLiteChain && chainId === destinationChainId) || (deposit.fromLiteChain && chainId === originChainId);
+      const ignoreOverageBuffer = isLiteChain && chainId != originChainId;
+      const effectiveTargetPct = ignoreOverageBuffer ? tokenConfig.targetPct : tokenConfig.targetPct.mul(targetOverageBuffer).div(fixedPointAdjustment);
 
       this.log(
         `Evaluated taking repayment on ${


### PR DESCRIPTION
We will sometimes take repayments on on lite chains for routes from non-lite chains to lite chains. This is undesirable since it requires the relayer to manually pull funds back via the canonical bridge. We should prioritize taking repayment on non-lite chains whenever possible, so this PR makes the inventory client always select either a slow repayment chain or the origin chain when filling on a lite chain.