### PR TITLE
nit: prefer use of chain id alias in constants

### DIFF
--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -44,7 +44,7 @@ export const CONTRACT_ADDRESSES: {
     };
   };
 } = {
-  1: {
+  [CHAIN_IDs.MAINNET]: {
     lineaMessageService: {
       address: "0xd19d4B5d358258f05D7B411E21A1460D11B0876F",
       abi: LINEA_MESSAGE_SERVICE_ABI,
@@ -204,7 +204,7 @@ export const CONTRACT_ADDRESSES: {
       abi: SCROLL_GAS_PRICE_ORACLE_ABI,
     },
   },
-  10: {
+  [CHAIN_IDs.OPTIMISM]: {
     daiOptimismBridge: {
       address: "0x467194771dae2967aef3ecbedd3bf9a310c76c65",
       abi: DAI_OPTIMISM_BRIDGE_L2_ABI,
@@ -229,7 +229,7 @@ export const CONTRACT_ADDRESSES: {
       abi: CCTP_TOKEN_MESSENGER_ABI,
     },
   },
-  137: {
+  [CHAIN_IDs.POLYGON]: {
     withdrawableErc20: {
       abi: POLYGON_WITHDRAWABLE_ERC20_ABI,
     },
@@ -248,7 +248,7 @@ export const CONTRACT_ADDRESSES: {
       address: "0x0000000000000000000000000000000000001010",
     },
   },
-  324: {
+  [CHAIN_IDs.ZK_SYNC]: {
     zkSyncDefaultErc20Bridge: {
       address: "0x11f943b2c77b743AB90f4A0Ae7d5A4e7FCA3E102",
       abi: ZK_SYNC_DEFAULT_ERC20_BRIDGE_L2_ABI,
@@ -258,7 +258,7 @@ export const CONTRACT_ADDRESSES: {
       abi: WETH_ABI,
     },
   },
-  480: {
+  [CHAIN_IDs.WORLD_CHAIN]: {
     opUSDCBridge: {
       address: "0xbD80b06d3dbD0801132c6689429aC09Ca6D27f82",
       abi: OP_USDC_BRIDGE_ABI,
@@ -271,7 +271,7 @@ export const CONTRACT_ADDRESSES: {
       address: "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
     },
   },
-  690: {
+  [CHAIN_IDs.REDSTONE]: {
     ovmStandardBridge: {
       address: "0x4200000000000000000000000000000000000010",
       abi: OVM_L2_STANDARD_BRIDGE_ABI,
@@ -280,7 +280,7 @@ export const CONTRACT_ADDRESSES: {
       address: "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
     },
   },
-  1135: {
+  [CHAIN_IDs.LISK]: {
     ovmStandardBridge: {
       address: "0x4200000000000000000000000000000000000010",
       abi: OVM_L2_STANDARD_BRIDGE_ABI,
@@ -289,7 +289,7 @@ export const CONTRACT_ADDRESSES: {
       address: "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
     },
   },
-  8453: {
+  [CHAIN_IDs.BASE]: {
     ovmStandardBridge: {
       address: "0x4200000000000000000000000000000000000010",
       abi: OVM_L2_STANDARD_BRIDGE_ABI,
@@ -306,7 +306,7 @@ export const CONTRACT_ADDRESSES: {
       abi: CCTP_TOKEN_MESSENGER_ABI,
     },
   },
-  34443: {
+  [CHAIN_IDs.MODE]: {
     ovmStandardBridge: {
       address: "0x4200000000000000000000000000000000000010",
       abi: OVM_L2_STANDARD_BRIDGE_ABI,
@@ -315,7 +315,7 @@ export const CONTRACT_ADDRESSES: {
       address: "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
     },
   },
-  57073: {
+  [CHAIN_IDs.INK]: {
     ovmStandardBridge: {
       address: "0x4200000000000000000000000000000000000010",
       abi: OVM_L2_STANDARD_BRIDGE_ABI,
@@ -324,7 +324,7 @@ export const CONTRACT_ADDRESSES: {
       address: "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
     },
   },
-  81457: {
+  [CHAIN_IDs.BLAST]: {
     ovmStandardBridge: {
       address: "0x4200000000000000000000000000000000000010",
       abi: OVM_L2_STANDARD_BRIDGE_ABI,
@@ -337,7 +337,7 @@ export const CONTRACT_ADDRESSES: {
       abi: BLAST_BRIDGE_ABI,
     },
   },
-  42161: {
+  [CHAIN_IDs.ARBITRUM]: {
     erc20Gateway: {
       abi: ARBITRUM_ERC20_GATEWAY_L2_ABI,
     },
@@ -350,7 +350,7 @@ export const CONTRACT_ADDRESSES: {
       abi: CCTP_TOKEN_MESSENGER_ABI,
     },
   },
-  41455: {
+  [CHAIN_IDs.ALEPH_ZERO]: {
     erc20Gateway: {
       address: "0x2A5a79061b723BBF453ef7E07c583C750AFb9BD6",
       abi: ARBITRUM_ERC20_GATEWAY_L2_ABI,
@@ -360,7 +360,7 @@ export const CONTRACT_ADDRESSES: {
       abi: ARBSYS_L2_ABI,
     },
   },
-  59144: {
+  [CHAIN_IDs.LINEA]: {
     l2MessageService: {
       address: "0x508Ca82Df566dCD1B0DE8296e70a96332cD644ec",
       abi: LINEA_MESSAGE_SERVICE_ABI,
@@ -377,7 +377,7 @@ export const CONTRACT_ADDRESSES: {
       address: "0x0000000000000000000000000000000000000000",
     },
   },
-  534352: {
+  [CHAIN_IDs.SCROLL]: {
     scrollGatewayRouter: {
       address: "0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79",
       abi: SCROLL_GATEWAY_ROUTER_L2_ABI,
@@ -401,7 +401,7 @@ export const CONTRACT_ADDRESSES: {
     },
   },
   // Testnets
-  11155111: {
+  [CHAIN_IDs.SEPOLIA]: {
     ovmStandardBridge_4202: {
       address: "0x1Fb30e446eA791cd1f011675E5F3f5311b70faF5",
       abi: OVM_L1_STANDARD_BRIDGE_ABI,
@@ -490,12 +490,6 @@ export const CONTRACT_ADDRESSES: {
     scrollGatewayRouter: {
       address: "0x9aD3c5617eCAa556d6E166787A97081907171230",
       abi: SCROLL_GATEWAY_ROUTER_L2_ABI,
-    },
-  },
-  59140: {
-    l2MessageService: {
-      address: "0xC499a572640B64eA1C8c194c43Bc3E19940719dC",
-      abi: LINEA_MESSAGE_SERVICE_ABI,
     },
   },
 };


### PR DESCRIPTION
Using the chain id alias instead of the actual number should make this file easier to read, which will become more important the more chains we add.