### PR TITLE
fix: do not submit multicall transactions with no calldata

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -633,7 +633,8 @@ export class TryMulticallClient extends MultiCallerClient {
           mrkdwn: mrkdwn.join(""),
         };
       };
-      txnRequestsToSubmit.push(...txnCalldataToRebuild.map(rebuildTryMulticall));
+      const tryMulticallTxns = txnCalldataToRebuild.filter((txn) => txn.calldata.length !== 0).map(rebuildTryMulticall);
+      txnRequestsToSubmit.push(...tryMulticallTxns);
     }
 
     if (simulate) {


### PR DESCRIPTION
This should prevent submitting transactions when we build a tryMulticall and all internal transactions revert in simulation.