### PR TITLE
fix(OpStackWethBridge): bridgeEthTo() call should be able to fail simulaton following unwrap()

### DIFF
--- a/src/adapter/l2Bridges/OpStackWethBridge.ts
+++ b/src/adapter/l2Bridges/OpStackWethBridge.ts
@@ -57,6 +57,8 @@ export class OpStackWethBridge extends BaseL2BridgeAdapter {
         "0x", // extraData
       ],
       nonMulticall: true,
+      canFailInSimulation: true, // This will fail in simulation unless we simulate adding the WETH balance
+      // to the relayer.
       value: amount,
       message: "🎰 Withdrew OpStack WETH to L1",
       mrkdwn: `Withdrew ${formatter(amount.toString())} ${l1TokenInfo.symbol} from ${getNetworkName(


### PR DESCRIPTION
Constructing an L2 to L1 WETH withdrawal takes two transactions: unwrap() WETH followed by bridgeETHTo(). The second will almost always fail simulation because the caller doesn't have enough WETH in their actual balance. We also can't batch simulate these transactions because of the requirement that msg.sender has the funds.
