### PR TITLE
fix: ignore logsBloom field for eth_getBlockByNumber rpc

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -134,7 +134,7 @@ function compareRpcResults(method: string, rpcResultA: unknown, rpcResultB: unkn
         "l1BatchTimestamp", // zkSync
         "size", // Alchemy/Arbitrum (temporary)
         "totalDifficulty", // Quicknode/Alchemy (sometimes)
-        "logsBloom", // zkSync
+        "logsBloom", // zkSync (third-party providers return 0x0..0)
       ],
       rpcResultA as Record<string, unknown>,
       rpcResultB as Record<string, unknown>

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -134,6 +134,7 @@ function compareRpcResults(method: string, rpcResultA: unknown, rpcResultB: unkn
         "l1BatchTimestamp", // zkSync
         "size", // Alchemy/Arbitrum (temporary)
         "totalDifficulty", // Quicknode/Alchemy (sometimes)
+        "logsBloom", // zkSync
       ],
       rpcResultA as Record<string, unknown>,
       rpcResultB as Record<string, unknown>


### PR DESCRIPTION
The zkSync public provider is returning different results than the Alchemy and Quicknode providers since the `logsBloom` field is non-empty. 
To reproduce, run `cast rpc eth_getBlockByNumber 0x28d20b6 false --rpc-url $RPC`.
Public zkSync logsBloom:
```
0x00000000000400000000202000200000000000000000000200001000006810000000004000200000380000440028000000010000000002000400000000600200000284000108040000400008000050000000000010000120002400000002080000000000020010000000000050000904004000000600000000400050000000000000002000000000000004200004010120000000006000100004020000000100022001200100100000100000000014200000000000000801000000000000400000001002008400000001000040600800000000800000000000028000000020000410004000000050000000000000000000008100908800000000244000043000
```
Alchemy/Quicknode logsBloom (all zeros):
```
0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```