### PR TITLE
fix: define OptimismPortal2 and DisputeGameFactory for Base

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -540,6 +540,22 @@ export const EXPECTED_L1_TO_L2_MESSAGE_TIME = {
 };
 
 export const OPSTACK_CONTRACT_OVERRIDES = {
+  [CHAIN_IDs.BASE]: {
+    // https://github.com/ethereum-optimism/ecosystem/blob/8df6ab1afcf49312dc7e89ed079f910843d74427/packages/sdk/src/utils/chain-constants.ts#L252
+    l1: {
+      AddressManager: "0x8EfB6B5c4767B09Dc9AA6Af4eAA89F749522BaE2",
+      L1CrossDomainMessenger: "0x866E82a600A1414e583f7F13623F1aC5d58b0Afa",
+      L1StandardBridge: CONTRACT_ADDRESSES[CHAIN_IDs.MAINNET].ovmStandardBridge_8453.address,
+      StateCommitmentChain: ZERO_ADDRESS,
+      CanonicalTransactionChain: ZERO_ADDRESS,
+      BondManager: ZERO_ADDRESS,
+      OptimismPortal: "0x49048044D57e1C92A77f79988d21Fa8fAF74E97e",
+      L2OutputOracle: "0x56315b90c40730925ec5485cf004d835058518A0",
+      OptimismPortal2: "0x49048044D57e1C92A77f79988d21Fa8fAF74E97e",
+      DisputeGameFactory: "0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e",
+    },
+    l2: DEFAULT_L2_CONTRACT_ADDRESSES,
+  },
   [CHAIN_IDs.BLAST]: {
     l1: {
       AddressManager: "0xE064B565Cf2A312a3e66Fe4118890583727380C0",


### PR DESCRIPTION
When calling `getMessageStatus` on the optimism SDK, a change to base (presumably adding fault proofs) caused us to enter [this conditional](https://github.com/ethereum-optimism/ecosystem/blob/8df6ab1afcf49312dc7e89ed079f910843d74427/packages/sdk/src/cross-chain-messenger.ts#L792). This requires two contract addresses which are not defined by default [here](https://github.com/ethereum-optimism/ecosystem/blob/8df6ab1afcf49312dc7e89ed079f910843d74427/packages/sdk/src/utils/chain-constants.ts#L252): The OptimismPortalProxy2 and the DisputeGameFactory. These contracts were taken from [this page](https://docs.base.org/docs/base-contracts/).

The OptimismPortal2 is the same address as the OptimismPortal. Calling it with any of these (bytes32,address) pairs seems to indicate that it is correct to do so (since these withdrawals exist), but I still want to verify this.
```
0xd8f757a752edd33356a9f3211698c27b14d3e390dfd083be5fe9e989d1ebd390
0xcA11bde05977b3631167028862bE2a173976CA11

0xaa1c2e2a27dae86b59c9ed91be35329066ff7adc665ab8453e8edf7bb45211c8
0xcA11bde05977b3631167028862bE2a173976CA11

0x1a045577e48e236dfb7b6eed7d4ec10010da06ccd9cf3ac2ad7ee99333ea2b55
0xcA11bde05977b3631167028862bE2a173976CA11

0x3493afe6c5cd0848551700cab169a1f707e25344577997cbbc1bf26aa0c7a5b2
0xcA11bde05977b3631167028862bE2a173976CA11

0x4cd23510934732ddcd44af31c1175094e7975262e40fde92081d91b57dc2f853
0xcA11bde05977b3631167028862bE2a173976CA11

0xa6cd0fc31252b3a35f249610b73d326b74f3fd84dc5896735a63d1b7e1655576
0xcA11bde05977b3631167028862bE2a173976CA11

0x93d9e5a8d339becfa15c1c55eb522cd5cc3e8cd1dbc3ddb8c98e6506e793677c
0xcA11bde05977b3631167028862bE2a173976CA11

0xf45ae807d98121ac2cc7f81e33f800e63e1fecf9808ab81cb6fcd091abe7c688
0xcA11bde05977b3631167028862bE2a173976CA11

0x50631b152ae09330c6dfbccf0c9675f0d7b421719e495c98f06113ce4c5108c7
0xcA11bde05977b3631167028862bE2a173976CA11

0x85ad01de4cf9e8cefe7ab54ba7b322932ad3468d7795d78220d2c95fe0a2f735
0xcA11bde05977b3631167028862bE2a173976CA11
``` 