### PR TITLE
fix: set default logger for retry providers

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -3,7 +3,7 @@ import { providers as sdkProviders } from "@across-protocol/sdk";
 import { ethers } from "ethers";
 import winston from "winston";
 import { CHAIN_CACHE_FOLLOW_DISTANCE, DEFAULT_NO_TTL_DISTANCE } from "../common";
-import { delay, getOriginFromURL } from "./";
+import { delay, getOriginFromURL, Logger } from "./";
 import { getRedisCache } from "./RedisUtils";
 import { isDefined } from "./TypeGuards";
 
@@ -45,7 +45,11 @@ export function getChainQuorum(chainId: number): number {
  * with a redis client attached so that all RPC requests are cached. Will load the provider from an in memory
  * "provider cache" if this function was called once before with the same chain ID.
  */
-export async function getProvider(chainId: number, logger?: winston.Logger, useCache = true): Promise<RetryProvider> {
+export async function getProvider(
+  chainId: number,
+  logger: winston.Logger = Logger,
+  useCache = true
+): Promise<RetryProvider> {
   const redisClient = await getRedisCache(logger);
   if (useCache) {
     const cachedProvider = providerCache[getProviderCacheKey(chainId, redisClient !== undefined)];


### PR DESCRIPTION
`logger` used to be globally defined in the `ProviderUtils` file. See [here](https://github.com/across-protocol/relayer/blob/955d2da9c373143ecb4e6ed1c8a383d0acd5006b/src/utils/ProviderUtils.ts#L19) and [here](https://github.com/across-protocol/relayer/blob/955d2da9c373143ecb4e6ed1c8a383d0acd5006b/src/utils/ProviderUtils.ts#L504)

As for most of the `getProvider` calls we are not explicitly setting the logger (see [here](https://github.com/across-protocol/relayer/blob/mguevara/default-logger/src/libexec/RelayerSpokePoolIndexer.ts#L226) for example), we should set a default logger for the `RetryProvider`.