### PR TITLE
improve(relayer): Better support for custom Across API host

### DIFF
--- a/scripts/spokepool.ts
+++ b/scripts/spokepool.ts
@@ -4,9 +4,11 @@ import { groupBy } from "lodash";
 import { config } from "dotenv";
 import { Contract, ethers, Signer } from "ethers";
 import { LogDescription } from "@ethersproject/abi";
+import { CHAIN_IDs } from "@across-protocol/constants";
 import { constants as sdkConsts, utils as sdkUtils } from "@across-protocol/sdk";
 import { ExpandedERC20__factory as ERC20 } from "@across-protocol/contracts";
 import { RelayData } from "../src/interfaces";
+import { getAcrossHost } from "../src/clients";
 import {
   BigNumber,
   formatFeePct,
@@ -32,8 +34,6 @@ type RelayerFeeQuery = {
   skipAmountLimit?: string;
   timestamp?: number;
 };
-
-const { ACROSS_API_HOST = "across.to" } = process.env;
 
 const { NODE_SUCCESS, NODE_INPUT_ERR, NODE_APP_ERR } = utils;
 const { fixedPointAdjustment: fixedPoint } = sdkUtils;
@@ -87,8 +87,9 @@ function printFill(destinationChainId: number, log: LogDescription): void {
 }
 
 async function getSuggestedFees(params: RelayerFeeQuery, timeout: number) {
+  const hubChainId = sdkUtils.chainIsProd(params.originChainId) ? CHAIN_IDs.MAINNET : CHAIN_IDs.SEPOLIA;
   const path = "api/suggested-fees";
-  const url = `https://${ACROSS_API_HOST}/${path}`;
+  const url = `https://${getAcrossHost(hubChainId)}/${path}`;
 
   try {
     const quote = await axios.get(url, { timeout, params });

--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -19,6 +19,10 @@ export interface DepositLimits {
 
 const API_UPDATE_RETENTION_TIME = 60; // seconds
 
+export function getAcrossHost(hubChainId: number): string {
+  return process.env.ACROSS_API_HOST ?? (hubChainId === CHAIN_IDs.MAINNET ? "app.across.to" : "testnet.across.to");
+}
+
 export class AcrossApiClient {
   private endpoint: string;
   private chainIds: number[];
@@ -36,7 +40,7 @@ export class AcrossApiClient {
     readonly timeout: number = 3000
   ) {
     const hubChainId = hubPoolClient.chainId;
-    this.endpoint = `https://${hubChainId === CHAIN_IDs.MAINNET ? "app.across.to" : "testnet.across.to"}/api`;
+    this.endpoint = `https://${getAcrossHost(hubChainId)}/api`;
     if (Object.keys(tokensQuery).length === 0) {
       this.tokensQuery = dedupArray(Object.values(TOKEN_SYMBOLS_MAP).map(({ addresses }) => addresses[hubChainId]));
     }

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -30,7 +30,8 @@ import {
   ZERO_ADDRESS,
 } from "../utils";
 import { Deposit, DepositWithBlock, L1Token, SpokePoolClientsByChain } from "../interfaces";
-import { HubPoolClient } from ".";
+import { getAcrossHost } from "./AcrossAPIClient";
+import { HubPoolClient } from "./HubPoolClient";
 
 type TransactionCostEstimate = sdkUtils.TransactionCostEstimate;
 
@@ -129,7 +130,7 @@ export class ProfitClient {
     );
 
     this.priceClient = new PriceClient(logger, [
-      new acrossApi.PriceFeed(),
+      new acrossApi.PriceFeed({ host: getAcrossHost(hubPoolClient.chainId) }),
       new coingecko.PriceFeed({ apiKey: process.env.COINGECKO_PRO_API_KEY }),
       new defiLlama.PriceFeed(),
     ]);
@@ -527,7 +528,7 @@ export class ProfitClient {
         .filter(({ symbol }) => isDefined(TOKEN_SYMBOLS_MAP[symbol]))
         .map(({ symbol }) => {
           const { addresses } = TOKEN_SYMBOLS_MAP[symbol];
-          const address = addresses[1];
+          const address = addresses[CHAIN_IDs.MAINNET];
           return [symbol, address];
         })
     );
@@ -550,7 +551,7 @@ export class ProfitClient {
     // Also ensure all gas tokens are included in the lookup.
     this.enabledChainIds.forEach((chainId) => {
       const symbol = getNativeTokenSymbol(chainId);
-      tokens[symbol] ??= TOKEN_SYMBOLS_MAP[symbol].addresses[1];
+      tokens[symbol] ??= TOKEN_SYMBOLS_MAP[symbol].addresses[CHAIN_IDs.MAINNET];
     });
 
     this.logger.debug({ at: "ProfitClient", message: "Updating Profit client", tokens });


### PR DESCRIPTION
Permit the ACROSS_API_HOST env var to override the standard app.across.to and testnet.across.to API hostnames.

While here, sub out some hardcoded chain IDs.