### PR TITLE
fix(relayer): Lower log severity on listener SIGKILL

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -131,7 +131,7 @@ export class IndexedSpokePoolClient extends clients.SpokePoolClient {
       return;
     }
 
-    this.logger.warn({
+    this.logger[signal === "SIGKILL" ? "debug" : "warn"]({
       at: "SpokePoolClient#childExit",
       message: `${this.chain} SpokePool listener exited.`,
       code,


### PR DESCRIPTION
This is normal behaviour but it's interesting to know if the parent does not register that the child exits, so continue to log on SIGKILL but at a lower log severity.