### PR TITLE
chore: Bump SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.14",
     "@across-protocol/contracts": "^3.0.10",
-    "@across-protocol/sdk": "^3.1.34",
+    "@across-protocol/sdk": "^3.1.36",
     "@arbitrum/sdk": "^3.1.3",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,15 +50,16 @@
     axios "^1.6.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.1.34":
-  version "3.1.34"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.1.34.tgz#b4f641fea762e8c3d27b344b85ac6351a13e1f49"
-  integrity sha512-7ryd+gx4I4AZBT3BHbOGZqhdRSFgCtoaiDS8JytqHqyrsoNnE02jOElj1JF4UarhG+ABp/ywbQFXs3Tr64tPvA==
+"@across-protocol/sdk@^3.1.36":
+  version "3.1.36"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.1.36.tgz#8187f4771ca68f14c165033f0c6cc6e35e211919"
+  integrity sha512-Im9ELYj+m0WMow1zUWYerU5v+A+Tpty2jC/7pUSI2pMnHn/mdAWmMoL/EKMqpaxMFucGw6d4fUb1EvLeazBqlg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.14"
     "@across-protocol/contracts" "^3.0.10"
     "@eth-optimism/sdk" "^3.3.1"
+    "@ethersproject/bignumber" "^5.7.0"
     "@pinata/sdk" "^2.1.0"
     "@types/mocha" "^10.0.1"
     "@uma/sdk" "^0.34.1"


### PR DESCRIPTION
Primarily for some Polygon GasStation updates, which will support troubleshooting of the GasStation API and will also enforce a floor on the Polygon PoS priority fee in the event that the GasStation times out.