### PR TITLE
improve: clean up Lens utility functions

### DIFF
--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -569,11 +569,11 @@ export const CONTRACT_ADDRESSES: {
       address: "0x427373Be173120D7A042b44D0804E37F25E7330b",
       abi: ZK_SYNC_DEFAULT_ERC20_BRIDGE_L2_ABI,
     },
-    gasToken: {
+    nativeToken: {
       address: "0x000000000000000000000000000000000000800A",
       abi: WETH_ABI,
     },
-    wrappedGasToken: {
+    wrappedNativeToken: {
       address: "0xeee5a340Cdc9c179Db25dea45AcfD5FE8d4d3eB8",
       abi: WETH_ABI,
     },

--- a/src/utils/TokenUtils.ts
+++ b/src/utils/TokenUtils.ts
@@ -12,13 +12,15 @@ export function getNativeTokenAddressForChain(chainId: number): string {
   return CONTRACT_ADDRESSES[chainId]?.nativeToken?.address ?? ZERO_ADDRESS;
 }
 
-export function getWrappedNativeTokenAddress(chainId: number): string | undefined {
+export function getWrappedNativeTokenAddress(chainId: number): string {
   const tokenSymbol = utils.getNativeTokenSymbol(chainId);
-  return (
-    TOKEN_SYMBOLS_MAP[`W${tokenSymbol}`].addresses[chainId] ||
-    TOKEN_SYMBOLS_MAP[`w${tokenSymbol}`].addresses[chainId] ||
-    undefined
-  );
+  // If the native token is ETH, then we know the wrapped native token is WETH. Otherwise, some ERC20 token is the native token.
+  // In PUBLIC_NETWORKS, the native token symbol is the symbol corresponding to the L1 token contract, so "W" should not be prepended
+  // to the symbol.
+  const wrappedTokenSymbol = tokenSymbol === "ETH" ? "WETH" : tokenSymbol;
+
+  // Undefined returns should be caught and handled by consumers of this function.
+  return TOKEN_SYMBOLS_MAP[wrappedTokenSymbol]?.addresses[chainId];
 }
 
 /**


### PR DESCRIPTION
This updates information needed for the rebalancer. The rebalancer has only been tested with weth, but it functions as expected.
[L1](https://etherscan.io/tx/0xad9d37bcf961a5084ee96e1df9cd90b9885d7830b522074eebd915b0112057bf) [L2](https://explorer.lens.xyz/tx/0xc5b187049e7eb46ed7837414e5b3d56fbc8865aad585c40abb722db553107ee7)