### PR TITLE
improve(relayer): Override fast relayer bigint JSON encoder

### DIFF
--- a/src/libexec/SpokePoolListenerExperimental.ts
+++ b/src/libexec/SpokePoolListenerExperimental.ts
@@ -55,6 +55,11 @@ const _chains = {
   [CHAIN_IDs.ZORA]: chains.zora,
 } as const;
 
+// Teach BigInt how to be represented as JSON.
+(BigInt.prototype as any).toJSON = function() {
+    return this.toString()
+}
+
 /**
  * Aggregate utils/scrapeEvents for a series of event names.
  * @param spokePool Ethers Constract instance.

--- a/src/libexec/SpokePoolListenerExperimental.ts
+++ b/src/libexec/SpokePoolListenerExperimental.ts
@@ -56,9 +56,9 @@ const _chains = {
 } as const;
 
 // Teach BigInt how to be represented as JSON.
-(BigInt.prototype as any).toJSON = function() {
-    return this.toString()
-}
+(BigInt.prototype as any).toJSON = function () {
+  return this.toString();
+};
 
 /**
  * Aggregate utils/scrapeEvents for a series of event names.

--- a/src/libexec/SpokePoolListenerExperimental.ts
+++ b/src/libexec/SpokePoolListenerExperimental.ts
@@ -94,7 +94,8 @@ async function listen(eventMgr: EventManager, spokePool: Contract, eventNames: s
   const providers = urls.map((url) =>
     createPublicClient({
       chain: _chains[chainId],
-      transport: webSocket(url, { name: getOriginFromURL(url) }),
+      transport: webSocket(url),
+      name: getOriginFromURL(url),
     })
   );
 


### PR DESCRIPTION
The viem provider has suffered from odd performance issues on some chains, whereby subscriptions have seemed not to work. This has produced very long fill times, but only on some chains.

After some debugging, poor performance is isolated to chains with quorum > 1. This was ultimately traced to the naming of the client vs. the naming of the transport, which is currently what is named uniquely. Because the top-level client was named generically "Public Client", the downstream event manager was unable to distinguish the same event from different providers, so these chains typically did not meet the quorum requirement with quorum > 1.

While here, restore the JSON stringification hack for bigints. Without this, any JSON.stringify() involving a BigInt produces an exception. This makes debugging _really_ difficult.