### PR TITLE
improve(Relayer): Reduce size of overallocated-lite-chain log and send to special channel

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -916,7 +916,7 @@ export class Relayer {
         message: deposit.fromLiteChain
           ? `Deposit ${depositId} originated from over-allocated lite chain`
           : `Unable to identify a preferred repayment chain for ${originChain} deposit ${depositId}.`,
-        deposit,
+        notificationPath: "across-unprofitable-fills",
       });
       return {
         repaymentChainProfitability: {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -914,8 +914,9 @@ export class Relayer {
       this.logger[this.config.sendingRelaysEnabled ? "warn" : "debug"]({
         at: "Relayer::resolveRepaymentChain",
         message: deposit.fromLiteChain
-          ? `Deposit ${depositId} originated from over-allocated lite chain`
+          ? `Deposit ${depositId} originated from over-allocated lite chain ${originChain}`
           : `Unable to identify a preferred repayment chain for ${originChain} deposit ${depositId}.`,
+        txn: blockExplorerLink(transactionHash, originChainId),
         notificationPath: "across-unprofitable-fills",
       });
       return {


### PR DESCRIPTION
No reason to log the full deposit object, and send to unprofitable fill channel. You can argue that an over allocated lite chain produces deposits that are unprofitable from a rebalancing perspective to fill
