### PR TITLE
fix: variable naming issue for withmaxFeePerGas

### DIFF
--- a/scripts/sendTokens.ts
+++ b/scripts/sendTokens.ts
@@ -64,7 +64,7 @@ export async function run(): Promise<void> {
       ? { maxFeePerGas, maxPriorityFeePerGas }
       : await getGasPrice(connectedSigner.provider);
   console.log(
-    `Submitting txn withmaxFeePerGas ${gas.maxFeePerGas.toString()} and priority fee ${gas.maxPriorityFeePerGas.toString()} with overridden nonce ${nonce}`
+    `Submitting txn with maxFeePerGas ${gas.maxFeePerGas.toString()} and priority fee ${gas.maxPriorityFeePerGas.toString()} with overridden nonce ${nonce}`
   );
   // Send ETH
   if (token === ZERO_ADDRESS || token === "0x") {


### PR DESCRIPTION
noticed a small issue where the variable was written as `withmaxFeePerGas` instead of `with maxFeePerGas`.
fixed.