### PR TITLE
feat: add zkStack adapters

### DIFF
--- a/src/adapter/bridges/ZKStackBridge.ts
+++ b/src/adapter/bridges/ZKStackBridge.ts
@@ -1,0 +1,130 @@
+import { Contract, BigNumber, Signer, EventSearchConfig, Provider, ethers, TOKEN_SYMBOLS_MAP } from "../../utils";
+import { CONTRACT_ADDRESSES } from "../../common";
+import { BridgeTransactionDetails, BaseBridgeAdapter, BridgeEvents } from "./BaseBridgeAdapter";
+import * as zksync from "zksync-ethers";
+import { gasPriceOracle } from "@across-protocol/sdk";
+import { PUBLIC_NETWORKS } from "@across-protocol/constants";
+
+/* For both the canonical bridge (this bridge) and the ZkSync Weth
+ * bridge, we need to assume that the l1 and l2 signers contain
+ * associated providers, since we need to get information about
+ * addresses and gas prices (this is also why `constructL1toL2Txn`
+ * is an async fn).
+ */
+export class ZKStackBridge extends BaseBridgeAdapter {
+  readonly gasPerPubdataLimit = zksync.utils.REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT;
+  readonly l2GasLimit = BigNumber.from(2_000_000);
+  readonly sharedBridgeAddress;
+
+  constructor(
+    l2chainId: number,
+    hubChainId: number,
+    l1Signer: Signer,
+    l2SignerOrProvider: Signer | Provider,
+    _l1Token: string
+  ) {
+    // Lint Appeasement
+    _l1Token;
+    const sharedBridgeAddress = CONTRACT_ADDRESSES[hubChainId][`zkStackSharedBridge_${l2chainId}`].address;
+    super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, [sharedBridgeAddress]);
+
+    const nativeToken = PUBLIC_NETWORKS[l2chainId].nativeToken;
+    // Only set nonstandard gas tokens.
+    if (nativeToken !== "ETH") {
+      this.gasToken = TOKEN_SYMBOLS_MAP[nativeToken].addresses[hubChainId];
+    }
+
+    const { address: l1Address, abi: l1Abi } = CONTRACT_ADDRESSES[hubChainId].zkStackBridgeHub;
+    this.l1Bridge = new Contract(l1Address, l1Abi, l1Signer);
+
+    this.sharedBridgeAddress = sharedBridgeAddress;
+
+    const { address: l2Address, abi: l2Abi } = CONTRACT_ADDRESSES[l2chainId].zkSyncDefaultErc20Bridge;
+    this.l2Bridge = new Contract(l2Address, l2Abi, l2SignerOrProvider);
+  }
+
+  async constructL1ToL2Txn(
+    toAddress: string,
+    l1Token: string,
+    l2Token: string,
+    amount: BigNumber
+  ): Promise<BridgeTransactionDetails> {
+    // The zkStack bridges need to know information relating to the l2 gas price bid.
+    const txBaseCost = await this._txBaseCost();
+    const secondBridgeCalldata = this._secondBridgeCalldata(toAddress, l1Token, amount);
+
+    // The method/arguments change depending on whether or not we are bridging the gas token or another ERC20.
+    const bridgingGasToken = l1Token === this.gasToken;
+    const method = bridgingGasToken ? "requestL2TransactionDirect" : "requestL2TransactionTwoBridges";
+    const args = bridgingGasToken
+      ? [
+          [
+            this.l2chainId,
+            txBaseCost.add(amount),
+            toAddress,
+            amount,
+            "0x",
+            this.l2GasLimit,
+            this.gasPerPubdataLimit,
+            [],
+            toAddress,
+          ],
+        ]
+      : [
+          [
+            this.l2chainId,
+            txBaseCost,
+            0,
+            this.l2GasLimit,
+            this.gasPerPubdataLimit,
+            toAddress,
+            this.sharedBridgeAddress,
+            0,
+            secondBridgeCalldata,
+          ],
+        ];
+
+    return Promise.resolve({
+      contract: this.getL1Bridge(),
+      method,
+      args,
+    });
+  }
+
+  async queryL1BridgeInitiationEvents(
+    l1Token: string,
+    fromAddress: string,
+    toAddress: string,
+    eventConfig: EventSearchConfig
+  ): Promise<BridgeEvents> {
+    return Promise.resolve({});
+  }
+
+  async queryL2BridgeFinalizationEvents(
+    l1Token: string,
+    fromAddress: string,
+    toAddress: string,
+    eventConfig: EventSearchConfig
+  ): Promise<BridgeEvents> {
+    return Promise.resolve({});
+  }
+
+  _secondBridgeCalldata(toAddress: string, l1Token: string, amount: BigNumber): string {
+    return ethers.utils.defaultAbiCoder.encode(["address", "uint256", "address"], [l1Token, amount, toAddress]);
+  }
+
+  async _txBaseCost(): Promise<BigNumber> {
+    const l1GasPriceData = await gasPriceOracle.getGasPriceEstimate(this.getL1Bridge().provider!);
+
+    // Similar to the ZkSyncBridge types, we must calculate the l2 gas cost by querying, in this case,
+    // the bridge hub contract.
+    const estimatedL1GasPrice = l1GasPriceData.maxPriorityFeePerGas.add(l1GasPriceData.maxFeePerGas);
+    const l2Gas = await this.getL1Bridge().l2TransactionBaseCost(
+      this.l2chainId,
+      estimatedL1GasPrice,
+      this.l2GasLimit,
+      this.gasPerPubdataLimit
+    );
+    return l2Gas;
+  }
+}

