### PR TITLE
Update spokepool.ts

### DIFF
--- a/scripts/spokepool.ts
+++ b/scripts/spokepool.ts
@@ -224,7 +224,7 @@ async function deposit(args: Record<string, number | string>, signer: Signer): P
     exclusiveRelayer ?? depositQuote.exclusiveRelayer,
     depositQuote.quoteTimestamp,
     Number(currentTime) + Number(fillDeadlineBuffer),
-    exclusivityDeadline ?? depositQuote.exclusivityDeadline,
+    isNaN(exclusivityDeadline) ? depositQuote.exclusivityDeadline : exclusivityDeadline,
     message
   );
   const { hash: transactionHash } = deposit;


### PR DESCRIPTION
Null coalesce (??) doesn't work as one would expect with `NaN`. So this fixes an issue when not supplying the `--exclusivityDeadline` directly

## Example

```typescript
$> NaN ?? "works"
NaN
```