### PR TITLE
improve(relayer): Ensure relayer yields execution between loops

### DIFF
--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -111,10 +111,12 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
           message: "Completed relayer execution loop.",
           loopCount: run,
         });
-        const runTime = Math.round(runTimeMilliseconds / 1000);
+        if (!stop) {
+          const runTime = Math.round(runTimeMilliseconds / 1000);
 
-        if (!stop && runTime < pollingDelay) {
-          const delta = pollingDelay - runTime;
+          // When txns are pending submission, yield execution to ensure they can be submitted.
+          const minDelay = Object.values(txnReceipts).length > 0 ? 0.1 : 0;
+          const delta = pollingDelay > runTime ? pollingDelay - runTime : minDelay;
           logger.debug({
             at: "relayer#run",
             message: `Waiting ${delta} s before next loop.`,


### PR DESCRIPTION
If the relayer's execution loop is taking long enough that it does not sleep between loops, a transaction that is pending submission may appear to take a long time because its post-submission task cannot be scheduled.

This change enforces a minimum delay of 0.1 seconds when there are transactions pending submission in order to ensure the submission tasks are not CPU-starved.