### PR TITLE
hotfix(soneium): cast to codename

### DIFF
--- a/src/utils/ContractUtils.ts
+++ b/src/utils/ContractUtils.ts
@@ -26,6 +26,8 @@ export function castSpokePoolName(networkId: number): string {
       return "Arbitrum_SpokePool";
     case CHAIN_IDs.ZK_SYNC:
       return "ZkSync_SpokePool";
+    case CHAIN_IDs.SONEIUM:
+      return "Cher_SpokePool";
     default:
       networkName = getNetworkName(networkId);
   }


### PR DESCRIPTION
Required because `SONEIUM` uses the codename `Cher` therefore we have:

```
export { Cher_SpokePool__factory } from "./factories/contracts/Cher_SpokePool__factory";
```