### PR TITLE
fix(relayer): Skip logging contract object on eth wrap

### DIFF
--- a/src/adapter/BaseChainAdapter.ts
+++ b/src/adapter/BaseChainAdapter.ts
@@ -219,7 +219,12 @@ export class BaseChainAdapter {
     const augmentedTxn = { contract, chainId: this.chainId, method, args: [], value, mrkdwn, message };
     if (simMode) {
       const { succeed, reason } = (await this.transactionClient.simulate([augmentedTxn]))[0];
-      this.log("Simulation result", { succeed, reason, contract, value }, "debug", "wrapEthIfAboveThreshold");
+      this.log(
+        "Simulation result",
+        { succeed, reason, contract: contract.address, value },
+        "debug",
+        "wrapEthIfAboveThreshold"
+      );
       return { hash: ZERO_ADDRESS } as TransactionResponse;
     } else {
       (await this.transactionClient.submit(this.chainId, [augmentedTxn]))[0];


### PR DESCRIPTION
The contract object is quite large and seems to be upsetting the logger
\- potentially due to recursion when unpacking the JSON object. There's
no need to log the contract anyway; the intention is only to log the
address.