### PR TITLE
fix: give a provider to the hub pool contract in ZkStackWethBridge

### DIFF
--- a/src/adapter/bridges/ZKStackBridge.ts
+++ b/src/adapter/bridges/ZKStackBridge.ts
@@ -59,7 +59,7 @@ export class ZKStackBridge extends BaseBridgeAdapter {
 
     // This bridge treats hub pool transfers differently from EOA rebalances, so we must know the hub pool address.
     const { address: hubPoolAddress, abi: hubPoolAbi } = CONTRACT_ADDRESSES[hubChainId].hubPool;
-    this.hubPool = new Contract(hubPoolAddress, hubPoolAbi);
+    this.hubPool = new Contract(hubPoolAddress, hubPoolAbi, l1Signer);
   }
 
   async constructL1ToL2Txn(


### PR DESCRIPTION
The latest PR replaced the `ZKSyncWethBridge` with the `ZKStackWethBridge`. Since we [query hub pool events](https://github.com/across-protocol/relayer/blob/19865446407b590b99248b6f0d9350b0755da73f/src/adapter/bridges/ZKStackWethBridge.ts#L97) in this bridge, we need to provide that contract with an ethers provider the same way we did on the [previous bridge](https://github.com/across-protocol/relayer/blob/6df8eca644fc542c40e324f4345939857ea3007d/src/adapter/bridges/ZKSyncWethBridge.ts#L199).