### PR TITLE
fix(relayer): Origin chain commitments should include invalid fills

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -473,7 +473,7 @@ export class Relayer {
       const fill = spokePoolClients[deposit.destinationChainId]
         ?.getFillsForDeposit(deposit)
         ?.find((f) => f.relayer === this.relayerAddress);
-      if (!isDefined(fill) || !validateFillForDeposit(fill, deposit).valid) {
+      if (!isDefined(fill)) {
         return acc;
       }
 

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -22,7 +22,6 @@ import {
   Profiler,
   formatGwei,
   toBytes32,
-  validateFillForDeposit,
 } from "../utils";
 import { RelayerClients } from "./RelayerClientHelper";
 import { RelayerConfig } from "./RelayerConfig";


### PR DESCRIPTION
The intention of computing origin chain commitments is to identify how much the relayer has filled for a given origin chain within a given timeframe. Filtering out invalid fills incorrectly reduces the perceived commitment and makes this feature effective.