### PR TITLE
improve(relayer): Permit testnet deposit confirmation override

### DIFF
--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -262,7 +262,7 @@ export class RelayerConfig extends CommonConfig {
     // Transform deposit confirmation requirements into an array of ascending
     // deposit confirmations, sorted by the corresponding threshold in USD.
     this.minDepositConfirmations = {};
-    if (this.hubPoolChainId !== CHAIN_IDs.MAINNET) {
+    if (this.hubPoolChainId !== CHAIN_IDs.MAINNET && !isDefined(MIN_DEPOSIT_CONFIRMATIONS)) {
       // Sub in permissive defaults for testnet.
       const standardConfig = { usdThreshold: toBNWei(Number.MAX_SAFE_INTEGER), minConfirmations: 1 };
       Object.values(TESTNET_CHAIN_IDs).forEach((chainId) => (this.minDepositConfirmations[chainId] = [standardConfig]));


### PR DESCRIPTION
This will be used to limit the fill size on testnet in order to preserve the relayer's token balance.