### PR TITLE
improve: Reduce transaction submission retries

### DIFF
--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -63,7 +63,7 @@ export async function runTransaction(
   value = bnZero,
   gasLimit: BigNumber | null = null,
   nonce: number | null = null,
-  retriesRemaining = 2
+  retriesRemaining = 1
 ): Promise<TransactionResponse> {
   const { provider } = contract;
   const { chainId } = await provider.getNetwork();


### PR DESCRIPTION
Because there are multiple providers for each chain, reduce the number of retries on transaction submission to speed-up the case where a transaction is actually unable to be submitted.

There are two layers of transaction submission at play - one at the quorum provider level, and one above. The quorum provider ensures that transactions are submitted successively to each provider until success or failure. For most chains, this means that transactions are submitted to 2 - 3 providers per retry. The upper layer then implements its own retry mechanism, currently at 2 retries. In cases where the transaction is ultimately unable to be submitted (i.e. underpriced replacement), this results in multiple futile submission attempts.