### PR TITLE
improve(Relayer): Log clearer about overallocated lite chain deposits 

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1352,8 +1352,9 @@ export class Relayer {
         const formattedLpFeePct = formatFeePct(lpFeePct);
 
         // @dev If the origin chain is a lite chain and the LP fee percentage is infinity, then we can assume that the
-        // deposit originated from an over-allocated lite chain so the "unprofitable" log should be modified to be
-        // less confusing.
+        // deposit originated from an over-allocated lite chain because the originChain, the only possible
+        // repayment chain, was not selected for repayment. So the "unprofitable" log should be modified to indicate
+        // this lite chain edge case.
         const fromOverallocatedLiteChain = deposit.fromLiteChain && lpFeePct.isEqualTo(bnUint256Max);
         depositMrkdwn +=
           `- DepositId ${deposit.depositId} (tx: ${depositblockExplorerLink})` +

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1354,6 +1354,7 @@ export class Relayer {
         // @dev If the origin chain is a lite chain and the LP fee percentage is infinity, then we can assume that the
         // deposit originated from an over-allocated lite chain so the "unprofitable" log should be modified to be
         // less confusing.
+        const fromOverallocatedLiteChain = deposit.fromLiteChain && lpFeePct.isEqualTo(bnUint256Max);
         depositMrkdwn +=
           `- DepositId ${deposit.depositId} (tx: ${depositblockExplorerLink})` +
           ` of input amount ${formattedInputAmount} ${inputSymbol}` +

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1065,7 +1065,7 @@ export class Relayer {
       // @dev If the origin chain is a lite chain and there are no preferred repayment chains, then we can assume
       // that the origin chain, the only possible repayment chain, is over-allocated. We should log this case because
       // it is a special edge case the relayer should be aware of.
-      this.logger[this.config.sendingRelaysEnabled ? "warn" : "debug"]({
+      this.logger.debug({
         at: "Relayer::resolveRepaymentChain",
         message: deposit.fromLiteChain
           ? `Deposit ${depositId} originated from over-allocated lite chain ${originChain}`
@@ -1351,13 +1351,17 @@ export class Relayer {
         const formattedRelayerFeePct = formatFeePct(relayerFeePct);
         const formattedLpFeePct = formatFeePct(lpFeePct);
 
+        // @dev If the origin chain is a lite chain and the LP fee percentage is infinity, then we can assume that the
+        // deposit originated from an over-allocated lite chain so the "unprofitable" log should be modified to be
+        // less confusing.
         depositMrkdwn +=
           `- DepositId ${deposit.depositId} (tx: ${depositblockExplorerLink})` +
           ` of input amount ${formattedInputAmount} ${inputSymbol}` +
           ` and output amount ${formattedOutputAmount} ${outputSymbol}` +
           ` from ${getNetworkName(originChainId)} to ${getNetworkName(destinationChainId)}` +
-          ` with relayerFeePct ${formattedRelayerFeePct}%, lpFeePct ${formattedLpFeePct}%,` +
-          ` and gas cost ${formattedGasCost} ${gasTokenSymbol} is unprofitable!\n`;
+          fromOverallocatedLiteChain
+            ? " is from an over-allocated lite chain.\n"
+            : ` with relayerFeePct ${formattedRelayerFeePct}%, lpFeePct ${formattedLpFeePct}%, and gas cost ${formattedGasCost} ${gasTokenSymbol} is unprofitable!\n`;
       });
 
       if (depositMrkdwn) {


### PR DESCRIPTION
We currently log deposits that are ignored because they are from over-allocated lite-chains as unprofitable, but this isn't super clear.

These deposits will have no preferred repayment chain [chosen](https://github.com/across-protocol/relayer/blob/72279954ddb71e008b1e7a6c43c8b901b55acc53/src/relayer/Relayer.ts#L1064) by the inventory client and the lpFeePct will get set to [infinity](https://github.com/across-protocol/relayer/blob/72279954ddb71e008b1e7a6c43c8b901b55acc53/src/relayer/Relayer.ts#L1082). This produces a very noisy log that claims the deposit is unproftable but in reality, it was ignored because it came from an overallocated lite chain.