### PR TITLE
fix(validateRootBundle): Bump DATAWORKER_FAST_LOOKBACK_COUNT

### DIFF
--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -48,7 +48,7 @@ export async function validate(_logger: winston.Logger, baseSigner: Signer): Pro
   // enough data to limit # of excess historical deposit queries.
   // - SPOKE_ROOTS_LOOKBACK_COUNT unused in this script so set to something < DATAWORKER_FAST_LOOKBACK_COUNT
   // to avoid configuration error.
-  process.env.DATAWORKER_FAST_LOOKBACK_COUNT = "8";
+  process.env.DATAWORKER_FAST_LOOKBACK_COUNT = "10";
   process.env.SPOKE_ROOTS_LOOKBACK_COUNT = "1";
   const { clients, config, dataworker } = await createDataworker(logger, baseSigner);
   logger[startupLogLevel(config)]({


### PR DESCRIPTION
The Dataworker complains that 8 bundles is insufficient to cover the 6
hour fillDeadlineBuffer with a 1 hour challenge window, so bump it to 10.