### PR TITLE
fix(Dataworker): Check fillDeadline when batch-executing L1 slow fill leaves with PoolLeaves

### DIFF
--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -73,7 +73,9 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
   let proposedBundleData: BundleData | undefined = undefined;
   let poolRebalanceLeafExecutionCount = 0;
   try {
-    logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Dataworker started 👩‍🔬", config });
+    // Explicitly don't log addressFilter because it can be huge and can overwhelm log transports.
+    const { addressFilter: _addressFilter, ...loggedConfig } = config;
+    logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Dataworker started 👩‍🔬", loggedConfig });
 
     for (;;) {
       profiler.mark("loopStart");


### PR DESCRIPTION
I moved the `fillDeadline` check from `executeSlowRelayLeaves`, which is used to execute L2 leaves, into `_executeSlowRelayLeaf` which is used to execute L1 leaves as well as L2 leaves.

I also opportunistically fixed the Dataworker logs to not include `addressFilter`
