### PR TITLE
improve(CCTPFinalizer): Simulate transactions earlier to produce better failure logs

### DIFF
--- a/src/finalizer/utils/cctp/l2ToL1.ts
+++ b/src/finalizer/utils/cctp/l2ToL1.ts
@@ -1,21 +1,18 @@
-import { TransactionRequest } from "@ethersproject/abstract-provider";
 import { ethers } from "ethers";
 import { HubPoolClient, SpokePoolClient } from "../../../clients";
 import { CONTRACT_ADDRESSES } from "../../../common";
 import {
-  Contract,
   Signer,
   TOKEN_SYMBOLS_MAP,
-  assert,
   compareAddressesSimple,
   groupObjectCountsByProp,
-  Multicall2Call,
   isDefined,
   winston,
   convertFromWei,
 } from "../../../utils";
 import { CCTPMessageStatus, DecodedCCTPMessage, resolveCCTPRelatedTxns } from "../../../utils/CCTPUtils";
 import { FinalizerPromise, CrossChainMessage } from "../../types";
+import { generateMultiCallData } from "./utils";
 
 export async function cctpL2toL1Finalizer(
   logger: winston.Logger,
@@ -41,13 +38,14 @@ export async function cctpL2toL1Finalizer(
     statusesGrouped,
   });
 
+  const callData = await generateMultiCallData(contract, unprocessedMessages, logger, spokePoolClient.chainId);
   return {
     crossChainMessages: await generateWithdrawalData(
-      unprocessedMessages,
+      unprocessedMessages.filter((_message, i) => isDefined(callData[i])),
       spokePoolClient.chainId,
       hubPoolClient.chainId
     ),
-    callData: await generateMultiCallData(contract, unprocessedMessages),
+    callData: callData.filter((_message, i) => isDefined(callData[i])),
   };
 }
 
@@ -72,31 +70,6 @@ async function resolveRelatedTxnReceipts(
   );
 
   return resolveCCTPRelatedTxns(txnReceipts, sourceChainId, targetDestinationChainId);
-}
-
-/**
- * Generates a series of populated transactions that can be consumed by the Multicall2 contract.
- * @param messageTransmitter The CCTPMessageTransmitter contract that will be used to populate the transactions.
- * @param messages The messages to generate transactions for.
- * @returns A list of populated transactions that can be consumed by the Multicall2 contract.
- */
-async function generateMultiCallData(
-  messageTransmitter: Contract,
-  messages: DecodedCCTPMessage[]
-): Promise<Multicall2Call[]> {
-  assert(messages.every((message) => isDefined(message.attestation)));
-  return Promise.all(
-    messages.map(async (message) => {
-      const txn = (await messageTransmitter.populateTransaction.receiveMessage(
-        message.messageBytes,
-        message.attestation
-      )) as TransactionRequest;
-      return {
-        target: txn.to,
-        callData: txn.data,
-      };
-    })
-  );
 }
 
 /**

--- a/src/finalizer/utils/cctp/utils.ts
+++ b/src/finalizer/utils/cctp/utils.ts
@@ -10,37 +10,37 @@ import { DecodedCCTPMessage } from "../../../utils/CCTPUtils";
  * fails to simulate, it will be undefined.
  */
 export async function generateMultiCallData(
-    messageTransmitter: Contract,
-    messages: DecodedCCTPMessage[],
-    logger: winston.Logger,
-    l2ChainId
-  ): Promise<(Multicall2Call | undefined)[]> {
-    assert(messages.every((message) => isDefined(message.attestation)));
-    return Promise.all(
-      messages.map(async (message) => {
-        try {
-          await messageTransmitter.estimateGas.receiveMessage(message.messageBytes, message.attestation);
-          // Try to simulate transaction to give more detailed error log if it would fail in the multicaller.
-          const txn = (await messageTransmitter.populateTransaction.receiveMessage(
-            message.messageBytes,
-            message.attestation
-          )) as TransactionRequest;
-          return {
-            target: txn.to,
-            callData: txn.data,
-          };
-        } catch (error) {
-          logger.warn({
-            at: `Finalizer#CCTPFinalizer:${l2ChainId}:generateMultiCallData`,
-            message: "Finalizing CCTP transfer failed simulation",
-            l2ChainId,
-            target: messageTransmitter.address,
-            method: "receiveMessage",
-            args: [message.messageBytes, message.attestation],
-            error,
-          });
-          return undefined;
-        }
-      })
-    );
-  }
+  messageTransmitter: Contract,
+  messages: DecodedCCTPMessage[],
+  logger: winston.Logger,
+  l2ChainId
+): Promise<(Multicall2Call | undefined)[]> {
+  assert(messages.every((message) => isDefined(message.attestation)));
+  return Promise.all(
+    messages.map(async (message) => {
+      try {
+        await messageTransmitter.estimateGas.receiveMessage(message.messageBytes, message.attestation);
+        // Try to simulate transaction to give more detailed error log if it would fail in the multicaller.
+        const txn = (await messageTransmitter.populateTransaction.receiveMessage(
+          message.messageBytes,
+          message.attestation
+        )) as TransactionRequest;
+        return {
+          target: txn.to,
+          callData: txn.data,
+        };
+      } catch (error) {
+        logger.warn({
+          at: `Finalizer#CCTPFinalizer:${l2ChainId}:generateMultiCallData`,
+          message: "Finalizing CCTP transfer failed simulation",
+          l2ChainId,
+          target: messageTransmitter.address,
+          method: "receiveMessage",
+          args: [message.messageBytes, message.attestation],
+          error,
+        });
+        return undefined;
+      }
+    })
+  );
+}

