### PR TITLE
[WIP] improve(relayer): Improve resilience against non-updated SpokePoolClient

### DIFF
--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -61,9 +61,9 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
       const ready = await relayer.update();
       const activeRelayer = redis ? await redis.get(botIdentifier) : undefined;
 
-      // If there is another active relayer, allow up to 10 update cycles for this instance to be ready,
+      // If there is another active relayer, allow up to 60 seconds for this instance to be ready,
       // then proceed unconditionally to protect against any RPC outages blocking the relayer.
-      if (!ready && activeRelayer && run < 10) {
+      if (!ready && activeRelayer && run * pollingDelay < 60) {
         const runTime = Math.round((performance.now() - tLoopStart) / 1000);
         const delta = pollingDelay - runTime;
         logger.debug({ at: "Relayer#run", message: `Not ready to relay, waiting ${delta} seconds.` });

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -61,8 +61,8 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
       const ready = await relayer.update();
       const activeRelayer = redis ? await redis.get(botIdentifier) : undefined;
 
-      // If there is another active relayer, allow up to 60 seconds for this instance to be ready,
-      // then proceed unconditionally to protect against any RPC outages blocking the relayer.
+      // If there is another active relayer, allow up to 120 seconds for this instance to be ready.
+      // If this instance can't update, throw an error (for now).
       if (!ready && activeRelayer) {
         if (run * pollingDelay < 120) {
           const runTime = Math.round((performance.now() - tLoopStart) / 1000);

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -63,12 +63,17 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
 
       // If there is another active relayer, allow up to 60 seconds for this instance to be ready,
       // then proceed unconditionally to protect against any RPC outages blocking the relayer.
-      if (!ready && activeRelayer && run * pollingDelay < 60) {
-        const runTime = Math.round((performance.now() - tLoopStart) / 1000);
-        const delta = pollingDelay - runTime;
-        logger.debug({ at: "Relayer#run", message: `Not ready to relay, waiting ${delta} seconds.` });
-        await delay(delta);
-        continue;
+      if (!ready && activeRelayer) {
+        if (run * pollingDelay < 120) {
+          const runTime = Math.round((performance.now() - tLoopStart) / 1000);
+          const delta = pollingDelay - runTime;
+          logger.debug({ at: "Relayer#run", message: `Not ready to relay, waiting ${delta} seconds.` });
+          await delay(delta);
+          continue;
+        }
+
+        const badChains = Object.values(spokePoolClients).filter(({ isUpdated }) => !isUpdated);
+        throw new Error(`Unable to start relayer due to chains ${badChains}`);
       }
 
       // Signal to any existing relayer that a handover is underway, or alternatively

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -61,7 +61,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
       const ready = await relayer.update();
       const activeRelayer = redis ? await redis.get(botIdentifier) : undefined;
 
-      // If there is another active relayer, allow up to 20 update cycles for this instance to be ready,
+      // If there is another active relayer, allow up to 120 seconds for this instance to be ready,
       // then proceed unconditionally to protect against any RPC outages blocking the relayer.
       if (!ready && activeRelayer) {
         if (run * pollingDelay < 120) {


### PR DESCRIPTION
The BundleDataClient asserts that all SpokePoolClient instances have been updated. Ideally it could handle a non-updated SpokePoolClient, but in advance of that, filter the relayer's set of SpokePoolClients to exclude any that have not been updated after some defined time period.