### PR TITLE
feat: Manual withdrawals of ERC20 on OpStack lite chains

### DIFF
--- a/scripts/withdrawFromOpStack.ts
+++ b/scripts/withdrawFromOpStack.ts
@@ -117,7 +117,7 @@ export async function run(): Promise<void> {
     `Unexpected L1 standard bridge address in ovmStandardBridge contract, expected: ${expectedL1StandardBridge}, got: ${l1StandardBridge}`
   );
   const customTokenBridge = await spokePool.tokenBridges(l2Token);
-  assert(customTokenBridge === ZERO_ADDRESS, `Custom token bridge set for token ${l2Token} (${customTokenBridge})");
+  assert(customTokenBridge === ZERO_ADDRESS, `Custom token bridge set for token ${l2Token} (${customTokenBridge})`);
   if (!(await askYesNoQuestion("\nDo you want to proceed?"))) {
     return;
   }

--- a/scripts/withdrawFromOpStack.ts
+++ b/scripts/withdrawFromOpStack.ts
@@ -77,24 +77,25 @@ export async function run(): Promise<void> {
   const ovmStandardBridgeObj = CONTRACT_ADDRESSES[chainId].ovmStandardBridge;
   assert(CONTRACT_ADDRESSES[chainId].ovmStandardBridge, "ovmStandardBridge for chain not found in CONTRACT_ADDRESSES");
   const ovmStandardBridge = new Contract(ovmStandardBridgeObj.address, ovmStandardBridgeObj.abi, connectedSigner);
-  const bridgeArgs = l1TokenInfo.symbol === "ETH"
-    ? [
-        signerAddr, // to
-        200_000, // minGasLimit
-        "0x", // extraData
-        { value: amount }, // msg.value
-      ]
-    : [
-        l2Token, // _localToken
-        TOKEN_SYMBOLS_MAP[args.token]?.addresses[CHAIN_IDs.MAINNET], // Remote token to be received on L1 side. If the
-        // remoteL1Token on the other chain does not recognize the local token as the correct
-        // pair token, the ERC20 bridge will fail and the tokens will be returned to sender on
-        // this chain.
-        signerAddr, // _to
-        amount, // _amount
-        200_000, // minGasLimit
-        "0x", // _data
-      ];
+  const bridgeArgs =
+    l1TokenInfo.symbol === "ETH"
+      ? [
+          signerAddr, // to
+          200_000, // minGasLimit
+          "0x", // extraData
+          { value: amount }, // msg.value
+        ]
+      : [
+          l2Token, // _localToken
+          TOKEN_SYMBOLS_MAP[args.token]?.addresses[CHAIN_IDs.MAINNET], // Remote token to be received on L1 side. If the
+          // remoteL1Token on the other chain does not recognize the local token as the correct
+          // pair token, the ERC20 bridge will fail and the tokens will be returned to sender on
+          // this chain.
+          signerAddr, // _to
+          amount, // _amount
+          200_000, // minGasLimit
+          "0x", // _data
+        ];
 
   console.log(
     `Submitting bridgeETHTo on the OVM standard bridge @ ${ovmStandardBridge.address} with the following args: `,

--- a/scripts/withdrawFromOpStack.ts
+++ b/scripts/withdrawFromOpStack.ts
@@ -77,27 +77,24 @@ export async function run(): Promise<void> {
   const ovmStandardBridgeObj = CONTRACT_ADDRESSES[chainId].ovmStandardBridge;
   assert(CONTRACT_ADDRESSES[chainId].ovmStandardBridge, "ovmStandardBridge for chain not found in CONTRACT_ADDRESSES");
   const ovmStandardBridge = new Contract(ovmStandardBridgeObj.address, ovmStandardBridgeObj.abi, connectedSigner);
-  let bridgeArgs;
-  if (l1TokenInfo.symbol === "ETH") {
-    bridgeArgs = [
-      signerAddr, // to
-      200_000, // minGasLimit
-      "0x", // extraData
-      { value: amount }, // msg.value
-    ];
-  } else {
-    bridgeArgs = [
-      l2Token, // _localToken
-      TOKEN_SYMBOLS_MAP[args.token]?.addresses[CHAIN_IDs.MAINNET], // Remote token to be received on L1 side. If the
-      // remoteL1Token on the other chain does not recognize the local token as the correct
-      // pair token, the ERC20 bridge will fail and the tokens will be returned to sender on
-      // this chain.
-      signerAddr, // _to
-      amount, // _amount
-      200_000, // minGasLimit
-      "0x", // _data
-    ];
-  }
+  const bridgeArgs = l1TokenInfo.symbol === "ETH"
+    ? [
+        signerAddr, // to
+        200_000, // minGasLimit
+        "0x", // extraData
+        { value: amount }, // msg.value
+      ]
+    : [
+        l2Token, // _localToken
+        TOKEN_SYMBOLS_MAP[args.token]?.addresses[CHAIN_IDs.MAINNET], // Remote token to be received on L1 side. If the
+        // remoteL1Token on the other chain does not recognize the local token as the correct
+        // pair token, the ERC20 bridge will fail and the tokens will be returned to sender on
+        // this chain.
+        signerAddr, // _to
+        amount, // _amount
+        200_000, // minGasLimit
+        "0x", // _data
+      ];
 
   console.log(
     `Submitting bridgeETHTo on the OVM standard bridge @ ${ovmStandardBridge.address} with the following args: `,

--- a/scripts/withdrawFromOpStack.ts
+++ b/scripts/withdrawFromOpStack.ts
@@ -14,6 +14,7 @@ import {
   fromWei,
   blockExplorerLink,
   CHAIN_IDs,
+  ZERO_ADDRESS,
 } from "../src/utils";
 import { CONTRACT_ADDRESSES } from "../src/common";
 import { askYesNoQuestion, getOvmSpokePoolContract } from "./utils";
@@ -118,6 +119,8 @@ export async function run(): Promise<void> {
     l1StandardBridge === expectedL1StandardBridge,
     `Unexpected L1 standard bridge address in ovmStandardBridge contract, expected: ${expectedL1StandardBridge}, got: ${l1StandardBridge}`
   );
+  const customTokenBridge = await spokePool.tokenBridges(l2Token);
+  assert(customTokenBridge === ZERO_ADDRESS, "Custom token bridge set for token");
   if (!(await askYesNoQuestion("\nDo you want to proceed?"))) {
     return;
   }

--- a/scripts/withdrawFromOpStack.ts
+++ b/scripts/withdrawFromOpStack.ts
@@ -117,7 +117,7 @@ export async function run(): Promise<void> {
     `Unexpected L1 standard bridge address in ovmStandardBridge contract, expected: ${expectedL1StandardBridge}, got: ${l1StandardBridge}`
   );
   const customTokenBridge = await spokePool.tokenBridges(l2Token);
-  assert(customTokenBridge === ZERO_ADDRESS, "Custom token bridge set for token");
+  assert(customTokenBridge === ZERO_ADDRESS, `Custom token bridge set for token ${l2Token} (${customTokenBridge})");
   if (!(await askYesNoQuestion("\nDo you want to proceed?"))) {
     return;
   }

--- a/scripts/withdrawFromOpStack.ts
+++ b/scripts/withdrawFromOpStack.ts
@@ -20,7 +20,7 @@ import { askYesNoQuestion, getOvmSpokePoolContract } from "./utils";
 
 import minimist from "minimist";
 
-const cliArgs = ["amount", "chainId"];
+const cliArgs = ["amount", "chainId", "token"];
 const args = minimist(process.argv.slice(2), {
   string: cliArgs,
 });
@@ -30,6 +30,7 @@ const args = minimist(process.argv.slice(2), {
 // \ --amount 3000000000000000000
 // \ --chainId 1135
 // \ --wallet gckms
+// \ --token WETH
 // \ --keys bot1
 
 export async function run(): Promise<void> {
@@ -41,11 +42,10 @@ export async function run(): Promise<void> {
   const signerAddr = await baseSigner.getAddress();
   const chainId = parseInt(args.chainId);
   const connectedSigner = baseSigner.connect(await getProvider(chainId));
-  const l2Token = TOKEN_SYMBOLS_MAP.WETH?.addresses[chainId];
-  assert(l2Token, `WETH not found on chain ${chainId} in TOKEN_SYMBOLS_MAP`);
+  const l2Token = TOKEN_SYMBOLS_MAP[args.token]?.addresses[chainId];
+  assert(l2Token, `${args.token} not found on chain ${chainId} in TOKEN_SYMBOLS_MAP`);
   const l1TokenInfo = getL1TokenInfo(l2Token, chainId);
   console.log("Fetched L1 token info:", l1TokenInfo);
-  assert(l1TokenInfo.symbol === "ETH", "Only WETH withdrawals are supported for now.");
   const amount = args.amount;
   const amountFromWei = ethers.utils.formatUnits(amount, l1TokenInfo.decimals);
   console.log(`Amount to bridge from chain ${chainId}: ${amountFromWei} ${l2Token}`);
@@ -54,33 +54,53 @@ export async function run(): Promise<void> {
   const currentBalance = await erc20.balanceOf(signerAddr);
   const currentEthBalance = await connectedSigner.getBalance();
   console.log(
-    `Current WETH balance for account ${signerAddr}: ${fromWei(currentBalance, l1TokenInfo.decimals)} ${l2Token}`
+    `Current ${l1TokenInfo.symbol} balance for account ${signerAddr}: ${fromWei(
+      currentBalance,
+      l1TokenInfo.decimals
+    )} ${l2Token}`
   );
   console.log(`Current ETH balance for account ${signerAddr}: ${fromWei(currentEthBalance, l1TokenInfo.decimals)}`);
 
-  // First offer user option to unwrap WETH into ETH.
-  const weth = new Contract(l2Token, WETH9.abi, connectedSigner);
-  if (await askYesNoQuestion(`\nUnwrap ${amount} of WETH @ ${weth.address}?`)) {
-    const unwrap = await weth.withdraw(amount);
-    console.log(`Submitted transaction: ${blockExplorerLink(unwrap.hash, chainId)}.`);
-    const receipt = await unwrap.wait();
-    console.log("Unwrap complete...", receipt);
+  // First offer user option to unwrap WETH into ETH
+  if (l1TokenInfo.symbol === "ETH") {
+    const weth = new Contract(l2Token, WETH9.abi, connectedSigner);
+    if (await askYesNoQuestion(`\nUnwrap ${amount} of WETH @ ${weth.address}?`)) {
+      const unwrap = await weth.withdraw(amount);
+      console.log(`Submitted transaction: ${blockExplorerLink(unwrap.hash, chainId)}.`);
+      const receipt = await unwrap.wait();
+      console.log("Unwrap complete...", receipt);
+    }
   }
 
-  // Now, submit a withdrawal:
+  // Now, submit a withdrawal. This might fail if the ERC20 uses a non-standard OVM bridge to withdraw.
   const ovmStandardBridgeObj = CONTRACT_ADDRESSES[chainId].ovmStandardBridge;
   assert(CONTRACT_ADDRESSES[chainId].ovmStandardBridge, "ovmStandardBridge for chain not found in CONTRACT_ADDRESSES");
   const ovmStandardBridge = new Contract(ovmStandardBridgeObj.address, ovmStandardBridgeObj.abi, connectedSigner);
-  const bridgeETHToArgs = [
-    signerAddr, // to
-    200_000, // minGasLimit
-    "0x", // extraData
-    { value: amount }, // msg.value
-  ];
+  let bridgeArgs;
+  if (l1TokenInfo.symbol === "ETH") {
+    bridgeArgs = [
+      signerAddr, // to
+      200_000, // minGasLimit
+      "0x", // extraData
+      { value: amount }, // msg.value
+    ];
+  } else {
+    bridgeArgs = [
+      l2Token, // _localToken
+      TOKEN_SYMBOLS_MAP[args.token]?.addresses[CHAIN_IDs.MAINNET], // Remote token to be received on L1 side. If the
+      // remoteL1Token on the other chain does not recognize the local token as the correct
+      // pair token, the ERC20 bridge will fail and the tokens will be returned to sender on
+      // this chain.
+      signerAddr, // _to
+      amount, // _amount
+      200_000, // minGasLimit
+      "0x", // _data
+    ];
+  }
 
   console.log(
     `Submitting bridgeETHTo on the OVM standard bridge @ ${ovmStandardBridge.address} with the following args: `,
-    ...bridgeETHToArgs
+    ...bridgeArgs
   );
 
   // Sanity check that the ovmStandardBridge contract is the one we expect by comparing its stored addresses
@@ -101,7 +121,9 @@ export async function run(): Promise<void> {
   if (!(await askYesNoQuestion("\nDo you want to proceed?"))) {
     return;
   }
-  const withdrawal = await ovmStandardBridge.bridgeETHTo(...bridgeETHToArgs);
+  const withdrawal = await ovmStandardBridge[l1TokenInfo.symbol === "ETH" ? "bridgeETHTo" : "bridgeERC20To"](
+    ...bridgeArgs
+  );
   console.log(`Submitted withdrawal: ${blockExplorerLink(withdrawal.hash, chainId)}.`);
   const receipt = await withdrawal.wait();
   console.log("Receipt", receipt);

--- a/src/common/abi/OpStackStandardBridgeL2.json
+++ b/src/common/abi/OpStackStandardBridgeL2.json
@@ -15,27 +15,16 @@
   {
     "anonymous": false,
     "inputs": [
-      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
-      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
-      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" },
-      { "indexed": false, "internalType": "bytes", "name": "extraData", "type": "bytes" }
-    ],
-    "name": "ETHBridgeInitiated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
       {
         "indexed": true,
         "internalType": "address",
-        "name": "localToken",
+        "name": "l1Token",
         "type": "address"
       },
       {
         "indexed": true,
         "internalType": "address",
-        "name": "remoteToken",
+        "name": "l2Token",
         "type": "address"
       },
       {
@@ -63,7 +52,7 @@
         "type": "bytes"
       }
     ],
-    "name": "ERC20BridgeInitiated",
+    "name": "WithdrawalInitiated",
     "type": "event"
   },
   {

--- a/src/common/abi/OpStackStandardBridgeL2.json
+++ b/src/common/abi/OpStackStandardBridgeL2.json
@@ -24,6 +24,49 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "localToken",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "remoteToken",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "from",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "bytes",
+            "name": "extraData",
+            "type": "bytes"
+        }
+    ],
+    "name": "ERC20BridgeInitiated",
+    "type": "event"
+},
+  {
     "inputs": [
       { "internalType": "address", "name": "_to", "type": "address" },
       { "internalType": "uint32", "name": "_minGasLimit", "type": "uint32" },
@@ -34,6 +77,44 @@
     "stateMutability": "payable",
     "type": "function"
   },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_localToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "_remoteToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "_to",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_amount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint32",
+                "name": "_minGasLimit",
+                "type": "uint32"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_extraData",
+                "type": "bytes"
+            }
+        ],
+        "name": "bridgeERC20To",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
   {
     "inputs": [],
     "name": "MESSENGER",

--- a/src/common/abi/OpStackStandardBridgeL2.json
+++ b/src/common/abi/OpStackStandardBridgeL2.json
@@ -26,46 +26,46 @@
   {
     "anonymous": false,
     "inputs": [
-        {
-            "indexed": true,
-            "internalType": "address",
-            "name": "localToken",
-            "type": "address"
-        },
-        {
-            "indexed": true,
-            "internalType": "address",
-            "name": "remoteToken",
-            "type": "address"
-        },
-        {
-            "indexed": true,
-            "internalType": "address",
-            "name": "from",
-            "type": "address"
-        },
-        {
-            "indexed": false,
-            "internalType": "address",
-            "name": "to",
-            "type": "address"
-        },
-        {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "amount",
-            "type": "uint256"
-        },
-        {
-            "indexed": false,
-            "internalType": "bytes",
-            "name": "extraData",
-            "type": "bytes"
-        }
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "localToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "remoteToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraData",
+        "type": "bytes"
+      }
     ],
     "name": "ERC20BridgeInitiated",
     "type": "event"
-},
+  },
   {
     "inputs": [
       { "internalType": "address", "name": "_to", "type": "address" },
@@ -77,44 +77,44 @@
     "stateMutability": "payable",
     "type": "function"
   },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_localToken",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_remoteToken",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_amount",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint32",
-                "name": "_minGasLimit",
-                "type": "uint32"
-            },
-            {
-                "internalType": "bytes",
-                "name": "_extraData",
-                "type": "bytes"
-            }
-        ],
-        "name": "bridgeERC20To",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_localToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_remoteToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_minGasLimit",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "bridgeERC20To",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
   {
     "inputs": [],
     "name": "MESSENGER",

--- a/src/common/abi/OpStackStandardBridgeL2.json
+++ b/src/common/abi/OpStackStandardBridgeL2.json
@@ -15,16 +15,27 @@
   {
     "anonymous": false,
     "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "indexed": false, "internalType": "bytes", "name": "extraData", "type": "bytes" }
+    ],
+    "name": "ETHBridgeInitiated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
       {
         "indexed": true,
         "internalType": "address",
-        "name": "l1Token",
+        "name": "localToken",
         "type": "address"
       },
       {
         "indexed": true,
         "internalType": "address",
-        "name": "l2Token",
+        "name": "remoteToken",
         "type": "address"
       },
       {
@@ -52,7 +63,7 @@
         "type": "bytes"
       }
     ],
-    "name": "WithdrawalInitiated",
+    "name": "ERC20BridgeInitiated",
     "type": "event"
   },
   {

--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -171,7 +171,7 @@ export async function opStackFinalizer(
         amountToReturn: event.args.amount,
         chainId,
         leafId: 0,
-        l2TokenAddress: TOKEN_SYMBOLS_MAP.WETH.addresses[chainId],
+        l2TokenAddress: event.l2TokenAddress,
       };
       if (event.blockNumber >= latestBlockToProve) {
         recentTokensBridgedEvents.push(tokenBridgedEvent);

--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -114,12 +114,30 @@ export async function opStackFinalizer(
       CONTRACT_ADDRESSES[chainId].ovmStandardBridge.abi,
       spokePoolClient.spokePool.provider
     );
-    const withdrawalEvents = (
+    const withdrawalEthEvents = (
       await paginatedEventQuery(
         ovmStandardBridge,
-        ovmStandardBridge.filters.WithdrawalInitiated(
-          null, // l1Token
-          null, // l2Token
+        ovmStandardBridge.filters.ETHBridgeInitiated(
+          null, // from
+          withdrawalToAddresses // to
+        ),
+        {
+          ...spokePoolClient.eventSearchConfig,
+          toBlock: spokePoolClient.latestBlockSearched,
+        }
+      )
+    ).map((event) => {
+      return {
+        ...event,
+        l2TokenAddress: TOKEN_SYMBOLS_MAP.WETH.addresses[chainId],
+      };
+    });
+    const withdrawalErc20Events = (
+      await paginatedEventQuery(
+        ovmStandardBridge,
+        ovmStandardBridge.filters.ERC20BridgeInitiated(
+          null, // localToken
+          null, // remoteToken
           withdrawalToAddresses // from
         ),
         {
@@ -133,17 +151,18 @@ export async function opStackFinalizer(
         getL1TokenInfo(event.args.localToken, chainId);
         return {
           ...event,
+          l2TokenAddress: event.args.localToken,
         };
       } catch (err) {
         logger.debug({
           at: "opStackFinalizer",
-          message: `Skipping ERC20 withdrawal event for unknown token ${event.args.l2Token} on chain ${networkName}`,
+          message: `Skipping ERC20 withdrawal event for unknown token ${event.args.localToken} on chain ${networkName}`,
           event: event,
         });
         return undefined;
       }
     });
-
+    const withdrawalEvents = [...withdrawalEthEvents, ...withdrawalErc20Events].filter((event) => event !== undefined);
     // If there are any found withdrawal initiated events, then add them to the list of TokenBridged events we'll
     // submit proofs and finalizations for.
     withdrawalEvents.forEach((event) => {
@@ -152,7 +171,7 @@ export async function opStackFinalizer(
         amountToReturn: event.args.amount,
         chainId,
         leafId: 0,
-        l2TokenAddress: event.args.l2Token,
+        l2TokenAddress: event.l2TokenAddress,
       };
       if (event.blockNumber >= latestBlockToProve) {
         recentTokensBridgedEvents.push(tokenBridgedEvent);


### PR DESCRIPTION
Updates script `withdrawFromOpStack` to support ERC20 withdrawals (e.g. USDT) and updates finalizer to automate these. Helps with withdrawing ERC20's from Lite chains