--- a/src/adapter/bridges/ZKStackWethBridge.ts
+++ b/src/adapter/bridges/ZKStackWethBridge.ts
@@ -1,0 +1,71 @@
+import assert from "assert";
+import { Contract, BigNumber, Signer, Provider, ZERO_ADDRESS, bnZero } from "../../utils";
+import { ZKStackBridge } from "./";
+import { CONTRACT_ADDRESSES } from "../../common";
+import { BridgeTransactionDetails } from "./BaseBridgeAdapter";
+
+/* For both the canonical bridge (this bridge) and the ZkSync Weth
+ * bridge, we need to assume that the l1 and l2 signers contain
+ * associated providers, since we need to get information about
+ * addresses and gas prices (this is also why `constructL1toL2Txn`
+ * is an async fn).
+ */
+
+const ETH_TOKEN_ADDRESS = "0x0000000000000000000000000000000000000001";
+export class ZKStackWethBridge extends ZKStackBridge {
+  private readonly atomicDepositor;
+
+  constructor(
+    l2chainId: number,
+    hubChainId: number,
+    l1Signer: Signer,
+    l2SignerOrProvider: Signer | Provider,
+    l1Token: string
+  ) {
+    super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, l1Token);
+    const { address: atomicDepositorAddress, abi: atomicDepositorAbi } = CONTRACT_ADDRESSES[hubChainId].atomicDepositor;
+    this.atomicDepositor = new Contract(atomicDepositorAddress, atomicDepositorAbi, l1Signer);
+
+    // Overwrite the bridge gateway to the correct gateway.
+    this.l1Gateways = [atomicDepositorAddress];
+  }
+
+  async constructL1ToL2Txn(
+    toAddress: string,
+    l1Token: string,
+    l2Token: string,
+    amount: BigNumber
+  ): Promise<BridgeTransactionDetails> {
+    assert(l1Token === ETH_TOKEN_ADDRESS);
+    // The zkStack bridges need to know information relating to the l2 gas price bid.
+    const txBaseCost = await this._txBaseCost();
+    const secondBridgeCalldata = this._secondBridgeCalldata(toAddress, l1Token, bnZero);
+
+    const bridgeCalldata = this.getL1Bridge().interface.encodeFunctionData("requestL2TransactionTwoBridges", [
+      [
+        this.l2chainId,
+        txBaseCost,
+        0,
+        this.l2GasLimit,
+        this.gasPerPubdataLimit,
+        toAddress,
+        this.sharedBridgeAddress,
+        amount,
+        secondBridgeCalldata,
+      ],
+    ]);
+    const usingCustomGasToken = this.gasToken !== ZERO_ADDRESS;
+    const netValue = usingCustomGasToken ? amount : amount.add(txBaseCost);
+    const feeAmount = usingCustomGasToken ? txBaseCost : bnZero;
+
+    return Promise.resolve({
+      contract: this.getAtomicDepositor(),
+      method: "bridgeWeth",
+      args: [this.l2chainId, netValue, amount, feeAmount, bridgeCalldata],
+    });
+  }
+
+  private getAtomicDepositor(): Contract {
+    return this.atomicDepositor;
+  }
+}

