### PR TITLE
fix: force maximum USDC rebalance amount over CCTP to 1M

### DIFF
--- a/src/adapter/bridges/UsdcCCTPBridge.ts
+++ b/src/adapter/bridges/UsdcCCTPBridge.ts
@@ -1,11 +1,21 @@
 import { Contract, Signer } from "ethers";
 import { CONTRACT_ADDRESSES, chainIdsToCctpDomains } from "../../common";
 import { BridgeTransactionDetails, BaseBridgeAdapter, BridgeEvents } from "./BaseBridgeAdapter";
-import { BigNumber, EventSearchConfig, Provider, TOKEN_SYMBOLS_MAP, compareAddressesSimple, assert } from "../../utils";
+import {
+  BigNumber,
+  EventSearchConfig,
+  Provider,
+  TOKEN_SYMBOLS_MAP,
+  compareAddressesSimple,
+  assert,
+  toBN,
+} from "../../utils";
 import { processEvent } from "../utils";
 import { cctpAddressToBytes32, retrieveOutstandingCCTPBridgeUSDCTransfers } from "../../utils/CCTPUtils";
 
 export class UsdcCCTPBridge extends BaseBridgeAdapter {
+  private CCTP_MAX_SEND_AMOUNT = toBN(1_000_000_000_000); // 1MM USDC.
+
   constructor(l2chainId: number, hubChainId: number, l1Signer: Signer, l2SignerOrProvider: Signer | Provider) {
     super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, [
       CONTRACT_ADDRESSES[hubChainId].cctpTokenMessenger.address,
@@ -38,6 +48,7 @@ export class UsdcCCTPBridge extends BaseBridgeAdapter {
     amount: BigNumber
   ): Promise<BridgeTransactionDetails> {
     assert(compareAddressesSimple(_l1Token, TOKEN_SYMBOLS_MAP.USDC.addresses[this.hubChainId]));
+    amount = amount.gt(this.CCTP_MAX_SEND_AMOUNT) ? this.CCTP_MAX_SEND_AMOUNT : amount;
     return Promise.resolve({
       contract: this.getL1Bridge(),
       method: "depositForBurn",


### PR DESCRIPTION
This is a simple fix to guarantee that the rebalancer will not try to send an amount over CCTP which is greater than 1 million USDC, however, if we needed to send over 1 million USDC, this fix would split the transfers into multiple runs. 

Currently in draft so that we can see if there is a simple solution to be able to send > 1M USDC with CCTP in the same rebalancer run.