### PR TITLE
improve: Use sendingTransactionsEnabled flag for all bots to toggle sim mode

### DIFF
--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -24,15 +24,6 @@ export class DataworkerConfig extends CommonConfig {
   // represents the bundle ranges that will be proposed per the chain id indices.
   readonly forceProposalBundleRange?: [number, number][];
 
-  // These variables can be toggled to choose whether the bot will submit transactions created
-  // by each function. For example, setting `sendingDisputesEnabled=false` but `disputerEnabled=true`
-  // means that the disputer logic will be run but won't send disputes on-chain.
-  // If you set `disputerEnabled=false`, then `sendinDisputesEnabled` doesn't change the code path.
-  readonly sendingDisputesEnabled: boolean;
-  readonly sendingProposalsEnabled: boolean;
-  readonly sendingExecutionsEnabled: boolean;
-  readonly sendingFinalizationsEnabled: boolean;
-
   // This variable should be set if the user wants to persist bundle data to Arweave.
   readonly persistingBundleData: boolean;
 
@@ -53,10 +44,6 @@ export class DataworkerConfig extends CommonConfig {
       L2_EXECUTOR_ENABLED,
       L1_EXECUTOR_ENABLED,
       SPOKE_ROOTS_LOOKBACK_COUNT,
-      SEND_DISPUTES,
-      SEND_PROPOSALS,
-      SEND_FINALIZATIONS,
-      SEND_EXECUTIONS,
       FINALIZER_ENABLED,
       BUFFER_TO_PROPOSE,
       DATAWORKER_FAST_LOOKBACK_COUNT,
@@ -95,10 +82,6 @@ export class DataworkerConfig extends CommonConfig {
       // should set spokeRootsLookbackCount == 0 if executor disabled and proposer/disputer enabled
       this.spokeRootsLookbackCount = 0;
     }
-    this.sendingDisputesEnabled = SEND_DISPUTES === "true";
-    this.sendingProposalsEnabled = SEND_PROPOSALS === "true";
-    this.sendingExecutionsEnabled = SEND_EXECUTIONS === "true";
-    this.sendingFinalizationsEnabled = SEND_FINALIZATIONS === "true";
     this.finalizerEnabled = FINALIZER_ENABLED === "true";
 
     this.forcePropose = FORCE_PROPOSAL === "true";
@@ -133,7 +116,7 @@ export class DataworkerConfig extends CommonConfig {
     }
 
     // We NEVER want to force propose if the proposer is enabled.
-    if (this.sendingProposalsEnabled) {
+    if (this.sendingTransactionsEnabled) {
       assert(!this.forcePropose, "Cannot force propose if sending proposals is enabled");
     }
 

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -122,7 +122,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
       if (config.disputerEnabled) {
         await dataworker.validatePendingRootBundle(
           spokePoolClients,
-          config.sendingDisputesEnabled,
+          config.sendingTransactionsEnabled,
           fromBlocks,
           // @dev Opportunistically publish bundle data to external storage layer since we're reconstructing it in this
           // process, if user has configured it so.
@@ -137,7 +137,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
         proposedBundleData = await dataworker.proposeRootBundle(
           spokePoolClients,
           config.rootBundleExecutionThreshold,
-          config.sendingProposalsEnabled,
+          config.sendingTransactionsEnabled,
           fromBlocks
         );
       } else {
@@ -151,7 +151,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
           poolRebalanceLeafExecutionCount = await dataworker.executePoolRebalanceLeaves(
             spokePoolClients,
             balanceAllocator,
-            config.sendingExecutionsEnabled,
+            config.sendingTransactionsEnabled,
             fromBlocks
           );
         }
@@ -161,13 +161,13 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
           await dataworker.executeSlowRelayLeaves(
             spokePoolClients,
             balanceAllocator,
-            config.sendingExecutionsEnabled,
+            config.sendingTransactionsEnabled,
             fromBlocks
           );
           await dataworker.executeRelayerRefundLeaves(
             spokePoolClients,
             balanceAllocator,
-            config.sendingExecutionsEnabled,
+            config.sendingTransactionsEnabled,
             fromBlocks
           );
         }

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -538,7 +538,7 @@ export async function runFinalizer(_logger: winston.Logger, baseSigner: Signer):
           spokePoolClients,
           config.chainsToFinalize.length === 0 ? availableChains : config.chainsToFinalize,
           config.addressesToMonitorForL1L2Finalizer,
-          config.sendingFinalizationsEnabled,
+          config.sendingTransactionsEnabled,
           config.finalizationStrategy
         );
       } else {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -90,11 +90,11 @@ export class Relayer {
     const { inventoryClient, tokenClient } = this.clients;
     await tokenClient.update();
 
-    if (this.config.sendingRelaysEnabled) {
+    if (this.config.sendingRelaysEnabled && this.config.sendingTransactionsEnabled) {
       await tokenClient.setOriginTokenApprovals();
     }
 
-    if (this.config.sendingRebalancesEnabled) {
+    if (this.config.sendingRebalancesEnabled && this.config.sendingTransactionsEnabled) {
       await inventoryClient.setL1TokenApprovals();
     }
 
@@ -671,7 +671,7 @@ export class Relayer {
       });
       // If we're in simulation mode, skip this early exit so that the user can evaluate
       // the full simulation run.
-      if (this.config.sendingRelaysEnabled) {
+      if (this.config.sendingTransactionsEnabled) {
         return;
       }
     }

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -173,7 +173,7 @@ export async function constructRelayerClients(
     bundleDataClient,
     adapterManager,
     crossChainTransferClient,
-    !config.sendingRebalancesEnabled
+    !config.sendingTransactionsEnabled
   );
 
   const tryMulticallClient = new TryMulticallClient(logger, multiCallerClient.chunkSize, multiCallerClient.baseSigner);

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -32,7 +32,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
 
   logger = _logger;
   const config = new RelayerConfig(process.env);
-  const { externalIndexer, pollingDelay, sendingRelaysEnabled, sendingSlowRelaysEnabled } = config;
+  const { externalIndexer, pollingDelay, sendingTransactionsEnabled, sendingSlowRelaysEnabled } = config;
 
   const loop = pollingDelay > 0;
   let stop = false;
@@ -56,7 +56,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
   await relayer.init();
 
   const { spokePoolClients } = relayerClients;
-  const simulate = !sendingRelaysEnabled;
+  const simulate = !sendingTransactionsEnabled;
   let txnReceipts: { [chainId: number]: Promise<string[]> } = {};
 
   try {


### PR DESCRIPTION
Each bot currently has different ways to toggle sim mode on its different functions. this is confusing and makes it hard to test.

Moreover, the InventoryClient has no way to simulate sending tokens across chains in sim mode, since its [sim mode flag](https://github.com/across-protocol/relayer/blob/37354395e9e77abd904171551be9019f43a1fde9/src/relayer/RelayerClientHelper.ts#L176) is the same flag that [activates its functionality](https://github.com/across-protocol/relayer/blob/37354395e9e77abd904171551be9019f43a1fde9/src/relayer/Relayer.ts#L167).
