### PR TITLE
fix(InventoryClient): avoid hubChain as eligible refund chain when origin is a lite chain

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -386,7 +386,7 @@ export class InventoryClient {
       return true;
     }
 
-    // Return true if input token is Native USDC token and output token is Bridged USDC or if input token
+    // Return true if input token is Native USDC and output token is Bridged USDC or if input token
     // is Bridged USDC and the output token is Native USDC.
     // @dev getUsdcSymbol() returns defined if the token on the origin chain is either USDC, USDC.e or USDbC.
     // The contracts should only allow deposits where the input token is the Across-supported USDC variant, so this
@@ -415,7 +415,7 @@ export class InventoryClient {
    * @dev If inventory management is disabled, then destinationChain is used as a default unless the
    * originChain is a lite chain, then originChain is the default used.
    * @param deposit Deposit to determine repayment chains for.
-   * @param l1Token L1Token linked with deposited inputToken and repayement chain refund token.
+   * @param l1Token L1Token linked with deposited inputToken and repayment chain refund token.
    * @returns list of chain IDs that are possible repayment chains for the deposit, sorted from highest
    * to lowest priority.
    */
@@ -547,7 +547,7 @@ export class InventoryClient {
         if (chainId === destinationChainId) {
           this.logger.debug({
             at: "InventoryClient#determineRefundChainId",
-            message: `Will consider to repayment on ${repaymentChain} as destination chain.`,
+            message: `Will consider to take repayment on ${repaymentChain} as destination chain.`,
           });
           eligibleRefundChains.push(chainId);
         }
@@ -594,14 +594,14 @@ export class InventoryClient {
     // chain, and the origin chain is not an eligible repayment chain, then we shouldn't fill this deposit otherwise
     // the filler will be forced to be over-allocated on the origin chain, which could be very difficult to withdraw
     // funds from.
-    // @dev The RHS of this conditional is essentially true if eligibleRefundChains does NOT deep equal [originChainid].
+    // @dev The RHS of this conditional is essentially true if eligibleRefundChains does NOT deep equal [originChainId].
     if (deposit.fromLiteChain && (eligibleRefundChains.length !== 1 || !eligibleRefundChains.includes(originChainId))) {
       return [];
     }
 
-    // Always add hubChain as a fallback option if inventory management is enabled. If none of the chainsToEvaluate
-    // were selected, then this function will return just the hub chain as a fallback option.
-    if (!eligibleRefundChains.includes(hubChainId)) {
+    // Always add hubChain as a fallback option if inventory management is enabled and origin chain is not a lite chain.
+    // If none of the chainsToEvaluate were selected, then this function will return just the hub chain as a fallback option.
+    if (!deposit.fromLiteChain && !eligibleRefundChains.includes(hubChainId)) {
       eligibleRefundChains.push(hubChainId);
     }
     return eligibleRefundChains;

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1219,8 +1219,8 @@ export class Relayer {
     // we come up with a smarter fee quoting algorithm that takes into account relayer inventory management more
     // accurately.
     //
-    // Additionally we don't want to take this code path if the chain is a lite chain because we can't reason about
-    // destination chain repayments on lite chains.
+    // Additionally we don't want to take this code path if the origin chain is a lite chain because we can't
+    // reason about destination chain repayments on lite chains.
     if (!isDefined(preferredChain) && !preferredChainIds.includes(destinationChainId) && !fromLiteChain) {
       this.logger.debug({
         at: "Relayer::resolveRepaymentChain",

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -150,6 +150,7 @@ describe("InventoryClient: Refund chain selection", async function () {
         outputToken: l2TokensForWeth[OPTIMISM],
         outputAmount: inputAmount,
         message: "0x",
+        messageHash: "0x",
         quoteTimestamp: hubPoolClient.currentTime!,
         fillDeadline: 0,
         exclusivityDeadline: 0,
@@ -330,6 +331,7 @@ describe("InventoryClient: Refund chain selection", async function () {
         outputToken: l2TokensForWeth[OPTIMISM],
         outputAmount: inputAmount,
         message: "0x",
+        messageHash: "0x",
         quoteTimestamp: hubPoolClient.currentTime!,
         fillDeadline: 0,
         exclusivityDeadline: 0,
@@ -458,6 +460,41 @@ describe("InventoryClient: Refund chain selection", async function () {
     });
   });
 
+  describe("origin chain is a lite chain", function () {
+    beforeEach(async function () {
+      const inputAmount = toBNWei(1);
+      sampleDepositData = {
+        depositId: bnZero,
+        fromLiteChain: true, // Pretend Polygon is a lite chain.
+        toLiteChain: false,
+        originChainId: POLYGON,
+        destinationChainId: ARBITRUM,
+        depositor: owner.address,
+        recipient: owner.address,
+        inputToken: l2TokensForWeth[POLYGON],
+        inputAmount,
+        outputToken: l2TokensForWeth[ARBITRUM],
+        outputAmount: inputAmount,
+        message: "0x",
+        messageHash: "0x",
+        quoteTimestamp: hubPoolClient.currentTime!,
+        fillDeadline: 0,
+        exclusivityDeadline: 0,
+        exclusiveRelayer: ZERO_ADDRESS,
+      };
+    });
+    it("returns only origin chain as repayment chain if it is underallocated", async function () {
+      tokenClient.setTokenData(POLYGON, l2TokensForWeth[POLYGON], toWei(0));
+      const refundChains = await inventoryClient.determineRefundChainId(sampleDepositData);
+      expect(refundChains).to.deep.equal([POLYGON]);
+    });
+    it("returns no repayment chains if origin chain is over allocated", async function () {
+      tokenClient.setTokenData(POLYGON, l2TokensForWeth[POLYGON], toWei(10));
+      const refundChains = await inventoryClient.determineRefundChainId(sampleDepositData);
+      expect(refundChains.length).to.equal(0);
+    });
+  });
+
   describe("evaluates slow withdrawal chains with excess running balances", function () {
     let excessRunningBalances: { [chainId: number]: BigNumber };
     beforeEach(async function () {
@@ -502,6 +539,7 @@ describe("InventoryClient: Refund chain selection", async function () {
         outputToken: l2TokensForWeth[MAINNET],
         outputAmount: inputAmount,
         message: "0x",
+        messageHash: "0x",
         quoteTimestamp: hubPoolClient.currentTime!,
         fillDeadline: 0,
         exclusivityDeadline: 0,
@@ -585,6 +623,7 @@ describe("InventoryClient: Refund chain selection", async function () {
         outputToken: bridgedUSDC[OPTIMISM],
         outputAmount: inputAmount,
         message: "0x",
+        messageHash: "0x",
         quoteTimestamp: hubPoolClient.currentTime!,
         fillDeadline: 0,
         exclusivityDeadline: 0,


### PR DESCRIPTION
We were including mainnet as a possible repayment chain even when deposits were originated from a lite chain.
That was raising the error `Lite chain deposits must be filled on its origin chain`.