### PR TITLE
across: Update token balances unconditionally on token shortfalls

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -148,8 +148,8 @@ export class Relayer {
     const { inventoryClient, tokenClient } = this.clients;
 
     const currentTime = getCurrentTime();
-    const update = tokenClient.anyCapturedShortFallFills() ||
-      currentTime < this.lastMaintenance + this.config.maintenanceInterval;
+    const update =
+      tokenClient.anyCapturedShortFallFills() || currentTime < this.lastMaintenance + this.config.maintenanceInterval;
 
     if (!update) {
       return; // Nothing to do.

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -148,7 +148,10 @@ export class Relayer {
     const { inventoryClient, tokenClient } = this.clients;
 
     const currentTime = getCurrentTime();
-    if (currentTime < this.lastMaintenance + this.config.maintenanceInterval) {
+    const update = tokenClient.anyCapturedShortFallFills() ||
+      currentTime < this.lastMaintenance + this.config.maintenanceInterval;
+
+    if (!update) {
       return; // Nothing to do.
     }
 


### PR DESCRIPTION
The relayer currently only updates its token balances every x seconds (nominally 60). This is a nice optimisation for the standard case, but results in unnecessary marginal delays in the case of proactive rebalancing or awaiting on repayments. Instead, modify the update logic to be conditional on token shortfalls OR at least x seconds (nominally 60).