### PR TITLE
improve: bump viem for finalizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "redis4": "npm:redis@^4.1.0",
     "superstruct": "^1.0.3",
     "ts-node": "^10.9.1",
-    "viem": "^2.25.0",
+    "viem": "^2.26.1",
     "winston": "^3.10.0",
     "zksync-ethers": "^5.7.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -16070,10 +16070,10 @@ viem@^2.21.15:
     webauthn-p256 "0.0.10"
     ws "8.18.0"
 
-viem@^2.25.0:
-  version "2.25.0"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-2.25.0.tgz#53e2438512f21233be1f2850b9862e80fc512041"
-  integrity sha512-TtFgfQkZOfb642s8+i+h27dRhBfZV//WWOkZ9saoS1Ml8kipj9RiOiDaSmAUly1rhq9kbnYhni1xVtb195XVGA==
+viem@^2.26.1:
+  version "2.26.1"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.26.1.tgz#1e012187916fc32ef55e6d9c70dc8e9bd3200dcb"
+  integrity sha512-bGRLLTHlmk9OEF9lvtAIv6eqQe9vIVDOWowBI05GM3npIwDD7WeTryBE8QeJZXb0ZTpDU/4Gf4iAWKZApKC4KQ==
   dependencies:
     "@noble/curves" "1.8.1"
     "@noble/hashes" "1.7.1"


### PR DESCRIPTION
Some finalizations are stuck in `waiting-to-prove`, which should be resolved after bumping viem to include [this](https://github.com/wevm/viem/commit/33a01b96554759bb9fa60d3c4bfc1c2cd5974ddc). 