### PR TITLE
improve: force nonce reset across all chains

### DIFF
--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -66,7 +66,7 @@ export async function runTransaction(
   const { provider } = contract;
   const { chainId } = await provider.getNetwork();
 
-  if (process.env[`ACROSS_RESET_NONCE_${chainId}`] && !nonceReset[chainId]) {
+  if (!nonceReset[chainId]) {
     nonce = await provider.getTransactionCount(await contract.signer.getAddress());
     nonceReset[chainId] = true;
   }


### PR DESCRIPTION
Continuation of https://github.com/across-protocol/relayer/pull/1834. Now, we will always get the nonce based off of the most-recent confirmed transaction for each new run of a bot.