### PR TITLE
improve: Log entire error

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -79,7 +79,10 @@ if (require.main === module) {
         args,
         notificationPath: "across-error",
       });
-      logger.debug({ at: cmd ?? "unknown process", message: "Logging full error", error });
+      if (process.env.CONSOLE_LOG_ERRORS) {
+        // eslint-disable-next-line no-console
+        console.error(error);
+      }
     })
     .finally(async () => {
       await waitForLogger(logger);

--- a/index.ts
+++ b/index.ts
@@ -79,6 +79,7 @@ if (require.main === module) {
         args,
         notificationPath: "across-error",
       });
+      logger.debug({ at: cmd ?? "unknown process", message: "Logging full error", error });
     })
     .finally(async () => {
       await waitForLogger(logger);


### PR DESCRIPTION
Ideally we should log the full error trace somewhere. Can we instead use a console.error() here?