### PR TITLE
fix(dataworker): Avoid unbounded getLogs queries

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2227,10 +2227,12 @@ export class Dataworker {
             rootBundleId,
             leaf.leafId
           );
-          const duplicateEvents = await client.spokePool.queryFilter(
-            eventFilter,
-            client.latestBlockSearched - (client.eventSearchConfig.maxBlockLookBack ?? 5_000)
-          );
+          const searchConfig = {
+            maxBlockLookBack: client.eventSearchConfig.maxBlockLookBack,
+            fromBlock: client.latestBlockSearched - client.eventSearchConfig.maxBlockLookBack,
+            toBlock: await client.spokePool.provider.getBlockNumber(),
+          };
+          const duplicateEvents = await sdkUtils.paginatedEventQuery(client.spokePool, eventFilter, searchConfig);
           if (duplicateEvents.length > 0) {
             this.logger.debug({
               at: "Dataworker#executeRelayerRefundLeaves",


### PR DESCRIPTION
This getLogs call caused a blowup on Blast this morning due to logs requests spanning > 10k blocks.