### PR TITLE
chore(relayer): Skip queries for V3 event types

### DIFF
--- a/src/libexec/RelayerSpokePoolIndexer.ts
+++ b/src/libexec/RelayerSpokePoolIndexer.ts
@@ -204,7 +204,7 @@ async function run(argv: string[]): Promise<void> {
   oldestTime ??= latestBlock.timestamp;
 
   // Events to listen for.
-  const events = ["FundsDeposited", "RequestedSpeedUpV3Deposit", "FilledRelay"];
+  const events = ["FundsDeposited", "RequestedSpeedUpDeposit", "FilledRelay"];
   const eventMgr = new EventManager(logger, chainId, quorum);
   const providers = getWSProviders(chainId, quorum);
   let nProviders = providers.length;

--- a/src/libexec/RelayerSpokePoolIndexer.ts
+++ b/src/libexec/RelayerSpokePoolIndexer.ts
@@ -195,12 +195,7 @@ async function run(argv: string[]): Promise<void> {
   };
 
   if (latestBlock.number > startBlock) {
-    const events = [
-      "FundsDeposited",
-      "FilledRelay",
-      "RelayedRootBundle",
-      "ExecutedRelayerRefundRoot",
-    ];
+    const events = ["FundsDeposited", "FilledRelay", "RelayedRootBundle", "ExecutedRelayerRefundRoot"];
     const _spokePool = spokePool.connect(quorumProvider);
     await Promise.all([resolveOldestTime(_spokePool, startBlock), scrapeEvents(_spokePool, events, opts)]);
   }

--- a/src/libexec/RelayerSpokePoolIndexer.ts
+++ b/src/libexec/RelayerSpokePoolIndexer.ts
@@ -197,9 +197,7 @@ async function run(argv: string[]): Promise<void> {
   if (latestBlock.number > startBlock) {
     const events = [
       "FundsDeposited",
-      "V3FundsDeposited",
       "FilledRelay",
-      "FilledV3Relay",
       "RelayedRootBundle",
       "ExecutedRelayerRefundRoot",
     ];
@@ -211,7 +209,7 @@ async function run(argv: string[]): Promise<void> {
   oldestTime ??= latestBlock.timestamp;
 
   // Events to listen for.
-  const events = ["FundsDeposited", "V3FundsDeposited", "RequestedSpeedUpV3Deposit", "FilledRelay", "FilledV3Relay"];
+  const events = ["FundsDeposited", "RequestedSpeedUpV3Deposit", "FilledRelay"];
   const eventMgr = new EventManager(logger, chainId, quorum);
   const providers = getWSProviders(chainId, quorum);
   let nProviders = providers.length;

--- a/src/libexec/RelayerSpokePoolIndexer.ts
+++ b/src/libexec/RelayerSpokePoolIndexer.ts
@@ -195,7 +195,7 @@ async function run(argv: string[]): Promise<void> {
   };
 
   if (latestBlock.number > startBlock) {
-    const events = ["FundsDeposited", "FilledRelay", "RelayedRootBundle", "ExecutedRelayerRefundRoot"];
+    const events = ["FundsDeposited", "FilledRelay", "RequestedSpeedUpDeposit", "RelayedRootBundle", "ExecutedRelayerRefundRoot"];
     const _spokePool = spokePool.connect(quorumProvider);
     await Promise.all([resolveOldestTime(_spokePool, startBlock), scrapeEvents(_spokePool, events, opts)]);
   }
@@ -204,7 +204,7 @@ async function run(argv: string[]): Promise<void> {
   oldestTime ??= latestBlock.timestamp;
 
   // Events to listen for.
-  const events = ["FundsDeposited", "RequestedSpeedUpDeposit", "FilledRelay"];
+  const events = ["FundsDeposited", "FilledRelay"];
   const eventMgr = new EventManager(logger, chainId, quorum);
   const providers = getWSProviders(chainId, quorum);
   let nProviders = providers.length;

--- a/src/libexec/RelayerSpokePoolIndexer.ts
+++ b/src/libexec/RelayerSpokePoolIndexer.ts
@@ -195,7 +195,13 @@ async function run(argv: string[]): Promise<void> {
   };
 
   if (latestBlock.number > startBlock) {
-    const events = ["FundsDeposited", "FilledRelay", "RequestedSpeedUpDeposit", "RelayedRootBundle", "ExecutedRelayerRefundRoot"];
+    const events = [
+      "FundsDeposited",
+      "FilledRelay",
+      "RequestedSpeedUpDeposit",
+      "RelayedRootBundle",
+      "ExecutedRelayerRefundRoot",
+    ];
     const _spokePool = spokePool.connect(quorumProvider);
     await Promise.all([resolveOldestTime(_spokePool, startBlock), scrapeEvents(_spokePool, events, opts)]);
   }

--- a/src/libexec/SpokePoolListenerExperimental.ts
+++ b/src/libexec/SpokePoolListenerExperimental.ts
@@ -242,9 +242,7 @@ async function run(argv: string[]): Promise<void> {
   if (latestBlock.number > startBlock) {
     const events = [
       "FundsDeposited",
-      "V3FundsDeposited",
       "FilledRelay",
-      "FilledV3Relay",
       "RelayedRootBundle",
       "ExecutedRelayerRefundRoot",
     ];
@@ -256,7 +254,7 @@ async function run(argv: string[]): Promise<void> {
   oldestTime ??= latestBlock.timestamp;
 
   // Events to listen for.
-  const events = ["FundsDeposited", "V3FundsDeposited", "FilledRelay", "FilledV3Relay"];
+  const events = ["FundsDeposited", "FilledRelay"];
   const eventMgr = new EventManager(logger, chainId, quorum);
 
   logger.debug({ at: "RelayerSpokePoolListener::run", message: `Starting ${chain} listener.`, events, opts });

--- a/src/libexec/SpokePoolListenerExperimental.ts
+++ b/src/libexec/SpokePoolListenerExperimental.ts
@@ -240,7 +240,13 @@ async function run(argv: string[]): Promise<void> {
   };
 
   if (latestBlock.number > startBlock) {
-    const events = ["FundsDeposited", "FilledRelay", "RequestedSpeedUpDeposit", "RelayedRootBundle", "ExecutedRelayerRefundRoot"];
+    const events = [
+      "FundsDeposited",
+      "FilledRelay",
+      "RequestedSpeedUpDeposit",
+      "RelayedRootBundle",
+      "ExecutedRelayerRefundRoot",
+    ];
     const _spokePool = spokePool.connect(quorumProvider);
     await Promise.all([resolveOldestTime(_spokePool, startBlock), scrapeEvents(_spokePool, events, opts)]);
   }

--- a/src/libexec/SpokePoolListenerExperimental.ts
+++ b/src/libexec/SpokePoolListenerExperimental.ts
@@ -240,12 +240,7 @@ async function run(argv: string[]): Promise<void> {
   };
 
   if (latestBlock.number > startBlock) {
-    const events = [
-      "FundsDeposited",
-      "FilledRelay",
-      "RelayedRootBundle",
-      "ExecutedRelayerRefundRoot",
-    ];
+    const events = ["FundsDeposited", "FilledRelay", "RelayedRootBundle", "ExecutedRelayerRefundRoot"];
     const _spokePool = spokePool.connect(quorumProvider);
     await Promise.all([resolveOldestTime(_spokePool, startBlock), scrapeEvents(_spokePool, events, opts)]);
   }

--- a/src/libexec/SpokePoolListenerExperimental.ts
+++ b/src/libexec/SpokePoolListenerExperimental.ts
@@ -240,7 +240,7 @@ async function run(argv: string[]): Promise<void> {
   };
 
   if (latestBlock.number > startBlock) {
-    const events = ["FundsDeposited", "FilledRelay", "RelayedRootBundle", "ExecutedRelayerRefundRoot"];
+    const events = ["FundsDeposited", "FilledRelay", "RequestedSpeedUpDeposit", "RelayedRootBundle", "ExecutedRelayerRefundRoot"];
     const _spokePool = spokePool.connect(quorumProvider);
     await Promise.all([resolveOldestTime(_spokePool, startBlock), scrapeEvents(_spokePool, events, opts)]);
   }

--- a/src/libexec/util/evm/util.ts
+++ b/src/libexec/util/evm/util.ts
@@ -21,7 +21,7 @@ export function getEventFilter(contract: Contract, eventName: string, filterArgs
 
 /**
  * Get a general event filter mapping to be used for filtering SpokePool contract events.
- * This is currently only useful for filtering the relayer address on FilledV3Relay events.
+ * This is currently only useful for filtering the relayer address on FilledRelay events.
  * @param relayer Optional relayer address to filter on.
  * @returns An argument array for input to an Ethers EventFilter.
  */
@@ -30,7 +30,7 @@ export function getEventFilterArgs(relayer?: string): { [event: string]: (null |
     ? undefined
     : [null, null, null, null, null, null, null, null, null, null, relayer];
 
-  return { FilledRelay, FilledV3Relay: FilledRelay };
+  return { FilledRelay };
 }
 
 /**


### PR DESCRIPTION
The fast relayer doesn't need to care about these anymore. Most other bots still do though.