### PR TITLE
chore: bump sdk version for new BundleDataClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.30",
     "@across-protocol/contracts": "^3.0.25",
-    "@across-protocol/sdk": "^3.4.15",
+    "@across-protocol/sdk": "^3.4.16",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.30",
     "@across-protocol/contracts": "^3.0.25",
-    "@across-protocol/sdk": "^3.4.14",
+    "@across-protocol/sdk": "^3.4.15",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/test/Dataworker.loadData.fill.ts
+++ b/test/Dataworker.loadData.fill.ts
@@ -640,7 +640,6 @@ describe("Dataworker: Load data used in all functions", async function () {
         fillDeadline: depositEvent.args.fillDeadline + 1,
         exclusivityDeadline: depositEvent.args.exclusivityDeadline + 1,
         message: randomAddress(),
-        destinationChainId: originChainId,
       };
       for (const [key, val] of Object.entries(invalidRelayData)) {
         const _depositEvent = cloneDeep(depositEvent);

--- a/test/Dataworker.loadData.fill.ts
+++ b/test/Dataworker.loadData.fill.ts
@@ -818,13 +818,7 @@ describe("Dataworker: Load data used in all functions", async function () {
         const relayer2 = randomAddress();
         fillV3Events.push(generateV3FillFromDeposit(deposits[0]));
         fillV3Events.push(generateV3FillFromDeposit(deposits[1]));
-        fillV3Events.push(
-          generateV3FillFromDeposit(
-            deposits[2],
-            {},
-            ethers.utils.randomBytes(32)
-          )
-        );
+        fillV3Events.push(generateV3FillFromDeposit(deposits[2], {}, ethers.utils.randomBytes(32)));
         await mockDestinationSpokePoolClient.update(["FilledV3Relay"]);
         // Replace the dataworker providers to use mock providers. We need to explicitly do this since we do not actually perform a contract call, so
         // we must inject a transaction response into the provider to simulate the case when the relayer repayment address is invalid.
@@ -878,7 +872,6 @@ describe("Dataworker: Load data used in all functions", async function () {
         const deposits = mockOriginSpokePoolClient.getDeposits();
 
         // Fill deposits from different relayers
-        const relayer2 = randomAddress();
         const invalidRelayer = ethers.utils.randomBytes(32);
         fillV3Events.push(generateV3FillFromDeposit(deposits[0]));
         fillV3Events.push(generateV3FillFromDeposit(deposits[1]));
@@ -990,7 +983,6 @@ describe("Dataworker: Load data used in all functions", async function () {
         const deposits = mockOriginSpokePoolClient.getDeposits();
 
         // Fill deposits from different relayers
-        const relayer2 = randomAddress();
         const invalidRelayer = ethers.utils.randomBytes(32);
         fillV3Events.push(generateV3FillFromDeposit(deposits[0]));
         fillV3Events.push(generateV3FillFromDeposit(deposits[1]));

--- a/test/Dataworker.loadData.fill.ts
+++ b/test/Dataworker.loadData.fill.ts
@@ -1089,7 +1089,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       ).to.equal(0);
     });
     it("getApproximateRefundsForBlockRange", async function () {
-      // Send two deposits on dioriginfferent chains
+      // Send two deposits on different chains
       // Fill both deposits and request repayment on same chain
       await depositV3(
         spokePool_1,

--- a/test/Dataworker.loadData.fill.ts
+++ b/test/Dataworker.loadData.fill.ts
@@ -822,7 +822,7 @@ describe("Dataworker: Load data used in all functions", async function () {
           generateV3FillFromDeposit(
             deposits[2],
             {},
-            ethers.utils.hexConcat(["0x11", ethers.utils.hexZeroPad(relayer2, 31)])
+            ethers.utils.randomBytes(32)
           )
         );
         await mockDestinationSpokePoolClient.update(["FilledV3Relay"]);
@@ -879,7 +879,7 @@ describe("Dataworker: Load data used in all functions", async function () {
 
         // Fill deposits from different relayers
         const relayer2 = randomAddress();
-        const invalidRelayer = ethers.utils.hexConcat(["0x11", ethers.utils.hexZeroPad(relayer2, 31)]);
+        const invalidRelayer = ethers.utils.randomBytes(32);
         fillV3Events.push(generateV3FillFromDeposit(deposits[0]));
         fillV3Events.push(generateV3FillFromDeposit(deposits[1]));
         fillV3Events.push(generateV3FillFromDeposit(deposits[2], {}, invalidRelayer));
@@ -929,7 +929,7 @@ describe("Dataworker: Load data used in all functions", async function () {
 
         // Fill deposits from different relayers
         const relayer2 = randomAddress();
-        const invalidRelayer = ethers.utils.hexConcat(["0x11", ethers.utils.hexZeroPad(relayer2, 31)]);
+        const invalidRelayer = ethers.utils.randomBytes(32);
         fillV3Events.push(generateV3FillFromDeposit(deposits[0]));
         fillV3Events.push(generateV3FillFromDeposit(deposits[1]));
         fillV3Events.push(generateV3FillFromDeposit(deposits[2], {}, invalidRelayer));
@@ -991,7 +991,7 @@ describe("Dataworker: Load data used in all functions", async function () {
 
         // Fill deposits from different relayers
         const relayer2 = randomAddress();
-        const invalidRelayer = ethers.utils.hexConcat(["0x11", ethers.utils.hexZeroPad(relayer2, 31)]);
+        const invalidRelayer = ethers.utils.randomBytes(32);
         fillV3Events.push(generateV3FillFromDeposit(deposits[0]));
         fillV3Events.push(generateV3FillFromDeposit(deposits[1]));
         fillV3Events.push(generateV3FillFromDeposit(deposits[2], {}, invalidRelayer));

--- a/test/Dataworker.loadData.fill.ts
+++ b/test/Dataworker.loadData.fill.ts
@@ -978,7 +978,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       ).to.equal(0);
     });
     it("getApproximateRefundsForBlockRange", async function () {
-      // Send two deposits on dioriginfferent chains
+      // Send two deposits on different chains
       // Fill both deposits and request repayment on same chain
       await depositV3(
         spokePool_1,

--- a/test/mocks/MockConfigStoreClient.ts
+++ b/test/mocks/MockConfigStoreClient.ts
@@ -26,4 +26,18 @@ export class MockConfigStoreClient extends clients.mocks.MockConfigStoreClient {
       enabledChainIds
     );
   }
+
+  _updateLiteChains(chainIds: number[], blockNumber = 0, blockTimestamp = 0) {
+    this.liteChainIndicesUpdates = [
+      {
+        ...this.liteChainIndicesUpdates,
+        value: [...(this.liteChainIndicesUpdates.value ?? []), ...chainIds],
+        blockNumber,
+        timestamp: blockTimestamp,
+        transactionIndex: Math.floor(Math.random() * 10),
+        logIndex: Math.floor(Math.random() * 10),
+        transactionHash: "",
+      },
+    ];
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,10 +53,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.4.15":
-  version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.15.tgz#76888e2230956a696cfa06982253196f50a7a20f"
-  integrity sha512-0ICm525mIBr+H7XrjY9M7Jo59P8Xvmu//85t0TZrcJlrn/qrDRetyst2nAFTb4CRZlJafJFKtvIieuClAqjTEg==
+"@across-protocol/sdk@^3.4.16":
+  version "3.4.16"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.16.tgz#ede633ea59003da78c77af4b185611499f837b45"
+  integrity sha512-9RLJxdHv7rJWiKVZ/VtPf9rcS+3phpDou0wu2B56NQ9dcfZUKaXHk+M3vm1A9NlSIiHoDHLowSkFztdhsnnbvQ==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.30"

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,10 +53,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.4.14":
-  version "3.4.14"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.14.tgz#3246e3b24a08fe0ca188d84c1b615ca0823ae5f8"
-  integrity sha512-rT+Q0Kh9t6bBdvxma407LSkUI1zN9+0f6X/20kOyuJz9zShCwqFusQ5k5vmLwHvwb7LRdpL5sKGlYTjU/fsT9g==
+"@across-protocol/sdk@^3.4.15":
+  version "3.4.15"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.15.tgz#76888e2230956a696cfa06982253196f50a7a20f"
+  integrity sha512-0ICm525mIBr+H7XrjY9M7Jo59P8Xvmu//85t0TZrcJlrn/qrDRetyst2nAFTb4CRZlJafJFKtvIieuClAqjTEg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.30"


### PR DESCRIPTION
This activates another upgrade to the BundleDataClient, which should now be able to (partially) handle bytes32 addresses.