### PR TITLE
improve(l1l2Finalizer): Make sure L1 finalizer uses hub chain spokepool's lookback

### DIFF
--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -246,6 +246,7 @@ export async function finalize(
           hubSigner,
           hubPoolClient,
           client,
+          spokePoolClients[hubChainId],
           l1ToL2AddressesToFinalize
         );
 

--- a/src/finalizer/types.ts
+++ b/src/finalizer/types.ts
@@ -35,7 +35,9 @@ export interface ChainFinalizer {
     logger: winston.Logger,
     signer: Signer,
     hubPoolClient: HubPoolClient,
-    spokePoolClient: SpokePoolClient,
+    l2SpokePoolClient: SpokePoolClient,
+    // The following types are only used in L1->L2 finalizers currently and can be omitted in L2->L1 finalizers.
+    l1SpokePoolClient: SpokePoolClient,
     l1ToL2AddressesToFinalize: string[]
   ): Promise<FinalizerPromise>;
 }

--- a/src/finalizer/utils/cctp/l1ToL2.ts
+++ b/src/finalizer/utils/cctp/l1ToL2.ts
@@ -80,7 +80,7 @@ async function findRelevantTxnReceiptsForCCTPDeposits(
   );
   const searchConfig: EventSearchConfig = {
     fromBlock: l1SpokePoolClient.eventSearchConfig.fromBlock,
-    toBlock: l1SpokePoolClient.eventSearchConfig.toBlock,
+    toBlock: l1SpokePoolClient.latestBlockSearched,
     maxBlockLookBack: l1SpokePoolClient.eventSearchConfig.maxBlockLookBack,
   };
   const events = await paginatedEventQuery(tokenMessengerContract, eventFilter, searchConfig);

--- a/src/finalizer/utils/linea/l1ToL2.ts
+++ b/src/finalizer/utils/linea/l1ToL2.ts
@@ -3,7 +3,7 @@ import { OnChainMessageStatus } from "@consensys/linea-sdk";
 import { Contract } from "ethers";
 import { groupBy } from "lodash";
 import { HubPoolClient, SpokePoolClient } from "../../../clients";
-import { CHAIN_MAX_BLOCK_LOOKBACK, CONTRACT_ADDRESSES } from "../../../common";
+import { CONTRACT_ADDRESSES } from "../../../common";
 import { EventSearchConfig, Signer, convertFromWei, winston, CHAIN_IDs, ethers, BigNumber } from "../../../utils";
 import { CrossChainMessage, FinalizerPromise } from "../../types";
 import {
@@ -11,7 +11,6 @@ import {
   findMessageFromTokenBridge,
   findMessageFromUsdcBridge,
   findMessageSentEvents,
-  getBlockRangeByHoursOffsets,
   getL1MessageServiceContractFromL1ClaimingService,
   initLineaSdk,
 } from "./common";
@@ -39,8 +38,8 @@ export async function lineaL1ToL2Finalizer(
   logger: winston.Logger,
   signer: Signer,
   hubPoolClient: HubPoolClient,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _spokePoolClient: SpokePoolClient,
+  l2SpokePoolClient: SpokePoolClient,
+  l1SpokePoolClient: SpokePoolClient,
   l1ToL2AddressesToFinalize: string[]
 ): Promise<FinalizerPromise> {
   const [l1ChainId] = [hubPoolClient.chainId, hubPoolClient.hubPool.address];
@@ -62,19 +61,10 @@ export async function lineaL1ToL2Finalizer(
     hubPoolClient.hubPool.provider
   );
 
-  // Optimize block range for querying Linea's MessageSent events on L1.
-  const { fromBlock, toBlock } = await getBlockRangeByHoursOffsets(l1ChainId, 24 * 7, 0);
-  logger.debug({
-    at: "Finalizer#LineaL1ToL2Finalizer",
-    message: "Linea MessageSent event filter",
-    fromBlock,
-    toBlock,
-  });
-
   const searchConfig: EventSearchConfig = {
-    fromBlock,
-    toBlock,
-    maxBlockLookBack: CHAIN_MAX_BLOCK_LOOKBACK[l1ChainId] || 10_000,
+    fromBlock: l1SpokePoolClient.eventSearchConfig.fromBlock,
+    toBlock: l1SpokePoolClient.eventSearchConfig.toBlock,
+    maxBlockLookBack: l1SpokePoolClient.eventSearchConfig.maxBlockLookBack,
   };
 
   const [wethAndRelayEvents, tokenBridgeEvents, usdcBridgeEvents] = await Promise.all([
@@ -100,7 +90,7 @@ export async function lineaL1ToL2Finalizer(
     const messageStatus = await getL1ToL2MessageStatusUsingCustomProvider(
       l2MessageServiceContract,
       _messageHash,
-      _spokePoolClient.spokePool.provider
+      l2SpokePoolClient.spokePool.provider
     );
     return {
       messageSender: _from,

--- a/src/finalizer/utils/linea/l1ToL2.ts
+++ b/src/finalizer/utils/linea/l1ToL2.ts
@@ -63,7 +63,7 @@ export async function lineaL1ToL2Finalizer(
 
   const searchConfig: EventSearchConfig = {
     fromBlock: l1SpokePoolClient.eventSearchConfig.fromBlock,
-    toBlock: l1SpokePoolClient.eventSearchConfig.toBlock,
+    toBlock: l1SpokePoolClient.latestBlockSearched,
     maxBlockLookBack: l1SpokePoolClient.eventSearchConfig.maxBlockLookBack,
   };
 


### PR DESCRIPTION
Currently we are always using the hub pool client's lookback to find events in the l1 to l2 direction, which is [hardcoded to 8 hours](https://github.com/across-protocol/relayer/blob/8028594423460034c064c73faf5ed994812bb6dc/src/finalizer/index.ts#L435). But if we wanted to increase this lookback using the MAX_FINALIZER_LOOKBACK environment variable, it would unexpectedly not affect the lookback in the L1 to L2 direction.
