### PR TITLE
Experimental: feat(Relayer): Read gas prices computed by API

### DIFF
--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -32,7 +32,7 @@ export class AcrossApiClient {
   private endpoint: string;
   private chainIds: number[];
   private limits: { [token: string]: BigNumber } = {};
-  private gasPrices: GasPrices;
+  private gasPrices: GasPrices = {};
   private updatedAt = 0;
   private profiler: sdkUtils.Profiler;
 

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1413,12 +1413,13 @@ export class Relayer {
     const totalFeePct = formatFeePct(_totalFeePct);
     const { symbol: outputTokenSymbol, decimals: outputTokenDecimals } =
       this.clients.hubPoolClient.getTokenInfoForAddress(deposit.outputToken, deposit.destinationChainId);
+    const apiGasPrice = this.clients.acrossApiClient.getGasPrice(deposit.destinationChainId);
     const _outputAmount = createFormatFunction(2, 4, false, outputTokenDecimals)(deposit.outputAmount.toString());
     msg +=
       ` and output ${_outputAmount} ${outputTokenSymbol}, with depositor ${depositor}.` +
       ` Realized LP fee: ${realizedLpFeePct}%, total fee: ${totalFeePct}%. Gas price used in profit calc: ${formatGwei(
         _gasPriceGwei.toString()
-      )} Gwei.`;
+      )} Gwei.${apiGasPrice ? ` API gas price: ${formatGwei(apiGasPrice)}.` : ""}`;
 
     return msg;
   }


### PR DESCRIPTION
Fetch and update gas prices from API (from new endpoint /gas-prices) and report them on each fill with the implied gas price computed by the relayer.

There is some expected error here because we're computing the present gas prices in the API with the gas cost implied by the deposit which is going to differ the more the deposit lags behind the fill time
