### PR TITLE
chore: Bump SDK for fast "replacement underpriced" resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.35",
     "@across-protocol/contracts": "^4.0.2",
-    "@across-protocol/sdk": "^4.1.15",
+    "@across-protocol/sdk": "^4.1.16",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,10 +54,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk@^4.1.15":
-  version "4.1.15"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.15.tgz#e526691b7b9fdd135f4fde9b2e2e646ce444d069"
-  integrity sha512-TaavKN3aOSjSnGAboaJyGK7BznjhyhPfPp3rPsvHJWVyAjIoC38MkewBRG0cZRSWl3cArJGamhKxwVIkmD/U6g==
+"@across-protocol/sdk@^4.1.16":
+  version "4.1.16"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.16.tgz#25fa57c13f25bab0269c2da11a229b104578870c"
+  integrity sha512-kmTRFngiDfbeLoEvaAD+p6N7sRjtfYkAZJczD8ki3lZ7IvQNUDv/w4KvzFIQhT3DMzS3IMcR42e4c7yhuw5mDw==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.34"
@@ -65,6 +65,7 @@
     "@eth-optimism/sdk" "^3.3.1"
     "@ethersproject/bignumber" "^5.7.0"
     "@pinata/sdk" "^2.1.0"
+    "@solana/web3.js" "^2.0.0"
     "@types/mocha" "^10.0.1"
     "@uma/sdk" "^0.34.10"
     arweave "^1.14.4"
@@ -3119,6 +3120,30 @@
     node-fetch "^2.7.0"
     rpc-websockets "^9.0.2"
     superstruct "^2.0.2"
+
+"@solana/web3.js@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-2.0.0.tgz#192918343982e1964269b3adb2567532c1e12c89"
+  integrity sha512-x+ZRB2/r5tVK/xw8QRbAfgPcX51G9f2ifEyAQ/J5npOO+6+MPeeCjtr5UxHNDAYs9Ypo0PN+YJATCO4vhzQJGg==
+  dependencies:
+    "@solana/accounts" "2.0.0"
+    "@solana/addresses" "2.0.0"
+    "@solana/codecs" "2.0.0"
+    "@solana/errors" "2.0.0"
+    "@solana/functional" "2.0.0"
+    "@solana/instructions" "2.0.0"
+    "@solana/keys" "2.0.0"
+    "@solana/programs" "2.0.0"
+    "@solana/rpc" "2.0.0"
+    "@solana/rpc-parsed-types" "2.0.0"
+    "@solana/rpc-spec-types" "2.0.0"
+    "@solana/rpc-subscriptions" "2.0.0"
+    "@solana/rpc-types" "2.0.0"
+    "@solana/signers" "2.0.0"
+    "@solana/sysvars" "2.0.0"
+    "@solana/transaction-confirmation" "2.0.0"
+    "@solana/transaction-messages" "2.0.0"
+    "@solana/transactions" "2.0.0"
 
 "@solidity-parser/parser@^0.14.0", "@solidity-parser/parser@^0.14.1":
   version "0.14.1"


### PR DESCRIPTION
Currently impacted by this on mainnet, and the relayer is retrying all providers before ultimately failing.