### PR TITLE
improve(dataworker): Update arweave bundle data

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -442,6 +442,8 @@ export const RELAYER_DEFAULT_SPOKEPOOL_INDEXER = "./dist/src/libexec/RelayerSpok
 
 export const DEFAULT_ARWEAVE_GATEWAY = { url: "arweave.net", port: 443, protocol: "https" };
 
+export const ARWEAVE_TAG_BYTE_LIMIT = 2048;
+
 // Chains with slow (> 2 day liveness) canonical L2-->L1 bridges that we prioritize taking repayment on.
 // This does not include all 7-day withdrawal chains because we don't necessarily prefer being repaid on some of these 7-day chains, like Mode.
 // This list should generally exclude Lite chains because the relayer ignores HubPool liquidity in that case which could cause the

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -31,7 +31,7 @@ import {
   FillStatus,
 } from "../interfaces";
 import { DataworkerClients } from "./DataworkerClientHelper";
-import { SpokePoolClient, BalanceAllocator } from "../clients";
+import { SpokePoolClient, BalanceAllocator, BundleDataClient } from "../clients";
 import * as PoolRebalanceUtils from "./PoolRebalanceUtils";
 import {
   blockRangesAreInvalidForSpokeClients,
@@ -632,7 +632,7 @@ export class Dataworker {
       // never be duplicated between bundles as long as the mainnet end block in the bundle block range
       // always progresses forwards, which I think is a safe assumption. Other chains might pause
       // but mainnet should never pause.
-      const partialArweaveDataKey = nextBundleMainnetStartBlock;
+      const partialArweaveDataKey = BundleDataClient.getArweaveClientKey(bundleData.bundleBlockRanges);
       await Promise.all([
         persistDataToArweave(
           this.clients.arweaveClient,

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -619,16 +619,34 @@ export class Dataworker {
     // Root bundle is valid, attempt to persist the raw bundle data and the merkle leaf data to DA layer
     // if not already there.
     if (persistBundleData && isDefined(bundleData)) {
+      const chainIds = this.clients.configStoreClient.getChainIdIndicesForBlock(nextBundleMainnetStartBlock);
+      // Store the bundle block ranges on Arweave as a map of chainId to block range to aid users in querying.
+      const bundleBlockRangeMap = Object.fromEntries(
+        bundleData.bundleBlockRanges.map((range, i) => {
+          const chainIdForRange = chainIds[i];
+          // The arweave tag cannot exceed 2048 bytes so only keep the end block in the tag.
+          return [chainIdForRange, range];
+        })
+      );
+      // As a unique key for this bundle, use the next bundle mainnet start block, which should
+      // never be duplicated between bundles as long as the mainnet end block in the bundle block range
+      // always progresses forwards, which I think is a safe assumption. Other chains might pause
+      // but mainnet should never pause.
+      const partialArweaveDataKey = nextBundleMainnetStartBlock;
       await Promise.all([
         persistDataToArweave(
           this.clients.arweaveClient,
-          bundleData,
+          {
+            ...bundleData,
+            bundleBlockRanges: bundleBlockRangeMap,
+          },
           this.logger,
-          `bundles-${bundleData.bundleBlockRanges}`
+          `bundles-${partialArweaveDataKey}`
         ),
         persistDataToArweave(
           this.clients.arweaveClient,
           {
+            bundleBlockRanges: bundleBlockRangeMap,
             poolRebalanceLeaves: expectedTrees.poolRebalanceTree.leaves.map((leaf) => {
               return {
                 ...leaf,
@@ -652,7 +670,7 @@ export class Dataworker {
             slowRelayRoot: expectedTrees.slowRelayTree.tree.getHexRoot(),
           },
           this.logger,
-          `merkletree-${bundleData.bundleBlockRanges}`
+          `merkletree-${partialArweaveDataKey}`
         ),
       ]);
     }
@@ -2297,7 +2315,10 @@ export class Dataworker {
       at: "Dataworker#_getPoolRebalanceRoot",
       message: "Constructed new pool rebalance root",
       key,
-      root: this.rootCache[key],
+      root: {
+        ...this.rootCache[key],
+        tree: this.rootCache[key].tree.getHexRoot(),
+      },
     });
 
     return _.cloneDeep(this.rootCache[key]);

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -1,7 +1,11 @@
 import assert from "assert";
 import { utils, interfaces, caching } from "@across-protocol/sdk";
 import { SpokePoolClient } from "../clients";
-import { CONSERVATIVE_BUNDLE_FREQUENCY_SECONDS, spokesThatHoldEthAndWeth } from "../common/Constants";
+import {
+  ARWEAVE_TAG_BYTE_LIMIT,
+  CONSERVATIVE_BUNDLE_FREQUENCY_SECONDS,
+  spokesThatHoldEthAndWeth,
+} from "../common/Constants";
 import { CONTRACT_ADDRESSES } from "../common/ContractAddresses";
 import {
   PoolRebalanceLeaf,
@@ -342,6 +346,10 @@ export async function persistDataToArweave(
   logger: winston.Logger,
   tag?: string
 ): Promise<void> {
+  assert(
+    Buffer.from(tag).length <= ARWEAVE_TAG_BYTE_LIMIT,
+    `Arweave tag cannot exceed ${ARWEAVE_TAG_BYTE_LIMIT} bytes`
+  );
   const startTime = performance.now();
   // Check if data already exists on Arweave with the given tag.
   // If so, we don't need to persist it again.


### PR DESCRIPTION
Duplicate of https://github.com/across-protocol/relayer/commit/0823a68f1f70bed68150e2064b3449e9df6418d5 but updates the arweave key logic to read from the SDK so we don't have two separate computations of the arweave key.