--- a/src/adapter/bridges/index.ts
+++ b/src/adapter/bridges/index.ts
@@ -16,3 +16,5 @@ export * from "./BlastBridge";
 export * from "./ScrollERC20Bridge";
 export * from "./OpStackUSDCBridge";
 export * from "./UsdcCCTPBridge";
+export * from "./ZKStackBridge";
+export * from "./ZKStackWethBridge";

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -18,6 +18,8 @@ import {
   ScrollERC20Bridge,
   OpStackUSDCBridge,
   UsdcCCTPBridge,
+  ZKStackBridge,
+  ZKStackWethBridge,
 } from "../adapter/bridges";
 import { DEFAULT_L2_CONTRACT_ADDRESSES } from "@eth-optimism/sdk";
 import { CONTRACT_ADDRESSES } from "./ContractAddresses";
@@ -361,7 +363,6 @@ export const CANONICAL_BRIDGE: {
   [CHAIN_IDs.BLAST]: OpStackDefaultERC20Bridge,
   [CHAIN_IDs.UNICHAIN]: OpStackDefaultERC20Bridge,
   [CHAIN_IDs.INK]: OpStackDefaultERC20Bridge,
-  [CHAIN_IDs.LENS_SEPOLIA]: ZKSyncBridge, // TODO
   [CHAIN_IDs.LINEA]: LineaBridge,
   [CHAIN_IDs.LISK]: OpStackDefaultERC20Bridge,
   [CHAIN_IDs.MODE]: OpStackDefaultERC20Bridge,
@@ -374,6 +375,7 @@ export const CANONICAL_BRIDGE: {
   [CHAIN_IDs.ZK_SYNC]: ZKSyncBridge,
   [CHAIN_IDs.ZORA]: OpStackDefaultERC20Bridge,
   // Testnets:
+  [CHAIN_IDs.LENS_SEPOLIA]: ZKStackBridge,
   [CHAIN_IDs.ARBITRUM_SEPOLIA]: ArbitrumOrbitBridge,
   [CHAIN_IDs.BASE_SEPOLIA]: OpStackDefaultERC20Bridge,
   [CHAIN_IDs.BLAST_SEPOLIA]: OpStackDefaultERC20Bridge,
@@ -480,6 +482,9 @@ export const CUSTOM_BRIDGE: {
   [CHAIN_IDs.POLYGON_AMOY]: {
     [TOKEN_SYMBOLS_MAP.WETH.addresses[CHAIN_IDs.SEPOLIA]]: PolygonWethBridge,
     [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.SEPOLIA]]: UsdcTokenSplitterBridge,
+  },
+  [CHAIN_IDs.LENS_SEPOLIA]: {
+    [TOKEN_SYMBOLS_MAP.WETH.addresses[CHAIN_IDs.SEPOLIA]]: ZKStackWethBridge,
   },
 };
 

--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -35,6 +35,7 @@ import BLAST_OPTIMISM_PORTAL_ABI from "./abi/BlastOptimismPortal.json";
 import SCROLL_GATEWAY_ROUTER_L1_ABI from "./abi/ScrollGatewayRouterL1.json";
 import SCROLL_GATEWAY_ROUTER_L2_ABI from "./abi/ScrollGatewayRouterL2.json";
 import SCROLL_GAS_PRICE_ORACLE_ABI from "./abi/ScrollGasPriceOracle.json";
+import ZKSTACK_BRIDGE_HUB_ABI from "./abi/ZkStackBridgeHub.json";
 
 // Constants file exporting hardcoded contract addresses per chain.
 export const CONTRACT_ADDRESSES: {
@@ -499,6 +500,14 @@ export const CONTRACT_ADDRESSES: {
     },
     orbitErc20Gateway_421614: {
       abi: ARBITRUM_ERC20_GATEWAY_L1_ABI,
+    },
+    zkStackBridgeHub: {
+      address: "0x236D1c3Ff32Bd0Ca26b72Af287E895627c0478cE",
+      abi: ZKSTACK_BRIDGE_HUB_ABI,
+    },
+    // The shared bridge is needed to approve the token, but we do not need its ABI.
+    zkStackSharedBridge_3771: {
+      address: "0x6F03861D12E6401623854E494beACd66BC46e6F0",
     },
     hubPool: {
       address: "0x14224e63716afAcE30C9a417E0542281869f7d9e",

--- a/src/common/abi/ZkStackBridgeHub.json
+++ b/src/common/abi/ZkStackBridgeHub.json
@@ -1,0 +1,1879 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_l1ChainId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "_owner",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_maxNumberOfZKChains",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "blockChainId",
+                "type": "uint256"
+            }
+        ],
+        "name": "AlreadyCurrentSL",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "assetId",
+                "type": "bytes32"
+            }
+        ],
+        "name": "AssetHandlerNotRegistered",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "AssetIdAlreadyRegistered",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "assetId",
+                "type": "bytes32"
+            }
+        ],
+        "name": "AssetIdNotSupported",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BridgeHubAlreadyRegistered",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "CTMAlreadyRegistered",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "CTMNotRegistered",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ChainIdAlreadyExists",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ChainIdAlreadyPresent",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ChainIdCantBeCurrentChain",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ChainIdMismatch",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "chainId",
+                "type": "uint256"
+            }
+        ],
+        "name": "ChainIdNotRegistered",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ChainIdTooBig",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ChainNotLegacy",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ChainNotPresentInCTM",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "EmptyAssetId",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "HyperchainNotRegistered",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "bridgehub",
+                "type": "address"
+            }
+        ],
+        "name": "IncorrectBridgeHubAddress",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "assetId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "assetIdFromChainId",
+                "type": "bytes32"
+            }
+        ],
+        "name": "IncorrectChainAssetId",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "prevMsgSender",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "chainAdmin",
+                "type": "address"
+            }
+        ],
+        "name": "IncorrectSender",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "MigrationPaused",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "expectedMsgValue",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "providedMsgValue",
+                "type": "uint256"
+            }
+        ],
+        "name": "MsgValueMismatch",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "assetId",
+                "type": "bytes32"
+            }
+        ],
+        "name": "NoCTMForAssetId",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "NonEmptyMsgValue",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "msgSender",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "sharedBridge",
+                "type": "address"
+            }
+        ],
+        "name": "NotAssetRouter",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "settlementLayerChainId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "blockChainId",
+                "type": "uint256"
+            }
+        ],
+        "name": "NotCurrentSL",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "NotInGatewayMode",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "NotInitializedReentrancyGuard",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "l1ChainId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "blockChainId",
+                "type": "uint256"
+            }
+        ],
+        "name": "NotL1",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "msgSender",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "settlementLayerRelaySender",
+                "type": "address"
+            }
+        ],
+        "name": "NotRelayedSender",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "Reentrancy",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SLNotWhitelisted",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "secondBridgeAddress",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "minSecondBridgeAddress",
+                "type": "address"
+            }
+        ],
+        "name": "SecondBridgeAddressTooLow",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SettlementLayersMustSettleOnL1",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SharedBridgeNotSet",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SlotOccupied",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "caller",
+                "type": "address"
+            }
+        ],
+        "name": "Unauthorized",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "expectedMagicValue",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "providedMagicValue",
+                "type": "uint256"
+            }
+        ],
+        "name": "WrongMagicValue",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ZKChainLimitReached",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ZeroAddress",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ZeroChainId",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "assetInfo",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "_assetAddress",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "additionalData",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "AssetRegistered",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "assetId",
+                "type": "bytes32"
+            }
+        ],
+        "name": "BaseTokenAssetIdRegistered",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "chainId",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "assetId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "receiver",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "BridgeBurn",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "chainId",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "assetId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "receiver",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "BridgeMint",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "chainTypeManager",
+                "type": "address"
+            }
+        ],
+        "name": "ChainTypeManagerAdded",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "chainTypeManager",
+                "type": "address"
+            }
+        ],
+        "name": "ChainTypeManagerRemoved",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint8",
+                "name": "version",
+                "type": "uint8"
+            }
+        ],
+        "name": "Initialized",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "chainId",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "assetId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "zkChain",
+                "type": "address"
+            }
+        ],
+        "name": "MigrationFinalized",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "chainId",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "assetId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "settlementLayerChainId",
+                "type": "uint256"
+            }
+        ],
+        "name": "MigrationStarted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "oldAdmin",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "newAdmin",
+                "type": "address"
+            }
+        ],
+        "name": "NewAdmin",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "chainId",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "chainTypeManager",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "chainGovernance",
+                "type": "address"
+            }
+        ],
+        "name": "NewChain",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "oldPendingAdmin",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "newPendingAdmin",
+                "type": "address"
+            }
+        ],
+        "name": "NewPendingAdmin",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "previousOwner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "OwnershipTransferStarted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "previousOwner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "OwnershipTransferred",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "Paused",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "chainId",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "bool",
+                "name": "isWhitelisted",
+                "type": "bool"
+            }
+        ],
+        "name": "SettlementLayerRegistered",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "Unpaused",
+        "type": "event"
+    },
+    {
+        "inputs": [],
+        "name": "L1_CHAIN_ID",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "MAX_NUMBER_OF_ZK_CHAINS",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "chainId",
+                "type": "uint256"
+            }
+        ],
+        "name": "__DEPRECATED_baseToken",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "baseToken",
+                "type": "address"
+            }
+        ],
+        "name": "__DEPRECATED_tokenIsRegistered",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "acceptAdmin",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "acceptOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_chainTypeManager",
+                "type": "address"
+            }
+        ],
+        "name": "addChainTypeManager",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "_baseTokenAssetId",
+                "type": "bytes32"
+            }
+        ],
+        "name": "addTokenAssetId",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "admin",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "baseTokenAssetId",
+                "type": "bytes32"
+            }
+        ],
+        "name": "assetIdIsRegistered",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "assetRouter",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_chainId",
+                "type": "uint256"
+            }
+        ],
+        "name": "baseToken",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "chainId",
+                "type": "uint256"
+            }
+        ],
+        "name": "baseTokenAssetId",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_settlementChainId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_l2MsgValue",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "_assetId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "_originalCaller",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_data",
+                "type": "bytes"
+            }
+        ],
+        "name": "bridgeBurn",
+        "outputs": [
+            {
+                "internalType": "bytes",
+                "name": "bridgehubMintData",
+                "type": "bytes"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "_assetId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_bridgehubMintData",
+                "type": "bytes"
+            }
+        ],
+        "name": "bridgeMint",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "_assetId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "_depositSender",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_data",
+                "type": "bytes"
+            }
+        ],
+        "name": "bridgeRecoverFailedTransfer",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "chainId",
+                "type": "uint256"
+            }
+        ],
+        "name": "chainTypeManager",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "chainTypeManager",
+                "type": "address"
+            }
+        ],
+        "name": "chainTypeManagerIsRegistered",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_chainId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "_chainTypeManager",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "_baseTokenAssetId",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_salt",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "_admin",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_initData",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "_factoryDeps",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "createNewChain",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "ctmAddress",
+                "type": "address"
+            }
+        ],
+        "name": "ctmAssetIdFromAddress",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "ctmAssetId",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_chainId",
+                "type": "uint256"
+            }
+        ],
+        "name": "ctmAssetIdFromChainId",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "ctmAssetId",
+                "type": "bytes32"
+            }
+        ],
+        "name": "ctmAssetIdToAddress",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "ctmAddress",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_chainId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "_canonicalTxHash",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "uint64",
+                "name": "_expirationTimestamp",
+                "type": "uint64"
+            }
+        ],
+        "name": "forwardTransactionOnGateway",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getAllZKChainChainIDs",
+        "outputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getAllZKChains",
+        "outputs": [
+            {
+                "internalType": "address[]",
+                "name": "chainAddresses",
+                "type": "address[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_chainId",
+                "type": "uint256"
+            }
+        ],
+        "name": "getHyperchain",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_chainId",
+                "type": "uint256"
+            }
+        ],
+        "name": "getZKChain",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "chainAddress",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_owner",
+                "type": "address"
+            }
+        ],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "initializeV2",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "l1CtmDeployer",
+        "outputs": [
+            {
+                "internalType": "contract ICTMDeploymentTracker",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_chainId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_gasPrice",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_l2GasLimit",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_l2GasPerPubdataByteLimit",
+                "type": "uint256"
+            }
+        ],
+        "name": "l2TransactionBaseCost",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "messageRoot",
+        "outputs": [
+            {
+                "internalType": "contract IMessageRoot",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "migrationPaused",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "owner",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "pause",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "pauseMigration",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "paused",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "pendingOwner",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_chainId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "_l2TxHash",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_l2BatchNumber",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_l2MessageIndex",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint16",
+                "name": "_l2TxNumberInBatch",
+                "type": "uint16"
+            },
+            {
+                "internalType": "bytes32[]",
+                "name": "_merkleProof",
+                "type": "bytes32[]"
+            },
+            {
+                "internalType": "enum TxStatus",
+                "name": "_status",
+                "type": "uint8"
+            }
+        ],
+        "name": "proveL1ToL2TransactionStatus",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_chainId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_batchNumber",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_index",
+                "type": "uint256"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "uint8",
+                        "name": "l2ShardId",
+                        "type": "uint8"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "isService",
+                        "type": "bool"
+                    },
+                    {
+                        "internalType": "uint16",
+                        "name": "txNumberInBatch",
+                        "type": "uint16"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "sender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "key",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "value",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct L2Log",
+                "name": "_log",
+                "type": "tuple"
+            },
+            {
+                "internalType": "bytes32[]",
+                "name": "_proof",
+                "type": "bytes32[]"
+            }
+        ],
+        "name": "proveL2LogInclusion",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_chainId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_batchNumber",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_index",
+                "type": "uint256"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "uint16",
+                        "name": "txNumberInBatch",
+                        "type": "uint16"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "sender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "data",
+                        "type": "bytes"
+                    }
+                ],
+                "internalType": "struct L2Message",
+                "name": "_message",
+                "type": "tuple"
+            },
+            {
+                "internalType": "bytes32[]",
+                "name": "_proof",
+                "type": "bytes32[]"
+            }
+        ],
+        "name": "proveL2MessageInclusion",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_chainId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "_zkChain",
+                "type": "address"
+            }
+        ],
+        "name": "registerAlreadyDeployedZKChain",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_chainId",
+                "type": "uint256"
+            }
+        ],
+        "name": "registerLegacyChain",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_newSettlementLayerChainId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bool",
+                "name": "_isWhitelisted",
+                "type": "bool"
+            }
+        ],
+        "name": "registerSettlementLayer",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_chainTypeManager",
+                "type": "address"
+            }
+        ],
+        "name": "removeChainTypeManager",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "renounceOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "chainId",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "mintValue",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "l2Contract",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "l2Value",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "l2Calldata",
+                        "type": "bytes"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "l2GasLimit",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "l2GasPerPubdataByteLimit",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes[]",
+                        "name": "factoryDeps",
+                        "type": "bytes[]"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "refundRecipient",
+                        "type": "address"
+                    }
+                ],
+                "internalType": "struct L2TransactionRequestDirect",
+                "name": "_request",
+                "type": "tuple"
+            }
+        ],
+        "name": "requestL2TransactionDirect",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "canonicalTxHash",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "chainId",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "mintValue",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "l2Value",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "l2GasLimit",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "l2GasPerPubdataByteLimit",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "refundRecipient",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "secondBridgeAddress",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "secondBridgeValue",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "secondBridgeCalldata",
+                        "type": "bytes"
+                    }
+                ],
+                "internalType": "struct L2TransactionRequestTwoBridgesOuter",
+                "name": "_request",
+                "type": "tuple"
+            }
+        ],
+        "name": "requestL2TransactionTwoBridges",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "canonicalTxHash",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_assetRouter",
+                "type": "address"
+            },
+            {
+                "internalType": "contract ICTMDeploymentTracker",
+                "name": "_l1CtmDeployer",
+                "type": "address"
+            },
+            {
+                "internalType": "contract IMessageRoot",
+                "name": "_messageRoot",
+                "type": "address"
+            }
+        ],
+        "name": "setAddresses",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "_additionalData",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "_assetAddress",
+                "type": "address"
+            }
+        ],
+        "name": "setCTMAssetAddress",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_newPendingAdmin",
+                "type": "address"
+            }
+        ],
+        "name": "setPendingAdmin",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "chainId",
+                "type": "uint256"
+            }
+        ],
+        "name": "settlementLayer",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "activeSettlementLayerChainId",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "sharedBridge",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "transferOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "unpause",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "unpauseMigration",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "chainId",
+                "type": "uint256"
+            }
+        ],
+        "name": "whitelistedSettlementLayers",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "isWhitelistedSettlementLayer",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+]


### PR DESCRIPTION
Needed to interface with ZkStack chains. The weth bridges will utilize the new functionality of the atomic depositor. The adapters should be functionally equivalent to the contract versions.