### PR TITLE
improve(relayer): Redirect in-protocol swap message

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -292,6 +292,7 @@ export class Relayer {
         at: "Relayer::filterDeposit",
         message: "Skipping deposit including in-protocol token swap.",
         deposit,
+        notificationPath: "across-unprofitable-fills",
       });
       return false;
     }


### PR DESCRIPTION
This message can be quite spammy in the main logging channel, so redirect it to the more acceptably-noisy "unprofitable fills" channel.