### PR TITLE
improve(relayer): Reduce token swap log spam

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -301,10 +301,13 @@ export class Relayer {
     }
 
     if (!this.clients.inventoryClient.validateOutputToken(deposit)) {
-      this.logger[this.config.sendingRelaysEnabled ? "warn" : "debug"]({
+      this.logger.debug({
         at: "Relayer::filterDeposit",
         message: "Skipping deposit including in-protocol token swap.",
-        deposit,
+        originChainId,
+        destinationChainId,
+        outputToken: deposit.outputToken,
+        transactionHash: deposit.transactionHash,
         notificationPath: "across-unprofitable-fills",
       });
       return false;


### PR DESCRIPTION
This log message was added during the v2 -> v3 transition where it was interesting to know about deposits with unsupported outputTokens. There are now other protocols building on top of Across and supporting this, so it generates quite a bit of log spam. Reduce the loglevel and the information bundled in the log.