### PR TITLE
fix(relayer): Don't log config on startup

### DIFF
--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -1,13 +1,5 @@
 import { utils as sdkUtils } from "@across-protocol/sdk";
-import {
-  config,
-  delay,
-  disconnectRedisClients,
-  getCurrentTime,
-  getNetworkName,
-  Signer,
-  winston,
-} from "../utils";
+import { config, delay, disconnectRedisClients, getCurrentTime, getNetworkName, Signer, winston } from "../utils";
 import { Relayer } from "./Relayer";
 import { RelayerConfig } from "./RelayerConfig";
 import { constructRelayerClients, updateRelayerClients } from "./RelayerClientHelper";

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -36,7 +36,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
 
   // Explicitly don't log ignoredAddresses because it can be huge and can overwhelm log transports.
   const { ignoredAddresses: _ignoredConfig, ...loggedConfig } = config;
-  logger[startupLogLevel(config)]({ at: "Relayer#run", message: "Relayer started 🏃‍♂️", loggedConfig, relayerRun });
+  logger.debug({ at: "Relayer#run", message: "Relayer started 🏃‍♂️", loggedConfig, relayerRun });
   const relayerClients = await constructRelayerClients(logger, config, baseSigner);
   const relayer = new Relayer(await baseSigner.getAddress(), logger, relayerClients, config);
 

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -6,7 +6,6 @@ import {
   getCurrentTime,
   getNetworkName,
   Signer,
-  startupLogLevel,
   winston,
 } from "../utils";
 import { Relayer } from "./Relayer";


### PR DESCRIPTION
This log message is too large and is overwhelming the Slack logging transport. Drop it for now to see whether relayer behaviour improves.