### PR TITLE
improve(arweave): Change arweave data key from list of chain ID's to map

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -442,6 +442,8 @@ export const RELAYER_DEFAULT_SPOKEPOOL_INDEXER = "./dist/src/libexec/RelayerSpok
 
 export const DEFAULT_ARWEAVE_GATEWAY = { url: "arweave.net", port: 443, protocol: "https" };
 
+export const ARWEAVE_TAG_BYTE_LIMIT = 2048;
+
 // Chains with slow (> 2 day liveness) canonical L2-->L1 bridges that we prioritize taking repayment on.
 // This does not include all 7-day withdrawal chains because we don't necessarily prefer being repaid on some of these 7-day chains, like Mode.
 // This list should generally exclude Lite chains because the relayer ignores HubPool liquidity in that case which could cause the

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2315,7 +2315,10 @@ export class Dataworker {
       at: "Dataworker#_getPoolRebalanceRoot",
       message: "Constructed new pool rebalance root",
       key,
-      root: this.rootCache[key],
+      root: {
+        ...this.rootCache[key],
+        tree: this.rootCache[key].tree.getHexRoot(),
+      },
     });
 
     return _.cloneDeep(this.rootCache[key]);

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -622,7 +622,7 @@ export class Dataworker {
       const chainIds = this.clients.configStoreClient.getChainIdIndicesForBlock(nextBundleMainnetStartBlock);
       // Store the bundle block ranges on Arweave as a map of chainId to block range to aid users in querying.
       const bundleBlockRangeMap = Object.fromEntries(
-        bundleData.bundleBlockRanges.map(([range], i) => {
+        bundleData.bundleBlockRanges.map((range, i) => {
           const chainIdForRange = chainIds[i];
           // The arweave tag cannot exceed 2048 bytes so only keep the end block in the tag.
           return [chainIdForRange, range];

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -1,7 +1,11 @@
 import assert from "assert";
 import { utils, interfaces, caching } from "@across-protocol/sdk";
 import { SpokePoolClient } from "../clients";
-import { ARWEAVE_TAG_BYTE_LIMIT, CONSERVATIVE_BUNDLE_FREQUENCY_SECONDS, spokesThatHoldEthAndWeth } from "../common/Constants";
+import {
+  ARWEAVE_TAG_BYTE_LIMIT,
+  CONSERVATIVE_BUNDLE_FREQUENCY_SECONDS,
+  spokesThatHoldEthAndWeth,
+} from "../common/Constants";
 import { CONTRACT_ADDRESSES } from "../common/ContractAddresses";
 import {
   PoolRebalanceLeaf,

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { utils, interfaces, caching } from "@across-protocol/sdk";
 import { SpokePoolClient } from "../clients";
-import { CONSERVATIVE_BUNDLE_FREQUENCY_SECONDS, spokesThatHoldEthAndWeth } from "../common/Constants";
+import { ARWEAVE_TAG_BYTE_LIMIT, CONSERVATIVE_BUNDLE_FREQUENCY_SECONDS, spokesThatHoldEthAndWeth } from "../common/Constants";
 import { CONTRACT_ADDRESSES } from "../common/ContractAddresses";
 import {
   PoolRebalanceLeaf,
@@ -342,6 +342,10 @@ export async function persistDataToArweave(
   logger: winston.Logger,
   tag?: string
 ): Promise<void> {
+  assert(
+    Buffer.from(tag).length <= ARWEAVE_TAG_BYTE_LIMIT,
+    `Arweave tag cannot exceed ${ARWEAVE_TAG_BYTE_LIMIT} bytes`
+  );
   const startTime = performance.now();
   // Check if data already exists on Arweave with the given tag.
   // If so, we don't need to persist it again.


### PR DESCRIPTION
We've received feedback from a user of the arweave data that its easier if the arweave stored `bundleBlockRanges` is a mapping of chainId to bundle block ranges rather than a list. This PR also shortens the `tag` used to uniquely identify bundle data to just a mainnet block associated with the bundle, which should always be unique. This avoids the 2048 tag length limit which we'd eventually run into.

example txn: https://arweave.app/tx/jBk5WzugtYMSa1jnXxEH7XN3Q6n0R_jxYsO6WkDHMc4
