### PR TITLE
refactor: Replace ethers Event with Log

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,10 @@ module.exports = {
       "error",
       {
         patterns: [{ group: ["@ethersproject/bignumber"], message: "Use 'src/utils/BNUtils' instead" }],
-        paths: [{ name: "ethers", importNames: ["BigNumber"], message: "Use 'src/utils/BNUtils' instead" }],
+        paths: [
+          { name: "ethers", importNames: ["BigNumber"], message: "Use 'src/utils/BNUtils' instead" },
+          { name: "ethers", importNames: ["Event"], message: "Use Log from 'src/interfaces/Common' instead" },
+        ],
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.14",
     "@across-protocol/contracts": "^3.0.10",
-    "@across-protocol/sdk": "^3.1.36",
+    "@across-protocol/sdk": "^3.1.37",
     "@arbitrum/sdk": "^3.1.3",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.14",
     "@across-protocol/contracts": "^3.0.10",
-    "@across-protocol/sdk": "^3.1.37",
+    "@across-protocol/sdk": "^3.2.0",
     "@arbitrum/sdk": "^3.1.3",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/src/adapter/bridges/OpStackWethBridge.ts
+++ b/src/adapter/bridges/OpStackWethBridge.ts
@@ -5,11 +5,11 @@ import {
   paginatedEventQuery,
   Signer,
   Provider,
-  Event,
   ZERO_ADDRESS,
   TOKEN_SYMBOLS_MAP,
 } from "../../utils";
 import { CONTRACT_ADDRESSES } from "../../common";
+import { Log } from "../../interfaces";
 import { matchL2EthDepositAndWrapEvents, processEvent } from "../utils";
 import { utils } from "@across-protocol/sdk";
 import { BridgeTransactionDetails, BaseBridgeAdapter, BridgeEvents } from "./BaseBridgeAdapter";
@@ -67,7 +67,7 @@ export class OpStackWethBridge extends BaseBridgeAdapter {
     });
   }
 
