### PR TITLE
improve: start calling `fillRelay` over `fillV3Relay`

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1044,7 +1044,7 @@ export class Relayer {
     );
 
     const [method, messageModifier, args] = !isDepositSpedUp(deposit)
-      ? ["fillV3Relay", "", [deposit, repaymentChainId]]
+      ? ["fillRelay", "", [convertRelayDataParamsToBytes32(deposit), repaymentChainId, this.relayerAddress]]
       : [
           "fillRelayWithUpdatedDeposit",
           " with updated parameters ",

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1044,7 +1044,7 @@ export class Relayer {
     );
 
     const [method, messageModifier, args] = !isDepositSpedUp(deposit)
-      ? ["fillRelay", "", [convertRelayDataParamsToBytes32(deposit), repaymentChainId, this.relayerAddress]]
+      ? ["fillRelay", "", [convertRelayDataParamsToBytes32(deposit), repaymentChainId, toBytes32(this.relayerAddress)]]
       : [
           "fillRelayWithUpdatedDeposit",
           " with updated parameters ",

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -229,7 +229,7 @@ describe("Relayer: Token balance shortfall", async function () {
     expect(txnHashes.length).to.equal(1);
     const txn = await spokePool_1.provider.getTransaction(txnHashes[0]);
     const { name: method, args } = spokePool_1.interface.parseTransaction(txn);
-    expect(method).to.equal("fillV3Relay");
+    expect(method).to.equal("fillRelay");
     expect(args[0].depositId).to.equal(0); // depositId 0
 
     expect(spyLogIncludes(spy, -5, `${await l1Token.symbol()} cumulative shortfall of 190.00`)).to.be.true;


### PR DESCRIPTION
Brought to our attention from other relayers, calling fillV3Relay does not let us fill deposits with deterministic deposit IDs, so we should start calling fillRelay.