### PR TITLE
fix: correctly accumulate refund amounts in spoke reporter

### DIFF
--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -839,7 +839,7 @@ export class Monitor {
               .filter(isDefined)
               .reduce((totalAmounts, outputAmount) => totalAmounts.add(outputAmount), bnZero);
             pendingRelayerRefunds[chainId][l2Token] =
-              pendingRelayerRefunds[chainId][l2Token].sub(pendingSlowFillAmounts);
+              pendingRelayerRefunds[chainId][l2Token].add(pendingSlowFillAmounts);
           });
       });
 


### PR DESCRIPTION
The spoke pool reporter keeps the total amount the spoke pool must pay out internally as a positive integer (e.g. it has balance of 100 ETH but must pay out 20 ETH on the next bundle). When there are slow fills for a specific token on a monitored network, the spoke pool reporter is incorrectly subtracting the slow fill amount from the total amount it must pay out from the spoke instead of adding it. This causes the reports to be incorrect, and when the slow fill amount exceeds the amount it needs to pay out with relayer refunds, we even get a "negative" refund amount, which clearly isn't possible. Here is an example incorrect log for USDC on Arbitrum (order is current balance, obligations, pool rebalance amounts, and virtual balance (current balance - obligations + pool rebalances)):
```
[USDC]
Optimism: 147,078.7, -58,965.5, 0, 88,113.2
Base: 270,748.1, -58,543.1, 0, 212,205.0
Arbitrum One: 177,547.7, --148,240.3, 53,942.9, 379,731.0
```
The fix is to just add the slow fill amount to the total obligations instead of subtracting, since the subtraction is done when actually outputting the report.