### PR TITLE
refactor(relayer): Add one-time relayer init

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -69,6 +69,23 @@ export class Relayer {
   }
 
   /**
+   * @description Perform one-time relayer init. Handle (for example) token approvals.
+   */
+  async init(): Promise<void> {
+    const { tokenClient } = this.clients;
+    await tokenClient.update();
+
+    if (this.config.sendingRelaysEnabled) {
+      await tokenClient.setOriginTokenApprovals();
+    }
+
+    this.logger.debug({
+      at: "Relayer::init",
+      message: "Completed one-time init."
+    });
+  }
+
+  /**
    * @description For a given deposit, apply relayer-specific filtering to determine whether it should be filled.
    * @param deposit Deposit object.
    * @param version Version identified for this deposit.

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -81,7 +81,7 @@ export class Relayer {
 
     this.logger.debug({
       at: "Relayer::init",
-      message: "Completed one-time init."
+      message: "Completed one-time init.",
     });
   }
 

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -51,6 +51,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
         await relayerClients.hubPoolClient.update();
         await tokenClient.update();
       }
+
       // SpokePoolClient client requires up to date HubPoolClient and ConfigStore client.
       // TODO: the code below can be refined by grouping with promise.all. however you need to consider the inter
       // dependencies of the clients. some clients need to be updated before others. when doing this refactor consider


### PR DESCRIPTION
This ensures that token approvals are in place for all tokens held by the relayer EOA. For 99.999% of the time it's fine to do this once on startup; it doesn't need to be repeated on each loop.

This also removes a redundant tokenClient.update() call that is being performed on each loop.