### PR TITLE
fix: make datadog logs more digestible in datadog

### DIFF
--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -321,6 +321,7 @@ export class Monitor {
                 balanceType,
                 balanceInWei: balance.toString(),
                 balance: Number(utils.formatUnits(balance, decimals)),
+                datadog: true,
               });
             });
           });

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -44,6 +44,7 @@ import {
   resolveTokenDecimals,
   sortEventsDescending,
   getWidestPossibleExpectedBlockRange,
+  utils
 } from "../utils";
 
 import { MonitorClients, updateMonitorClients } from "./MonitorClientHelper";
@@ -301,22 +302,29 @@ export class Monitor {
       });
 
       // Note: types are here for clarity, not necessity.
-      const machineReadableReport = lodash.mapValues(reports, (table: RelayerBalanceTable) =>
-        lodash.mapValues(table, (columns: RelayerBalanceColumns, tokenSymbol: string) => {
+
+      Object.entries(reports).forEach(([relayer, balanceTable]) => {
+        Object.entries(balanceTable).forEach(([tokenSymbol, columns]) => {
           const decimals = allL1Tokens.find((token) => token.symbol === tokenSymbol)?.decimals;
           if (!decimals) {
             throw new Error(`No decimals found for ${tokenSymbol}`);
           }
-          return lodash.mapValues(columns, (cell: RelayerBalanceCell) =>
-            lodash.mapValues(cell, (balance: BigNumber) => Number(convertFromWei(balance.toString(), decimals)))
-          );
-        })
-      );
-
-      this.logger.debug({
-        at: "Monitor#reportRelayerBalances",
-        message: "Machine-readable balance report",
-        report: machineReadableReport,
+          Object.entries(columns).forEach(([chainName, cell]) => {
+            Object.entries(cell).forEach(([balanceType, balance]) => {
+              this.logger.debug({
+                at: "Monitor#reportRelayerBalances",
+                message: "Machine-readable balance report",
+                relayer,
+                tokenSymbol,
+                decimals,
+                chainName,
+                balanceType,
+                balanceInWei: balance.toString(),
+                balance: Number(utils.formatUnits(balance, decimals)),
+              });
+            });
+          });
+        });
       });
     }
   }

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -313,7 +313,7 @@ export class Monitor {
             Object.entries(cell).forEach(([balanceType, balance]) => {
               this.logger.debug({
                 at: "Monitor#reportRelayerBalances",
-                message: "Machine-readable balance report",
+                message: "Machine-readable single balance report",
                 relayer,
                 tokenSymbol,
                 decimals,


### PR DESCRIPTION
This PR makes a few modifications to the balance reports that are sent to datadog.
1. It splits them into individual logs per balance. It is much easier for datadog to parse, filter, and groupBy if they are exported that way.
2. It uses normal ethers formatting as opposed to our custom formatter. @james-a-morris pointed this out in the previous PR, but I misunderstood what he was saying. Thank you @james-a-morris!
3. It uses datadog=true to export these logs rather than relying on a bespoke log sink.