### PR TITLE
improve: Follow up fixes to use correct precision on output token amounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.52",
     "@across-protocol/contracts": "^4.0.5",
-    "@across-protocol/sdk": "4.1.46-beta.1",
+    "@across-protocol/sdk": "4.1.45",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.52",
     "@across-protocol/contracts": "^4.0.5",
-    "@across-protocol/sdk": "4.1.45",
+    "@across-protocol/sdk": "4.1.46-beta.1",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.52",
     "@across-protocol/contracts": "^4.0.5",
-    "@across-protocol/sdk": "4.1.46-beta.4",
+    "@across-protocol/sdk": "4.1.46",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.52",
     "@across-protocol/contracts": "^4.0.5",
-    "@across-protocol/sdk": "4.1.45",
+    "@across-protocol/sdk": "4.1.46-beta.3",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.52",
     "@across-protocol/contracts": "^4.0.5",
-    "@across-protocol/sdk": "4.1.46-beta.3",
+    "@across-protocol/sdk": "4.1.46-beta.4",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -1165,7 +1165,7 @@ export class InventoryClient {
     const withdrawalsRequired: { [chainId: number]: L2Withdrawal[] } = {};
 
     await sdkUtils.forEachAsync(this.getL1Tokens(), async (l1Token) => {
-      const l1TokenInfo = getL1TokenInfo(l1Token, this.hubPoolClient.chainId);
+      const l1TokenInfo = this.hubPoolClient.getTokenInfoForL1Token(l1Token);
       const formatter = createFormatFunction(2, 4, false, l1TokenInfo.decimals);
 
       // We do not currently count any outstanding L2->L1 pending withdrawal balance in the cumulative balance

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -27,7 +27,6 @@ import {
   getUsdcSymbol,
   Profiler,
   getNativeTokenSymbol,
-  getL1TokenInfo,
   depositHasPoolRebalanceRouteMapping,
 } from "../utils";
 import { HubPoolClient, TokenClient, BundleDataClient } from ".";

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -331,7 +331,7 @@ export class ProfitClient {
   ): Promise<FillProfit> {
     const { hubPoolClient } = this;
 
-    const inputTokenInfo = hubPoolClient.getL1TokenInfoForL2Token(deposit.inputToken, deposit.originChainId);
+    const inputTokenInfo = hubPoolClient.getTokenInfoForAddress(deposit.inputToken, deposit.originChainId);
     const inputTokenPriceUsd = this.getPriceOfToken(inputTokenInfo.symbol);
     const inputTokenScalar = toBNWei(1, 18 - inputTokenInfo.decimals);
     const scaledInputAmount = deposit.inputAmount.mul(inputTokenScalar);
@@ -339,24 +339,10 @@ export class ProfitClient {
 
     // Unlike the input token, output token is not always resolvable via HubPoolClient since outputToken
     // can be any arbitrary token.
-    let outputTokenSymbol: string, outputTokenDecimals: number;
-    // If the output token and the input token are equivalent, then we can look up the token info
-    // via the HubPoolClient since the output token is mapped via PoolRebalanceRoute to the HubPool.
-    // If not, then we should look up outputToken in the TOKEN_SYMBOLS_MAP for the destination chain.
-    const matchingTokens =
-      TOKEN_SYMBOLS_MAP[inputTokenInfo.symbol]?.addresses[deposit.destinationChainId] === deposit.outputToken;
-    if (matchingTokens) {
-      ({ symbol: outputTokenSymbol, decimals: outputTokenDecimals } = hubPoolClient.getL1TokenInfoForL2Token(
-        deposit.outputToken,
-        deposit.destinationChainId
-      ));
-    } else {
-      // This function will throw if the token is not found in the TOKEN_SYMBOLS_MAP for the destination chain.
-      ({ symbol: outputTokenSymbol, decimals: outputTokenDecimals } = hubPoolClient.getTokenInfoForAddress(
-        deposit.outputToken,
-        deposit.destinationChainId
-      ));
-    }
+    const { symbol: outputTokenSymbol, decimals: outputTokenDecimals } = hubPoolClient.getTokenInfoForAddress(
+      deposit.outputToken,
+      deposit.destinationChainId
+    );
     const outputTokenPriceUsd = this.getPriceOfToken(outputTokenSymbol);
     const outputTokenScalar = toBNWei(1, 18 - outputTokenDecimals);
     const effectiveOutputAmount = min(deposit.outputAmount, deposit.updatedOutputAmount ?? deposit.outputAmount);
@@ -432,7 +418,8 @@ export class ProfitClient {
     const tokenPriceInUsd = this.getPriceOfToken(l1Token.symbol);
 
     // The USD amount of a fill must be normalised to 18 decimals, so factor out the token's own decimal promotion.
-    return outputAmount.mul(tokenPriceInUsd).div(bn10.pow(l1Token.decimals));
+    const outputTokenDecimals = this.hubPoolClient.getTokenInfoForAddress(outputToken, destinationChainId).decimals;
+    return outputAmount.mul(tokenPriceInUsd).div(bn10.pow(outputTokenDecimals));
   }
 
   async getFillProfitability(

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -17,7 +17,6 @@ import {
   BigNumber,
   formatFeePct,
   getCurrentTime,
-  getNetworkName,
   isDefined,
   min,
   winston,

--- a/src/clients/bridges/AdapterManager.ts
+++ b/src/clients/bridges/AdapterManager.ts
@@ -131,7 +131,7 @@ export class AdapterManager {
     const adapter = this.adapters[chainId];
     // @dev The adapter should filter out tokens that are not supported by the adapter, but we do it here as well.
     const adapterSupportedL1Tokens = l1Tokens.filter((token) => {
-      const tokenSymbol = this.hubPoolClient.getTokenInfo(this.hubPoolClient.chainId, token).symbol;
+      const tokenSymbol = this.hubPoolClient.getTokenInfoForL1Token(token).symbol;
       return (
         adapter.supportedTokens.includes(tokenSymbol) ||
         adapter.supportedTokens.includes(TOKEN_EQUIVALENCE_REMAPPING[tokenSymbol])

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1792,7 +1792,7 @@ export class Dataworker {
       const currentLiquidReserves = this.clients.hubPoolClient.getLpTokenInfoForL1Token(l1Token)?.liquidReserves;
       updatedLiquidReserves[l1Token] = currentLiquidReserves;
       assert(currentLiquidReserves !== undefined && currentLiquidReserves.gte(0), "Liquid reserves should be >= 0");
-      const tokenSymbol = this.clients.hubPoolClient.getTokenInfo(chainId, l1Token)?.symbol;
+      const tokenSymbol = this.clients.hubPoolClient.getTokenInfoForL1Token(l1Token)?.symbol;
 
       // If netSendAmounts is negative, there is no need to update this exchange rate.
       if (netSendAmounts[idx].lte(0)) {
@@ -1892,7 +1892,7 @@ export class Dataworker {
         return;
       }
 
-      const tokenSymbol = this.clients.hubPoolClient.getTokenInfo(hubPoolChainId, l1Token)?.symbol;
+      const tokenSymbol = this.clients.hubPoolClient.getTokenInfoForL1Token(l1Token)?.symbol;
       if (currHubPoolLiquidReserves.gte(requiredNetSendAmountForL1Token)) {
         this.logger.debug({
           at: "Dataworker#_updateExchangeRatesBeforeExecutingNonHubChainLeaves",
@@ -1964,7 +1964,7 @@ export class Dataworker {
     // multiple transactions for the same token.
     if (submitExecution) {
       for (const l1Token of updatedL1Tokens) {
-        const tokenSymbol = this.clients.hubPoolClient.getTokenInfo(hubPoolChainId, l1Token)?.symbol;
+        const tokenSymbol = this.clients.hubPoolClient.getTokenInfoForL1Token(l1Token)?.symbol;
         this.clients.multiCallerClient.enqueueTransaction({
           contract: this.clients.hubPoolClient.hubPool,
           chainId: hubPoolChainId,
@@ -1990,7 +1990,7 @@ export class Dataworker {
         return;
       }
       seenL1Tokens.add(l1Token);
-      const tokenSymbol = this.clients.hubPoolClient.getTokenInfo(chainId, l1Token)?.symbol;
+      const tokenSymbol = this.clients.hubPoolClient.getTokenInfoForL1Token(l1Token)?.symbol;
 
       // Exit early if we recently synced this token.
       const latestFeesCompoundedTime =

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -111,9 +111,9 @@ export function generateMarkdownForRootBundle(
     }`;
   });
 
-  const convertTokenListFromWei = (l1TokenAddresses: string[], weiVals: string[]) => {
-    return l1TokenAddresses.map((token, index) => {
-      const { decimals } = hubPoolClient.getTokenInfoForL1Token(token);
+  const convertTokenListFromWei = (chainId: number, tokenAddresses: string[], weiVals: string[]) => {
+    return tokenAddresses.map((token, index) => {
+      const { decimals } = hubPoolClient.getTokenInfoForAddress(token, chainId);
       return convertFromWei(weiVals[index], decimals);
     });
   };
@@ -131,9 +131,9 @@ export function generateMarkdownForRootBundle(
     delete leaf.leafId;
     leaf.groupId = leaf.groupIndex;
     delete leaf.groupIndex;
-    leaf.bundleLpFees = convertTokenListFromWei(leaf.l1Tokens, leaf.bundleLpFees);
-    leaf.runningBalances = convertTokenListFromWei(leaf.l1Tokens, leaf.runningBalances);
-    leaf.netSendAmounts = convertTokenListFromWei(leaf.l1Tokens, leaf.netSendAmounts);
+    leaf.bundleLpFees = convertTokenListFromWei(hubPoolChainId, leaf.l1Tokens, leaf.bundleLpFees);
+    leaf.runningBalances = convertTokenListFromWei(hubPoolChainId, leaf.l1Tokens, leaf.runningBalances);
+    leaf.netSendAmounts = convertTokenListFromWei(hubPoolChainId, leaf.l1Tokens, leaf.netSendAmounts);
     leaf.l1Tokens = convertL1TokenAddressesToSymbols(leaf.l1Tokens);
     poolRebalanceLeavesPretty += `\n\t\t\t${index}: ${JSON.stringify(leaf)}`;
   });
@@ -147,6 +147,7 @@ export function generateMarkdownForRootBundle(
       hubPoolClient.getTokenInfoForAddress(leaf.l2TokenAddress, leaf.chainId).decimals
     );
     leaf.refundAmounts = convertTokenListFromWei(
+      leaf.chainId,
       Array(leaf.refundAmounts.length).fill(leaf.l2TokenAddress),
       leaf.refundAmounts
     );

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -117,12 +117,12 @@ export function generateMarkdownForRootBundle(
       return convertFromWei(weiVals[index], decimals);
     });
   };
-  const convertTokenAddressToSymbol = (l1Token: string) => {
-    return hubPoolClient.getTokenInfoForL1Token(l1Token).symbol;
+  const convertTokenAddressToSymbol = (chainId: number, tokenAddress: string) => {
+    return hubPoolClient.getTokenInfoForAddress(tokenAddress, chainId).symbol;
   };
   const convertL1TokenAddressesToSymbols = (l1Tokens: string[]) => {
     return l1Tokens.map((l1Token) => {
-      return convertTokenAddressToSymbol(l1Token);
+      return convertTokenAddressToSymbol(hubPoolChainId, l1Token);
     });
   };
   let poolRebalanceLeavesPretty = "";
@@ -150,7 +150,7 @@ export function generateMarkdownForRootBundle(
       Array(leaf.refundAmounts.length).fill(leaf.l2TokenAddress),
       leaf.refundAmounts
     );
-    leaf.l2Token = convertTokenAddressToSymbol(leaf.l2TokenAddress);
+    leaf.l2Token = convertTokenAddressToSymbol(leaf.chainId, leaf.l2TokenAddress);
     delete leaf.l2TokenAddress;
     leaf.refundAddresses = shortenHexStrings(leaf.refundAddresses);
     relayerRefundLeavesPretty += `\n\t\t\t${index}: ${JSON.stringify(leaf)}`;

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -111,18 +111,18 @@ export function generateMarkdownForRootBundle(
     }`;
   });
 
-  const convertTokenListFromWei = (chainId: number, tokenAddresses: string[], weiVals: string[]) => {
-    return tokenAddresses.map((token, index) => {
-      const { decimals } = hubPoolClient.getTokenInfo(chainId, token);
+  const convertTokenListFromWei = (l1TokenAddresses: string[], weiVals: string[]) => {
+    return l1TokenAddresses.map((token, index) => {
+      const { decimals } = hubPoolClient.getTokenInfoForL1Token(token);
       return convertFromWei(weiVals[index], decimals);
     });
   };
-  const convertTokenAddressToSymbol = (chainId: number, tokenAddress: string) => {
-    return hubPoolClient.getTokenInfo(chainId, tokenAddress).symbol;
+  const convertTokenAddressToSymbol = (l1Token: string) => {
+    return hubPoolClient.getTokenInfoForL1Token(l1Token).symbol;
   };
   const convertL1TokenAddressesToSymbols = (l1Tokens: string[]) => {
     return l1Tokens.map((l1Token) => {
-      return convertTokenAddressToSymbol(hubPoolChainId, l1Token);
+      return convertTokenAddressToSymbol(l1Token);
     });
   };
   let poolRebalanceLeavesPretty = "";
@@ -131,9 +131,9 @@ export function generateMarkdownForRootBundle(
     delete leaf.leafId;
     leaf.groupId = leaf.groupIndex;
     delete leaf.groupIndex;
-    leaf.bundleLpFees = convertTokenListFromWei(hubPoolChainId, leaf.l1Tokens, leaf.bundleLpFees);
-    leaf.runningBalances = convertTokenListFromWei(hubPoolChainId, leaf.l1Tokens, leaf.runningBalances);
-    leaf.netSendAmounts = convertTokenListFromWei(hubPoolChainId, leaf.l1Tokens, leaf.netSendAmounts);
+    leaf.bundleLpFees = convertTokenListFromWei(leaf.l1Tokens, leaf.bundleLpFees);
+    leaf.runningBalances = convertTokenListFromWei(leaf.l1Tokens, leaf.runningBalances);
+    leaf.netSendAmounts = convertTokenListFromWei(leaf.l1Tokens, leaf.netSendAmounts);
     leaf.l1Tokens = convertL1TokenAddressesToSymbols(leaf.l1Tokens);
     poolRebalanceLeavesPretty += `\n\t\t\t${index}: ${JSON.stringify(leaf)}`;
   });

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -147,11 +147,10 @@ export function generateMarkdownForRootBundle(
       hubPoolClient.getTokenInfoForAddress(leaf.l2TokenAddress, leaf.chainId).decimals
     );
     leaf.refundAmounts = convertTokenListFromWei(
-      leaf.chainId,
       Array(leaf.refundAmounts.length).fill(leaf.l2TokenAddress),
       leaf.refundAmounts
     );
-    leaf.l2Token = convertTokenAddressToSymbol(leaf.chainId, leaf.l2TokenAddress);
+    leaf.l2Token = convertTokenAddressToSymbol(leaf.l2TokenAddress);
     delete leaf.l2TokenAddress;
     leaf.refundAddresses = shortenHexStrings(leaf.refundAddresses);
     relayerRefundLeavesPretty += `\n\t\t\t${index}: ${JSON.stringify(leaf)}`;

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -144,7 +144,7 @@ export function generateMarkdownForRootBundle(
     delete leaf.leafId;
     leaf.amountToReturn = convertFromWei(
       leaf.amountToReturn,
-      hubPoolClient.getTokenInfo(leaf.chainId, leaf.l2TokenAddress).decimals
+      hubPoolClient.getTokenInfoForAddress(leaf.l2TokenAddress, leaf.chainId).decimals
     );
     leaf.refundAmounts = convertTokenListFromWei(
       leaf.chainId,
@@ -161,7 +161,7 @@ export function generateMarkdownForRootBundle(
   slowRelayLeaves.forEach((leaf, index) => {
     const { outputToken } = leaf.relayData;
     const destinationChainId = leaf.chainId;
-    const outputTokenDecimals = hubPoolClient.getTokenInfo(destinationChainId, outputToken).decimals;
+    const outputTokenDecimals = hubPoolClient.getTokenInfoForAddress(outputToken, destinationChainId).decimals;
     const lpFeePct = sdkUtils.getSlowFillLeafLpFeePct(leaf);
 
     // Scale amounts to 18 decimals for realizedLpFeePct computation.

--- a/src/finalizer/utils/linea/common.ts
+++ b/src/finalizer/utils/linea/common.ts
@@ -226,7 +226,7 @@ export function determineMessageType(
     );
     const decoded = contractInterface.decodeFunctionData("completeBridging", _calldata);
     // If we've made it this far, then the calldata is a valid TokenBridge calldata.
-    const token = hubPoolClient.getTokenInfo(hubPoolClient.chainId, decoded._nativeToken);
+    const token = hubPoolClient.getTokenInfoForL1Token(decoded._nativeToken);
     return {
       type: "bridge",
       l1TokenSymbol: token.symbol,

--- a/src/finalizer/utils/linea/l1ToL2.ts
+++ b/src/finalizer/utils/linea/l1ToL2.ts
@@ -144,7 +144,7 @@ export async function lineaL1ToL2Finalizer(
         miscReason: "lineaClaim:relayMessage",
       };
     } else {
-      const { decimals, symbol: l1TokenSymbol } = hubPoolClient.getTokenInfo(l1ChainId, messageType.l1TokenAddress);
+      const { decimals, symbol: l1TokenSymbol } = hubPoolClient.getTokenInfoForL1Token(messageType.l1TokenAddress);
       const amountFromWei = convertFromWei(messageType.amount.toString(), decimals);
       crossChainCall = {
         originationChainId: l1ChainId,

--- a/src/finalizer/utils/scroll.ts
+++ b/src/finalizer/utils/scroll.ts
@@ -172,7 +172,7 @@ function populateClaimWithdrawal(
   l2ChainId: number,
   hubPoolClient: HubPoolClient
 ): CrossChainMessage {
-  const l1Token = hubPoolClient.getTokenInfo(hubPoolClient.chainId, claim.l1Token);
+  const l1Token = hubPoolClient.getTokenInfoForL1Token(claim.l1Token);
   return {
     originationChainId: l2ChainId,
     l1TokenSymbol: l1Token.symbol,

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -253,6 +253,7 @@ export class Monitor {
       address: TOKEN_SYMBOLS_MAP["USDC.e"].addresses[this.clients.hubPoolClient.chainId],
       decimals: 6,
     });
+    // @dev TODO: Handle special case for tokens that do not have an L1 token mapped to them via PoolRebalanceRoutes
     const chainIds = this.monitorChains;
     const allChainNames = chainIds.map(getNetworkName).concat([ALL_CHAINS_NAME]);
     const reports = this.initializeBalanceReports(relayers, allL1Tokens, allChainNames);

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1481,7 +1481,10 @@ export class Relayer {
   }
 
   private constructBaseFillMarkdown(deposit: Deposit, _realizedLpFeePct: BigNumber, _gasPriceGwei: BigNumber): string {
-    const { symbol, decimals } = this.clients.hubPoolClient.getTokenInfoForAddress(deposit.inputToken, deposit.originChainId);
+    const { symbol, decimals } = this.clients.hubPoolClient.getTokenInfoForAddress(
+      deposit.inputToken,
+      deposit.originChainId
+    );
     const srcChain = getNetworkName(deposit.originChainId);
     const dstChain = getNetworkName(deposit.destinationChainId);
     const depositor = blockExplorerLink(deposit.depositor, deposit.originChainId);

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1481,7 +1481,7 @@ export class Relayer {
   }
 
   private constructBaseFillMarkdown(deposit: Deposit, _realizedLpFeePct: BigNumber, _gasPriceGwei: BigNumber): string {
-    const { symbol, decimals } = this.clients.hubPoolClient.getTokenInfoForDeposit(deposit);
+    const { symbol, decimals } = this.clients.hubPoolClient.getTokenInfoForAddress(deposit.inputToken, deposit.originChainId);
     const srcChain = getNetworkName(deposit.originChainId);
     const dstChain = getNetworkName(deposit.destinationChainId);
     const depositor = blockExplorerLink(deposit.depositor, deposit.originChainId);

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1026,7 +1026,7 @@ export class Relayer {
     }
 
     const formatSlowFillRequestMarkdown = (): string => {
-      const { symbol, decimals } = hubPoolClient.getTokenInfo(destinationChainId, outputToken);
+      const { symbol, decimals } = hubPoolClient.getTokenInfoForAddress(outputToken, destinationChainId);
       const formatter = createFormatFunction(2, 4, false, decimals);
       const outputAmount = formatter(deposit.outputAmount);
       const [srcChain, dstChain] = [getNetworkName(originChainId), getNetworkName(destinationChainId)];
@@ -1469,9 +1469,9 @@ export class Relayer {
       ` Relayer repayment: ${getNetworkName(repaymentChainId)}.`;
 
     if (isDepositSpedUp(deposit)) {
-      const { symbol, decimals } = this.clients.hubPoolClient.getTokenInfo(
-        deposit.destinationChainId,
-        deposit.outputToken
+      const { symbol, decimals } = this.clients.hubPoolClient.getTokenInfoForAddress(
+        deposit.outputToken,
+        deposit.destinationChainId
       );
       const updatedOutputAmount = createFormatFunction(2, 4, false, decimals)(deposit.updatedOutputAmount.toString());
       mrkdwn += ` Reduced output amount: ${updatedOutputAmount} ${symbol}.`;

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -156,7 +156,7 @@ export async function runScript(baseSigner: Signer): Promise<void> {
       }
       for (let i = 0; i < leaf.l1Tokens.length; i++) {
         const l1Token = leaf.l1Tokens[i];
-        const tokenInfo = clients.hubPoolClient.getTokenInfo(clients.hubPoolClient.chainId, l1Token);
+        const tokenInfo = clients.hubPoolClient.getTokenInfoForL1Token(l1Token);
         if (process.env.SINGLE_TOKEN && tokenInfo.symbol !== process.env.SINGLE_TOKEN) {
           continue;
         }

--- a/src/utils/SDKUtils.ts
+++ b/src/utils/SDKUtils.ts
@@ -56,7 +56,6 @@ export const {
   blockExplorerLinks,
   createShortHexString: shortenHexString,
   compareAddressesSimple,
-  getTokenInfo,
   getL1TokenInfo,
   getUsdcSymbol,
   Profiler,

--- a/test/Dataworker.executePoolRebalanceUtils.ts
+++ b/test/Dataworker.executePoolRebalanceUtils.ts
@@ -63,7 +63,6 @@ describe("Dataworker: Utilities to execute pool rebalance leaves", async functio
       hubPoolClient.configStoreClient as unknown as ConfigStoreClient
     );
     mockHubPoolClient.chainId = hubPoolClient.chainId;
-    mockHubPoolClient.setTokenInfoToReturn({ address: l1Token_1.address, decimals: 18, symbol: "TEST" });
 
     // Sub in a dummy root bundle proposal for use in HubPoolClient update.
     const zero = "0x0000000000000000000000000000000000000000000000000000000000000000";

--- a/test/Dataworker.executePoolRebalances.ts
+++ b/test/Dataworker.executePoolRebalances.ts
@@ -68,7 +68,6 @@ describe("Dataworker: Execute pool rebalances", async function () {
       hubPoolClient.configStoreClient as unknown as ConfigStoreClient
     );
     mockHubPoolClient.chainId = hubPoolClient.chainId;
-    mockHubPoolClient.setTokenInfoToReturn({ address: l1Token_1.address, decimals: 18, symbol: "TEST" });
     mockHubPoolClient.setTokenMapping(l1Token_1.address, hubPoolClient.chainId, l1Token_1.address);
 
     // Sub in a dummy root bundle proposal for use in HubPoolClient update.

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -323,6 +323,7 @@ describe("ProfitClient: Consider relay profit", () => {
           };
           hubPoolClient.setTokenMapping(token.address, deposit.originChainId, deposit.inputToken);
           hubPoolClient.mapTokenInfo(deposit.outputToken, token.symbol, token.decimals);
+          hubPoolClient.mapTokenInfo(deposit.inputToken, token.symbol, token.decimals);
           const tokenPriceUsd = profitClient.getPriceOfToken(token.symbol);
 
           // Normalise any tokens with <18 decimals to 18 decimals.
@@ -499,6 +500,7 @@ describe("ProfitClient: Consider relay profit", () => {
     const l1Token = tokens.WETH;
     hubPoolClient.setTokenMapping(l1Token.address, originChainId, deposit.inputToken);
     hubPoolClient.mapTokenInfo(deposit.outputToken, l1Token.symbol, l1Token.decimals);
+    hubPoolClient.mapTokenInfo(deposit.inputToken, l1Token.symbol, l1Token.decimals);
     randomiseGasCost(destinationChainId);
 
     const outputTokenPriceUsd = profitClient.getPriceOfToken(l1Token.symbol);
@@ -518,6 +520,7 @@ describe("ProfitClient: Consider relay profit", () => {
 
     hubPoolClient.setTokenMapping(tokens.WETH.address, originChainId, deposit.inputToken);
     hubPoolClient.mapTokenInfo(deposit.outputToken, tokens.WETH.symbol, tokens.WETH.decimals);
+    hubPoolClient.mapTokenInfo(deposit.inputToken, tokens.WETH.symbol, tokens.WETH.decimals);
     const outputTokenPriceUsd = profitClient.getPriceOfToken(tokens.WETH.symbol);
 
     let expectedOutputAmountUsd = deposit.outputAmount.mul(outputTokenPriceUsd).div(fixedPoint);

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -270,7 +270,6 @@ describe("ProfitClient: Consider relay profit", () => {
   it("Verify token price and gas cost lookup failures", async () => {
     const outputAmount = toBNWei(1);
     const l1Token = tokens.WETH;
-    hubPoolClient.setTokenInfoToReturn(l1Token);
 
     for (const destinationChainId of chainIds) {
       const deposit = { ...v3DepositTemplate, outputAmount, destinationChainId };

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -18,7 +18,13 @@ import {
   destinationChainId,
   repaymentChainId,
 } from "./constants";
-import { MockInventoryClient, MockProfitClient, MockConfigStoreClient, MockedMultiCallerClient } from "./mocks";
+import {
+  MockInventoryClient,
+  MockProfitClient,
+  MockConfigStoreClient,
+  MockedMultiCallerClient,
+  SimpleMockHubPoolClient,
+} from "./mocks";
 import {
   BigNumber,
   Contract,
@@ -103,8 +109,11 @@ describe("Relayer: Unfilled Deposits", async function () {
     configStoreClient = new MockConfigStoreClient(spyLogger, configStore, undefined, undefined, CHAIN_ID_TEST_LIST);
     await configStoreClient.update();
 
-    hubPoolClient = new HubPoolClient(spyLogger, hubPool, configStoreClient);
+    hubPoolClient = new SimpleMockHubPoolClient(spyLogger, hubPool, configStoreClient);
     await hubPoolClient.update();
+    (hubPoolClient as SimpleMockHubPoolClient).mapTokenInfo(l1Token.address, "L1Token1");
+    (hubPoolClient as SimpleMockHubPoolClient).mapTokenInfo(erc20_1.address, "L1Token1");
+    (hubPoolClient as SimpleMockHubPoolClient).mapTokenInfo(erc20_2.address, "L1Token1");
 
     spokePoolClient_1 = new SpokePoolClient(
       spyLogger,

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -29,7 +29,7 @@ import { Dataworker } from "../../src/dataworker/Dataworker"; // Tested
 import { BundleDataClient, TokenClient } from "../../src/clients";
 import { DataworkerConfig } from "../../src/dataworker/DataworkerConfig";
 import { DataworkerClients } from "../../src/dataworker/DataworkerClientHelper";
-import { MockConfigStoreClient, MockedMultiCallerClient } from "../mocks";
+import { MockConfigStoreClient, MockedMultiCallerClient, SimpleMockHubPoolClient } from "../mocks";
 import { EthersTestLibrary } from "../types";
 import { clients as sdkClients } from "@across-protocol/sdk";
 
@@ -174,13 +174,18 @@ export async function setupDataworker(
 
   await configStoreClient.update();
 
-  const hubPoolClient = new sdkClients.HubPoolClient(
+  const hubPoolClient = new SimpleMockHubPoolClient(
     spyLogger,
     hubPool,
     configStoreClient,
     hubPoolDeploymentBlock,
     hubPoolChainId
   );
+  hubPoolClient.mapTokenInfo(l1Token_1.address, "TEST");
+  hubPoolClient.mapTokenInfo(l1Token_2.address, "TEST");
+  hubPoolClient.mapTokenInfo(erc20_1.address, "TEST");
+  hubPoolClient.mapTokenInfo(erc20_2.address, "TEST");
+
   const multiCallerClient = new MockedMultiCallerClient(spyLogger); // leave out the gasEstimator for now.
 
   const [spokePoolClient_1, spokePoolClient_2, spokePoolClient_3, spokePoolClient_4] =

--- a/test/mocks/MockHubPoolClient.ts
+++ b/test/mocks/MockHubPoolClient.ts
@@ -3,7 +3,6 @@ import { Contract, winston, BigNumber } from "../utils";
 import { ConfigStoreClient, HubPoolClient } from "../../src/clients";
 import { MockConfigStoreClient } from "./MockConfigStoreClient";
 import { L1Token } from "../../src/interfaces";
-import { L1Token } from "@across-protocol/sdk/dist/cjs/interfaces/HubPool";
 
 // Adds functions to MockHubPoolClient to facilitate Dataworker unit testing.
 export class MockHubPoolClient extends clients.mocks.MockHubPoolClient {
@@ -75,7 +74,7 @@ export class MockHubPoolClient extends clients.mocks.MockHubPoolClient {
   }
 }
 
-export class SimpleMockHubPoolClient extends HubPoolClient {
+export class SimpleMockHubPoolClient extends clients.HubPoolClient {
   private tokenInfoMap: { [tokenAddress: string]: L1Token } = {};
 
   mapTokenInfo(token: string, symbol: string, decimals = 18): void {

--- a/test/mocks/MockHubPoolClient.ts
+++ b/test/mocks/MockHubPoolClient.ts
@@ -1,6 +1,6 @@
 import { clients } from "@across-protocol/sdk";
 import { Contract, winston, BigNumber } from "../utils";
-import { ConfigStoreClient, HubPoolClient } from "../../src/clients";
+import { ConfigStoreClient } from "../../src/clients";
 import { MockConfigStoreClient } from "./MockConfigStoreClient";
 import { L1Token } from "../../src/interfaces";
 

--- a/test/mocks/MockHubPoolClient.ts
+++ b/test/mocks/MockHubPoolClient.ts
@@ -3,6 +3,7 @@ import { Contract, winston, BigNumber } from "../utils";
 import { ConfigStoreClient, HubPoolClient } from "../../src/clients";
 import { MockConfigStoreClient } from "./MockConfigStoreClient";
 import { L1Token } from "../../src/interfaces";
+import { L1Token } from "@across-protocol/sdk/dist/cjs/interfaces/HubPool";
 
 // Adds functions to MockHubPoolClient to facilitate Dataworker unit testing.
 export class MockHubPoolClient extends clients.mocks.MockHubPoolClient {
@@ -92,5 +93,12 @@ export class SimpleMockHubPoolClient extends HubPoolClient {
       return this.tokenInfoMap[token];
     }
     return super.getTokenInfoForAddress(token, chainId);
+  }
+
+  getTokenInfoForL1Token(l1Token: string): L1Token | undefined {
+    if (this.tokenInfoMap[l1Token]) {
+      return this.tokenInfoMap[l1Token];
+    }
+    return super.getTokenInfoForL1Token(l1Token);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,10 +65,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@4.1.45":
-  version "4.1.45"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.45.tgz#e1a1210b3dce09b85b7ebe23fa04d25f94532e76"
-  integrity sha512-tnlI+pGUZt1kEnZxx3qf7UdyhfrNnjCEBSWNnevpIZD4Q8cLaguarSSg5klhB4zhxspo0X+dBvsNgHVkStDLEg==
+"@across-protocol/sdk@4.1.46-beta.3":
+  version "4.1.46-beta.3"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.46-beta.3.tgz#04efb17989021ffe2b58a062cd2f71b13cad36f1"
+  integrity sha512-FAdgkdJeyHba4/uixZMxij2mUSB1tOMVO8StzK74myjoiqm5IhJL7fsUdHlOAmLs4k2+KItEvHulqcdZ/TC3xA==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.51"

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,10 +65,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@4.1.46-beta.1":
-  version "4.1.46-beta.1"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.46-beta.1.tgz#b4a0cff461a4765ea2622bd9a7e8097f64431ceb"
-  integrity sha512-iFFp3OBA3L9RF3ylphndpRiVhz0/cOJqwwJkPeIYXPcdNm+/74i9wKAtlZQA0mExiqTgA7fnesoaih6/jbSmvg==
+"@across-protocol/sdk@4.1.45":
+  version "4.1.45"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.45.tgz#e1a1210b3dce09b85b7ebe23fa04d25f94532e76"
+  integrity sha512-tnlI+pGUZt1kEnZxx3qf7UdyhfrNnjCEBSWNnevpIZD4Q8cLaguarSSg5klhB4zhxspo0X+dBvsNgHVkStDLEg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.51"

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,10 +65,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@4.1.46-beta.3":
-  version "4.1.46-beta.3"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.46-beta.3.tgz#04efb17989021ffe2b58a062cd2f71b13cad36f1"
-  integrity sha512-FAdgkdJeyHba4/uixZMxij2mUSB1tOMVO8StzK74myjoiqm5IhJL7fsUdHlOAmLs4k2+KItEvHulqcdZ/TC3xA==
+"@across-protocol/sdk@4.1.46-beta.4":
+  version "4.1.46-beta.4"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.46-beta.4.tgz#1140f93b84d9e1433d12386f4f231101e6942a29"
+  integrity sha512-3o0ZVRIeqSAyJ0bQ3/JnS9bKaJToxijemfPwZm76GALphBo1yL9cYF5SKXoQEdRZpiw5Rl1+wzGjyeznV482Hg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.51"

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,10 +65,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@4.1.45":
-  version "4.1.45"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.45.tgz#e1a1210b3dce09b85b7ebe23fa04d25f94532e76"
-  integrity sha512-tnlI+pGUZt1kEnZxx3qf7UdyhfrNnjCEBSWNnevpIZD4Q8cLaguarSSg5klhB4zhxspo0X+dBvsNgHVkStDLEg==
+"@across-protocol/sdk@4.1.46-beta.1":
+  version "4.1.46-beta.1"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.46-beta.1.tgz#b4a0cff461a4765ea2622bd9a7e8097f64431ceb"
+  integrity sha512-iFFp3OBA3L9RF3ylphndpRiVhz0/cOJqwwJkPeIYXPcdNm+/74i9wKAtlZQA0mExiqTgA7fnesoaih6/jbSmvg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.51"

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,10 +65,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@4.1.46-beta.4":
-  version "4.1.46-beta.4"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.46-beta.4.tgz#1140f93b84d9e1433d12386f4f231101e6942a29"
-  integrity sha512-3o0ZVRIeqSAyJ0bQ3/JnS9bKaJToxijemfPwZm76GALphBo1yL9cYF5SKXoQEdRZpiw5Rl1+wzGjyeznV482Hg==
+"@across-protocol/sdk@4.1.46":
+  version "4.1.46"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.46.tgz#9baae08b09072db78bddd685a3333cc9770ecb18"
+  integrity sha512-UrObJckBdg7j0vszBa6X+hGv+4OcuOTE7Zrclzwhk8etUGagCGt5mdDEevOX9Jb9FIXgjbV2pxfkXHOSg/C9TA==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.51"


### PR DESCRIPTION
- ProfitClient assumes in a few places that output amount is denominated in same precision as equivalent L1 token
- Monitor will not currently report balances of L2 tokens that are not mapped to L1 tokens, which I've left a TODO comment for
- PoolRebalance logs might not render correctly without adjusting for output token decimals

This PR also replaces use of functions in the SDK that might not resolve the correct `L1TokenInfo` object if different entries in TOKEN_SYMBOLS_MAP have the same mainnet token. These functions are removed in this SDK [pr](https://github.com/across-protocol/sdk/pull/981/files) and this PR uses the safer SDK functions that grabs the correct L2 chain's decimals