### PR TITLE
Reapply "improve: Use base fee multiplier option in SDK to resolve gas fees (#1969)" (#1985)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.25",
     "@across-protocol/contracts": "^3.0.19",
-    "@across-protocol/sdk": "^3.4.5",
+    "@across-protocol/sdk": "^3.4.6",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.25",
     "@across-protocol/contracts": "^3.0.19",
-    "@across-protocol/sdk": "^3.4.6",
+    "@across-protocol/sdk": "^3.4.7",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.25",
     "@across-protocol/contracts": "^3.0.19",
-    "@across-protocol/sdk": "^3.3.32",
+    "@across-protocol/sdk": "^3.4.5",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/scripts/zkSyncDemo.ts
+++ b/scripts/zkSyncDemo.ts
@@ -62,7 +62,7 @@ export async function run(): Promise<void> {
     connectedSigner
   );
   const l2PubdataByteLimit = zksync.utils.REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT;
-  const l1GasPriceData = await gasPriceOracle.getGasPriceEstimate(l1Provider, l1ChainId);
+  const l1GasPriceData = await gasPriceOracle.getGasPriceEstimate(l1Provider, { chainId: l1ChainId });
   const estimatedL1GasPrice = l1GasPriceData.maxPriorityFeePerGas.add(l1GasPriceData.maxFeePerGas);
   // The ZkSync Mailbox contract checks that the msg.value of the transaction is enough to cover the transaction base
   // cost. The transaction base cost can be queried from the Mailbox by passing in an L1 "executed" gas price,

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -84,10 +84,8 @@ export async function runTransaction(
     const gas = await getGasPrice(
       provider,
       priorityFeeScaler,
-      maxFeePerGasScaler
-      // TODO: For now, do not pass in unsignedTx that is used specifically for Linea priroity gas fee estimation.
-      // There might be an issue with our usage.
-      // await contract.populateTransaction[method](...(args as Array<unknown>), { value })
+      maxFeePerGasScaler,
+      await contract.populateTransaction[method](...(args as Array<unknown>), { value })
     );
 
     logger.debug({

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -8,7 +8,6 @@ import {
   BigNumber,
   bnZero,
   Contract,
-  fixedPointAdjustment as fixedPoint,
   isDefined,
   TransactionResponse,
   ethers,
@@ -82,7 +81,12 @@ export async function runTransaction(
       Number(process.env[`MAX_FEE_PER_GAS_SCALER_${chainId}`] || process.env.MAX_FEE_PER_GAS_SCALER) ||
       DEFAULT_GAS_FEE_SCALERS[chainId]?.maxFeePerGasScaler;
 
-    const gas = await getGasPrice(provider, priorityFeeScaler, maxFeePerGasScaler);
+    const gas = await getGasPrice(
+      provider,
+      priorityFeeScaler,
+      maxFeePerGasScaler,
+      await contract.populateTransaction[method](...(args as Array<unknown>), { value })
+    );
 
     logger.debug({
       at: "TxUtil",
@@ -154,30 +158,30 @@ export async function runTransaction(
   }
 }
 
-// TODO: add in gasPrice when the SDK has this for the given chainId. TODO: improve how we fetch prices.
-// For now this method will extract the provider's Fee data from the associated network and scale it by a priority
-// scaler. This works on both mainnet and L2's by the utility switching the response structure accordingly.
 export async function getGasPrice(
   provider: ethers.providers.Provider,
   priorityScaler = 1.2,
-  maxFeePerGasScaler = 3
+  maxFeePerGasScaler = 3,
+  transactionObject?: ethers.PopulatedTransaction
 ): Promise<Partial<FeeData>> {
+  // Floor scalers at 1.0 as we'll rarely want to submit too low of a gas price. We mostly
+  // just want to submit with as close to prevailing fees as possible.
+  maxFeePerGasScaler = Math.max(1, maxFeePerGasScaler);
+  priorityScaler = Math.max(1, priorityScaler);
   const { chainId } = await provider.getNetwork();
-  const feeData = await gasPriceOracle.getGasPriceEstimate(provider, chainId);
+  // Pass in unsignedTx here for better Linea gas price estimations via the Linea Viem provider.
+  const feeData = await gasPriceOracle.getGasPriceEstimate(provider, {
+    chainId,
+    baseFeeMultiplier: toBNWei(maxFeePerGasScaler),
+    priorityFeeMultiplier: toBNWei(priorityScaler),
+    unsignedTx: transactionObject,
+  });
 
-  if (feeData.maxPriorityFeePerGas.gt(feeData.maxFeePerGas)) {
-    feeData.maxFeePerGas = scaleByNumber(feeData.maxPriorityFeePerGas, 1.5);
-  }
-
-  // Handle chains with legacy pricing.
-  if (feeData.maxPriorityFeePerGas.eq(bnZero)) {
-    return { gasPrice: scaleByNumber(feeData.maxFeePerGas, priorityScaler) };
-  }
-
-  // Default to EIP-1559 (type 2) pricing.
+  // Default to EIP-1559 (type 2) pricing. If gasPriceOracle is using a legacy adapter for this chain then
+  // the priority fee will be 0.
   return {
-    maxFeePerGas: scaleByNumber(feeData.maxFeePerGas, Math.max(priorityScaler * maxFeePerGasScaler, 1)),
-    maxPriorityFeePerGas: scaleByNumber(feeData.maxPriorityFeePerGas, priorityScaler),
+    maxFeePerGas: feeData.maxFeePerGas,
+    maxPriorityFeePerGas: feeData.maxPriorityFeePerGas,
   };
 }
 
@@ -230,8 +234,4 @@ export function getTarget(targetAddress: string):
   } catch (error) {
     return { targetAddress };
   }
-}
-
-function scaleByNumber(amount: BigNumber, scaling: number) {
-  return amount.mul(toBNWei(scaling)).div(fixedPoint);
 }

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -84,8 +84,10 @@ export async function runTransaction(
     const gas = await getGasPrice(
       provider,
       priorityFeeScaler,
-      maxFeePerGasScaler,
-      await contract.populateTransaction[method](...(args as Array<unknown>), { value })
+      maxFeePerGasScaler
+      // TODO: For now, do not pass in unsignedTx that is used specifically for Linea priroity gas fee estimation.
+      // There might be an issue with our usage.
+      // await contract.populateTransaction[method](...(args as Array<unknown>), { value })
     );
 
     logger.debug({

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,10 +58,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.4.6":
-  version "3.4.6"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.6.tgz#e5e3c79e25387d2272ba4e4a26e4b34d6dfc441b"
-  integrity sha512-FfXtteh8IoQp/1RafxMxx/M/9XpVcHX7s/qz3bIWc7IcE62zV7ihu7jhDwRC/Mflb/Z51RZuZny3yzsP9P/y4Q==
+"@across-protocol/sdk@^3.4.7":
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.7.tgz#6ddf9698f918d7b7e0216327d60b54b37fe14f22"
+  integrity sha512-GeyzDG8EzlN8oddmjXASqND+usZPkWDLpzbdWfAfBfHT3pjIMatntZqZghfCfjy+ICf+rlYrAb8I24H4jlct8Q==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.25"

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,10 +58,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.4.5":
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.5.tgz#343f53be92e92afd2fd4dbea16f180533093ea26"
-  integrity sha512-o1DovRfSriL0GTa304rd2KcBDwWYbK2SHT8mElyCLg6beX5RnJKT0YiMUMuCMfZ7MZJscdGzV023e5BhbyeP5A==
+"@across-protocol/sdk@^3.4.6":
+  version "3.4.6"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.6.tgz#e5e3c79e25387d2272ba4e4a26e4b34d6dfc441b"
+  integrity sha512-FfXtteh8IoQp/1RafxMxx/M/9XpVcHX7s/qz3bIWc7IcE62zV7ihu7jhDwRC/Mflb/Z51RZuZny3yzsP9P/y4Q==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.25"

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,10 +58,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.3.32":
-  version "3.3.32"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.3.32.tgz#fa2428df5f9b6cb0392c46f742f11265efa4abb3"
-  integrity sha512-ADyZQeWxjGAreLoeVQYNiJN4zMmmJ7h6ItgbSjP2+JvZENPaH9t23xCegPIyI0oiVqLrOHOGCJ/yEdX6X3HqpQ==
+"@across-protocol/sdk@^3.4.5":
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.5.tgz#343f53be92e92afd2fd4dbea16f180533093ea26"
+  integrity sha512-o1DovRfSriL0GTa304rd2KcBDwWYbK2SHT8mElyCLg6beX5RnJKT0YiMUMuCMfZ7MZJscdGzV023e5BhbyeP5A==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.25"


### PR DESCRIPTION
This reverts commit 72279954ddb71e008b1e7a6c43c8b901b55acc53.

This imports 3.4.7 as well as reverts the above commit. This SDK change will use the priorityFeeMultiplier correctly for Linea, previously the baseFeeMultiplier was used to scale the Linea priority fee.