--- a/src/finalizer/utils/cctp/utils.ts
+++ b/src/finalizer/utils/cctp/utils.ts
@@ -13,7 +13,7 @@ export async function generateMultiCallData(
   messageTransmitter: Contract,
   messages: DecodedCCTPMessage[],
   logger: winston.Logger,
-  l2ChainId
+  l2ChainId: number
 ): Promise<(Multicall2Call | undefined)[]> {
   assert(messages.every((message) => isDefined(message.attestation)));
   return Promise.all(

--- a/src/finalizer/utils/cctp/utils.ts
+++ b/src/finalizer/utils/cctp/utils.ts
@@ -1,0 +1,46 @@
+import { TransactionRequest } from "@ethersproject/abstract-provider";
+import { Contract, assert, isDefined, Multicall2Call, winston } from "../../../utils";
+import { DecodedCCTPMessage } from "../../../utils/CCTPUtils";
+
+/**
+ * Generates a series of populated transactions that can be consumed by the Multicall2 contract.
+ * @param messageTransmitter The CCTPMessageTransmitter contract that will be used to populate the transactions.
+ * @param messages The messages to generate transactions for.
+ * @returns A list of populated transactions that can be consumed by the Multicall2 contract. If any message
+ * fails to simulate, it will be undefined.
+ */
+export async function generateMultiCallData(
+    messageTransmitter: Contract,
+    messages: DecodedCCTPMessage[],
+    logger: winston.Logger,
+    l2ChainId
+  ): Promise<(Multicall2Call | undefined)[]> {
+    assert(messages.every((message) => isDefined(message.attestation)));
+    return Promise.all(
+      messages.map(async (message) => {
+        try {
+          await messageTransmitter.estimateGas.receiveMessage(message.messageBytes, message.attestation);
+          // Try to simulate transaction to give more detailed error log if it would fail in the multicaller.
+          const txn = (await messageTransmitter.populateTransaction.receiveMessage(
+            message.messageBytes,
+            message.attestation
+          )) as TransactionRequest;
+          return {
+            target: txn.to,
+            callData: txn.data,
+          };
+        } catch (error) {
+          logger.warn({
+            at: `Finalizer#CCTPFinalizer:${l2ChainId}:generateMultiCallData`,
+            message: "Finalizing CCTP transfer failed simulation",
+            l2ChainId,
+            target: messageTransmitter.address,
+            method: "receiveMessage",
+            args: [message.messageBytes, message.attestation],
+            error,
+          });
+          return undefined;
+        }
+      })
+    );
+  }


### PR DESCRIPTION
We can follow this pattern for the other finalizers too, I just wanted to try this for CCTP because there are some finalizations whose errors are only more clear when you simulate them directly before using the Multicall2 contract to simulate them