### PR TITLE
feat(alephzero): make arb finalizer generic

### DIFF
--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -32,7 +32,7 @@ import {
 } from "../utils";
 import { ChainFinalizer, CrossChainMessage } from "./types";
 import {
-  arbitrumOneFinalizer,
+  arbStackFinalizer,
   cctpL1toL2Finalizer,
   cctpL2toL1Finalizer,
   lineaL1ToL2Finalizer,
@@ -79,11 +79,11 @@ const chainFinalizers: { [chainId: number]: { finalizeOnL2: ChainFinalizer[]; fi
     finalizeOnL2: [cctpL1toL2Finalizer],
   },
   [CHAIN_IDs.ALEPH_ZERO]: {
-    finalizeOnL1: [arbitrumOneFinalizer],
+    finalizeOnL1: [arbStackFinalizer],
     finalizeOnL2: [],
   },
   [CHAIN_IDs.ARBITRUM]: {
-    finalizeOnL1: [arbitrumOneFinalizer, cctpL2toL1Finalizer],
+    finalizeOnL1: [arbStackFinalizer, cctpL2toL1Finalizer],
     finalizeOnL2: [cctpL1toL2Finalizer],
   },
   [CHAIN_IDs.LINEA]: {

--- a/src/finalizer/utils/arbStack.ts
+++ b/src/finalizer/utils/arbStack.ts
@@ -13,16 +13,13 @@ import {
   getL1TokenInfo,
   compareAddressesSimple,
   TOKEN_SYMBOLS_MAP,
-  CHAIN_IDs,
 } from "../../utils";
 import { TokensBridged } from "../../interfaces";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
 import { CONTRACT_ADDRESSES, Multicall2Call } from "../../common";
 import { FinalizerPromise, CrossChainMessage } from "../types";
 
-const CHAIN_ID = CHAIN_IDs.ARBITRUM;
-
-export async function arbitrumOneFinalizer(
+export async function arbStackFinalizer(
   logger: winston.Logger,
   signer: Signer,
   hubPoolClient: HubPoolClient,
@@ -48,25 +45,26 @@ export async function arbitrumOneFinalizer(
     (e) =>
       e.blockNumber <= latestBlockToFinalize &&
       // USDC withdrawals for Arbitrum should be finalized via the CCTP Finalizer.
-      !compareAddressesSimple(e.l2TokenAddress, TOKEN_SYMBOLS_MAP["USDC"].addresses[CHAIN_ID])
+      !compareAddressesSimple(e.l2TokenAddress, TOKEN_SYMBOLS_MAP["USDC"].addresses[chainId])
   );
 
-  return await multicallArbitrumFinalizations(olderTokensBridgedEvents, signer, hubPoolClient, logger);
+  return await multicallArbitrumFinalizations(olderTokensBridgedEvents, signer, hubPoolClient, logger, chainId);
 }
 
 async function multicallArbitrumFinalizations(
   tokensBridged: TokensBridged[],
   hubSigner: Signer,
   hubPoolClient: HubPoolClient,
-  logger: winston.Logger
+  logger: winston.Logger,
+  chainId: number
 ): Promise<FinalizerPromise> {
-  const finalizableMessages = await getFinalizableMessages(logger, tokensBridged, hubSigner);
-  const callData = await Promise.all(finalizableMessages.map((message) => finalizeArbitrum(message.message)));
+  const finalizableMessages = await getFinalizableMessages(logger, tokensBridged, hubSigner, chainId);
+  const callData = await Promise.all(finalizableMessages.map((message) => finalizeArbitrum(message.message, chainId)));
   const crossChainTransfers = finalizableMessages.map(({ info: { l2TokenAddress, amountToReturn } }) => {
-    const l1TokenInfo = getL1TokenInfo(l2TokenAddress, CHAIN_ID);
+    const l1TokenInfo = getL1TokenInfo(l2TokenAddress, chainId);
     const amountFromWei = convertFromWei(amountToReturn.toString(), l1TokenInfo.decimals);
     const withdrawal: CrossChainMessage = {
-      originationChainId: CHAIN_ID,
+      originationChainId: chainId,
       l1TokenSymbol: l1TokenInfo.symbol,
       amount: amountFromWei,
       type: "withdrawal",
@@ -81,10 +79,10 @@ async function multicallArbitrumFinalizations(
   };
 }
 
-async function finalizeArbitrum(message: L2ToL1MessageWriter): Promise<Multicall2Call> {
-  const l2Provider = getCachedProvider(CHAIN_ID, true);
+async function finalizeArbitrum(message: L2ToL1MessageWriter, chainId: number): Promise<Multicall2Call> {
+  const l2Provider = getCachedProvider(chainId, true);
   const proof = await message.getOutboxProof(l2Provider);
-  const { address, abi } = CONTRACT_ADDRESSES[CHAIN_ID].outbox;
+  const { address, abi } = CONTRACT_ADDRESSES[chainId].outbox;
   const outbox = new Contract(address, abi);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const eventData = (message as any).nitroWriter.event; // nitroWriter is a private property on the
@@ -110,7 +108,8 @@ async function finalizeArbitrum(message: L2ToL1MessageWriter): Promise<Multicall
 async function getFinalizableMessages(
   logger: winston.Logger,
   tokensBridged: TokensBridged[],
-  l1Signer: Signer
+  l1Signer: Signer,
+  chainId: number
 ): Promise<
   {
     info: TokensBridged;
@@ -118,7 +117,7 @@ async function getFinalizableMessages(
     status: string;
   }[]
 > {
-  const allMessagesWithStatuses = await getAllMessageStatuses(tokensBridged, logger, l1Signer);
+  const allMessagesWithStatuses = await getAllMessageStatuses(tokensBridged, logger, l1Signer, chainId);
   const statusesGrouped = groupObjectCountsByProp(
     allMessagesWithStatuses,
     (message: { status: string }) => message.status
@@ -134,7 +133,8 @@ async function getFinalizableMessages(
 async function getAllMessageStatuses(
   tokensBridged: TokensBridged[],
   logger: winston.Logger,
-  mainnetSigner: Signer
+  mainnetSigner: Signer,
+  chainId: number
 ): Promise<
   {
     info: TokensBridged;
@@ -147,7 +147,9 @@ async function getAllMessageStatuses(
   const logIndexesForMessage = getUniqueLogIndex(tokensBridged);
   return (
     await Promise.all(
-      tokensBridged.map((e, i) => getMessageOutboxStatusAndProof(logger, e, mainnetSigner, logIndexesForMessage[i]))
+      tokensBridged.map((e, i) =>
+        getMessageOutboxStatusAndProof(logger, e, mainnetSigner, logIndexesForMessage[i], chainId)
+      )
     )
   )
     .map((result, i) => {
@@ -163,12 +165,13 @@ async function getMessageOutboxStatusAndProof(
   logger: winston.Logger,
   event: TokensBridged,
   l1Signer: Signer,
-  logIndex: number
+  logIndex: number,
+  chainId: number
 ): Promise<{
   message: L2ToL1MessageWriter;
   status: string;
 }> {
-  const l2Provider = getCachedProvider(CHAIN_ID, true);
+  const l2Provider = getCachedProvider(chainId, true);
   const receipt = await l2Provider.getTransactionReceipt(event.transactionHash);
   const l2Receipt = new L2TransactionReceipt(receipt);
 

--- a/src/finalizer/utils/index.ts
+++ b/src/finalizer/utils/index.ts
@@ -1,5 +1,5 @@
 export * from "./polygon";
-export * from "./arbitrum";
+export * from "./arbStack";
 export * from "./opStack";
 export * from "./zkSync";
 export * from "./scroll";


### PR DESCRIPTION
The Arbitrum finalizer was using `CHAIN_IDs.ARBITRUM` in all locations.