### PR TITLE
fix(BundleDataClient): Don't mark deposits in the future as invalid

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -762,43 +762,40 @@ export class BundleDataClient {
           continue;
         }
 
-        originClient
-          .getDepositsForDestinationChain(destinationChainId)
-          .filter((deposit) => deposit.blockNumber <= originChainBlockRange[1])
-          .forEach((deposit) => {
-            depositCounter++;
-            const relayDataHash = this.getRelayHashFromEvent(deposit);
-            if (v3RelayHashes[relayDataHash]) {
-              // If we've seen this deposit before, then skip this deposit. This can happen if our RPC provider
-              // gives us bad data.
-              return;
-            }
-            // Even if deposit is not in bundle block range, store all deposits we can see in memory in this
-            // convenient dictionary.
-            v3RelayHashes[relayDataHash] = {
-              deposit: deposit,
-              fill: undefined,
-              slowFillRequest: undefined,
-            };
+        originClient.getDepositsForDestinationChain(destinationChainId).forEach((deposit) => {
+          depositCounter++;
+          const relayDataHash = this.getRelayHashFromEvent(deposit);
+          if (v3RelayHashes[relayDataHash]) {
+            // If we've seen this deposit before, then skip this deposit. This can happen if our RPC provider
+            // gives us bad data.
+            return;
+          }
+          // Even if deposit is not in bundle block range, store all deposits we can see in memory in this
+          // convenient dictionary.
+          v3RelayHashes[relayDataHash] = {
+            deposit: deposit,
+            fill: undefined,
+            slowFillRequest: undefined,
+          };
 
-            // If deposit block is within origin chain bundle block range, then save as bundle deposit.
-            // If deposit is in bundle and it has expired, additionally save it as an expired deposit.
-            // If deposit is not in the bundle block range, then save it as an older deposit that
-            // may have expired.
-            if (deposit.blockNumber >= originChainBlockRange[0]) {
-              // Deposit is a V3 deposit in this origin chain's bundle block range and is not a duplicate.
-              updateBundleDepositsV3(bundleDepositsV3, deposit);
-              // We don't check that fillDeadline >= bundleBlockTimestamps[destinationChainId][0] because
-              // that would eliminate any deposits in this bundle with a very low fillDeadline like equal to 0
-              // for example. Those should be impossible to create but technically should be included in this
-              // bundle of refunded deposits.
-              if (deposit.fillDeadline < bundleBlockTimestamps[destinationChainId][1]) {
-                expiredBundleDepositHashes.add(relayDataHash);
-              }
-            } else {
-              olderDepositHashes.add(relayDataHash);
+          // If deposit block is within origin chain bundle block range, then save as bundle deposit.
+          // If deposit is in bundle and it has expired, additionally save it as an expired deposit.
+          // If deposit is not in the bundle block range, then save it as an older deposit that
+          // may have expired.
+          if (deposit.blockNumber >= originChainBlockRange[0] && deposit.blockNumber <= originChainBlockRange[1]) {
+            // Deposit is a V3 deposit in this origin chain's bundle block range and is not a duplicate.
+            updateBundleDepositsV3(bundleDepositsV3, deposit);
+            // We don't check that fillDeadline >= bundleBlockTimestamps[destinationChainId][0] because
+            // that would eliminate any deposits in this bundle with a very low fillDeadline like equal to 0
+            // for example. Those should be impossible to create but technically should be included in this
+            // bundle of refunded deposits.
+            if (deposit.fillDeadline < bundleBlockTimestamps[destinationChainId][1]) {
+              expiredBundleDepositHashes.add(relayDataHash);
             }
-          });
+          } else if (deposit.blockNumber < originChainBlockRange[0]) {
+            olderDepositHashes.add(relayDataHash);
+          }
+        });
       }
     }
     this.logger.debug({

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -579,3 +579,5 @@ export const DEFAULT_GAS_MULTIPLIER: { [chainId: number]: number } = {
   [CHAIN_IDs.REDSTONE]: 1.5,
   [CHAIN_IDs.ZORA]: 1.5,
 };
+
+export const CONSERVATIVE_BUNDLE_FREQUENCY_SECONDS = 3 * 60 * 60; // 3 hours is a safe assumption for the time

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { utils, interfaces, caching } from "@across-protocol/sdk";
 import { SpokePoolClient } from "../clients";
-import { spokesThatHoldEthAndWeth } from "../common/Constants";
+import { CONSERVATIVE_BUNDLE_FREQUENCY_SECONDS, spokesThatHoldEthAndWeth } from "../common/Constants";
 import { CONTRACT_ADDRESSES } from "../common/ContractAddresses";
 import {
   PoolRebalanceLeaf,
@@ -132,8 +132,8 @@ export async function blockRangesAreInvalidForSpokeClients(
       // In this case, we have all the information for this SpokePool possible so there are no older deposits
       // that might have expired that we might miss.
       const conservativeBundleFrequencySeconds = Number(
-        process.env.CONSERVATIVE_BUNDLE_FREQUENCY_SECONDS ?? 3 * 60 * 60
-      ); // 3 hours.
+        process.env.CONSERVATIVE_BUNDLE_FREQUENCY_SECONDS ?? CONSERVATIVE_BUNDLE_FREQUENCY_SECONDS
+      );
       if (
         spokePoolClient.eventSearchConfig.fromBlock > spokePoolClient.deploymentBlock &&
         // @dev The maximum lookback window we need to evaluate expired deposits is the max fill deadline buffer,

--- a/test/Dataworker.blockRangeUtils.ts
+++ b/test/Dataworker.blockRangeUtils.ts
@@ -11,6 +11,7 @@ import { getDeployedBlockNumber } from "@across-protocol/contracts";
 import { MockHubPoolClient, MockSpokePoolClient } from "./mocks";
 import { getTimestampsForBundleEndBlocks } from "../src/utils/BlockUtils";
 import { assert } from "../src/utils";
+import { CONSERVATIVE_BUNDLE_FREQUENCY_SECONDS } from "../src/common";
 
 let dataworkerClients: DataworkerClients;
 let spokePoolClients: { [chainId: number]: SpokePoolClient };
@@ -314,8 +315,9 @@ describe("Dataworker block range-related utility methods", async function () {
     ).to.equal(false);
 
     // Set oldest time older such that fill deadline buffer now exceeds the time between the end block and the oldest
-    // time. Block ranges should now be valid.
-    const oldestBlockTimestampOverride = endBlockTimestamps[originChainId] - fillDeadlineOverride - 1;
+    // time plus the conservative bundle time. Block ranges should now be valid.
+    const oldestBlockTimestampOverride =
+      endBlockTimestamps[originChainId] - fillDeadlineOverride - CONSERVATIVE_BUNDLE_FREQUENCY_SECONDS - 1;
     assert(oldestBlockTimestampOverride > 0, "unrealistic oldest block timestamp");
     mockSpokePoolClient.setOldestBlockTimestampOverride(oldestBlockTimestampOverride);
     expect(


### PR DESCRIPTION
Bundle data client incorrectly marks a deposit as invalid when its origin chain block number is greater than the origin chain bundle end block
- This bug was discovered after https://github.com/across-protocol/relayer/commit/aa1ec0d4b9fe6f902be298632dd01e786e07c17c was deployed and it marked a deposit as invalid. Ironically, it wasn't a deposit that was too old that was triggered an invalid fill, but a deposit that was in the future that was ignored
- I would label this as a fix for a long-standing bug

Separately, increase lookback required for spoke pool clients to better accomodate situation where a fill is sent well after a deposit was mined but before it expired.
- This is a follow up to https://github.com/across-protocol/relayer/commit/aa1ec0d4b9fe6f902be298632dd01e786e07c17c
