### PR TITLE
refactor: Confine oldestTime update to Dataworker

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -20,7 +20,6 @@ type SpokePoolEventRemoved = {
 type SpokePoolEventsAdded = {
   blockNumber: number;
   currentTime: number;
-  oldestTime: number;
   nEvents: number; // Number of events.
   data: string;
 };
@@ -42,7 +41,6 @@ export class IndexedSpokePoolClient extends clients.SpokePoolClient {
   private worker: ChildProcess;
   private pendingBlockNumber: number;
   private pendingCurrentTime: number;
-  private pendingOldestTime: number;
 
   private pendingEvents: Log[][];
   private pendingEventsRemoved: Log[];
@@ -157,7 +155,7 @@ export class IndexedSpokePoolClient extends clients.SpokePoolClient {
 
     assert(isSpokePoolEventsAdded(message), `Expected ${this.chain} SpokePoolEventsAdded message`);
 
-    const { blockNumber, currentTime, oldestTime, nEvents, data } = message;
+    const { blockNumber, currentTime, nEvents, data } = message;
     if (nEvents > 0) {
       const pendingEvents = JSON.parse(data, sdkUtils.jsonReviverWithBigNumbers);
       assert(
@@ -185,9 +183,6 @@ export class IndexedSpokePoolClient extends clients.SpokePoolClient {
 
     this.pendingBlockNumber = blockNumber;
     this.pendingCurrentTime = currentTime;
-    if (!isDefined(this.pendingOldestTime) && oldestTime > 0) {
-      this.pendingOldestTime = oldestTime;
-    }
   }
 
   /**
@@ -289,7 +284,6 @@ export class IndexedSpokePoolClient extends clients.SpokePoolClient {
     return {
       success: true,
       currentTime: this.pendingCurrentTime,
-      oldestTime: this.pendingOldestTime,
       firstDepositId,
       latestDepositId,
       searchEndBlock: this.pendingBlockNumber,

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -97,18 +97,19 @@ export async function blockRangesAreInvalidForSpokeClients(
       const conservativeBundleFrequencySeconds = Number(
         process.env.CONSERVATIVE_BUNDLE_FREQUENCY_SECONDS ?? CONSERVATIVE_BUNDLE_FREQUENCY_SECONDS
       );
-      if (
-        spokePoolClient.eventSearchConfig.fromBlock > spokePoolClient.deploymentBlock &&
+      if (spokePoolClient.eventSearchConfig.fromBlock > spokePoolClient.deploymentBlock) {
         // @dev The maximum lookback window we need to evaluate expired deposits is the max fill deadline buffer,
         // which captures all deposits that newly expired, plus the bundle time (e.g. 1 hour) to account for the
         // maximum time it takes for a newly expired deposit to be included in a bundle. A conservative value for
         // this bundle time is 3 hours. This `conservativeBundleFrequencySeconds` buffer also ensures that all deposits
         // that are technically "expired", but have fills in the bundle, are also included. This can happen if a fill
         // is sent pretty late into the deposit's expiry period.
-        endBlockTimestamps[chainId] - spokePoolClient.getOldestTime() <
-          maxFillDeadlineBufferInBlockRange + conservativeBundleFrequencySeconds
-      ) {
-        return true;
+        const oldestTime = await spokePoolClient.getTimeAt(spokePoolClient.eventSearchConfig.fromBlock);
+        const expiryWindow = endBlockTimestamps[chainId] - oldestTime;
+        const safeExpiryWindow = maxFillDeadlineBufferInBlockRange + conservativeBundleFrequencySeconds;
+        if (expiryWindow < safeExpiryWindow) {
+          return true;
+        }
       }
     }
     // We must now assume that all newly expired deposits at the time of the bundle end blocks are contained within

--- a/src/libexec/RelayerSpokePoolIndexer.ts
+++ b/src/libexec/RelayerSpokePoolIndexer.ts
@@ -33,7 +33,6 @@ const WS_PONG_TIMEOUT = WS_PING_INTERVAL / 2;
 let logger: winston.Logger;
 let chain: string;
 let stop = false;
-let oldestTime = 0;
 
 /**
  * Aggregate utils/scrapeEvents for a series of event names.
@@ -49,7 +48,7 @@ export async function scrapeEvents(spokePool: Contract, eventNames: string[], op
   );
 
   if (!stop) {
-    postEvents(toBlock, oldestTime, currentTime, events.flat());
+    postEvents(toBlock, currentTime, events.flat());
   }
 }
 
@@ -83,7 +82,7 @@ async function listen(
     // Post an update to the parent. Do this irrespective of whether there were new events or not, since there's
     // information in blockNumber and currentTime alone.
     if (!stop) {
-      postEvents(blockNumber, oldestTime, currentTime, events);
+      postEvents(blockNumber, currentTime, events);
     }
   });
 
@@ -176,20 +175,11 @@ async function run(argv: string[]): Promise<void> {
   // Note: An event emitted between scrapeEvents() and listen(). @todo: Ensure that there is overlap and dedpulication.
   logger.debug({ at: "RelayerSpokePoolIndexer::run", message: `Scraping previous ${chain} events.`, opts });
 
-  // The SpokePoolClient reports on the timestamp of the oldest block searched. The relayer likely doesn't need this,
-  // but resolve it anyway for consistency with the main SpokePoolClient implementation.
-  const resolveOldestTime = async (spokePool: Contract, blockTag: ethersProviders.BlockTag) => {
-    oldestTime = (await spokePool.getCurrentTime({ blockTag })).toNumber();
-  };
-
   if (latestBlock.number > startBlock) {
     const events = ["V3FundsDeposited", "FilledV3Relay", "RelayedRootBundle", "ExecutedRelayerRefundRoot"];
     const _spokePool = spokePool.connect(quorumProvider);
-    await Promise.all([resolveOldestTime(_spokePool, startBlock), scrapeEvents(_spokePool, events, opts)]);
+    await scrapeEvents(_spokePool, events, opts);
   }
-
-  // If no lookback was specified then default to the timestamp of the latest block.
-  oldestTime ??= latestBlock.timestamp;
 
   // Events to listen for.
   const events = ["V3FundsDeposited", "RequestedSpeedUpV3Deposit", "FilledV3Relay"];

--- a/src/libexec/util/ipc.ts
+++ b/src/libexec/util/ipc.ts
@@ -10,7 +10,7 @@ import { Log, SpokePoolClientMessage } from "./../types";
  * @param events An array of Log objects to be submitted.
  * @returns void
  */
-export function postEvents(blockNumber: number, oldestTime: number, currentTime: number, events: Log[]): void {
+export function postEvents(blockNumber: number, currentTime: number, events: Log[]): void {
   if (!isDefined(process.send)) {
     return;
   }
@@ -19,7 +19,6 @@ export function postEvents(blockNumber: number, oldestTime: number, currentTime:
   const message: SpokePoolClientMessage = {
     blockNumber,
     currentTime,
-    oldestTime,
     nEvents: events.length,
     data: JSON.stringify(events, sdkUtils.jsonReplacerWithBigNumbers),
   };


### PR DESCRIPTION
The Dataworker is the only SpokePoolClient user that needs to know the time at a historical SpokePool block, so permit it to resolve this on the fly and free up other users from having to query it.