### PR TITLE
refactor(relayer): Drop SKIP_RELAYS env configurable

### DIFF
--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -31,9 +31,6 @@ export class RelayerConfig extends CommonConfig {
   readonly indexerPath: string;
   readonly inventoryConfig: InventoryConfig;
   readonly debugProfitability: boolean;
-  // Whether token price fetch failures will be ignored when computing relay profitability.
-  // If this is false, the relayer will throw an error when fetching prices fails.
-  readonly skipRelays: boolean;
   readonly skipRebalancing: boolean;
   readonly sendingRelaysEnabled: boolean;
   readonly sendingRebalancesEnabled: boolean;
@@ -79,7 +76,6 @@ export class RelayerConfig extends CommonConfig {
       SEND_RELAYS,
       SEND_REBALANCES,
       SEND_MESSAGE_RELAYS,
-      SKIP_RELAYS,
       SKIP_REBALANCING,
       SEND_SLOW_RELAYS,
       MIN_RELAYER_FEE_PCT,
@@ -249,7 +245,6 @@ export class RelayerConfig extends CommonConfig {
     this.sendingRelaysEnabled = SEND_RELAYS === "true";
     this.sendingRebalancesEnabled = SEND_REBALANCES === "true";
     this.sendingMessageRelaysEnabled = SEND_MESSAGE_RELAYS === "true";
-    this.skipRelays = SKIP_RELAYS === "true";
     this.skipRebalancing = SKIP_REBALANCING === "true";
     this.sendingSlowRelaysEnabled = SEND_SLOW_RELAYS === "true";
     this.acceptInvalidFills = ACCEPT_INVALID_FILLS === "true";

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -30,6 +30,8 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
   logger.debug({ at: "Relayer#run", message: "Relayer started 🏃‍♂️", loggedConfig, relayerRun });
   const relayerClients = await constructRelayerClients(logger, config, baseSigner);
   const relayer = new Relayer(await baseSigner.getAddress(), logger, relayerClients, config);
+  const simulate = !config.sendingRelaysEnabled;
+  const enableSlowFills = config.sendingSlowRelaysEnabled;
 
   let run = 1;
   let txnReceipts: { [chainId: number]: Promise<string[]> };
@@ -46,13 +48,10 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
       }
       await updateRelayerClients(relayerClients, config);
 
-      if (!config.skipRelays) {
-        // Since the above spoke pool updates are slow, refresh token client before sending rebalances now:
-        relayerClients.tokenClient.clearTokenData();
-        await relayerClients.tokenClient.update();
-        const simulate = !config.sendingRelaysEnabled;
-        txnReceipts = await relayer.checkForUnfilledDepositsAndFill(config.sendingSlowRelaysEnabled, simulate);
-      }
+      // Since the above spoke pool updates are slow, refresh token client before sending rebalances now:
+      relayerClients.tokenClient.clearTokenData();
+      await relayerClients.tokenClient.update();
+      txnReceipts = await relayer.checkForUnfilledDepositsAndFill(enableSlowFills, simulate);
 
       // Unwrap WETH after filling deposits so we don't mess up slow fill logic, but before rebalancing
       // any tokens so rebalancing can take into account unwrapped WETH balances.


### PR DESCRIPTION
This is not used in prod and it introduces unnecessary branching logic, so drop it to enable some subsequent refactoring.