### PR TITLE
fix: log error stack when stringifying

### DIFF
--- a/src/utils/LogUtils.ts
+++ b/src/utils/LogUtils.ts
@@ -3,7 +3,9 @@ export type DefaultLogLevels = "debug" | "info" | "warn" | "error";
 export function stringifyThrownValue(value: unknown): string {
   if (value instanceof Error) {
     const errToString = value.toString();
-    return value.stack || value.message || errToString !== "[object Object]"
+    return value.stack
+      ? value.stack
+      : value.message || errToString !== "[object Object]"
       ? errToString
       : "could not extract error from 'Error' instance";
   } else if (value instanceof Object) {


### PR DESCRIPTION
`Error.toString()` doesn't stringify the stack. This change always try to log the trace now if available