### PR TITLE
improve(InventoryClient): Normalize l2 chain amounts to correct decimals if l2 token decimals differs from l1 token equivalent's

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -700,7 +700,7 @@ export class InventoryClient {
         // one of the refund entries for a chain can be undefined.
         const upcomingRefundsAfterLastValidatedBundle = Object.values(
           allBundleRefunds.pop()?.[chainId]?.[l2Token] ?? {}
-        ).reduce((acc, curr) => acc.add(curr), bnZero);
+        ).reduce((acc, curr) => acc.add(l2AmountToL1Amount(curr)), bnZero);
 
         // Updated running balance is last known running balance minus deposits plus upcoming refunds.
         const latestRunningBalance = lastValidatedRunningBalance

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -172,7 +172,7 @@ export class Relayer {
       // It's necessary to update token balances in case WETH was wrapped.
       tokenClient.clearTokenData();
       await tokenClient.update();
-      await inventoryClient.rebalanceInventoryIfNeeded();
+      // await inventoryClient.rebalanceInventoryIfNeeded();
       await inventoryClient.withdrawExcessBalances();
     }
 

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1328,7 +1328,7 @@ export class Relayer {
         let crossChainLog = "";
         if (this.clients.inventoryClient.isInventoryManagementEnabled() && chainId !== hubChainId) {
           // Shortfalls are mapped to deposit output tokens so look up output token in token symbol map.
-          const l1Token = this.clients.hubPoolClient.getL1TokenInfoForAddress(token, chainId);
+          const l1Token = this.clients.hubPoolClient.getL1TokenInfoForL2Token(token, chainId);
           const outstandingCrossChainTransferAmount =
             this.clients.inventoryClient.crossChainTransferClient.getOutstandingCrossChainTransferAmount(
               this.relayerAddress,

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -172,7 +172,7 @@ export class Relayer {
       // It's necessary to update token balances in case WETH was wrapped.
       tokenClient.clearTokenData();
       await tokenClient.update();
-      // await inventoryClient.rebalanceInventoryIfNeeded();
+      await inventoryClient.rebalanceInventoryIfNeeded();
       await inventoryClient.withdrawExcessBalances();
     }
 

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -104,7 +104,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
       }
 
       if (!stop) {
-        txnReceipts = await relayer.checkForUnfilledDepositsAndFill(sendingSlowRelaysEnabled, simulate);
+        // txnReceipts = await relayer.checkForUnfilledDepositsAndFill(sendingSlowRelaysEnabled, simulate);
         await relayer.runMaintenance();
       }
 

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -104,7 +104,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
       }
 
       if (!stop) {
-        // txnReceipts = await relayer.checkForUnfilledDepositsAndFill(sendingSlowRelaysEnabled, simulate);
+        txnReceipts = await relayer.checkForUnfilledDepositsAndFill(sendingSlowRelaysEnabled, simulate);
         await relayer.runMaintenance();
       }
 

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -57,7 +57,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
 
   const { spokePoolClients } = relayerClients;
   const simulate = !sendingTransactionsEnabled;
-  const txnReceipts: { [chainId: number]: Promise<string[]> } = {};
+  let txnReceipts: { [chainId: number]: Promise<string[]> } = {};
 
   try {
     for (let run = 1; !stop; ++run) {

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -57,7 +57,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
 
   const { spokePoolClients } = relayerClients;
   const simulate = !sendingTransactionsEnabled;
-  let txnReceipts: { [chainId: number]: Promise<string[]> } = {};
+  const txnReceipts: { [chainId: number]: Promise<string[]> } = {};
 
   try {
     for (let run = 1; !stop; ++run) {

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -27,6 +27,7 @@ import {
   MockInventoryClient,
   MockTokenClient,
 } from "./mocks";
+import { utils as sdkUtils } from "@across-protocol/sdk";
 
 describe("InventoryClient: Refund chain selection", async function () {
   const { MAINNET, OPTIMISM, POLYGON, ARBITRUM } = CHAIN_IDs;
@@ -187,6 +188,43 @@ describe("InventoryClient: Refund chain selection", async function () {
       expect(spyLogIncludes(spy, -1, 'expectedPostRelayAllocation":"74074074074074074"')).to.be.true; // (5+5)/(135)=0.074074
     });
 
+    it("Normalizes repayment amount to correct precision", async function () {
+      // Identical setup to previous test but we'll pretend the L2 token uses a different precision than the L1 token.
+      hubPoolClient.mapTokenInfo(l2TokensForWeth[ARBITRUM], "WETH", 6);
+      const toL2Decimals = sdkUtils.ConvertDecimals(18, 6);
+      tokenClient.setTokenData(
+        ARBITRUM,
+        l2TokensForWeth[ARBITRUM],
+        toL2Decimals(initialAllocation[ARBITRUM][mainnetWeth])
+      );
+
+      // The repayment amount should be added to the numerator in the case where the repayment chain choice is not
+      // equal to the destination chain, and otherwise it should have no affect. The repayment amount should not
+      // affect the allocation percentage computation, which intuitively means that the relayer's overall inventory is
+      // decreasing on the destination chain by the output amount but increasing by the input amount.
+      sampleDepositData.originChainId = ARBITRUM;
+      sampleDepositData.inputToken = l2TokensForWeth[ARBITRUM];
+
+      // First destination chain is evaluated, then origin chain.
+      sampleDepositData.inputAmount = toMegaWei(1);
+      sampleDepositData.outputAmount = sdkUtils.ConvertDecimals(6, 18)(await computeOutputAmount(sampleDepositData));
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([MAINNET]);
+      // Starts with 20 tokens on Optimism and ends up with 20 post-repayment.
+      expect(spyLogIncludes(spy, -2, 'expectedPostRelayAllocation":"142857142857142857"')).to.be.true; // (20)/(140)=0.1428
+      // Starts with 10 tokens on Arbitrum and ends up with 11 post-repayment.
+      expect(spyLogIncludes(spy, -1, 'expectedPostRelayAllocation":"78571428571428571"')).to.be.true; // (10+1)/(140)=0.15
+
+      // Now, transfer away tokens from the origin chain to make it look under allocated:
+      tokenClient.setTokenData(ARBITRUM, l2TokensForWeth[ARBITRUM], toMegaWei(5));
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([ARBITRUM, MAINNET]);
+      expect(spyLogIncludes(spy, -1, 'expectedPostRelayAllocation":"44444444444444444"')).to.be.true; // (5+1)/(135)=0.044444
+
+      // If we set the fill amount large enough, the origin chain choice won't be picked anymore.
+      sampleDepositData.inputAmount = toMegaWei(5);
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([MAINNET]);
+      expect(spyLogIncludes(spy, -1, 'expectedPostRelayAllocation":"74074074074074074"')).to.be.true; // (5+5)/(135)=0.074074
+    });
+
     it("Correctly factors in cross chain transfers when deciding where to refund", async function () {
       // The relayer should correctly factor in pending cross-chain relays when thinking about shortfalls. Consider a large
       // fictitious relay that exceeds all outstanding liquidity on the target chain(Arbitrum) of 15 Weth (target only)
@@ -242,6 +280,70 @@ describe("InventoryClient: Refund chain selection", async function () {
       expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"35555555555555555')).to.be.true; // 4.8/(140-5)
     });
 
+    it("Normalizes shortfalls to correct precision", async function () {
+      // Identical setup to previous test but we'll pretend the L2 token uses a different precision than the L1 token.
+      hubPoolClient.mapTokenInfo(l2TokensForWeth[ARBITRUM], "WETH", 6);
+      const toL2Decimals = sdkUtils.ConvertDecimals(18, 6);
+      tokenClient.setTokenData(
+        ARBITRUM,
+        l2TokensForWeth[ARBITRUM],
+        toL2Decimals(initialAllocation[ARBITRUM][mainnetWeth])
+      );
+
+      // The relayer should correctly factor in pending cross-chain relays when thinking about shortfalls. Consider a large
+      // fictitious relay that exceeds all outstanding liquidity on the target chain(Arbitrum) of 15 Weth (target only)
+      // has 10 WETH in it.
+      const largeRelayAmount = toMegaWei(15);
+      tokenClient.setTokenShortFallData(ARBITRUM, l2TokensForWeth[ARBITRUM], [6969], largeRelayAmount); // Mock the shortfall.
+      // The expected cross chain transfer amount is (0.05+0.02-(10-15)/140)*140=14.8 // Mock the cross-chain transfer
+      // leaving L1 to go to arbitrum by adding it to the mock cross chain transfers and removing from l1 balance.
+      const bridgedAmount = toWei(14.8);
+      adapterManager.setMockedOutstandingCrossChainTransfers(ARBITRUM, owner.address, mainnetWeth, bridgedAmount);
+      await inventoryClient.update();
+      tokenClient.setTokenData(MAINNET, mainnetWeth, initialAllocation[MAINNET][mainnetWeth].sub(bridgedAmount));
+
+      // Now, consider that the bot is run while these funds for the above deposit are in the canonical bridge and cant
+      // be filled yet. When it runs it picks up a relay that it can do, of size 1.69 WETH. Each part of the computation
+      // is broken down to explain how the bot chooses where to allocate funds:
+      // 1. chainVirtualBalance: Considering the funds on the target chain we have a balance of 10 WETH, with an amount of
+      //    14.8 that is currently coming over the bridge. This totals a "virtual" balance of (10+14.8)=24.8.
+      // 2. chainVirtualBalanceWithShortfall: this is the virtual balance minus the shortfall. 24.9-15=9.8.
+      // 3. chainVirtualBalanceWithShortfallPostRelay: virtual balance with shortfall minus the relay amount should be
+      //    same as above for destination chain.
+      // 4. cumulativeVirtualBalance: total balance across all chains considering fund movement. funds moving over the bridge
+      //    does not impact the balance; they are just "moving" so it should be 140-15+15=140
+      // 5. cumulativeVirtualBalancePostRefunds: should be same as above because there are no refunds.
+      // 6. expectedPostRelayAllocation: the expected post relay allocation is the chainVirtualBalanceWithShortfallPostRelay
+      //    divided by the cumulativeVirtualBalancePostRefunds. 9.8/140
+      // This number is then used to decide on where funds should be allocated! If this number is above the threshold plus
+      // the buffer then refund on L1. if it is below the threshold then refund on the target chain.
+
+      sampleDepositData.destinationChainId = ARBITRUM;
+      sampleDepositData.outputToken = l2TokensForWeth[ARBITRUM];
+      sampleDepositData.inputAmount = toWei(1.69);
+      sampleDepositData.outputAmount = toMegaWei(1.69);
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([ARBITRUM, MAINNET]);
+
+      // We're evaluating destination chain since origin chain is mainnet which always gets evaluated last.
+      expect(lastSpyLogIncludes(spy, 'chainShortfall":"15000000000000000000"')).to.be.true;
+      expect(lastSpyLogIncludes(spy, 'chainVirtualBalance":"24800000000000000000"')).to.be.true; // (10+14.8)=24.8
+      expect(lastSpyLogIncludes(spy, 'chainVirtualBalanceWithShortfall":"9800000000000000000"')).to.be.true; // 24.8-15=9.8
+      expect(lastSpyLogIncludes(spy, 'chainVirtualBalanceWithShortfallPostRelay":"9800000000000000000"')).to.be.true;
+      // same as above for destination chain
+      expect(lastSpyLogIncludes(spy, 'cumulativeVirtualBalance":"140000000000000000000')).to.be.true; // 140-15+15=140
+      expect(lastSpyLogIncludes(spy, 'cumulativeVirtualBalancePostRefunds":"140000000000000000000"')).to.be.true;
+      expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"70000000000000000')).to.be.true; // 9.8 / 140
+
+      // Consider that we decrease the relayer's balance while it's large transfer is currently in the bridge.
+      tokenClient.setTokenData(
+        ARBITRUM,
+        l2TokensForWeth[ARBITRUM],
+        toL2Decimals(initialAllocation[ARBITRUM][mainnetWeth].sub(toWei(5)))
+      );
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([ARBITRUM, MAINNET]);
+      expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"35555555555555555')).to.be.true; // 4.8/(140-5)
+    });
+
     it("Correctly decides where to refund based on upcoming refunds", async function () {
       // Consider a case where the relayer is filling a marginally larger relay of size 5 WETH. Without refunds, the post relay
       // allocation on optimism would be (15)/(135)=11.1%. This would be below the target plus buffer of 12%. However, if we now
@@ -258,6 +360,33 @@ describe("InventoryClient: Refund chain selection", async function () {
       });
       bundleDataClient.setReturnedNextBundleRefunds({
         [OPTIMISM]: createRefunds(owner.address, toWei(5), l2TokensForWeth[OPTIMISM]),
+      });
+      // We need HubPoolClient.l2TokenEnabledForL1Token() to return true for a given
+      // L1 token and destination chain ID, otherwise it won't be counted in upcoming
+      // refunds.
+      hubPoolClient.setEnableAllL2Tokens(true);
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([MAINNET]);
+      expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"166666666666666666"')).to.be.true;
+
+      // If we set this to false in this test, the destination chain will be default used since the refund data
+      // will be ignored.
+      hubPoolClient.setEnableAllL2Tokens(false);
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([OPTIMISM, MAINNET]);
+    });
+
+    it("Normalizes upcoming refunds to correct precision", async function () {
+      // Identical setup to previous test but we'll pretend the L2 token uses a different precision than the L1 token.
+      hubPoolClient.mapTokenInfo(l2TokensForWeth[OPTIMISM], "WETH", 6);
+      tokenClient.setTokenData(OPTIMISM, l2TokensForWeth[OPTIMISM], toMegaWei(15));
+
+      sampleDepositData.inputAmount = toWei(5);
+      sampleDepositData.outputAmount = sdkUtils.ConvertDecimals(18, 6)(await computeOutputAmount(sampleDepositData));
+      bundleDataClient.setReturnedPendingBundleRefunds({
+        [MAINNET]: createRefunds(owner.address, toWei(5), mainnetWeth),
+        [OPTIMISM]: createRefunds(owner.address, toMegaWei(5), l2TokensForWeth[OPTIMISM]),
+      });
+      bundleDataClient.setReturnedNextBundleRefunds({
+        [OPTIMISM]: createRefunds(owner.address, toMegaWei(5), l2TokensForWeth[OPTIMISM]),
       });
       // We need HubPoolClient.l2TokenEnabledForL1Token() to return true for a given
       // L1 token and destination chain ID, otherwise it won't be counted in upcoming

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -91,6 +91,8 @@ describe("InventoryClient: Refund chain selection", async function () {
       tokenClient.setTokenData(chainId, l2TokensForUsdc[chainId], seedBalances[chainId][mainnetUsdc]);
       hubPoolClient.setTokenMapping(mainnetWeth, chainId, l2TokensForWeth[chainId]);
       hubPoolClient.setTokenMapping(mainnetUsdc, chainId, l2TokensForUsdc[chainId]);
+      hubPoolClient.mapTokenInfo(l2TokensForUsdc[chainId], "USDC", 6);
+      hubPoolClient.mapTokenInfo(mainnetWeth[chainId], "WETH", 18);
     });
   };
 

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -717,6 +717,8 @@ describe("InventoryClient: Refund chain selection", async function () {
     const bridgedUSDC = { ...TOKEN_SYMBOLS_MAP["USDC.e"].addresses, ...TOKEN_SYMBOLS_MAP["USDbC"].addresses };
 
     beforeEach(async function () {
+      hubPoolClient.mapTokenInfo(nativeUSDC[ARBITRUM], "USDC", 6);
+
       // Sub in a nested USDC config for the existing USDC config.
       const usdcConfig = {
         [nativeUSDC[OPTIMISM]]: {

--- a/test/mocks/MockAdapterManager.ts
+++ b/test/mocks/MockAdapterManager.ts
@@ -1,14 +1,20 @@
 import { AdapterManager } from "../../src/clients/bridges";
-import { BigNumber, TransactionResponse, getTranslatedTokenAddress } from "../../src/utils";
+import { BigNumber, TransactionResponse, bnZero, getTranslatedTokenAddress } from "../../src/utils";
 
 import { createRandomBytes32 } from "../utils";
 import { OutstandingTransfers } from "../../src/interfaces";
+import { BaseChainAdapter } from "../../src/adapter";
 
+type L2Withdrawal = { l2Token: string; amountToWithdraw: BigNumber; l2ChainId: number; address: string };
 export class MockAdapterManager extends AdapterManager {
   public adapterChains: number[] | undefined;
   public tokensSentCrossChain: {
     [chainId: number]: { [l1Token: string]: { amount: BigNumber; hash: string } };
   } = {};
+  public pendingL2WithdrawalAmounts: {
+    [timePeriod: number]: BigNumber;
+  } = {};
+  public withdrawalsRequired: L2Withdrawal[] = [];
 
   public mockedOutstandingCrossChainTransfers: { [chainId: number]: OutstandingTransfers } = {};
   async sendTokenCrossChain(
@@ -23,6 +29,10 @@ export class MockAdapterManager extends AdapterManager {
     const hash = createRandomBytes32();
     this.tokensSentCrossChain[chainId][l1Token] = { amount, hash };
     return { hash } as TransactionResponse;
+  }
+
+  setAdapters(chainId, adapter: BaseChainAdapter): void {
+    this.adapters[chainId] = adapter;
   }
 
   setSupportedChains(chains: number[]): void {
@@ -60,5 +70,36 @@ export class MockAdapterManager extends AdapterManager {
       totalAmount: amount,
       depositTxHashes: [],
     };
+  }
+
+  setL2PendingWithdrawalAmount(timePeriod: number, amount: BigNumber): void {
+    this.pendingL2WithdrawalAmounts ??= {};
+    this.pendingL2WithdrawalAmounts[timePeriod] = amount;
+  }
+
+  getL2PendingWithdrawalAmount(withdrawExcessPeriod: number): Promise<BigNumber> {
+    const pendingWithdrawalThresholds = Object.entries(this.pendingL2WithdrawalAmounts)
+      .filter(([timePeriod]) => Number(timePeriod) >= withdrawExcessPeriod)
+      .sort(([timePeriod]) => Number(timePeriod));
+    if (pendingWithdrawalThresholds.length > 0) {
+      return Promise.resolve(pendingWithdrawalThresholds[0][1]);
+    } else {
+      return Promise.resolve(bnZero);
+    }
+  }
+
+  withdrawTokenFromL2(
+    address: string,
+    l2ChainId: number,
+    l2Token: string,
+    amountToWithdraw: BigNumber
+  ): Promise<string[]> {
+    this.withdrawalsRequired.push({
+      l2Token,
+      amountToWithdraw,
+      l2ChainId,
+      address,
+    });
+    return Promise.resolve(["0xabcd"]);
   }
 }

--- a/test/mocks/MockBaseChainAdapter.ts
+++ b/test/mocks/MockBaseChainAdapter.ts
@@ -1,0 +1,27 @@
+import { BaseChainAdapter } from "../../src/adapter";
+import { EventSearchConfig, MakeOptional, winston } from "../../src/utils";
+
+export class MockBaseChainAdapter extends BaseChainAdapter {
+  constructor() {
+    super(
+      {},
+      0,
+      0,
+      [],
+      winston.createLogger({
+        level: "debug",
+        transports: [new winston.transports.Console()],
+      }),
+      [],
+      {},
+      {},
+      0
+    );
+  }
+  getSearchConfig(): MakeOptional<EventSearchConfig, "toBlock"> {
+    return { fromBlock: 0 };
+  }
+  isSupportedL2Bridge(): boolean {
+    return true;
+  }
+}


### PR DESCRIPTION
Currently the InventoryClient would not be able to compute allocation %'s correctly if an L2 token had a different decimal than the L1 token.

This PR normalizes the following L2 values to the same decimals as L1 so that the internal inventory calculations work:
- chain virtual balance
- cumulative virtual balance
- short falls when a deposit is outstanding for a chain
- repayment amounts (relevant for `determineRefundChain` for a Deposit)
- upcoming bundle refunds
