### PR TITLE
feat: handle Polygon finalizer edge case when CCTP limit is breached

### DIFF
--- a/src/finalizer/utils/polygon.ts
+++ b/src/finalizer/utils/polygon.ts
@@ -16,6 +16,8 @@ import {
   compareAddressesSimple,
   TOKEN_SYMBOLS_MAP,
   CHAIN_IDs,
+  sortEventsAscending,
+  toBNWei,
 } from "../../utils";
 import { EthersError, TokensBridged } from "../../interfaces";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
@@ -35,6 +37,8 @@ enum POLYGON_MESSAGE_STATUS {
 // Unique signature used to identify Polygon L2 transactions that were erc20 withdrawals from the Polygon
 // canonical bridge. Do not change.
 const BURN_SIG = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+const CCTP_WITHDRAWAL_LIMIT_WEI = toBNWei(1_000_000, 6);
 
 export interface PolygonTokensBridged extends TokensBridged {
   payload: string;
@@ -61,7 +65,26 @@ export async function polygonFinalizer(
 
   // Unlike the rollups, withdrawals process very quickly on polygon, so we can conservatively remove any events
   // that are older than 1 day old:
-  const recentTokensBridgedEvents = spokePoolClient.getTokensBridged().filter((e) => e.blockNumber >= fromBlock);
+  let recentTokensBridgedEvents = spokePoolClient.getTokensBridged().filter((e) => e.blockNumber >= fromBlock);
+
+  // The SpokePool emits one TokensBridged event even if the token is USDC and it gets withdrawn in two separate
+  // CCTP events. We can't filter out these USDC events here (see comment below in `getFinalizableTransactions()`)
+  // but we do need to add in more TokensBridged events so that the call to `getUniqueLogIndex` will work.
+  recentTokensBridgedEvents.forEach((e) => {
+    if (
+      compareAddressesSimple(e.l2TokenAddress, TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_ID]) &&
+      e.amountToReturn.gt(CCTP_WITHDRAWAL_LIMIT_WEI)
+    ) {
+      // Inject one TokensBridged event for each CCTP withdrawal that needs to be processed.
+      const numberOfEventsToAdd = Math.ceil(e.amountToReturn.div(CCTP_WITHDRAWAL_LIMIT_WEI).toNumber());
+      for (let i = 0; i < numberOfEventsToAdd; i++) {
+        recentTokensBridgedEvents.push({
+          ...e,
+        });
+      }
+    }
+  });
+  recentTokensBridgedEvents = sortEventsAscending(recentTokensBridgedEvents);
 
   return multicallPolygonFinalizations(recentTokensBridgedEvents, posClient, signer, hubPoolClient, logger);
 }

--- a/src/finalizer/utils/polygon.ts
+++ b/src/finalizer/utils/polygon.ts
@@ -38,6 +38,7 @@ enum POLYGON_MESSAGE_STATUS {
 // canonical bridge. Do not change.
 const BURN_SIG = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
+// We should ideally read this limit from a contract call, but for now we'll hardcode it.
 const CCTP_WITHDRAWAL_LIMIT_WEI = toBNWei(1_000_000, 6);
 
 export interface PolygonTokensBridged extends TokensBridged {


### PR DESCRIPTION
There is a bug in the Polygon finalizer where a single transaction contains multiple token withdrawals from Spoke to Hub in which more than 1 million USDC are withdrawn, resulting in a single `TokensBridged` event getting emitted but multiple USDC "burns" happening (due to the CCTP 1mil withdrawal limit).

This messes up the `logIndex` computation math for any withdrawals that take place after the USDC withdrawals. This logic isn't needed in other chains with CCTP like Arbitrum or Optimism because the `logIndex` is relative to all other non-CCTP withdrawals, whereas in Polygon it seems that CCTP withdrawals also count towards the `logIndex` of non CCTP withdrawals
