### PR TITLE
improve(Relayer): Add information about message size to unprofitability log

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -213,7 +213,7 @@ export class ProfitClient {
         message: "Failed to simulate fill for deposit.",
         reason,
         deposit,
-        notificationPath: "across-unprofitable-fills",
+        notificationPath: "across-warn",
       });
       return { nativeGasCost: uint256Max, tokenGasCost: uint256Max, gasPrice: uint256Max };
     }

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1324,8 +1324,8 @@ export class Relayer {
   }
 
   // TODO: This should really be renamed to "handleUnfillableDeposit" since it not only logs about unprofitable relayer
-  // fees but also about fills with messages that fail to simulate and deposits from lite chains that are 
-  // over-allocated. 
+  // fees but also about fills with messages that fail to simulate and deposits from lite chains that are
+  // over-allocated.
   private handleUnprofitableFill() {
     const { profitClient } = this.clients;
     const unprofitableDeposits = profitClient.getUnprofitableFills();

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1356,7 +1356,7 @@ export class Relayer {
         // this lite chain edge case.
         const fromOverallocatedLiteChain = deposit.fromLiteChain && lpFeePct.isEqualTo(bnUint256Max);
         depositMrkdwn +=
-          `- Deposit ${
+          `- Deposit${
             isMessageEmpty(deposit.message)
               ? ""
               : ` with message of size ${ethersUtils.hexDataLength(deposit.message)} bytes`

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1357,20 +1357,19 @@ export class Relayer {
         const fromOverallocatedLiteChain = deposit.fromLiteChain && lpFeePct.eq(bnUint256Max);
         const depositFailedToSimulateWithMessage = isMessageEmpty(deposit.message) && gasCost.eq(bnUint256Max);
         depositMrkdwn +=
-          `- Deposit${
+          `- DepositId ${deposit.depositId} (tx: ${depositblockExplorerLink})` +
+          ` of input amount ${formattedInputAmount} ${inputSymbol}` +
+          ` and output amount ${formattedOutputAmount} ${outputSymbol}` +
+          ` from ${getNetworkName(originChainId)} to ${getNetworkName(destinationChainId)}` +
+          `${fromOverallocatedLiteChain ? " is from an over-allocated lite chain and" : ""}` +
+          `${
             depositFailedToSimulateWithMessage
               ? ""
               : ` failed to simulate with message of size ${ethersUtils.hexDataLength(deposit.message)} bytes`
           }` +
-          ` ID ${deposit.depositId} (tx: ${depositblockExplorerLink})` +
-          ` of input amount ${formattedInputAmount} ${inputSymbol}` +
-          ` and output amount ${formattedOutputAmount} ${outputSymbol}` +
-          ` from ${getNetworkName(originChainId)} to ${getNetworkName(destinationChainId)}` +
-          `${fromOverallocatedLiteChain ? " and is from an over-allocated lite chain" : ""}` +
           `${` with relayerFeePct ${formattedRelayerFeePct}% lpFeePct ${
-            lpFeePct.eq(bnUint256Max) ? "INF" : formattedLpFeePct
-          }%
-           and gas cost ${gasCost.eq(bnUint256Max) ? "INF" : formattedGasCost} ${gasTokenSymbol}\n`}`;
+            lpFeePct.eq(bnUint256Max) ? "∞" : formattedLpFeePct
+          }% and gas cost ${gasCost.eq(bnUint256Max) ? "∞" : formattedGasCost} ${gasTokenSymbol}\n`}`;
       });
 
       if (depositMrkdwn) {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1355,21 +1355,21 @@ export class Relayer {
         // repayment chain, was not selected for repayment. So the "unprofitable" log should be modified to indicate
         // this lite chain edge case.
         const fromOverallocatedLiteChain = deposit.fromLiteChain && lpFeePct.eq(bnUint256Max);
+        const depositFailedToSimulateWithMessage = isMessageEmpty(deposit.message) && gasCost.eq(bnUint256Max);
         depositMrkdwn +=
           `- Deposit${
-            isMessageEmpty(deposit.message)
+            depositFailedToSimulateWithMessage
               ? ""
-              : ` with message of size ${ethersUtils.hexDataLength(deposit.message)} bytes`
+              : ` failed to simulate with message of size ${ethersUtils.hexDataLength(deposit.message)} bytes`
           }` +
           ` ID ${deposit.depositId} (tx: ${depositblockExplorerLink})` +
           ` of input amount ${formattedInputAmount} ${inputSymbol}` +
           ` and output amount ${formattedOutputAmount} ${outputSymbol}` +
           ` from ${getNetworkName(originChainId)} to ${getNetworkName(destinationChainId)}` +
-          `${
-            fromOverallocatedLiteChain
-              ? " is from an over-allocated lite chain.\n"
-              : ` with relayerFeePct ${formattedRelayerFeePct}%, lpFeePct ${formattedLpFeePct}%, and gas cost ${formattedGasCost} ${gasTokenSymbol} is unprofitable!\n`
-          }`;
+          `${fromOverallocatedLiteChain ? " and is from an over-allocated lite chain" : ""}` +
+          `${` with relayerFeePct ${formattedRelayerFeePct}%${
+            lpFeePct.eq(bnUint256Max) ? "" : ` lpFeePct ${formattedLpFeePct}%`
+          }${gasCost.eq(bnUint256Max) ? "" : ` and gas cost ${formattedGasCost} ${gasTokenSymbol}`}\n`}`;
       });
 
       if (depositMrkdwn) {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1323,6 +1323,9 @@ export class Relayer {
     return { symbol, decimals, formatter: createFormatFunction(2, 4, false, decimals) };
   }
 
+  // TODO: This should really be renamed to "handleUnfillableDeposit" since it not only logs about unprofitable relayer
+  // fees but also about fills with messages that fail to simulate and deposits from lite chains that are 
+  // over-allocated. 
   private handleUnprofitableFill() {
     const { profitClient } = this.clients;
     const unprofitableDeposits = profitClient.getUnprofitableFills();

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1364,7 +1364,7 @@ export class Relayer {
           ` of input amount ${formattedInputAmount} ${inputSymbol}` +
           ` and output amount ${formattedOutputAmount} ${outputSymbol}` +
           ` from ${getNetworkName(originChainId)} to ${getNetworkName(destinationChainId)}` +
-          `${fromOverallocatedLiteChain ? " is from an over-allocated lite chain and" : ""}` +
+          `${fromOverallocatedLiteChain ? " is from an over-allocated lite chain" : ""}` +
           `${
             depositFailedToSimulateWithMessage
               ? ""

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1367,9 +1367,10 @@ export class Relayer {
           ` and output amount ${formattedOutputAmount} ${outputSymbol}` +
           ` from ${getNetworkName(originChainId)} to ${getNetworkName(destinationChainId)}` +
           `${fromOverallocatedLiteChain ? " and is from an over-allocated lite chain" : ""}` +
-          `${` with relayerFeePct ${formattedRelayerFeePct}%${
-            lpFeePct.eq(bnUint256Max) ? "" : ` lpFeePct ${formattedLpFeePct}%`
-          }${gasCost.eq(bnUint256Max) ? "" : ` and gas cost ${formattedGasCost} ${gasTokenSymbol}`}\n`}`;
+          `${` with relayerFeePct ${formattedRelayerFeePct}% lpFeePct ${
+            lpFeePct.eq(bnUint256Max) ? "INF" : formattedLpFeePct
+          }%
+           and gas cost ${gasCost.eq(bnUint256Max) ? "INF" : formattedGasCost} ${gasTokenSymbol}\n`}`;
       });
 
       if (depositMrkdwn) {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1071,7 +1071,6 @@ export class Relayer {
           ? `Deposit ${depositId} originated from over-allocated lite chain ${originChain}`
           : `Unable to identify a preferred repayment chain for ${originChain} deposit ${depositId}.`,
         txn: blockExplorerLink(transactionHash, originChainId),
-        notificationPath: "across-unprofitable-fills",
       });
       return {
         repaymentChainProfitability: {
@@ -1357,7 +1356,12 @@ export class Relayer {
         // this lite chain edge case.
         const fromOverallocatedLiteChain = deposit.fromLiteChain && lpFeePct.isEqualTo(bnUint256Max);
         depositMrkdwn +=
-          `- DepositId ${deposit.depositId} (tx: ${depositblockExplorerLink})` +
+          `- Deposit ${
+            isMessageEmpty(deposit.message)
+              ? ` with message of size ${ethersUtils.hexDataLength(deposit.message)} bytes`
+              : ""
+          }` +
+          ` ID ${deposit.depositId} (tx: ${depositblockExplorerLink})` +
           ` of input amount ${formattedInputAmount} ${inputSymbol}` +
           ` and output amount ${formattedOutputAmount} ${outputSymbol}` +
           ` from ${getNetworkName(originChainId)} to ${getNetworkName(destinationChainId)}` +

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1358,8 +1358,8 @@ export class Relayer {
         depositMrkdwn +=
           `- Deposit ${
             isMessageEmpty(deposit.message)
-              ? ` with message of size ${ethersUtils.hexDataLength(deposit.message)} bytes`
-              : ""
+              ? ""
+              : ` with message of size ${ethersUtils.hexDataLength(deposit.message)} bytes`
           }` +
           ` ID ${deposit.depositId} (tx: ${depositblockExplorerLink})` +
           ` of input amount ${formattedInputAmount} ${inputSymbol}` +


### PR DESCRIPTION
When determining why a deposit is unprofitable its definitely useful to know upfront if there is a non empty message in the deposit, which often indicates we failed to simulate the fill.

This PR also sends the warning about failure to estimate gas costs for deposit to a different slack channel than "unprofitable fills". 

We should isolate across-unprofitable-fills channel to only include messages for deposits that are unprofitable. The developer should then go to across-warn to figure
