### PR TITLE
chore: Bump SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.14",
     "@across-protocol/contracts": "^3.0.10",
-    "@across-protocol/sdk": "^3.2.0",
+    "@across-protocol/sdk": "^3.2.4",
     "@arbitrum/sdk": "^3.1.3",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,10 +50,10 @@
     axios "^1.6.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.2.0.tgz#bd011965c7c3ffc6c76c9e00bb9baa5f80d33c7d"
-  integrity sha512-ks+A9fvXMdcstedvMzV+uTAFObSuXs/4xSm11CEIMu2RfgGTQe/pCN0KSqPhW+H4v53sblxGJpsL8Y/msfH/HQ==
+"@across-protocol/sdk@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.2.4.tgz#3c7b9dac1c289ca6161c61358f3efb56e97d8d49"
+  integrity sha512-3/BzwgQdsWv4MsFsmj5OsmjV66QHHBfAuefPOA/TmPK9PC6CAgpNZNuNmp17Kk5pgagy3UDwBF7EDvWLY+aOhQ==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.14"


### PR DESCRIPTION
This includes a change that speeds up deposit/fill matching. In the relayer this can save multiple seconds per loop, so it's going to have a meaningful impact on performance.