### PR TITLE
fix(relayer): Invert gasLimit nullification

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -695,7 +695,7 @@ export class Relayer {
         // Update local balance to account for the enqueued fill.
         tokenClient.decrementLocalBalance(destinationChainId, outputToken, outputAmount);
 
-        const gasLimit = isMessageEmpty(resolveDepositMessage(deposit)) ? undefined : _gasLimit;
+        const gasLimit = isMessageEmpty(resolveDepositMessage(deposit)) ? _gasLimit : undefined;
         this.fillRelay(deposit, repaymentChainId, realizedLpFeePct, gasLimit);
       }
     } else if (selfRelay) {


### PR DESCRIPTION
The relayer has had a bug for a while where it is incorrectly dropping the precomputed gas limit for non-message fills. Instead, it was retaining the limit for message fills. This can lead to unnecessary transaction simulation later on, increasing RPC consumption and potentially delaying fills.