### PR TITLE
improve(finalizer): Finalize ZkStack withdrawals via SharedBridge 

### DIFF
--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -18,6 +18,7 @@ import POLYGON_WITHDRAWABLE_ERC20_ABI from "./abi/PolygonWithdrawableErc20.json"
 import ZK_SYNC_DEFAULT_ERC20_BRIDGE_L1_ABI from "./abi/ZkSyncDefaultErc20BridgeL1.json";
 import ZK_SYNC_DEFAULT_ERC20_BRIDGE_L2_ABI from "./abi/ZkSyncDefaultErc20BridgeL2.json";
 import ZK_SYNC_MAILBOX_ABI from "./abi/ZkSyncMailbox.json";
+import ZK_STACK_SHARED_BRIDGE_ABI from "./abi/ZkStackSharedBridge.json";
 import ARBITRUM_ERC20_GATEWAY_ROUTER_L1_ABI from "./abi/ArbitrumErc20GatewayRouterL1.json";
 import ARBITRUM_ERC20_GATEWAY_ROUTER_L2_ABI from "./abi/ArbitrumErc20GatewayRouterL2.json";
 import ARBITRUM_ERC20_GATEWAY_L1_ABI from "./abi/ArbitrumErc20GatewayL1.json";
@@ -62,6 +63,10 @@ export const CONTRACT_ADDRESSES: {
     zkSyncMailbox: {
       address: "0x32400084C286CF3E17e7B677ea9583e60a000324",
       abi: ZK_SYNC_MAILBOX_ABI,
+    },
+    zkSyncSharedBridge: {
+      address: "0xD7f9f54194C633F36CCD5F3da84ad4a1c38cB2cB",
+      abi: ZK_STACK_SHARED_BRIDGE_ABI,
     },
     zkSyncDefaultErc20Bridge: {
       address: "0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063",

--- a/src/common/abi/ZkStackSharedBridge.json
+++ b/src/common/abi/ZkStackSharedBridge.json
@@ -1,0 +1,29 @@
+[
+    {
+        "inputs":[
+            {
+                "internalType":"uint256","name":"_chainId","type":"uint256"
+            },
+            {
+                "internalType":"uint256","name":"_l2BatchNumber","type":"uint256"
+            },
+            {
+                "internalType":"uint256","name":"_l2MessageIndex","type":"uint256"
+            },
+            {
+                "internalType":"uint16","name":"_l2TxNumberInBatch","type":"uint16"
+            },
+            {   
+                "internalType":"bytes","name":"_message","type":"bytes"
+            },
+            {
+                "internalType":"bytes32[]","name":"_merkleProof","type":"bytes32[]"
+            }
+        ],
+        "name":"finalizeWithdrawal",
+        "outputs":[],
+        "stateMutability":"nonpayable",
+        "type":"function"
+    }
+]
+  

--- a/src/common/abi/ZkStackSharedBridge.json
+++ b/src/common/abi/ZkStackSharedBridge.json
@@ -1,29 +1,40 @@
 [
-    {
-        "inputs":[
-            {
-                "internalType":"uint256","name":"_chainId","type":"uint256"
-            },
-            {
-                "internalType":"uint256","name":"_l2BatchNumber","type":"uint256"
-            },
-            {
-                "internalType":"uint256","name":"_l2MessageIndex","type":"uint256"
-            },
-            {
-                "internalType":"uint16","name":"_l2TxNumberInBatch","type":"uint16"
-            },
-            {   
-                "internalType":"bytes","name":"_message","type":"bytes"
-            },
-            {
-                "internalType":"bytes32[]","name":"_merkleProof","type":"bytes32[]"
-            }
-        ],
-        "name":"finalizeWithdrawal",
-        "outputs":[],
-        "stateMutability":"nonpayable",
-        "type":"function"
-    }
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2BatchNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2MessageIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_l2TxNumberInBatch",
+        "type": "uint16"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_message",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "_merkleProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "finalizeWithdrawal",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
 ]
-  

--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -43,15 +43,10 @@ export async function zkSyncFinalizer(
   const l2Provider = zkSyncUtils.convertEthersRPCToZKSyncRPC(spokePoolClient.spokePool.provider);
   const wallet = new zkWallet((signer as Wallet).privateKey, l2Provider, l1Provider);
 
-  // Zksync takes 1 day to finalize so ignore any events
-  // earlier than 1 day.
+  // Zksync takes ~6 hours to finalize so ignore any events
+  // earlier than that.
   const redis = await getRedisCache(logger);
-  const latestBlockToFinalize = await getBlockForTimestamp(
-    l2ChainId,
-    getCurrentTime() - 1 * 60 * 60 * 24,
-    undefined,
-    redis
-  );
+  const latestBlockToFinalize = await getBlockForTimestamp(l2ChainId, getCurrentTime() - 60 * 60 * 6, undefined, redis);
 
   logger.debug({
     at: "Finalizer#ZkSyncFinalizer",

--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -171,7 +171,7 @@ async function getWithdrawalParams(
 async function prepareFinalization(
   withdrawal: zkSyncWithdrawalData,
   l2ChainId: number,
-  l1SharedBridge: Contract,
+  l1SharedBridge: Contract
 ): Promise<Multicall2Call> {
   const args = [
     l2ChainId,


### PR DESCRIPTION
this isn't required but its probably more future proof. We can still use the old mailbox to finalize