### PR TITLE
fix(Relayer): Identify correct fills when computing commitments

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -464,7 +464,9 @@ export class Relayer {
 
     const deposits = originSpoke.getDeposits({ fromBlock, toBlock });
     const commitment = deposits.reduce((acc, deposit) => {
-      const fill = spokePoolClients[deposit.destinationChainId]?.getFillsForDeposit(deposit).find(f => f.relayer === this.relayerAddress);
+      const fill = spokePoolClients[deposit.destinationChainId]
+        ?.getFillsForDeposit(deposit)
+        .find((f) => f.relayer === this.relayerAddress);
       if (!isDefined(fill)) {
         return acc;
       }

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -464,8 +464,8 @@ export class Relayer {
 
     const deposits = originSpoke.getDeposits({ fromBlock, toBlock });
     const commitment = deposits.reduce((acc, deposit) => {
-      const fill = spokePoolClients[deposit.destinationChainId]?.getFillForDeposit(deposit);
-      if (!isDefined(fill) || fill.relayer !== this.relayerAddress) {
+      const fill = spokePoolClients[deposit.destinationChainId]?.getFillsForDeposit(deposit).find(f => f.relayer === this.relayerAddress);
+      if (!isDefined(fill)) {
         return acc;
       }
 


### PR DESCRIPTION
The relayer calls SpokePoolClient.getFillForDeposit to find a fill to determine if its committed capital to filling deposits from an origin chain. This function however can match with an invalid fill.