### PR TITLE
improve(BaseBridgeAdapter): Remove unused event parsing logic

### DIFF
--- a/src/adapter/bridges/ArbitrumOrbitBridge.ts
+++ b/src/adapter/bridges/ArbitrumOrbitBridge.ts
@@ -105,7 +105,7 @@ export class ArbitrumOrbitBridge extends BaseBridgeAdapter {
     return {
       [this.resolveL2TokenAddress(l1Token)]: events
         .filter(({ args }) => args.l1Token === l1Token)
-        .map((event) => processEvent(event, "_amount", "_to", "_from")),
+        .map((event) => processEvent(event, "_amount")),
     };
   }
 
@@ -121,7 +121,7 @@ export class ArbitrumOrbitBridge extends BaseBridgeAdapter {
       eventConfig
     );
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "amount", "to", "from")),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "amount")),
     };
   }
 }

--- a/src/adapter/bridges/BaseBridgeAdapter.ts
+++ b/src/adapter/bridges/BaseBridgeAdapter.ts
@@ -18,8 +18,6 @@ export interface BridgeTransactionDetails {
 }
 
 export type BridgeEvent = SortableEvent & {
-  to: string;
-  from: string;
   amount: BigNumber;
 };
 

--- a/src/adapter/bridges/BlastBridge.ts
+++ b/src/adapter/bridges/BlastBridge.ts
@@ -49,7 +49,7 @@ export class BlastBridge extends BaseBridgeAdapter {
       eventConfig
     );
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "amount", "to", "from")),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "amount")),
     };
   }
 
@@ -66,7 +66,7 @@ export class BlastBridge extends BaseBridgeAdapter {
       eventConfig
     );
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "amount", "to", "from")),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "amount")),
     };
   }
 }

--- a/src/adapter/bridges/LineaBridge.ts
+++ b/src/adapter/bridges/LineaBridge.ts
@@ -46,9 +46,7 @@ export class LineaBridge extends BaseBridgeAdapter {
       eventConfig
     );
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) =>
-        processEvent(event, "amount", "recipient", "sender")
-      ),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "amount")),
     };
   }
 
@@ -65,9 +63,7 @@ export class LineaBridge extends BaseBridgeAdapter {
     );
     // There is no "from" field in this event, so we set it to the L2 token received.
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) =>
-        processEvent(event, "amount", "recipient", "bridgedToken")
-      ),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "amount")),
     };
   }
 }

--- a/src/adapter/bridges/LineaUSDCBridge.ts
+++ b/src/adapter/bridges/LineaUSDCBridge.ts
@@ -46,7 +46,7 @@ export class LineaUSDCBridge extends BaseBridgeAdapter {
       eventConfig
     );
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "amount", "to", "depositor")),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "amount")),
     };
   }
 
@@ -63,9 +63,7 @@ export class LineaUSDCBridge extends BaseBridgeAdapter {
     );
     // There is no "from" address in this event.
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) =>
-        processEvent(event, "amount", "recipient", "recipient")
-      ),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "amount")),
     };
   }
 }

--- a/src/adapter/bridges/LineaWethBridge.ts
+++ b/src/adapter/bridges/LineaWethBridge.ts
@@ -74,7 +74,7 @@ export class LineaWethBridge extends BaseBridgeAdapter {
     // those with 0 value.
     return {
       [this.resolveL2TokenAddress(l1Token)]: events
-        .map((event) => processEvent(event, "_value", "_to", "_from"))
+        .map((event) => processEvent(event, "_value"))
         .filter(({ amount }) => amount > bnZero),
     };
   }

--- a/src/adapter/bridges/OpStackDefaultErc20Bridge.ts
+++ b/src/adapter/bridges/OpStackDefaultErc20Bridge.ts
@@ -51,7 +51,7 @@ export class OpStackDefaultERC20Bridge extends BaseBridgeAdapter {
       eventConfig
     );
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "_amount", "_to", "_from")),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "_amount")),
     };
   }
 
@@ -67,7 +67,7 @@ export class OpStackDefaultERC20Bridge extends BaseBridgeAdapter {
       eventConfig
     );
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "_amount", "_to", "_from")),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "_amount")),
     };
   }
 }

--- a/src/adapter/bridges/OpStackUSDCBridge.ts
+++ b/src/adapter/bridges/OpStackUSDCBridge.ts
@@ -45,7 +45,7 @@ export class OpStackUSDCBridge extends BaseBridgeAdapter {
     const l1Bridge = this.getL1Bridge();
     const events = await paginatedEventQuery(l1Bridge, l1Bridge.filters.MessageSent(undefined, toAddress), eventConfig);
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "_amount", "_to", "_user")),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "_amount")),
     };
   }
 
