### PR TITLE
improve(relayer): Defer deposit version computation

### DIFF
--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -32,11 +32,14 @@ export function getUnfilledDeposits(
 
   return deposits
     .map((deposit) => {
-      const version = hubPoolClient.configStoreClient.getConfigStoreVersionForTimestamp(deposit.quoteTimestamp);
       const { unfilledAmount, invalidFills } = destinationClient.getValidUnfilledAmountForDeposit(deposit);
-      return { deposit, version, unfilledAmount, invalidFills };
+      return { deposit, unfilledAmount, invalidFills };
     })
-    .filter(({ unfilledAmount }) => unfilledAmount.gt(bnZero));
+    .filter(({ unfilledAmount }) => unfilledAmount.gt(bnZero))
+    .map(({ deposit, ...rest }) => {
+      const version = hubPoolClient.configStoreClient.getConfigStoreVersionForTimestamp(deposit.quoteTimestamp);
+      return { deposit, ...rest, version };
+    });
 }
 
 export function getAllUnfilledDeposits(


### PR DESCRIPTION
getUnfilledDeposits() currently unconditionally computes the deposit version (i.e. the ConfigStore VERSION value applicable at the deposit quoteTimestamp), and then filters out all the deposits that have been filled. Determining the relevant version implies a lot of Array.find() calls, all of which is wasted when the object is subsequently discarded.