### PR TITLE
fix(InventoryClient): Handle when ProposedRootBundle event preceding RootBundleExecuted event cannot be found

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -662,9 +662,14 @@ export class InventoryClient {
         if (latestValidatedBundle) {
           proposedRootBundle = this.hubPoolClient.getLatestFullyExecutedRootBundle(
             latestValidatedBundle.blockNumber // The ProposeRootBundle event must precede the ExecutedRootBundle
-            // event we grabbed above.
+            // event we grabbed above. However, it might not exist if the ExecutedRootBundle event is old enough
+            // that the preceding ProposeRootBundle is older than the lookback. In this case, leave the
+            // last validated bundle end block as 0, since it must be before the earliest lookback block since it was
+            // before the ProposeRootBundle event and we can't even find that.
           );
-          lastValidatedBundleEndBlock = proposedRootBundle.bundleEvaluationBlockNumbers[chainIdIndex].toNumber();
+          if (proposedRootBundle) {
+            lastValidatedBundleEndBlock = proposedRootBundle.bundleEvaluationBlockNumbers[chainIdIndex].toNumber();
+          }
         }
         const upcomingDepositsAfterLastValidatedBundle = this.bundleDataClient.getUpcomingDepositAmount(
           chainId,


### PR DESCRIPTION
Its possible that the RootBundleExecued event for a chain and token is old enough that the ProposedRootBundle event is older than the earliest block searched. In this case,  our best way to approximate the running balance is to use the running balance from the RootBundleExecuted event plus any deposits and minus any refunds seen in the entire spoke pool client's lookback. This lookback window is correct to use because the bundle end block associated with the RootBundleExecued by definition must be older than the spoke pool client's lookback. If we can't even see the ProposedRootBundle event then the bundle end block must be even older
