### PR TITLE
Fix typos in JSDoc comments

### DIFF
--- a/src/libexec/RelayerSpokePoolListener.ts
+++ b/src/libexec/RelayerSpokePoolListener.ts
@@ -61,7 +61,7 @@ const _chains = {
 
 /**
  * Aggregate utils/scrapeEvents for a series of event names.
- * @param spokePool Ethers Constract instance.
+ * @param spokePool Ethers Contract instance.
  * @param eventNames The array of events to be queried.
  * @param opts Options to configure event scraping behaviour.
  * @returns void
@@ -80,7 +80,7 @@ export async function scrapeEvents(spokePool: Contract, eventNames: string[], op
 /**
  * Given a SpokePool contract instance and an array of event names, subscribe to all future event emissions.
  * Periodically transmit received events to the parent process (if defined).
- * @param eventMgr Ethers Constract instance.
+ * @param eventMgr Ethers Contract instance.
  * @param eventName The name of the event to be filtered.
  * @param opts Options to configure event scraping behaviour.
  * @returns void

--- a/src/libexec/RelayerSpokePoolListenerHTTPS.ts
+++ b/src/libexec/RelayerSpokePoolListenerHTTPS.ts
@@ -63,7 +63,7 @@ const _chains = {
 
 /**
  * Aggregate utils/scrapeEvents for a series of event names.
- * @param spokePool Ethers Constract instance.
+ * @param spokePool Ethers Contract instance.
  * @param eventNames The array of events to be queried.
  * @param opts Options to configure event scraping behaviour.
  * @returns void
@@ -82,7 +82,7 @@ export async function scrapeEvents(spokePool: Contract, eventNames: string[], op
 /**
  * Given a SpokePool contract instance and an array of event names, subscribe to all future event emissions.
  * Periodically transmit received events to the parent process (if defined).
- * @param eventMgr Ethers Constract instance.
+ * @param eventMgr Ethers Contract instance.
  * @param eventName The name of the event to be filtered.
  * @param opts Options to configure event scraping behaviour.
  * @returns void

--- a/src/libexec/util/evm/util.ts
+++ b/src/libexec/util/evm/util.ts
@@ -5,7 +5,7 @@ import { Log, ScraperOpts } from "../../types";
 
 /**
  * Given an event name and contract, return the corresponding Ethers EventFilter object.
- * @param contract Ethers Constract instance.
+ * @param contract Ethers Contract instance.
  * @param eventName The name of the event to be filtered.
  * @param filterArgs Optional filter arguments to be applied.
  * @returns An Ethers EventFilter instance.
@@ -36,7 +36,7 @@ export function getEventFilterArgs(relayer?: string): { [event: string]: (null |
 /**
  * Given a SpokePool contract instance and an event name, scrape all corresponding events and submit them to the
  * parent process (if defined).
- * @param spokePool Ethers Constract instance.
+ * @param spokePool Ethers Contract instance.
  * @param eventName The name of the event to be filtered.
  * @param opts Options to configure event scraping behaviour.
  * @returns void


### PR DESCRIPTION
This PR fixes typos in JSDoc comments across multiple files where `Constract` was incorrectly used instead of `Contract`.

**Files affected:**

- **`src/libexec/RelayerSpokePoolListener.ts`**
- **`src/libexec/RelayerSpokePoolListenerHTTPS.ts`**
- **`src/libexec/util/evm/util.ts`**

These changes improve code documentation accuracy without affecting functionality.