### PR TITLE
fix: make datadog types numbers rather than strings

### DIFF
--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -308,7 +308,7 @@ export class Monitor {
             throw new Error(`No decimals found for ${tokenSymbol}`);
           }
           return lodash.mapValues(columns, (cell: RelayerBalanceCell) =>
-            lodash.mapValues(cell, (balance: BigNumber) => convertFromWei(balance.toString(), decimals))
+            lodash.mapValues(cell, (balance: BigNumber) => Number(convertFromWei(balance.toString(), decimals)))
           );
         })
       );


### PR DESCRIPTION
Right now, we're exporting strings to datadog, which you can't do numerical aggregations on. This changes the output to numbers.