### PR TITLE
improve(relayer): Ensure bi-directional handover logging

### DIFF
--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -90,7 +90,10 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
       if (loop && runIdentifier && redis) {
         if (activeRelayer !== runIdentifier) {
           if (!activeRelayerUpdated) {
-            logger.debug({ at: "Relayer#run", message: `Taking over from ${botIdentifier} instance ${activeRelayer}.` });
+            logger.debug({
+              at: "Relayer#run",
+              message: `Taking over from ${botIdentifier} instance ${activeRelayer}.`,
+            });
             await redis.set(botIdentifier, runIdentifier, ACTIVE_RELAYER_EXPIRY);
             activeRelayerUpdated = true;
           } else {

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -90,6 +90,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
       if (loop && runIdentifier && redis) {
         if (activeRelayer !== runIdentifier) {
           if (!activeRelayerUpdated) {
+            logger.debug({ at: "Relayer#run", message: `Taking over from ${botIdentifier} instance ${activeRelayer}.` });
             await redis.set(botIdentifier, runIdentifier, ACTIVE_RELAYER_EXPIRY);
             activeRelayerUpdated = true;
           } else {


### PR DESCRIPTION
This makes it possible to bi-directionally trace handovers from one relayer to another. At the moment it's only possible to do this forwards in time, because the existing relayer logs the runIdentifier of the subsequent relayer, but the subsequent relayer does not log the runIdentifier of the preceding relayer.