### PR TITLE
fix(relayer): Don't prematurely mark deposits as filled

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -592,12 +592,12 @@ export class Relayer {
     const { depositId, depositor, recipient, destinationChainId, originChainId, inputToken, transactionHash } = deposit;
     const { hubPoolClient, profitClient, spokePoolClients, tokenClient } = this.clients;
     const { slowDepositors } = this.config;
-    const dstChain = getNetworkName(destinationChainId);
+    const [originChain, destChain] = [getNetworkName(originChainId), getNetworkName(destinationChainId)];
 
     if (isDefined(this.pendingTxnReceipts[destinationChainId])) {
       this.logger.info({
         at: "Relayer::evaluateFill",
-        message: `${dstChain} transaction queue has pending fills; skipping...`,
+        message: `${destChain} transaction queue has pending fills; skipping ${originChain} deposit ${depositId}...`,
         originChainId,
         depositId,
         transactionHash,
@@ -606,7 +606,6 @@ export class Relayer {
     }
 
     // If the deposit does not meet the minimum number of block confirmations, skip it.
-    const originChain = getNetworkName(originChainId);
     if (deposit.blockNumber > maxBlockNumber) {
       this.logger.debug({
         at: "Relayer::evaluateFill",
@@ -646,7 +645,7 @@ export class Relayer {
       if (minFillTime > depositAge) {
         this.logger.debug({
           at: "Relayer::evaluateFill",
-          message: `Skipping ${originChain} deposit due to insufficient fill time for ${dstChain}.`,
+          message: `Skipping ${originChain} deposit due to insufficient fill time for ${destChain}.`,
           depositAge,
           minFillTime,
           transactionHash,


### PR DESCRIPTION
Per current implementation, the relayer can prematurely mark a deposit as filled if it _intends_ to fill it. This can however be derailed in the event that the destination chain has pending fills, in which case the fill transaction is discarded. This creates problems for fill status tracking, which is otherwise marked at the time the transaction is enqueued.

The simple fix is to filter candidate deposits by whether their destination chain has pending fills. A more optimised version, which might follow, would apply a pending status for these fills and would apply that pending status at the time of transaction submission. That's more complex for an (at best) marginal benefit, so proceed with the simple solution for now.