### PR TITLE
fix: error log stringify

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,15 @@
 import minimist from "minimist";
-import { config, delay, exit, retrieveSignerFromCLIArgs, help, Logger, usage, waitForLogger } from "./src/utils";
+import {
+  config,
+  delay,
+  exit,
+  retrieveSignerFromCLIArgs,
+  help,
+  Logger,
+  usage,
+  waitForLogger,
+  stringifyThrownValue,
+} from "./src/utils";
 import { runRelayer } from "./src/relayer";
 import { runDataworker } from "./src/dataworker";
 import { runMonitor } from "./src/monitor";
@@ -61,12 +71,13 @@ if (require.main === module) {
   run(args)
     .catch(async (error) => {
       exitCode = 1;
+      const stringifiedError = stringifyThrownValue(error);
       logger.error({
         at: cmd ?? "unknown process",
         message: "There was an execution error!",
-        reason: error,
-        e: error,
-        error,
+        reason: stringifiedError,
+        e: stringifiedError,
+        error: stringifiedError,
         args,
         notificationPath: "across-error",
       });

--- a/index.ts
+++ b/index.ts
@@ -75,8 +75,6 @@ if (require.main === module) {
       logger.error({
         at: cmd ?? "unknown process",
         message: "There was an execution error!",
-        reason: stringifiedError,
-        e: stringifiedError,
         error: stringifiedError,
         args,
         notificationPath: "across-error",

--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -11,6 +11,7 @@ import {
   TransactionResponse,
   TransactionSimulationResult,
   willSucceed,
+  stringifyThrownValue,
 } from "../utils";
 
 export interface AugmentedTransaction {
@@ -100,7 +101,7 @@ export class TransactionClient {
           mrkdwn,
           // @dev `error` _sometimes_ doesn't decode correctly (especially on Polygon), so fish for the reason.
           errorMessage: isError(error) ? (error as Error).message : undefined,
-          error,
+          error: stringifyThrownValue(error),
           notificationPath: "across-error",
         });
         return txnResponses;

--- a/src/utils/LogUtils.ts
+++ b/src/utils/LogUtils.ts
@@ -1,1 +1,15 @@
 export type DefaultLogLevels = "debug" | "info" | "warn" | "error";
+
+export function stringifyThrownValue(value: unknown): string {
+  if (value instanceof Error) {
+    const errToString = value.toString();
+    return value.stack || value.message || errToString !== "[object Object]"
+      ? errToString
+      : "could not extract error from 'Error' instance";
+  } else if (value instanceof Object) {
+    const objStringified = JSON.stringify(value);
+    return objStringified !== "{}" ? objStringified : "could not extract error from 'Object' instance";
+  } else {
+    return `ThrownValue: ${value.toString()}`;
+  }
+}

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -16,6 +16,7 @@ import {
   Signer,
   toBNWei,
   winston,
+  stringifyThrownValue,
 } from "../utils";
 dotenv.config();
 
@@ -107,7 +108,7 @@ export async function runTransaction(
       logger.debug({
         at: "TxUtil#runTransaction",
         message: "Retrying txn due to expected error",
-        error: JSON.stringify(error),
+        error: stringifyThrownValue(error),
         retriesRemaining,
       });
 
@@ -143,7 +144,7 @@ export async function runTransaction(
       } else {
         logger[txnRetryable(error) ? "warn" : "error"]({
           ...commonFields,
-          error: JSON.stringify(error),
+          error: stringifyThrownValue(error),
         });
       }
       throw error;


### PR DESCRIPTION
Closes ACX-3032

We've been seeing occasional error logs like `error: "[object Object]"`. AFAICT these can occur if the caught value is not an instance of the `Error` class. We _might_ be able to get more information if we use `JSON.stringify` instead if the thrown value is not an error. 

Also, if we use `JSON.stringify` on an error instance it returns `{}` if it doesn't implement a custom `toJSON` method. 

To cover both cases above, this PR therefore introduces a `stringifyThrownValue` that can be used for logging. 