### PR TITLE
fix(IndexedSpokePoolClient): Cast depositId correctly

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -285,8 +285,8 @@ export class IndexedSpokePoolClient extends clients.SpokePoolClient {
     const _firstDepositId = events[fundsDeposited].at(0)?.args?.depositId;
     const _latestDepositId = events[fundsDeposited].at(-1)?.args?.depositId;
     const [firstDepositId, latestDepositId] = [
-      _firstDepositId ? BigNumber.from(_firstDepositId) : this.getDeposits().at(0)?.depositId ?? bnZero,
-      _latestDepositId ? BigNumber.from(_latestDepositId) : this.getDeposits().at(-1)?.depositId ?? bnZero,
+      isDefined(_firstDepositId) ? BigNumber.from(_firstDepositId) : this.getDeposits().at(0)?.depositId ?? bnZero,
+      isDefined(_latestDepositId) ? BigNumber.from(_latestDepositId) : this.getDeposits().at(-1)?.depositId ?? bnZero,
     ];
 
     return {

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -4,7 +4,7 @@ import { Contract } from "ethers";
 import { clients, utils as sdkUtils } from "@across-protocol/sdk";
 import { Log } from "../interfaces";
 import { CHAIN_MAX_BLOCK_LOOKBACK, RELAYER_DEFAULT_SPOKEPOOL_INDEXER } from "../common/Constants";
-import { bnZero, EventSearchConfig, getNetworkName, isDefined, MakeOptional, winston } from "../utils";
+import { bnZero, EventSearchConfig, getNetworkName, isDefined, MakeOptional, winston, BigNumber } from "../utils";
 import { EventsAddedMessage, EventRemovedMessage } from "../utils/SuperstructUtils";
 
 export type SpokePoolClient = clients.SpokePoolClient;
@@ -282,9 +282,11 @@ export class IndexedSpokePoolClient extends clients.SpokePoolClient {
 
     // Find the latest deposit Ids, and if there are no new events, fall back to already stored values.
     const fundsDeposited = eventsToQuery.indexOf("V3FundsDeposited");
+    const _firstDepositId = events[fundsDeposited].at(0)?.args?.depositId;
+    const _latestDepositId = events[fundsDeposited].at(-1)?.args?.depositId;
     const [firstDepositId, latestDepositId] = [
-      events[fundsDeposited].at(0)?.args?.depositId ?? this.getDeposits().at(0) ?? bnZero,
-      events[fundsDeposited].at(-1)?.args?.depositId ?? this.getDeposits().at(-1) ?? bnZero,
+      _firstDepositId ? BigNumber.from(_firstDepositId) : this.getDeposits().at(0)?.depositId ?? bnZero,
+      _latestDepositId ? BigNumber.from(_latestDepositId) : this.getDeposits().at(-1)?.depositId ?? bnZero,
     ];
 
     return {

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1290,7 +1290,7 @@ export class Dataworker {
         `slowRelayRoot: ${slowRelayTree.getHexRoot()}\n` +
         `Origin chain: ${relayData.originChainId}\n` +
         `Destination chain:${chainId}\n` +
-        `Deposit Id: ${relayData.depositId}\n` +
+        `Deposit Id: ${relayData.depositId.toString()}\n` +
         `amount: ${outputAmount.toString()}`;
 
       if (submitExecution) {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1071,7 +1071,7 @@ export class Relayer {
       this.logger.debug({
         at: "Relayer::resolveRepaymentChain",
         message: deposit.fromLiteChain
-          ? `Deposit ${depositId} originated from over-allocated lite chain ${originChain}`
+          ? `Deposit ${depositId.toString()} originated from over-allocated lite chain ${originChain}`
           : `Unable to identify a preferred repayment chain for ${originChain} deposit ${depositId.toString()}.`,
         txn: blockExplorerLink(transactionHash, originChainId),
       });


### PR DESCRIPTION
SpokePoolClient doesn't set depositId correctly in a rare case.

Also, to be safe, log a known BN as a string where we currently don't do so