### PR TITLE
improve(relayer): Permit configuration of max startup delay

### DIFF
--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -16,7 +16,13 @@ config();
 let logger: winston.Logger;
 
 const ACTIVE_RELAYER_EXPIRY = 600; // 10 minutes.
-const { RUN_IDENTIFIER: runIdentifier, BOT_IDENTIFIER: botIdentifier = "across-relayer" } = process.env;
+const {
+  RUN_IDENTIFIER: runIdentifier,
+  BOT_IDENTIFIER: botIdentifier = "across-relayer",
+  RELAYER_MAX_STARTUP_DELAY = "120"
+} = process.env;
+
+const maxStartupDelay = Number(RELAYER_MAX_STARTUP_DELAY);
 
 export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
   const profiler = new Profiler({
@@ -65,7 +71,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
       // If there is another active relayer, allow up to 120 seconds for this instance to be ready.
       // If this instance can't update, throw an error (for now).
       if (!ready && activeRelayer) {
-        if (run * pollingDelay < 120) {
+        if (run * pollingDelay < maxStartupDelay) {
           const runTime = Math.round((performance.now() - tLoopStart.startTime) / 1000);
           const delta = pollingDelay - runTime;
           logger.debug({ at: "Relayer#run", message: `Not ready to relay, waiting ${delta} seconds.` });

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -19,7 +19,7 @@ const ACTIVE_RELAYER_EXPIRY = 600; // 10 minutes.
 const {
   RUN_IDENTIFIER: runIdentifier,
   BOT_IDENTIFIER: botIdentifier = "across-relayer",
-  RELAYER_MAX_STARTUP_DELAY = "120"
+  RELAYER_MAX_STARTUP_DELAY = "120",
 } = process.env;
 
 const maxStartupDelay = Number(RELAYER_MAX_STARTUP_DELAY);


### PR DESCRIPTION
Currently seeing some issues on startup and it'd be nice to be able to extend the wait time before bailing.