### PR TITLE
chore: Bump SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.16",
     "@across-protocol/contracts": "^3.0.11",
-    "@across-protocol/sdk": "^3.2.6",
+    "@across-protocol/sdk": "^3.2.7",
     "@arbitrum/sdk": "^3.1.3",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,10 +45,10 @@
     axios "^1.7.4"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.2.6":
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.2.6.tgz#3b3158d2b38d968829b6030ca1d75b53f8e31556"
-  integrity sha512-ANMQg8WN52WXUqk8NK/abKkze/b5b25Hbe//NhCCzxbsy41W0jaq7fPtwq5gllXc8wHeu+Uvb45WPqM89ByLCw==
+"@across-protocol/sdk@^3.2.7":
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.2.7.tgz#c0d2ad49065a33d05f01f846e328989c4e6585c2"
+  integrity sha512-oUZ8uIw10/y+ZsRjlZTivJnK3AGpwCJbt3VLMHhv6TUYGNcQW/Vr71LFhyeieKfoY4+lGZq/UV4QIqsNSWiSZA==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.16"


### PR DESCRIPTION
This includes an optimisation for the SpokePoolClient to bundle two separate SpokePool calls into a SpokePool multicall. Ideally this will reduce the instance of RPC errors when this query occurs against a block that's slightly ahead of one of the RPC providers, or when a single RPC provider has not reached internal consistency on the latest block.