@@ -62,7 +62,7 @@ export class OpStackUSDCBridge extends BaseBridgeAdapter {
       eventConfig
     );
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "_amount", "_user", "_spender")),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "_amount")),
     };
   }
 }

--- a/src/adapter/bridges/OpStackWethBridge.ts
+++ b/src/adapter/bridges/OpStackWethBridge.ts
@@ -75,7 +75,7 @@ export class OpStackWethBridge extends BaseBridgeAdapter {
   private convertEventListToBridgeEvents(events: Log[]): BridgeEvents {
     return {
       [this.resolveL2TokenAddress(TOKEN_SYMBOLS_MAP.WETH.addresses[this.hubChainId])]: events.map((event) =>
-        processEvent(event, "_amount", "_to", "_from")
+        processEvent(event, "_amount")
       ),
     };
   }

--- a/src/adapter/bridges/PolygonERC20Bridge.ts
+++ b/src/adapter/bridges/PolygonERC20Bridge.ts
@@ -68,9 +68,7 @@ export class PolygonERC20Bridge extends BaseBridgeAdapter {
       eventConfig
     );
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) =>
-        processEvent(event, "amount", "depositReceiver", "depositor")
-      ),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "amount")),
     };
   }
 
@@ -86,7 +84,7 @@ export class PolygonERC20Bridge extends BaseBridgeAdapter {
       eventConfig
     );
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "value", "to", "from")),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "value")),
     };
   }
 }

--- a/src/adapter/bridges/PolygonWethBridge.ts
+++ b/src/adapter/bridges/PolygonWethBridge.ts
@@ -74,9 +74,7 @@ export class PolygonWethBridge extends BaseBridgeAdapter {
       eventConfig
     );
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) =>
-        processEvent(event, "amount", "depositReceiver", "depositor")
-      ),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "amount")),
     };
   }
 
@@ -92,7 +90,7 @@ export class PolygonWethBridge extends BaseBridgeAdapter {
       eventConfig
     );
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "value", "to", "from")),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "value")),
     };
   }
 }

--- a/src/adapter/bridges/ScrollERC20Bridge.ts
+++ b/src/adapter/bridges/ScrollERC20Bridge.ts
@@ -115,7 +115,7 @@ export class ScrollERC20Bridge extends BaseBridgeAdapter {
       eventConfig
     );
     const processedEvents = events
-      .map((event) => processEvent(event, "amount", "to", "from"))
+      .map((event) => processEvent(event, "amount"))
       .filter(({ amount }) => amount > bnZero);
     return {
       [this.resolveL2TokenAddress(l1Token)]: processedEvents.filter(({ to }) => to === toAddress),

--- a/src/adapter/bridges/SnxOptimismBridge.ts
+++ b/src/adapter/bridges/SnxOptimismBridge.ts
@@ -67,7 +67,7 @@ export class SnxOptimismBridge extends BaseBridgeAdapter {
       eventConfig
     );
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "_amount", "_to", "_from")),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "_amount")),
     };
   }
 
@@ -83,7 +83,7 @@ export class SnxOptimismBridge extends BaseBridgeAdapter {
       eventConfig
     );
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "_amount", "_to", "_from")),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "_amount")),
     };
   }
 

--- a/src/adapter/bridges/UsdcCCTPBridge.ts
+++ b/src/adapter/bridges/UsdcCCTPBridge.ts
@@ -74,9 +74,7 @@ export class UsdcCCTPBridge extends BaseBridgeAdapter {
       fromAddress
     );
     return {
-      [this.resolveL2TokenAddress(l1Token)]: events.map((event) =>
-        processEvent(event, "amount", "mintRecipient", "depositor")
-      ),
+      [this.resolveL2TokenAddress(l1Token)]: events.map((event) => processEvent(event, "amount")),
     };
   }
 

--- a/src/adapter/bridges/ZKStackBridge.ts
+++ b/src/adapter/bridges/ZKStackBridge.ts
@@ -157,7 +157,7 @@ export class ZKStackBridge extends BaseBridgeAdapter {
       );
       processedEvents = rawEvents
         .filter((event) => compareAddressesSimple(event.args.receiver, toAddress))
