### PR TITLE
improve(relayer): Warn on invalid repaymentChainId selection

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1028,13 +1028,6 @@ export class Relayer {
     gasLimit?: BigNumber
   ): void {
     const { spokePoolClients } = this.clients;
-    this.logger.debug({
-      at: "Relayer::fillRelay",
-      message: `Filling v3 deposit ${deposit.depositId.toString()} with repayment on ${repaymentChainId}.`,
-      deposit,
-      repaymentChainId,
-      realizedLpFeePct,
-    });
 
     // If a deposit originates from a lite chain, then the repayment chain must be the origin chain.
     if (deposit.fromLiteChain && repaymentChainId !== deposit.originChainId) {
@@ -1042,9 +1035,18 @@ export class Relayer {
         at: "Relayer::fillRelay",
         message: "Suppressed fill for lite chain deposit where repaymentChainId != originChainId",
         deposit,
+        repaymentChainId,
       });
       return;
     }
+
+    this.logger.debug({
+      at: "Relayer::fillRelay",
+      message: `Filling v3 deposit ${deposit.depositId.toString()} with repayment on ${repaymentChainId}.`,
+      deposit,
+      repaymentChainId,
+      realizedLpFeePct,
+    });
 
     const [method, messageModifier, args] = !isDepositSpedUp(deposit)
       ? ["fillRelay", "", [convertRelayDataParamsToBytes32(deposit), repaymentChainId, toBytes32(this.relayerAddress)]]

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1037,12 +1037,14 @@ export class Relayer {
     });
 
     // If a deposit originates from a lite chain, then the repayment chain must be the origin chain.
-    assert(
-      !deposit.fromLiteChain || repaymentChainId === deposit.originChainId,
-      `Lite chain deposits must be filled on its origin chain (${
-        deposit.originChainId
-      }). Deposit Id: ${deposit.depositId.toString()}.`
-    );
+    if (deposit.fromLiteChain && repaymentChainId !== deposit.originChainId) {
+      this.logger.warn({
+        at: "Relayer::fillRelay",
+        message: "Suppressed fill for lite chain deposit where repaymentChainId != originChainId",
+        deposit,
+      });
+      return;
+    }
 
     const [method, messageModifier, args] = !isDepositSpedUp(deposit)
       ? ["fillRelay", "", [convertRelayDataParamsToBytes32(deposit), repaymentChainId, toBytes32(this.relayerAddress)]]


### PR DESCRIPTION
This asserted in production today, taking the relayer down. Warn about this condition instead.