### PR TITLE
feat: bump sdk to use new utilites

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.30",
     "@across-protocol/contracts": "^3.0.25",
-    "@across-protocol/sdk": "^3.4.18",
+    "@across-protocol/sdk": "^3.4.19",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.30",
     "@across-protocol/contracts": "^3.0.25",
-    "@across-protocol/sdk": "^3.4.19",
+    "@across-protocol/sdk": "^3.4.20",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/test/Dataworker.loadData.fill.ts
+++ b/test/Dataworker.loadData.fill.ts
@@ -818,7 +818,9 @@ describe("Dataworker: Load data used in all functions", async function () {
         const relayer2 = randomAddress();
         fillV3Events.push(generateV3FillFromDeposit(deposits[0]));
         fillV3Events.push(generateV3FillFromDeposit(deposits[1]));
-        fillV3Events.push(generateV3FillFromDeposit(deposits[2], {}, ethers.utils.randomBytes(32)));
+        fillV3Events.push(
+          generateV3FillFromDeposit(deposits[2], {}, ethers.utils.hexlify(ethers.utils.randomBytes(32)))
+        );
         await mockDestinationSpokePoolClient.update(["FilledV3Relay"]);
         // Replace the dataworker providers to use mock providers. We need to explicitly do this since we do not actually perform a contract call, so
         // we must inject a transaction response into the provider to simulate the case when the relayer repayment address is invalid.
@@ -872,7 +874,7 @@ describe("Dataworker: Load data used in all functions", async function () {
         const deposits = mockOriginSpokePoolClient.getDeposits();
 
         // Fill deposits from different relayers
-        const invalidRelayer = ethers.utils.randomBytes(32);
+        const invalidRelayer = ethers.utils.hexlify(ethers.utils.randomBytes(32));
         fillV3Events.push(generateV3FillFromDeposit(deposits[0]));
         fillV3Events.push(generateV3FillFromDeposit(deposits[1]));
         fillV3Events.push(generateV3FillFromDeposit(deposits[2], {}, invalidRelayer));
@@ -922,7 +924,7 @@ describe("Dataworker: Load data used in all functions", async function () {
 
         // Fill deposits from different relayers
         const relayer2 = randomAddress();
-        const invalidRelayer = ethers.utils.randomBytes(32);
+        const invalidRelayer = ethers.utils.hexlify(ethers.utils.randomBytes(32));
         fillV3Events.push(generateV3FillFromDeposit(deposits[0]));
         fillV3Events.push(generateV3FillFromDeposit(deposits[1]));
         fillV3Events.push(generateV3FillFromDeposit(deposits[2], {}, invalidRelayer));
@@ -983,7 +985,7 @@ describe("Dataworker: Load data used in all functions", async function () {
         const deposits = mockOriginSpokePoolClient.getDeposits();
 
         // Fill deposits from different relayers
-        const invalidRelayer = ethers.utils.randomBytes(32);
+        const invalidRelayer = ethers.utils.hexlify(ethers.utils.randomBytes(32));
         fillV3Events.push(generateV3FillFromDeposit(deposits[0]));
         fillV3Events.push(generateV3FillFromDeposit(deposits[1]));
         fillV3Events.push(generateV3FillFromDeposit(deposits[2], {}, invalidRelayer));

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,10 +53,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.4.19":
-  version "3.4.19"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.19.tgz#6c2025d5224877e8139c4de713b217cecdd13168"
-  integrity sha512-HBQFAq+N6JsFcTfCgtwDYHC4Q7l6TabbZSoLrPbzCyGpnSGYCEGbXNg2TFsDox3jui6O+Te7P22C6Ue46Wc3jg==
+"@across-protocol/sdk@^3.4.20":
+  version "3.4.20"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.20.tgz#0fa2b223e264fc8ff9ea47ab9e65ad9cd176848d"
+  integrity sha512-HUgWYfbH0haa2r9nl892IE6U+z+QtowcYwHzcimiBlux2+tn6Ztq80CEOpp1367GB4gBiWz1stL5TQfRi+vxtg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.30"

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,10 +53,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@^3.4.18":
-  version "3.4.18"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.18.tgz#a01efad8c24b36a4a725aace4edb307b8fab8083"
-  integrity sha512-KQG4BEWIxKYUF12B529E7FAvwVZg84T1c+4RJFClRlxGpV7Kk8jydFbFqWWee4bG1eOaIgFbX26Nq9DQOFK7lA==
+"@across-protocol/sdk@^3.4.19":
+  version "3.4.19"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-3.4.19.tgz#6c2025d5224877e8139c4de713b217cecdd13168"
+  integrity sha512-HBQFAq+N6JsFcTfCgtwDYHC4Q7l6TabbZSoLrPbzCyGpnSGYCEGbXNg2TFsDox3jui6O+Te7P22C6Ue46Wc3jg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.30"


### PR DESCRIPTION
The main utility of this PR is to now coerce specific address fields ingested by the spoke pool client to bytes20 addresses. Functionally, this should have no effect on any of the bots, since all spoke pool events emit `address`es and not `bytes32` values, but this will be necessary to have active when the contracts upgrade goes live.