-        .map((e) => processEvent(e, "amount", "receiver", "sender"));
+        .map((e) => processEvent(e, "amount"));
     } else {
       if (isL2Contract) {
         const rawEvents = await paginatedEventQuery(this.hubPool, this.hubPool.filters.TokensRelayed(), eventConfig);
@@ -167,7 +167,7 @@ export class ZKStackBridge extends BaseBridgeAdapter {
           )
           .map((e) => {
             return {
-              ...processEvent(e, "amount", "to", "to"),
+              ...processEvent(e, "amount"),
               from: this.hubPool.address,
             };
           });
@@ -179,7 +179,7 @@ export class ZKStackBridge extends BaseBridgeAdapter {
         );
         processedEvents = rawEvents.map((e) => {
           return {
-            ...processEvent(e, "amount", "from", "from"),
+            ...processEvent(e, "amount"),
             to: toAddress, // Overwrite the from field with toAddress since if we hit this branch we know an EOA initiated the bridge.
           };
         });
@@ -222,7 +222,7 @@ export class ZKStackBridge extends BaseBridgeAdapter {
         .filter((event) => compareAddressesSimple(event.args.receiver, toAddress))
         .map((event) => {
           return {
-            ...processEvent(event, "amount", "receiver", "receiver"),
+            ...processEvent(event, "amount"),
             from: isSpokePool ? this.hubPool.address : fromAddress,
           };
         });
@@ -243,7 +243,7 @@ export class ZKStackBridge extends BaseBridgeAdapter {
         ]);
         events = matchL2EthDepositAndWrapEvents(_events, wrapEvents);
       }
-      processedEvents = events.map((e) => processEvent(e, "_amount", "_to", "from"));
+      processedEvents = events.map((e) => processEvent(e, "_amount"));
     }
     return {
       [l2Token]: processedEvents,

--- a/src/adapter/bridges/ZKStackWethBridge.ts
+++ b/src/adapter/bridges/ZKStackWethBridge.ts
@@ -118,7 +118,7 @@ export class ZKStackWethBridge extends ZKStackBridge {
         .filter((e) => compareAddressesSimple(e.args.to, toAddress) && compareAddressesSimple(e.args.l1Token, l1Token))
         .map((e) => {
           return {
-            ...processEvent(e, "amount", "to", "to"),
+            ...processEvent(e, "amount"),
             from: this.hubPool.address,
           };
         });
@@ -129,8 +129,7 @@ export class ZKStackWethBridge extends ZKStackBridge {
         this.getAtomicDepositor().filters.AtomicWethDepositInitiated(fromAddress, this.l2chainId),
         eventConfig
       );
-      // If we are in this branch, then the depositor is an EOA, so we can assume that from == to.
-      processedEvents = events.map((e) => processEvent(e, "amount", "from", "from"));
+      processedEvents = events.map((e) => processEvent(e, "amount"));
     }
     return {
       [this.resolveL2TokenAddress(l1Token)]: processedEvents,
@@ -181,7 +180,7 @@ export class ZKStackWethBridge extends ZKStackBridge {
       );
     }
     return {
-      [this.resolveL2TokenAddress(l1Token)]: processedEvents.map((e) => processEvent(e, "_amount", "_to", "from")),
+      [this.resolveL2TokenAddress(l1Token)]: processedEvents.map((e) => processEvent(e, "_amount")),
     };
   }
   private getAtomicDepositor(): Contract {

--- a/src/adapter/utils.ts
+++ b/src/adapter/utils.ts
@@ -54,16 +54,10 @@ export async function approveTokens(
   return ["*Approval transactions:*", ...approvalMarkdwn].join("\n");
 }
 
-export function processEvent(event: Log, amountField: string, toField: string, fromField: string): BridgeEvent {
-  const eventSpread = spreadEventWithBlockNumber(event) as SortableEvent & {
-    amount: BigNumber;
-    to: string;
-    from: string;
-  };
+export function processEvent(event: Log, amountField: string): BridgeEvent {
+  const eventSpread = spreadEventWithBlockNumber(event) as SortableEvent;
   return {
     amount: eventSpread[amountField],
-    to: eventSpread[toField],
-    from: eventSpread[fromField],
     ...eventSpread,
   };
 }


### PR DESCRIPTION
The motivation behind this PR is to reduce the amount of work it costs to support a new canonical bridge in the BaseBridgeAdapter. Currently this involves adding event querying logic for any L1-->L2 transfers through a bridge contract which involves adding logic to handle two events:

1. Initiating the deposit on L1
2. Receiving the deposit on L2

Despite each bridge event looking different, we attempt to unify the logic (so that we can easily track the status of these deposits across different bridges) by implementing an interface for each bridge:
- `queryL1BridgeInitiationEvents()`
- `queryL2BridgeFinalizationEvents()`

These functions ideally should return the same object type, `BridgeEvent` that we can use to then implement `getOutstandingCrossChainTransfers`, which is used by the rebalancer and monitor. To make this work, we modify all `BridgeEvents` to have the same properties: `from`, `to` and `amount`. The latter property, `amount` is super important to make `getOutstandingCrossChainTransfers` work but the former two, `from` and `to` are not actually used anywhere in the code.

This PR removes `from` and `to` from `BridgeEvent` which marginally reduces the work to add a new event.
