### PR TITLE
improve: swap Optimism and Base OpStackAdapters with BaseChainAdapters

### DIFF
--- a/src/clients/bridges/AdapterManager.ts
+++ b/src/clients/bridges/AdapterManager.ts
@@ -9,7 +9,7 @@ import {
 import { InventoryConfig, OutstandingTransfers } from "../../interfaces";
 import { BigNumber, isDefined, winston, Signer, getL2TokenAddresses, TransactionResponse, assert } from "../../utils";
 import { SpokePoolClient, HubPoolClient } from "../";
-import { ArbitrumAdapter, PolygonAdapter, ZKSyncAdapter, LineaAdapter, OpStackAdapter, ScrollAdapter } from "./";
+import { ArbitrumAdapter, PolygonAdapter, ZKSyncAdapter, LineaAdapter, ScrollAdapter } from "./";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
 
 import { BaseChainAdapter } from "../../adapter";
@@ -60,12 +60,15 @@ export class AdapterManager {
       );
     };
     if (this.spokePoolClients[OPTIMISM] !== undefined) {
-      this.adapters[OPTIMISM] = new OpStackAdapter(
+      this.adapters[OPTIMISM] = new BaseChainAdapter(
+        spokePoolClients,
         OPTIMISM,
+        hubChainId,
+        filterMonitoredAddresses(OPTIMISM),
         logger,
         SUPPORTED_TOKENS[OPTIMISM],
-        spokePoolClients,
-        filterMonitoredAddresses(OPTIMISM)
+        constructBridges(OPTIMISM),
+        DEFAULT_GAS_MULTIPLIER[OPTIMISM] ?? 1
       );
     }
     if (this.spokePoolClients[POLYGON] !== undefined) {
@@ -78,12 +81,15 @@ export class AdapterManager {
       this.adapters[ZK_SYNC] = new ZKSyncAdapter(logger, spokePoolClients, filterMonitoredAddresses(ZK_SYNC));
     }
     if (this.spokePoolClients[BASE] !== undefined) {
-      this.adapters[BASE] = new OpStackAdapter(
+      this.adapters[BASE] = new BaseChainAdapter(
+        spokePoolClients,
         BASE,
+        hubChainId,
+        filterMonitoredAddresses(BASE),
         logger,
         SUPPORTED_TOKENS[BASE],
-        spokePoolClients,
-        filterMonitoredAddresses(BASE)
+        constructBridges(BASE),
+        DEFAULT_GAS_MULTIPLIER[BASE] ?? 1
       );
     }
     if (this.spokePoolClients[LINEA] !== undefined) {

--- a/test/AdapterManager.SendTokensCrossChain.ts
+++ b/test/AdapterManager.SendTokensCrossChain.ts
@@ -126,7 +126,7 @@ describe("AdapterManager: Send tokens cross-chain", async function () {
       mainnetTokens.bal, // l1 token
       getL2TokenAddresses(mainnetTokens.bal)[chainId], // l2 token
       amountToSend, // amount
-      addAttrib(adapterManager.adapters[chainId]).l2Gas, // l2Gas
+      addAttrib(adapterManager.adapters[chainId]).bridges[mainnetTokens.bal].l2Gas, // l2Gas
       "0x" // data
     );
 
@@ -142,7 +142,7 @@ describe("AdapterManager: Send tokens cross-chain", async function () {
       mainnetTokens.usdc, // l1 token
       TOKEN_SYMBOLS_MAP["USDC.e"].addresses[chainId], // l2 token
       amountToSend, // amount
-      addAttrib(adapterManager.adapters[chainId]).l2Gas, // l2Gas
+      addAttrib(adapterManager.adapters[chainId]).bridges[mainnetTokens.usdc].canonicalBridge.l2Gas, // l2Gas
       "0x" // data
     );
 
@@ -175,7 +175,7 @@ describe("AdapterManager: Send tokens cross-chain", async function () {
       mainnetTokens.dai, // l1 token
       getL2TokenAddresses(mainnetTokens.dai)[chainId], // l2 token
       amountToSend, // amount
-      addAttrib(adapterManager.adapters[chainId]).l2Gas, // l2Gas
+      addAttrib(adapterManager.adapters[chainId]).bridges[mainnetTokens.dai].l2Gas, // l2Gas
       "0x" // data
     );
 
@@ -184,7 +184,7 @@ describe("AdapterManager: Send tokens cross-chain", async function () {
     expect(l1AtomicDepositor.bridgeWethToOvm).to.have.been.calledWith(
       relayer.address, // to
       amountToSend, // amount
-      addAttrib(adapterManager.adapters[chainId]).l2Gas, // l2Gas
+      addAttrib(adapterManager.adapters[chainId]).bridges[mainnetTokens.weth].l2Gas, // l2Gas
       chainId // chainId
     );
   });
@@ -354,7 +354,7 @@ describe("AdapterManager: Send tokens cross-chain", async function () {
       mainnetTokens.usdc, // l1 token
       TOKEN_SYMBOLS_MAP.USDbC.addresses[chainId], // l2 token
       amountToSend, // amount
-      addAttrib(adapterManager.adapters[chainId]).l2Gas, // l2Gas
+      addAttrib(adapterManager.adapters[chainId]).bridges[mainnetTokens.usdc].canonicalBridge.l2Gas, // l2Gas
       "0x" // data
     );
 
@@ -363,7 +363,7 @@ describe("AdapterManager: Send tokens cross-chain", async function () {
       mainnetTokens.bal, // l1 token
       getL2TokenAddresses(mainnetTokens.bal)[chainId], // l2 token
       amountToSend, // amount
-      addAttrib(adapterManager.adapters[chainId]).l2Gas, // l2Gas
+      addAttrib(adapterManager.adapters[chainId]).bridges[mainnetTokens.bal].l2Gas, // l2Gas
       "0x" // data
     );
 
@@ -373,7 +373,7 @@ describe("AdapterManager: Send tokens cross-chain", async function () {
       mainnetTokens.dai, // l1 token
       getL2TokenAddresses(mainnetTokens.dai)[chainId], // l2 token
       amountToSend, // amount
-      addAttrib(adapterManager.adapters[chainId]).l2Gas, // l2Gas
+      addAttrib(adapterManager.adapters[chainId]).bridges[mainnetTokens.dai].l2Gas, // l2Gas
       "0x" // data
     );
 
@@ -382,7 +382,7 @@ describe("AdapterManager: Send tokens cross-chain", async function () {
     expect(l1AtomicDepositor.bridgeWethToOvm).to.have.been.calledWith(
       relayer.address, // to
       amountToSend, // amount
-      addAttrib(adapterManager.adapters[chainId]).l2Gas, // l2Gas
+      addAttrib(adapterManager.adapters[chainId]).bridges[mainnetTokens.weth].l2Gas, // l2Gas
       chainId // chainId
     );
   });


### PR DESCRIPTION
This completes the migration of all adapters. There is now a significant amount of unused code in `src/clients/bridges` which can be removed in follow up PRs.