-  private convertEventListToBridgeEvents(events: Event[]): BridgeEvents {
+  private convertEventListToBridgeEvents(events: Log[]): BridgeEvents {
     return {
       [this.resolveL2TokenAddress(TOKEN_SYMBOLS_MAP.WETH.addresses[this.hubChainId])]: events.map((event) =>
         processEvent(event, "_amount", "_to", "_from")
@@ -176,7 +176,7 @@ export class OpStackWethBridge extends BaseBridgeAdapter {
     fromAddress: string,
     eventConfig: EventSearchConfig,
     l2Weth = this.l2Weth
-  ): Promise<Event[]> {
+  ): Promise<Log[]> {
     return paginatedEventQuery(l2Weth, l2Weth.filters.Deposit(fromAddress), eventConfig);
   }
 }

--- a/src/adapter/utils.ts
+++ b/src/adapter/utils.ts
@@ -1,4 +1,3 @@
-import { Event } from "ethers";
 import { TOKEN_APPROVALS_TO_FIRST_ZERO } from "../common";
 import {
   BigNumber,
@@ -13,7 +12,7 @@ import {
   winston,
 } from "../utils";
 import { BridgeEvent } from "./bridges/BaseBridgeAdapter";
-import { SortableEvent } from "../interfaces";
+import { Log, SortableEvent } from "../interfaces";
 import { ExpandedERC20 } from "@across-protocol/contracts";
 
 export {
@@ -55,7 +54,7 @@ export async function approveTokens(
   return ["*Approval transactions:*", ...approvalMarkdwn].join("\n");
 }
 
-export function processEvent(event: Event, amountField: string, toField: string, fromField: string): BridgeEvent {
+export function processEvent(event: Log, amountField: string, toField: string, fromField: string): BridgeEvent {
   const eventSpread = spreadEventWithBlockNumber(event) as SortableEvent & {
     amount: BigNumber;
     to: string;

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -1,7 +1,8 @@
 import assert from "assert";
 import { ChildProcess, spawn } from "child_process";
-import { Contract, Event } from "ethers";
+import { Contract } from "ethers";
 import { clients, utils as sdkUtils } from "@across-protocol/sdk";
+import { Log } from "../interfaces";
 import { CHAIN_MAX_BLOCK_LOOKBACK, RELAYER_DEFAULT_SPOKEPOOL_INDEXER } from "../common/Constants";
 import { EventSearchConfig, getNetworkName, isDefined, MakeOptional, winston } from "../utils";
 import { EventsAddedMessage, EventRemovedMessage } from "../utils/SuperstructUtils";
@@ -43,8 +44,8 @@ export class IndexedSpokePoolClient extends clients.SpokePoolClient {
   private pendingCurrentTime: number;
   private pendingOldestTime: number;
 
-  private pendingEvents: Event[][];
-  private pendingEventsRemoved: Event[];
+  private pendingEvents: Log[][];
+  private pendingEventsRemoved: Log[];
 
   constructor(
     readonly logger: winston.Logger,
@@ -194,7 +195,7 @@ export class IndexedSpokePoolClient extends clients.SpokePoolClient {
    * @param event An Ethers event instance.
    * @returns void
    */
-  protected removeEvent(event: Event): boolean {
+  protected removeEvent(event: Log): boolean {
     let removed = false;
     const eventIdx = this.queryableEventNames.indexOf(event.event);
     const pendingEvents = this.pendingEvents[eventIdx];

--- a/src/clients/TokenTransferClient.ts
+++ b/src/clients/TokenTransferClient.ts
@@ -3,12 +3,11 @@ import {
   winston,
   assign,
   ERC20,
-  Event,
   Contract,
   paginatedEventQuery,
   spreadEventWithBlockNumber,
 } from "../utils";
-import { TokenTransfer, TransfersByChain } from "../interfaces";
+import { Log, TokenTransfer, TransfersByChain } from "../interfaces";
 import { Provider } from "@ethersproject/abstract-provider";
 
 export class TokenTransferClient {
@@ -52,7 +51,7 @@ export class TokenTransferClient {
             this.querySendAndReceiveEvents(tokenContract, monitoredAddress, searchConfigByChainIds[chainId])
           )
         );
-        const transferEventsPerToken: { [tokenAddress: string]: Event[][] } = Object.fromEntries(
+        const transferEventsPerToken: { [tokenAddress: string]: Log[][] } = Object.fromEntries(
           transferEventsList.map((transferEvents, i) => [tokenContracts[i].address, transferEvents])
         );
 
@@ -89,7 +88,7 @@ export class TokenTransferClient {
   }
 
   // Returns outgoing and incoming transfers for the specified tokenContract and address.
-  querySendAndReceiveEvents(tokenContract: Contract, address: string, config: EventSearchConfig): Promise<Event[][]> {
+  querySendAndReceiveEvents(tokenContract: Contract, address: string, config: EventSearchConfig): Promise<Log[][]> {
     const eventFilters = [[address], [undefined, address]];
     return Promise.all(
       eventFilters.map((eventFilter) =>

--- a/src/clients/bridges/op-stack/OpStackAdapter.ts
+++ b/src/clients/bridges/op-stack/OpStackAdapter.ts
@@ -7,7 +7,6 @@ import {
   BigNumberish,
   bnZero,
   TransactionResponse,
-  Event,
   checkAddressChecksum,
   spreadEventWithBlockNumber,
   assign,
@@ -16,7 +15,7 @@ import {
 } from "../../../utils";
 import { SpokePoolClient } from "../../";
 import { BaseAdapter } from "../";
-import { SortableEvent, OutstandingTransfers } from "../../../interfaces";
+import { Log, SortableEvent, OutstandingTransfers } from "../../../interfaces";
 import { OpStackBridge } from "./OpStackBridgeInterface";
 import { WethBridge } from "./WethBridge";
 import { DefaultERC20Bridge } from "./DefaultErc20Bridge";
@@ -82,7 +81,7 @@ export class OpStackAdapter extends BaseAdapter {
     const { l1SearchConfig, l2SearchConfig } = this.getUpdatedSearchConfigs();
     const availableL1Tokens = this.filterSupportedTokens(l1Tokens);
 
-    const processEvent = (event: Event) => {
+    const processEvent = (event: Log) => {
       const eventSpread = spreadEventWithBlockNumber(event) as SortableEvent & {
         _amount: BigNumberish;
         _to: string;

--- a/src/clients/bridges/op-stack/OpStackBridgeInterface.ts
+++ b/src/clients/bridges/op-stack/OpStackBridgeInterface.ts
@@ -1,12 +1,5 @@
 import { Log } from "../../../interfaces";
-import {
-  Contract,
-  BigNumber,
-  EventSearchConfig,
-  Signer,
-  Provider,
-  getTranslatedTokenAddress,
-} from "../../../utils";
+import { Contract, BigNumber, EventSearchConfig, Signer, Provider, getTranslatedTokenAddress } from "../../../utils";
 
 export interface BridgeTransactionDetails {
   readonly contract: Contract;

--- a/src/clients/bridges/op-stack/OpStackBridgeInterface.ts
+++ b/src/clients/bridges/op-stack/OpStackBridgeInterface.ts
@@ -1,7 +1,7 @@
+import { Log } from "../../../interfaces";
 import {
   Contract,
   BigNumber,
-  Event,
   EventSearchConfig,
   Signer,
   Provider,
@@ -14,7 +14,7 @@ export interface BridgeTransactionDetails {
   readonly args: unknown[];
 }
 
-export type OpStackEvents = { [l2Token: string]: Event[] };
+export type OpStackEvents = { [l2Token: string]: Log[] };
 
 export abstract class OpStackBridge {
   constructor(

--- a/src/clients/bridges/op-stack/WethBridge.ts
+++ b/src/clients/bridges/op-stack/WethBridge.ts
@@ -7,9 +7,9 @@ import {
   Signer,
   Provider,
   ZERO_ADDRESS,
-  Event,
   TOKEN_SYMBOLS_MAP,
 } from "../../../utils";
+import { Log } from "../../../interfaces";
 import { CONTRACT_ADDRESSES } from "../../../common";
 import { matchL2EthDepositAndWrapEvents } from "../utils";
 import { utils } from "@across-protocol/sdk";
@@ -81,7 +81,7 @@ export class WethBridge extends OpStackBridge {
     };
   }
 
-  private convertEventListToOpStackEvents(events: Event[]): OpStackEvents {
+  private convertEventListToOpStackEvents(events: Log[]): OpStackEvents {
     return {
       [this.resolveL2TokenAddress(TOKEN_SYMBOLS_MAP.WETH.addresses[this.hubChainId])]: events,
     };
@@ -195,7 +195,7 @@ export class WethBridge extends OpStackBridge {
     fromAddress: string,
     eventConfig: EventSearchConfig,
     l2Weth = this.l2Weth
-  ): Promise<Event[]> {
+  ): Promise<Log[]> {
     return paginatedEventQuery(l2Weth, l2Weth.filters.Deposit(fromAddress), eventConfig);
   }
 }

--- a/src/clients/bridges/utils.ts
+++ b/src/clients/bridges/utils.ts
@@ -1,4 +1,5 @@
-import { Contract, Event } from "ethers";
+import { Contract } from "ethers";
+import { Log } from "../../interfaces";
 import { TOKEN_APPROVALS_TO_FIRST_ZERO } from "../../common";
 import {
   BigNumber,
@@ -32,9 +33,9 @@ import {
  * @returns List of l2EthDepositEvents followed by a l2WrapEvent. None of the
  * l2EthDepositEvents will match with the same l2WrapEvent.
  */
-export function matchL2EthDepositAndWrapEvents(l2EthDepositEvents: Event[], _l2WrapEvents: Event[]): Event[] {
+export function matchL2EthDepositAndWrapEvents(l2EthDepositEvents: Log[], _l2WrapEvents: Log[]): Log[] {
   const l2WrapEvents = [..._l2WrapEvents]; // deep-copy because we're going to modify this in-place.
-  return l2EthDepositEvents.filter((l2EthDepositEvent: Event) => {
+  return l2EthDepositEvents.filter((l2EthDepositEvent) => {
     // Search from left to right to find the first following wrap event.
     const followingWrapEventIndex = l2WrapEvents.findIndex(
       (wrapEvent) => wrapEvent.blockNumber >= l2EthDepositEvent.blockNumber

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -22,6 +22,7 @@ export interface OutstandingTransfers {
 }
 
 // Common interfaces
+export type Log = interfaces.Log;
 export type SortableEvent = interfaces.SortableEvent;
 export type BigNumberForToken = interfaces.BigNumberForToken;
 

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -36,7 +36,6 @@ import {
   config,
   Logger,
   toBN,
-  Event,
   fromWei,
   isDefined,
   Contract,
@@ -56,7 +55,7 @@ import {
 } from "../utils";
 import { createDataworker } from "../dataworker";
 import { getBlockForChain } from "../dataworker/DataworkerUtils";
-import { ProposedRootBundle, SpokePoolClientsByChain, SlowFillLeaf } from "../interfaces";
+import { Log, ProposedRootBundle, SpokePoolClientsByChain, SlowFillLeaf } from "../interfaces";
 import { CONTRACT_ADDRESSES, constructSpokePoolClientsWithStartBlocks, updateSpokePoolClients } from "../common";
 import { createConsoleTransport } from "@uma/logger";
 
@@ -212,7 +211,7 @@ export async function runScript(_logger: winston.Logger, baseSigner: Signer): Pr
                   `Looking for previous net send amount between  blocks ${previousBundleEndBlockForChain.toNumber()} and ${bundleEndBlockForChain.toNumber()}`
                 );
                 const spokePoolAddress = spokePoolClients[leaf.chainId].spokePool.address;
-                let depositsToSpokePool: Event[];
+                let depositsToSpokePool: Log[];
                 // Handle the case that L1-->L2 deposits for some chains for ETH do not emit Transfer events, but
                 // emit other events instead. This is the case for OpStack chains which emit DepositFinalized events
                 // including the L1 and L2 ETH (native gas token) addresses.

--- a/src/utils/CCTPUtils.ts
+++ b/src/utils/CCTPUtils.ts
@@ -2,6 +2,7 @@ import { utils } from "@across-protocol/sdk";
 import { TransactionReceipt } from "@ethersproject/abstract-provider";
 import axios from "axios";
 import { ethers } from "ethers";
+import { Log } from "../interfaces";
 import { CONTRACT_ADDRESSES, chainIdsToCctpDomains } from "../common";
 import { EventSearchConfig, paginatedEventQuery } from "./EventUtils";
 import { BigNumber } from "./BNUtils";
@@ -80,7 +81,7 @@ export async function retrieveOutstandingCCTPBridgeUSDCTransfers(
   sourceChainId: number,
   destinationChainId: number,
   fromAddress: string
-): Promise<ethers.Event[]> {
+): Promise<Log[]> {
   const sourceDomain = chainIdsToCctpDomains[sourceChainId];
   const targetDestinationDomain = chainIdsToCctpDomains[destinationChainId];
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,7 +16,6 @@ export {
   BaseContract,
   Contract,
   ContractFactory,
-  Event,
   EventFilter,
   Signer,
   Transaction,

--- a/test/EventManager.ts
+++ b/test/EventManager.ts
@@ -1,13 +1,10 @@
-import { Event, providers, utils as ethersUtils } from "ethers";
+import { utils as ethersUtils } from "ethers";
 import winston from "winston";
 import { Result } from "@ethersproject/abi";
 import { CHAIN_IDs } from "@across-protocol/constants";
+import { Log } from "../src/interfaces";
 import { EventManager } from "../src/utils";
 import { createSpyLogger, expect, randomAddress } from "./utils";
-
-type Block = providers.Block;
-type TransactionReceipt = providers.TransactionReceipt;
-type TransactionResponse = providers.TransactionResponse;
 
 describe("EventManager: Event Handling ", async function () {
   const chainId = CHAIN_IDs.MAINNET;
@@ -17,17 +14,8 @@ describe("EventManager: Event Handling ", async function () {
   const makeHash = () => ethersUtils.id(randomNumber().toString());
   const makeTopic = () => ethersUtils.id(randomNumber().toString()).slice(0, 40);
 
-  // Stub getters to be used in the events. These are not used in practice.
-  const decodeError = new Error("Event decoding error");
-  const getBlock = (): Promise<Block> => Promise.resolve({} as Block);
-  const getTransaction = (): Promise<TransactionResponse> => Promise.resolve({} as TransactionResponse);
-  const getTransactionReceipt = (): Promise<TransactionReceipt> => Promise.resolve({} as TransactionReceipt);
-  const removeListener = (): void => {
-    return;
-  };
-
   const blockNumber = 100;
-  const eventTemplate: Event = {
+  const eventTemplate: Log = {
     blockNumber,
     transactionIndex: randomNumber(100),
     logIndex: randomNumber(100),
@@ -39,12 +27,6 @@ describe("EventManager: Event Handling ", async function () {
     args: [] as Result,
     blockHash: makeHash(),
     event: "randomEvent",
-    eventSignature: "",
-    decodeError,
-    getBlock,
-    getTransaction,
-    getTransactionReceipt,
-    removeListener,
   };
 
   let logger: winston.Logger;

--- a/test/Relayer.IndexedSpokePoolClient.ts
+++ b/test/Relayer.IndexedSpokePoolClient.ts
@@ -1,4 +1,4 @@
-import { Contract, providers, utils as ethersUtils } from "ethers";
+import { Contract, utils as ethersUtils } from "ethers";
 import winston from "winston";
 import { Result } from "@ethersproject/abi";
 import { CHAIN_IDs } from "@across-protocol/constants";

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,10 +50,10 @@
     axios "^1.6.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.1.36":
-  version "3.1.36"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.1.36.tgz#8187f4771ca68f14c165033f0c6cc6e35e211919"
-  integrity sha512-Im9ELYj+m0WMow1zUWYerU5v+A+Tpty2jC/7pUSI2pMnHn/mdAWmMoL/EKMqpaxMFucGw6d4fUb1EvLeazBqlg==
+"@across-protocol/sdk@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.2.0.tgz#bd011965c7c3ffc6c76c9e00bb9baa5f80d33c7d"
+  integrity sha512-ks+A9fvXMdcstedvMzV+uTAFObSuXs/4xSm11CEIMu2RfgGTQe/pCN0KSqPhW+H4v53sblxGJpsL8Y/msfH/HQ==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.14"


### PR DESCRIPTION
This follows a similar change in the SDK, with the same motivations. Reverting to Log instead of Event does not sacrifice any functionality but makes it easier to migrate away from ethers v5.