### PR TITLE
chore: bump sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.30",
     "@across-protocol/contracts": "^3.0.25",
-    "@across-protocol/sdk": "^3.4.16",
+    "@across-protocol/sdk": "^3.4.17",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,10 +53,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.4.16":
-  version "3.4.16"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.16.tgz#ede633ea59003da78c77af4b185611499f837b45"
-  integrity sha512-9RLJxdHv7rJWiKVZ/VtPf9rcS+3phpDou0wu2B56NQ9dcfZUKaXHk+M3vm1A9NlSIiHoDHLowSkFztdhsnnbvQ==
+"@across-protocol/sdk@^3.4.17":
+  version "3.4.17"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.17.tgz#00e1291437dc0d22201765f32e31b1d5ab11bccf"
+  integrity sha512-aWg4JG3z8srN1NkxBF/T9tdr0KgXecs/5zpB1DGujC5Fpo+Blpv0jguhK/taSdmx+hf1Ez0HY8Blxz6YBR66fw==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.30"


### PR DESCRIPTION
This is to widen the timestamp bounds on the bundle data client's block ranges.