### PR TITLE
feat: Handle cases where a deposit's inputToken and originChain cannot be mapped to a PoolRebalanceRoute

### DIFF
--- a/src/clients/bridges/AdapterManager.ts
+++ b/src/clients/bridges/AdapterManager.ts
@@ -254,7 +254,7 @@ export class AdapterManager {
   }
 
   l2TokenExistForL1Token(l1Token: string, l2ChainId: number): boolean {
-    return this.hubPoolClient.l2TokenEnabledForL1Token(l1Token, l2ChainId);
+    return this.hubPoolClient.l2TokenHasPoolRebalanceRoute(l1Token, l2ChainId);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -237,26 +237,37 @@ export function _buildRelayerRefundRoot(
   Object.entries(combinedRefunds).forEach(([_repaymentChainId, refundsForChain]) => {
     const repaymentChainId = Number(_repaymentChainId);
     Object.entries(refundsForChain).forEach(([l2TokenAddress, refunds]) => {
-      const l1TokenCounterpart = clients.hubPoolClient.getL1TokenForL2TokenAtBlock(
-        l2TokenAddress,
-        repaymentChainId,
-        endBlockForMainnet
-      );
+      // If the token cannot be mapped to any PoolRebalanceRoute, then the amount to return must be 0 since there
+      // is no way to send the token back to the HubPool.
+      if (!clients.hubPoolClient.l2TokenHasPoolRebalanceRoute(l2TokenAddress, repaymentChainId)) {
+        relayerRefundLeaves.push(..._getRefundLeaves(
+          refunds,
+          bnZero,
+          repaymentChainId,
+          l2TokenAddress,
+          maxRefundCount
+        ));
+      } else {
+        const l1TokenCounterpart = clients.hubPoolClient.getL1TokenForL2TokenAtBlock(
+          l2TokenAddress,
+          repaymentChainId,
+          endBlockForMainnet
+        );
+  
+        const spokePoolTargetBalance = clients.configStoreClient.getSpokeTargetBalancesForBlock(
+          l1TokenCounterpart,
+          repaymentChainId,
+          endBlockForMainnet
+        );
+  
+        // The `amountToReturn` for a { repaymentChainId, L2TokenAddress} should be set to max(-netSendAmount, 0).
+        const amountToReturn = getAmountToReturnForRelayerRefundLeaf(
+          spokePoolTargetBalance,
+          runningBalances[repaymentChainId][l1TokenCounterpart]
+        );
 
-      const spokePoolTargetBalance = clients.configStoreClient.getSpokeTargetBalancesForBlock(
-        l1TokenCounterpart,
-        repaymentChainId,
-        endBlockForMainnet
-      );
-
-      // The `amountToReturn` for a { repaymentChainId, L2TokenAddress} should be set to max(-netSendAmount, 0).
-      const amountToReturn = getAmountToReturnForRelayerRefundLeaf(
-        spokePoolTargetBalance,
-        runningBalances[repaymentChainId][l1TokenCounterpart]
-      );
-
-      const _refundLeaves = _getRefundLeaves(refunds, amountToReturn, repaymentChainId, l2TokenAddress, maxRefundCount);
-      relayerRefundLeaves.push(..._refundLeaves);
+        relayerRefundLeaves.push(..._getRefundLeaves(refunds, amountToReturn, repaymentChainId, l2TokenAddress, maxRefundCount));
+      }
     });
   });
 

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -121,7 +121,7 @@ export class Monitor {
     const tokensPerChain = Object.fromEntries(
       this.monitorChains.map((chainId) => {
         const l2Tokens = l1Tokens
-          .filter((l1Token) => hubPoolClient.l2TokenEnabledForL1Token(l1Token, chainId))
+          .filter((l1Token) => hubPoolClient.l2TokenHasPoolRebalanceRoute(l1Token, chainId))
           .map((l1Token) => {
             const l2Token = hubPoolClient.getL2TokenForL1TokenAtBlock(l1Token, chainId);
             return l2Token;
@@ -336,7 +336,7 @@ export class Monitor {
     for (const relayer of this.monitorConfig.monitoredRelayers) {
       for (const chainId of this.monitorChains) {
         const l1Tokens = _l1Tokens.filter(({ address: l1Token }) =>
-          hubPoolClient.l2TokenEnabledForL1Token(l1Token, chainId)
+          hubPoolClient.l2TokenHasPoolRebalanceRoute(l1Token, chainId)
         );
         const l2ToL1Tokens = this.getL2ToL1TokenMap(l1Tokens, chainId);
         const l2TokenAddresses = Object.keys(l2ToL1Tokens);

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -257,7 +257,7 @@ describe("InventoryClient: Refund chain selection", async function () {
       bundleDataClient.setReturnedNextBundleRefunds({
         [OPTIMISM]: createRefunds(owner.address, toWei(5), l2TokensForWeth[OPTIMISM]),
       });
-      // We need HubPoolClient.l2TokenEnabledForL1Token() to return true for a given
+      // We need HubPoolClient.l2TokenHasPoolRebalanceRoute() to return true for a given
       // L1 token and destination chain ID, otherwise it won't be counted in upcoming
       // refunds.
       hubPoolClient.setEnableAllL2Tokens(true);
@@ -440,7 +440,7 @@ describe("InventoryClient: Refund chain selection", async function () {
       bundleDataClient.setReturnedPendingBundleRefunds({
         [POLYGON]: createRefunds(owner.address, toWei(5), l2TokensForWeth[POLYGON]),
       });
-      // We need HubPoolClient.l2TokenEnabledForL1Token() to return true for a given
+      // We need HubPoolClient.l2TokenHasPoolRebalanceRoute() to return true for a given
       // L1 token and destination chain ID, otherwise it won't be counted in upcoming
       // refunds.
       hubPoolClient.setEnableAllL2Tokens(true);

--- a/test/mocks/MockHubPoolClient.ts
+++ b/test/mocks/MockHubPoolClient.ts
@@ -59,9 +59,9 @@ export class MockHubPoolClient extends clients.mocks.MockHubPoolClient {
     this.enableAllL2Tokens = enableAllL2Tokens;
   }
 
-  l2TokenEnabledForL1Token(l1Token: string, destinationChainId: number): boolean {
+  l2TokenHasPoolRebalanceRoute(l1Token: string, destinationChainId: number): boolean {
     if (this.enableAllL2Tokens === undefined) {
-      return super.l2TokenEnabledForL1Token(l1Token, destinationChainId);
+      return super.l2TokenHasPoolRebalanceRoute(l1Token, destinationChainId);
     }
     return this.enableAllL2Tokens;
   }


### PR DESCRIPTION
Relayer:
- Refuses to fill such deposits

Dataworker:
- Does not let such deposits affect bundle LP fees and running balance calculations
