### PR TITLE
feat: Treat lite chain deposits and forced origin chain repayments similarly

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -30,7 +30,6 @@ import {
   getL1TokenInfo,
   depositForcesOriginChainRepayment,
   getRemoteTokenForL1Token,
-  depositCanTakeDestinationChainRepayment,
 } from "../utils";
 import { HubPoolClient, TokenClient, BundleDataClient } from ".";
 import { Deposit, L1Token, ProposedRootBundle } from "../interfaces";

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -334,12 +334,16 @@ export class InventoryClient {
     const totalRefundsPerChain = this.getEnabledChains().reduce(
       (refunds: { [chainId: string]: BigNumber }, chainId) => {
         const destinationToken = this.getRemoteTokenForL1Token(l1Token, chainId);
-        const { decimals: l2TokenDecimals } = this.hubPoolClient.getTokenInfoForAddress(destinationToken, chainId);
-        refunds[chainId] = sdkUtils.ConvertDecimals(
-          l2TokenDecimals,
-          l1TokenDecimals
-        )(this.bundleDataClient.getTotalRefund(refundsToConsider, this.relayer, chainId, destinationToken));
-        return refunds;
+        if (!destinationToken) {
+          refunds[chainId] = bnZero;
+        } else {
+          const { decimals: l2TokenDecimals } = this.hubPoolClient.getTokenInfoForAddress(destinationToken, chainId);
+          refunds[chainId] = sdkUtils.ConvertDecimals(
+            l2TokenDecimals,
+            l1TokenDecimals
+          )(this.bundleDataClient.getTotalRefund(refundsToConsider, this.relayer, chainId, destinationToken));
+          return refunds;
+        }
       },
       {}
     );

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -369,14 +369,15 @@ export class InventoryClient {
     // Origin chain is always included in the repayment chain list.
     const { originChainId, destinationChainId, inputToken } = deposit;
     const chainIds = [originChainId];
-    if (
-      this.canTakeDestinationChainRepayment(deposit) &&
-      !depositForcesOriginChainRepayment(deposit, this.hubPoolClient)
-    ) {
+    if (depositForcesOriginChainRepayment(deposit, this.hubPoolClient)) {
+      return chainIds;
+    }
+
+    if (this.canTakeDestinationChainRepayment(deposit)) {
       chainIds.push(destinationChainId);
     }
 
-    if (this.isInventoryManagementEnabled() && originChainId !== this.hubPoolClient.chainId) {
+    if (this.isInventoryManagementEnabled()) {
       const l1Token = this.getL1TokenInfo(inputToken, originChainId).address;
       chainIds.push(
         ...this.getSlowWithdrawalRepaymentChains(l1Token).filter((chainId) =>
@@ -384,10 +385,7 @@ export class InventoryClient {
         )
       );
     }
-    if (
-      ![originChainId, destinationChainId].includes(this.hubPoolClient.chainId) &&
-      this.canTakeHubChainRepayment(deposit)
-    ) {
+    if (![originChainId, destinationChainId].includes(this.hubPoolClient.chainId)) {
       chainIds.push(this.hubPoolClient.chainId);
     }
     return chainIds;

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -344,6 +344,7 @@ export class InventoryClient {
           )(this.bundleDataClient.getTotalRefund(refundsToConsider, this.relayer, chainId, destinationToken));
           return refunds;
         }
+        return refunds;
       },
       {}
     );

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -382,10 +382,7 @@ export class InventoryClient {
         )
       );
     }
-    if (
-      this.canTakeHubChainRepayment(deposit) &&
-      ![originChainId, destinationChainId].includes(this.hubPoolClient.chainId)
-    ) {
+    if (![originChainId, destinationChainId].includes(this.hubPoolClient.chainId)) {
       chainIds.push(this.hubPoolClient.chainId);
     }
     return chainIds;
@@ -432,12 +429,6 @@ export class InventoryClient {
 
   private canTakeDestinationChainRepayment(deposit: Deposit): boolean {
     return this.hubPoolClient.l2TokenHasPoolRebalanceRoute(deposit.outputToken, deposit.destinationChainId);
-  }
-
-  private canTakeHubChainRepayment(deposit: Deposit): boolean {
-    // If input token maps to an L1 token then repayment can be taken on the hub chain in this input token
-    // equivalent.
-    return this.hubPoolClient.l2TokenHasPoolRebalanceRoute(deposit.inputToken, deposit.originChainId);
   }
 
   /*
@@ -677,11 +668,7 @@ export class InventoryClient {
 
     // Always add hubChain as a fallback option if inventory management is enabled and origin chain is not a lite chain.
     // If none of the chainsToEvaluate were selected, then this function will return just the hub chain as a fallback option.
-    if (
-      !depositForcesOriginChainRepayment(deposit, this.hubPoolClient) &&
-      this.canTakeHubChainRepayment(deposit) &&
-      !eligibleRefundChains.includes(hubChainId)
-    ) {
+    if (!depositForcesOriginChainRepayment(deposit, this.hubPoolClient) && !eligibleRefundChains.includes(hubChainId)) {
       eligibleRefundChains.push(hubChainId);
     }
     return eligibleRefundChains;

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -224,7 +224,7 @@ export class InventoryClient {
   /**
    * From an L1Token and remote chain ID, resolve all supported corresponding tokens.
    * This should include at least the relevant repayment token on the relevant chain, but may also include other
-   * "equivalent" tokens (i.e. as with Bridged & Native USDC).
+   * "equivalent" tokens (i.e. as with Bridged & Native USDC) as defined by a custom token configuration.
    * @param l1Token Mainnet token to query.
    * @param chainId Remove chain to query.
    * @returns An array of supported tokens on chainId that map back to l1Token on mainnet.
@@ -382,7 +382,10 @@ export class InventoryClient {
         )
       );
     }
-    if (![originChainId, destinationChainId].includes(this.hubPoolClient.chainId)) {
+    if (
+      this.canTakeHubChainRepayment(deposit) &&
+      ![originChainId, destinationChainId].includes(this.hubPoolClient.chainId)
+    ) {
       chainIds.push(this.hubPoolClient.chainId);
     }
     return chainIds;

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -29,6 +29,7 @@ import {
   ZERO_ADDRESS,
   formatGwei,
   fixedPointAdjustment,
+  getRemoteTokenForL1Token,
 } from "../utils";
 import { Deposit, DepositWithBlock, L1Token, SpokePoolClientsByChain } from "../interfaces";
 import { getAcrossHost } from "./AcrossAPIClient";
@@ -651,7 +652,7 @@ export class ProfitClient {
         const outputToken =
           destinationChainId === hubPoolClient.chainId
             ? hubToken
-            : hubPoolClient.getL2TokenForL1TokenAtBlock(hubToken, destinationChainId);
+            : getRemoteTokenForL1Token(hubToken, destinationChainId, this.hubPoolClient);
         assert(isDefined(outputToken), `Chain ${destinationChainId} SpokePool is not configured for ${symbol}`);
 
         const deposit = { ...sampleDeposit, destinationChainId, outputToken };

--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -19,6 +19,7 @@ import {
   winston,
   getRedisCache,
   TOKEN_SYMBOLS_MAP,
+  getRemoteTokenForL1Token,
 } from "../utils";
 
 export type TokenDataType = { [chainId: number]: { [token: string]: { balance: BigNumber; allowance: BigNumber } } };
@@ -185,7 +186,7 @@ export class TokenClient {
       .map(({ symbol, address }) => {
         let tokenAddrs: string[] = [];
         try {
-          const spokePoolToken = this.hubPoolClient.getL2TokenForL1TokenAtBlock(address, chainId);
+          const spokePoolToken = getRemoteTokenForL1Token(address, chainId, this.hubPoolClient);
           tokenAddrs.push(spokePoolToken);
         } catch {
           // No known deployment for this token on the SpokePool.

--- a/src/clients/bridges/AdapterManager.ts
+++ b/src/clients/bridges/AdapterManager.ts
@@ -21,6 +21,7 @@ import {
   EvmAddress,
   toAddressType,
   TOKEN_EQUIVALENCE_REMAPPING,
+  getRemoteTokenForL1Token,
 } from "../../utils";
 import { SpokePoolClient, HubPoolClient } from "../";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
@@ -239,7 +240,7 @@ export class AdapterManager {
     try {
       // That the line below is critical. if the hubpoolClient returns the wrong destination token for the L1 token then
       // the bot can irrecoverably send the wrong token to the chain and loose money. It should crash if this is detected.
-      const l2TokenForL1Token = this.hubPoolClient.getL2TokenForL1TokenAtBlock(l1Token, chainId);
+      const l2TokenForL1Token = getRemoteTokenForL1Token(l1Token, chainId, this.hubPoolClient);
       if (!l2TokenForL1Token) {
         throw new Error(`No L2 token found for L1 token ${l1Token} on chain ${chainId}`);
       }

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -22,7 +22,7 @@ import {
   Profiler,
   formatGwei,
   toBytes32,
-  depositHasPoolRebalanceRouteMapping,
+  depositForcesOriginChainRepayment,
 } from "../utils";
 import { RelayerClients } from "./RelayerClientHelper";
 import { RelayerConfig } from "./RelayerConfig";
@@ -235,16 +235,6 @@ export class Relayer {
       return ignoreDeposit();
     }
 
-    if (!depositHasPoolRebalanceRouteMapping(deposit, this.clients.hubPoolClient)) {
-      this.logger.debug({
-        at: "Relayer::filterDeposit",
-        message: `Skipping ${srcChain} deposit for input token ${inputToken} due to missing pool rebalance route.`,
-        deposit,
-        transactionHash: deposit.transactionHash,
-      });
-      return ignoreDeposit();
-    }
-
     if (sdkUtils.invalidOutputToken(deposit)) {
       this.logger.debug({
         at: "Relayer::filterDeposit",
@@ -328,8 +318,8 @@ export class Relayer {
 
     // Skip any L1 tokens that are not specified in the config.
     // If relayerTokens is an empty list, we'll assume that all tokens are supported.
-    const l1Token = hubPoolClient.getL1TokenInfoForL2Token(inputToken, originChainId);
-    if (relayerTokens.length > 0 && !relayerTokens.includes(l1Token.address)) {
+    const l1Token = this.clients.inventoryClient.getL1TokenInfo(inputToken, originChainId).address;
+    if (relayerTokens.length > 0 && !relayerTokens.includes(l1Token)) {
       this.logger.debug({
         at: "Relayer::filterDeposit",
         message: "Skipping deposit for unwhitelisted token",
@@ -407,7 +397,7 @@ export class Relayer {
     // The relayer should *not* be filling deposits that the HubPool doesn't have liquidity for otherwise the relayer's
     // refund will be stuck for potentially 7 days. Note: Filter for supported tokens first, since the relayer only
     // queries for limits on supported tokens.
-    if (!ignoreLimits && !deposit.fromLiteChain) {
+    if (!ignoreLimits && !depositForcesOriginChainRepayment(deposit, hubPoolClient)) {
       const { inputAmount } = deposit;
       const limit = acrossApiClient.getLimit(originChainId, l1Token.address);
       if (acrossApiClient.updatedLimits && inputAmount.gt(limit)) {
@@ -672,7 +662,7 @@ export class Relayer {
     sendSlowRelays: boolean
   ): Promise<void> {
     const { depositId, depositor, destinationChainId, originChainId, inputToken, transactionHash } = deposit;
-    const { hubPoolClient, profitClient, spokePoolClients, tokenClient } = this.clients;
+    const { profitClient, spokePoolClients, tokenClient } = this.clients;
     const { slowDepositors } = this.config;
     const [originChain, destChain] = [getNetworkName(originChainId), getNetworkName(destinationChainId)];
 
@@ -736,7 +726,7 @@ export class Relayer {
       }
     }
 
-    const l1Token = hubPoolClient.getL1TokenInfoForL2Token(inputToken, originChainId);
+    const l1Token = this.clients.inventoryClient.getL1TokenInfo(inputToken, originChainId);
     if (tokenClient.hasBalanceForFill(deposit)) {
       const { repaymentChainId, repaymentChainProfitability } = await this.resolveRepaymentChain(
         deposit,
@@ -787,10 +777,10 @@ export class Relayer {
       }
     } else {
       // Exit early if we want to request a slow fill for a lite chain.
-      if (deposit.fromLiteChain) {
+      if (depositForcesOriginChainRepayment(deposit, this.clients.hubPoolClient)) {
         this.logger.debug({
           at: "Relayer::evaluateFill",
-          message: "Skipping requesting slow fill for deposit originating from lite chain.",
+          message: "Skipping requesting slow fill for deposit that forces origin chain repayment",
           originChainId,
           depositId: depositId.toString(),
         });
@@ -997,10 +987,10 @@ export class Relayer {
 
   requestSlowFill(deposit: Deposit): void {
     // don't request slow fill if origin/destination chain is a lite chain
-    if (deposit.fromLiteChain || deposit.toLiteChain) {
+    if (depositForcesOriginChainRepayment(deposit, this.clients.hubPoolClient) || deposit.toLiteChain) {
       this.logger.debug({
         at: "Relayer::requestSlowFill",
-        message: "Prevent requesting slow fill request to/from lite chain.",
+        message: "Prevent requesting slow fill request from chain that forces origin chain repayment or to lite chain.",
         deposit,
       });
       return;
@@ -1062,10 +1052,13 @@ export class Relayer {
     const { spokePoolClients } = this.clients;
 
     // If a deposit originates from a lite chain, then the repayment chain must be the origin chain.
-    if (deposit.fromLiteChain && repaymentChainId !== deposit.originChainId) {
+    if (
+      depositForcesOriginChainRepayment(deposit, this.clients.hubPoolClient) &&
+      repaymentChainId !== deposit.originChainId
+    ) {
       this.logger.warn({
         at: "Relayer::fillRelay",
-        message: "Suppressed fill for lite chain deposit where repaymentChainId != originChainId",
+        message: "Suppressed fill for deposit that forces origin chain repayment but repaymentChainId != originChainId",
         deposit,
         repaymentChainId,
       });
@@ -1125,8 +1118,7 @@ export class Relayer {
     repaymentChainProfitability: RepaymentChainProfitability;
   }> {
     const { inventoryClient, profitClient } = this.clients;
-    const { depositId, originChainId, destinationChainId, inputAmount, outputAmount, transactionHash, fromLiteChain } =
-      deposit;
+    const { depositId, originChainId, destinationChainId, inputAmount, outputAmount, transactionHash } = deposit;
     const originChain = getNetworkName(originChainId);
     const destinationChain = getNetworkName(destinationChainId);
 
@@ -1138,8 +1130,8 @@ export class Relayer {
       // it is a special edge case the relayer should be aware of.
       this.logger.debug({
         at: "Relayer::resolveRepaymentChain",
-        message: deposit.fromLiteChain
-          ? `Deposit ${depositId.toString()} originated from over-allocated lite chain ${originChain}`
+        message: depositForcesOriginChainRepayment(deposit, this.clients.hubPoolClient)
+          ? `Deposit ${depositId.toString()} forces origin chain repayment and has an over-allocated origin chain ${originChain}`
           : `Unable to identify a preferred repayment chain for ${originChain} deposit ${depositId.toString()}.`,
         txn: blockExplorerLink(transactionHash, originChainId),
       });
@@ -1253,7 +1245,11 @@ export class Relayer {
     //
     // Additionally we don't want to take this code path if the origin chain is a lite chain because we can't
     // reason about destination chain repayments on lite chains.
-    if (!isDefined(preferredChain) && !preferredChainIds.includes(destinationChainId) && !fromLiteChain) {
+    if (
+      !isDefined(preferredChain) &&
+      !preferredChainIds.includes(destinationChainId) &&
+      !depositForcesOriginChainRepayment(deposit, this.clients.hubPoolClient)
+    ) {
       this.logger.debug({
         at: "Relayer::resolveRepaymentChain",
         message: `Preferred chains ${JSON.stringify(
@@ -1349,19 +1345,19 @@ export class Relayer {
         let crossChainLog = "";
         if (this.clients.inventoryClient.isInventoryManagementEnabled() && chainId !== hubChainId) {
           // Shortfalls are mapped to deposit output tokens so look up output token in token symbol map.
-          const l1Token = this.clients.hubPoolClient.getL1TokenInfoForL2Token(token, chainId);
+          const l1Token = this.clients.inventoryClient.getL1TokenInfo(token, chainId);
           const outstandingCrossChainTransferAmount =
             this.clients.inventoryClient.crossChainTransferClient.getOutstandingCrossChainTransferAmount(
               this.relayerAddress,
               chainId,
-              l1Token.address,
+              l1Token,
               token
             );
           crossChainLog = outstandingCrossChainTransferAmount.gt(0)
             ? " There is " +
               formatter(
                 this.clients.inventoryClient.crossChainTransferClient
-                  .getOutstandingCrossChainTransferAmount(this.relayerAddress, chainId, l1Token.address, token)
+                  .getOutstandingCrossChainTransferAmount(this.relayerAddress, chainId, l1Token, token)
                   // TODO: Add in additional l2Token param here once we can specify it
                   .toString()
               ) +
@@ -1422,18 +1418,23 @@ export class Relayer {
         const formattedRelayerFeePct = formatFeePct(relayerFeePct);
         const formattedLpFeePct = formatFeePct(lpFeePct);
 
-        // @dev If the origin chain is a lite chain and the LP fee percentage is infinity, then we can assume that the
-        // deposit originated from an over-allocated lite chain because the originChain, the only possible
-        // repayment chain, was not selected for repayment. So the "unprofitable" log should be modified to indicate
-        // this lite chain edge case.
-        const fromOverallocatedLiteChain = deposit.fromLiteChain && lpFeePct.eq(bnUint256Max);
+        // @dev If the deposit forces origin chain repayment and the LP fee percentage is infinity,
+        // then we can assume that the originChain, the only possible repayment chain,
+        // was not selected for repayment. So the "unprofitable" log should be modified to indicate
+        // this  edge case.
+        const fromOverallocatedLiteChain =
+          depositForcesOriginChainRepayment(deposit, this.clients.hubPoolClient) && lpFeePct.eq(bnUint256Max);
         const depositFailedToSimulateWithMessage = !isMessageEmpty(deposit.message) && gasCost.eq(bnUint256Max);
         depositMrkdwn +=
           `- DepositId ${deposit.depositId.toString()} (tx: ${depositblockExplorerLink})` +
           ` of input amount ${formattedInputAmount} ${inputSymbol}` +
           ` and output amount ${formattedOutputAmount} ${outputSymbol}` +
           ` from ${getNetworkName(originChainId)} to ${getNetworkName(destinationChainId)}` +
-          `${fromOverallocatedLiteChain ? " is from an over-allocated lite chain" : ""}` +
+          `${
+            fromOverallocatedLiteChain
+              ? " is from an over-allocated origin chain and it forces origin chain repayment"
+              : ""
+          }` +
           `${
             depositFailedToSimulateWithMessage
               ? ` failed to simulate with message of size ${ethersUtils.hexDataLength(deposit.message)} bytes`

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1350,14 +1350,14 @@ export class Relayer {
             this.clients.inventoryClient.crossChainTransferClient.getOutstandingCrossChainTransferAmount(
               this.relayerAddress,
               chainId,
-              l1Token,
+              l1Token.address,
               token
             );
           crossChainLog = outstandingCrossChainTransferAmount.gt(0)
             ? " There is " +
               formatter(
                 this.clients.inventoryClient.crossChainTransferClient
-                  .getOutstandingCrossChainTransferAmount(this.relayerAddress, chainId, l1Token, token)
+                  .getOutstandingCrossChainTransferAmount(this.relayerAddress, chainId, l1Token.address, token)
                   // TODO: Add in additional l2Token param here once we can specify it
                   .toString()
               ) +

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -318,8 +318,8 @@ export class Relayer {
 
     // Skip any L1 tokens that are not specified in the config.
     // If relayerTokens is an empty list, we'll assume that all tokens are supported.
-    const l1Token = this.clients.inventoryClient.getL1TokenInfo(inputToken, originChainId).address;
-    if (relayerTokens.length > 0 && !relayerTokens.includes(l1Token)) {
+    const l1Token = this.clients.inventoryClient.getL1TokenInfo(inputToken, originChainId);
+    if (relayerTokens.length > 0 && !relayerTokens.includes(l1Token.address)) {
       this.logger.debug({
         at: "Relayer::filterDeposit",
         message: "Skipping deposit for unwhitelisted token",

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -42,11 +42,13 @@ export function getUnfilledDeposits(
     });
 }
 
-export function depositHasPoolRebalanceRouteMapping(
-  deposit: Pick<DepositWithBlock, "inputToken" | "originChainId">,
+export function depositForcesOriginChainRepayment(
+  deposit: Pick<DepositWithBlock, "inputToken" | "originChainId" | "fromLiteChain">,
   hubPoolClient: HubPoolClient
 ): boolean {
-  return hubPoolClient.l2TokenHasPoolRebalanceRoute(deposit.inputToken, deposit.originChainId);
+  return (
+    deposit.fromLiteChain || !hubPoolClient.l2TokenHasPoolRebalanceRoute(deposit.inputToken, deposit.originChainId)
+  );
 }
 
 export function getAllUnfilledDeposits(

--- a/src/utils/TokenUtils.ts
+++ b/src/utils/TokenUtils.ts
@@ -1,12 +1,29 @@
-import { TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
+import { TOKEN_EQUIVALENCE_REMAPPING, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
 import { constants, utils } from "@across-protocol/sdk";
 import { CONTRACT_ADDRESSES } from "../common";
 import { BigNumberish } from "./BNUtils";
 import { formatUnits } from "./SDKUtils";
+import { HubPoolClient } from "../clients";
+import { isDefined } from "./TypeGuards";
 
 const { ZERO_ADDRESS } = constants;
 
 export const { fetchTokenInfo, getL2TokenAddresses } = utils;
+
+export function getRemoteTokenForL1Token(
+  l1Token: string,
+  chainId: number | string,
+  hubPoolClient: HubPoolClient
+): string | undefined {
+  const tokenMapping = Object.values(TOKEN_SYMBOLS_MAP).find(
+    ({ addresses }) => addresses[hubPoolClient.chainId] === l1Token && isDefined(addresses[chainId])
+  );
+  if (!tokenMapping) {
+    return undefined;
+  }
+  const l1TokenSymbol = TOKEN_EQUIVALENCE_REMAPPING[tokenMapping.symbol] ?? tokenMapping.symbol;
+  return TOKEN_SYMBOLS_MAP[l1TokenSymbol]?.addresses[chainId] ?? tokenMapping.addresses[chainId];
+}
 
 export function getNativeTokenAddressForChain(chainId: number): string {
   return CONTRACT_ADDRESSES[chainId]?.nativeToken?.address ?? ZERO_ADDRESS;

--- a/test/Dataworker.loadData.prefill.ts
+++ b/test/Dataworker.loadData.prefill.ts
@@ -664,7 +664,6 @@ describe("Dataworker: Load bundle data: Pre-fill and Pre-Slow-Fill request logic
         expect(mockDestinationSpokePoolClient.getSlowFillRequestsForOriginChain(originChainId).length).to.equal(1);
 
         const data1 = await dataworkerInstance.clients.bundleDataClient.loadData(bundleBlockRanges, spokePoolClients);
-        console.log(data1);
         expect(data1.bundleSlowFillsV3[destinationChainId][erc20_2.address].length).to.equal(1);
         expect(data1.bundleSlowFillsV3[destinationChainId][erc20_2.address][0].depositId).to.equal(
           request.args.depositId

--- a/test/Dataworker.loadData.prefill.ts
+++ b/test/Dataworker.loadData.prefill.ts
@@ -664,7 +664,7 @@ describe("Dataworker: Load bundle data: Pre-fill and Pre-Slow-Fill request logic
         expect(mockDestinationSpokePoolClient.getSlowFillRequestsForOriginChain(originChainId).length).to.equal(1);
 
         const data1 = await dataworkerInstance.clients.bundleDataClient.loadData(bundleBlockRanges, spokePoolClients);
-        console.log(data1)
+        console.log(data1);
         expect(data1.bundleSlowFillsV3[destinationChainId][erc20_2.address].length).to.equal(1);
         expect(data1.bundleSlowFillsV3[destinationChainId][erc20_2.address][0].depositId).to.equal(
           request.args.depositId

--- a/test/Dataworker.loadData.prefill.ts
+++ b/test/Dataworker.loadData.prefill.ts
@@ -664,6 +664,7 @@ describe("Dataworker: Load bundle data: Pre-fill and Pre-Slow-Fill request logic
         expect(mockDestinationSpokePoolClient.getSlowFillRequestsForOriginChain(originChainId).length).to.equal(1);
 
         const data1 = await dataworkerInstance.clients.bundleDataClient.loadData(bundleBlockRanges, spokePoolClients);
+        console.log(data1)
         expect(data1.bundleSlowFillsV3[destinationChainId][erc20_2.address].length).to.equal(1);
         expect(data1.bundleSlowFillsV3[destinationChainId][erc20_2.address][0].depositId).to.equal(
           request.args.depositId

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -647,6 +647,13 @@ describe("InventoryClient: Refund chain selection", async function () {
       const refundChains = await inventoryClient.determineRefundChainId(sampleDepositData);
       expect(refundChains.length).to.equal(0);
     });
+    it("includes only origin chain repayment chain list", async function () {
+      const possibleRepaymentChains = inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
+      [sampleDepositData.originChainId].forEach((chainId) => {
+        expect(possibleRepaymentChains).to.include(chainId);
+      });
+      expect(possibleRepaymentChains.length).to.equal(1);
+    });
   });
 
   describe("destination token and origin token are both not mapped to a PoolRebalanceRoute", function () {
@@ -687,6 +694,13 @@ describe("InventoryClient: Refund chain selection", async function () {
       tokenClient.setTokenData(ARBITRUM, l2TokensForWeth[ARBITRUM], toWei(10));
       const refundChains = await inventoryClient.determineRefundChainId(sampleDepositData);
       expect(refundChains.length).to.equal(0);
+    });
+    it("includes only origin chain repayment chain list", async function () {
+      const possibleRepaymentChains = inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
+      [sampleDepositData.originChainId].forEach((chainId) => {
+        expect(possibleRepaymentChains).to.include(chainId);
+      });
+      expect(possibleRepaymentChains.length).to.equal(1);
     });
   });
 

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -684,12 +684,10 @@ describe("InventoryClient: Refund chain selection", async function () {
       tokenClient.setTokenData(ARBITRUM, l2TokensForWeth[ARBITRUM], toWei(0));
     });
     it("only origin chain can be repayment chain", async function () {
-      hubPoolClient.deleteTokenMapping(mainnetWeth, POLYGON);
       const refundChains = await inventoryClient.determineRefundChainId(sampleDepositData);
       expect(refundChains).to.deep.equal([POLYGON]);
     });
     it("returns no repayment chains if origin chain is over allocated", async function () {
-      hubPoolClient.deleteTokenMapping(mainnetWeth, POLYGON);
       tokenClient.setTokenData(POLYGON, l2TokensForWeth[POLYGON], toWei(10));
       tokenClient.setTokenData(ARBITRUM, l2TokensForWeth[ARBITRUM], toWei(10));
       const refundChains = await inventoryClient.determineRefundChainId(sampleDepositData);
@@ -701,6 +699,51 @@ describe("InventoryClient: Refund chain selection", async function () {
         expect(possibleRepaymentChains).to.include(chainId);
       });
       expect(possibleRepaymentChains.length).to.equal(1);
+    });
+  });
+
+  describe("destination token is not mapped to a PoolRebalanceRoute", function () {
+    beforeEach(async function () {
+      const inputAmount = toBNWei(1);
+      sampleDepositData = {
+        depositId: bnZero,
+        fromLiteChain: false,
+        toLiteChain: false,
+        originChainId: POLYGON,
+        destinationChainId: ARBITRUM,
+        depositor: owner.address,
+        recipient: owner.address,
+        inputToken: l2TokensForWeth[POLYGON],
+        inputAmount,
+        outputToken: l2TokensForWeth[ARBITRUM],
+        outputAmount: inputAmount,
+        message: "0x",
+        messageHash: "0x",
+        quoteTimestamp: hubPoolClient.currentTime!,
+        fillDeadline: 0,
+        exclusivityDeadline: 0,
+        exclusiveRelayer: ZERO_ADDRESS,
+      };
+      hubPoolClient.deleteTokenMapping(mainnetWeth, ARBITRUM);
+      tokenClient.setTokenData(POLYGON, l2TokensForWeth[POLYGON], toWei(0));
+      tokenClient.setTokenData(ARBITRUM, l2TokensForWeth[ARBITRUM], toWei(0));
+    });
+    it("origin chain and hub chain can be repayment chain", async function () {
+      const refundChains = await inventoryClient.determineRefundChainId(sampleDepositData);
+      expect(refundChains).to.deep.equal([POLYGON, MAINNET]);
+    });
+    it("returns hub chain if origin chain is over allocated", async function () {
+      tokenClient.setTokenData(POLYGON, l2TokensForWeth[POLYGON], toWei(10));
+      const refundChains = await inventoryClient.determineRefundChainId(sampleDepositData);
+      expect(refundChains.length).to.equal(1);
+      expect(refundChains).to.deep.equal([MAINNET]);
+    });
+    it("includes hub chain and origin chain on repayment chain list", async function () {
+      const possibleRepaymentChains = inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
+      [sampleDepositData.originChainId, hubPoolClient.chainId].forEach((chainId) => {
+        expect(possibleRepaymentChains).to.include(chainId);
+      });
+      expect(possibleRepaymentChains.length).to.equal(2);
     });
   });
 

--- a/test/Monitor.ts
+++ b/test/Monitor.ts
@@ -44,6 +44,22 @@ class TestMonitor extends Monitor {
   protected getL2ToL1TokenMap(l1Tokens: L1Token[], chainId): TokenMap {
     return this.overriddenTokenMap[chainId] ?? super.getL2ToL1TokenMap(l1Tokens, chainId);
   }
+
+  getL1TokenInfo(l2Token: string, chainId: number): L1Token {
+    return this.overriddenTokenMap[chainId]
+      ? this.overriddenTokenMap[chainId]?.[l2Token]
+      : super.getL1TokenInfo(l2Token, chainId);
+  }
+
+  getRemoteTokenForL1Token(l1Token: string, chainId: number | string): string | undefined {
+    Object.values(this.overriddenTokenMap).forEach((tokenMap: TokenMap) => {
+      const matchedToken = Object.entries(tokenMap).find(([, l1TokenObject]) => l1TokenObject.address === l1Token);
+      if (matchedToken) {
+        return matchedToken[0];
+      }
+    });
+    return super.getRemoteTokenForL1Token(l1Token, chainId);
+  }
 }
 
 describe("Monitor", async function () {

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -146,7 +146,12 @@ describe("Relayer: Initiates slow fill requests", async function () {
       null,
       mockCrossChainTransferClient
     );
-
+    mockInventoryClient.setTokenMapping({
+      [l1Token.address]: {
+        [originChainId]: erc20_1.address,
+        [destinationChainId]: erc20_2.address,
+      },
+    });
     const chainIds = Object.values(spokePoolClients).map(({ chainId }) => chainId);
     relayerInstance = new Relayer(
       relayer.address,

--- a/test/TokenClient.Approval.ts
+++ b/test/TokenClient.Approval.ts
@@ -1,4 +1,4 @@
-import { ConfigStoreClient, SpokePoolClient, TokenClient } from "../src/clients";
+import { ConfigStoreClient, SpokePoolClient } from "../src/clients";
 import { originChainId, destinationChainId, ZERO_ADDRESS } from "./constants";
 import {
   Contract,
@@ -18,7 +18,7 @@ import {
   winston,
   deployMulticall3,
 } from "./utils";
-import { MockHubPoolClient } from "./mocks";
+import { MockHubPoolClient, SimpleMockTokenClient } from "./mocks";
 
 describe("TokenClient: Origin token approval", async function () {
   let spokePool_1: Contract, spokePool_2: Contract, hubPool: Contract;
@@ -30,7 +30,7 @@ describe("TokenClient: Origin token approval", async function () {
     l1Token_2: Contract;
   let hubPoolClient: MockHubPoolClient, spokePoolClient_1: SpokePoolClient, spokePoolClient_2: SpokePoolClient;
   let owner: SignerWithAddress, spy: sinon.SinonSpy, spyLogger: winston.Logger;
-  let tokenClient: TokenClient; // tested
+  let tokenClient: SimpleMockTokenClient; // tested
   let spokePool1DeploymentBlock: number, spokePool2DeploymentBlock: number;
 
   const updateAllClients = async () => {
@@ -103,7 +103,8 @@ describe("TokenClient: Origin token approval", async function () {
     // Deploy Multicall3 to the hardhat test networks.
     await deployMulticall3(owner);
 
-    tokenClient = new TokenClient(spyLogger, owner.address, spokePoolClients, hubPoolClient);
+    tokenClient = new SimpleMockTokenClient(spyLogger, owner.address, spokePoolClients, hubPoolClient);
+    tokenClient.setRemoteTokens([l1Token_1, l1Token_2, erc20_1, erc20_2, weth_1, weth_2]);
   });
 
   it("Executes expected L2 token approvals and produces logs", async function () {

--- a/test/TokenClient.BalanceAlowance.ts
+++ b/test/TokenClient.BalanceAlowance.ts
@@ -1,6 +1,6 @@
-import { ConfigStoreClient, SpokePoolClient, TokenClient, TokenDataType } from "../src/clients"; // Tested
+import { ConfigStoreClient, SpokePoolClient, TokenDataType } from "../src/clients"; // Tested
 import { originChainId, destinationChainId, ZERO_ADDRESS } from "./constants";
-import { MockHubPoolClient } from "./mocks";
+import { MockHubPoolClient, SimpleMockTokenClient } from "./mocks";
 import {
   Contract,
   SignerWithAddress,
@@ -21,7 +21,7 @@ describe("TokenClient: Balance and Allowance", async function () {
   let erc20_1: Contract, weth_1: Contract, erc20_2: Contract, weth_2: Contract;
   let hubPoolClient: MockHubPoolClient, spokePoolClient_1: SpokePoolClient, spokePoolClient_2: SpokePoolClient;
   let owner: SignerWithAddress, spyLogger: winston.Logger;
-  let tokenClient: TokenClient; // tested
+  let tokenClient: SimpleMockTokenClient; // tested
   let spokePool1DeploymentBlock: number, spokePool2DeploymentBlock: number;
 
   const updateAllClients = async () => {
@@ -104,7 +104,11 @@ describe("TokenClient: Balance and Allowance", async function () {
     // Deploy Multicall3 to the hardhat test networks.
     await deployMulticall3(owner);
 
-    tokenClient = new TokenClient(spyLogger, owner.address, spokePoolClients, hubPoolClient);
+    tokenClient = new SimpleMockTokenClient(spyLogger, owner.address, spokePoolClients, hubPoolClient);
+    tokenClient.setRemoteTokens([], {
+      [originChainId]: [erc20_1, weth_1],
+      [destinationChainId]: [erc20_2, weth_2],
+    });
   });
 
   it("Fetches all associated balances", async function () {

--- a/test/TokenClient.TokenShortfall.ts
+++ b/test/TokenClient.TokenShortfall.ts
@@ -1,5 +1,5 @@
-import { SpokePoolClient, TokenClient } from "../src/clients";
-import { MockConfigStoreClient, MockHubPoolClient } from "./mocks";
+import { SpokePoolClient } from "../src/clients";
+import { MockConfigStoreClient, MockHubPoolClient, SimpleMockTokenClient } from "./mocks";
 import { originChainId, destinationChainId, ZERO_ADDRESS } from "./constants";
 import {
   BigNumber,
@@ -21,7 +21,7 @@ describe("TokenClient: Token shortfall", async function () {
   let erc20_2: Contract;
   let spokePoolClient_1: SpokePoolClient, spokePoolClient_2: SpokePoolClient;
   let owner: SignerWithAddress, spyLogger: winston.Logger;
-  let tokenClient: TokenClient; // tested
+  let tokenClient: SimpleMockTokenClient; // tested
   let spokePool1DeploymentBlock: number, spokePool2DeploymentBlock: number;
 
   const updateAllClients = async () => {
@@ -76,7 +76,8 @@ describe("TokenClient: Token shortfall", async function () {
     // Deploy Multicall3 to the hardhat test networks.
     await deployMulticall3(owner);
 
-    tokenClient = new TokenClient(spyLogger, owner.address, spokePoolClients, hubPoolClient);
+    tokenClient = new SimpleMockTokenClient(spyLogger, owner.address, spokePoolClients, hubPoolClient);
+    tokenClient.setRemoteTokens([l1Token_1, erc20_2]);
   });
 
   it("Captures and tracks token shortfall", async function () {

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -32,6 +32,7 @@ import { DataworkerClients } from "../../src/dataworker/DataworkerClientHelper";
 import { MockConfigStoreClient, MockedMultiCallerClient, SimpleMockHubPoolClient } from "../mocks";
 import { EthersTestLibrary } from "../types";
 import { clients as sdkClients } from "@across-protocol/sdk";
+import { MockDataworker } from "../mocks/MockDataworker";
 
 export { DataworkerConfig } from "../../src/dataworker/DataworkerConfig";
 
@@ -236,7 +237,7 @@ export async function setupDataworker(
     configStoreClient: configStoreClient as unknown as sdkClients.AcrossConfigStoreClient,
     priceClient,
   };
-  const dataworkerInstance = new Dataworker(
+  const dataworkerInstance = new MockDataworker(
     spyLogger,
     {} as DataworkerConfig,
     dataworkerClients,
@@ -244,6 +245,21 @@ export async function setupDataworker(
     maxRefundPerRelayerRefundLeaf,
     maxL1TokensPerPoolRebalanceLeaf
   );
+  dataworkerInstance.setTokenMap(originChainId, erc20_1.address, {
+    address: l1Token_1.address,
+    symbol: "TEST",
+    decimals: 18,
+  });
+  dataworkerInstance.setTokenMap(destinationChainId, erc20_2.address, {
+    address: l1Token_1.address,
+    symbol: "TEST",
+    decimals: 18,
+  });
+  dataworkerInstance.setTokenMap(hubPoolChainId, l1Token_1.address, {
+    address: l1Token_1.address,
+    symbol: "TEST",
+    decimals: 18,
+  });
 
   // Give owner tokens to LP on HubPool with.
   await setupTokensForWallet(spokePool_1, owner, [l1Token_1, l1Token_2], undefined, 100); // Seed owner to LP.

--- a/test/generic-adapters/AdapterManager.SendTokensCrossChain.ts
+++ b/test/generic-adapters/AdapterManager.SendTokensCrossChain.ts
@@ -95,19 +95,6 @@ describe("AdapterManager: Send tokens cross-chain", async function () {
       thrown1 = true;
     }
     expect(thrown1).to.be.equal(true);
-
-    // Throws if there is a misconfiguration between L1 tokens and L2 tokens. This checks that the bot will error out
-    // if it tries to delete money in the bridge. configure hubpool to return the wrong token for Optimism
-
-    // bad config. map USDC on L1 to Arbitrum on L2. This is WRONG for chainID 10 and should error.
-    hubPoolClient.setTokenMapping(mainnetTokens["usdc"], 10, getL2TokenAddresses(mainnetTokens["usdc"])[42161]);
-    let thrown2 = false;
-    try {
-      await adapterManager.sendTokenCrossChain(relayer.address, CHAIN_IDs.OPTIMISM, mainnetTokens.usdc, amountToSend);
-    } catch (error) {
-      thrown2 = true;
-    }
-    expect(thrown2).to.be.equal(true);
   });
   it("Correctly sends tokens to chain: Optimism", async function () {
     const chainId = CHAIN_IDs.OPTIMISM;

--- a/test/mocks/MockDataworker.ts
+++ b/test/mocks/MockDataworker.ts
@@ -1,0 +1,44 @@
+import { Dataworker } from "../../src/dataworker/Dataworker";
+import { DataworkerClients } from "../../src/dataworker/DataworkerClientHelper";
+import { DataworkerConfig } from "../../src/dataworker/DataworkerConfig";
+import { L1Token } from "../../src/interfaces";
+import { winston } from "../../src/utils";
+
+export class MockDataworker extends Dataworker {
+  private tokenMap: { [chainId: number]: { [token: string]: L1Token } } = {};
+  constructor(
+    logger: winston.Logger,
+    config: DataworkerConfig,
+    clients: DataworkerClients,
+    chainIdListForBundleEvaluationBlockNumbers: number[],
+    maxRefundCountOverride: number | undefined,
+    maxL1TokenCountOverride: number | undefined,
+    spokeRootsLookbackCount = 0,
+    bufferToPropose = 0,
+    forceProposal = false,
+    forceBundleRange?: [number, number][]
+  ) {
+    super(
+      logger,
+      config,
+      clients,
+      chainIdListForBundleEvaluationBlockNumbers,
+      maxRefundCountOverride,
+      maxL1TokenCountOverride,
+      spokeRootsLookbackCount,
+      bufferToPropose,
+      forceProposal,
+      forceBundleRange
+    );
+  }
+
+  setTokenMap(chainId: number, token: string, tokenInfo: L1Token): void {
+    if (!this.tokenMap[chainId]) {
+      this.tokenMap[chainId] = {};
+    }
+    this.tokenMap[chainId][token] = tokenInfo;
+  }
+  override getL1TokenInfo(l2Token: string, chainId: number): L1Token {
+    return this.tokenMap[chainId]?.[l2Token] ?? super.getL1TokenInfo(l2Token, chainId);
+  }
+}

--- a/test/mocks/MockHubPoolClient.ts
+++ b/test/mocks/MockHubPoolClient.ts
@@ -66,9 +66,9 @@ export class MockHubPoolClient extends clients.mocks.MockHubPoolClient {
     return this.enableAllL2Tokens;
   }
 
-  l2TokenHasPoolRebalanceRoute(l2Token: string, l2ChainId: number): boolean {
+  l2TokenHasPoolRebalanceRoute(l2Token: string, l2ChainId: number, hubPoolBlock: number): boolean {
     if (this.enableAllL2Tokens === undefined) {
-      return super.l2TokenHasPoolRebalanceRoute(l2Token, l2ChainId);
+      return super.l2TokenHasPoolRebalanceRoute(l2Token, l2ChainId, hubPoolBlock);
     }
     return this.enableAllL2Tokens;
   }

--- a/test/mocks/MockInventoryClient.ts
+++ b/test/mocks/MockInventoryClient.ts
@@ -1,13 +1,16 @@
-import { Deposit, InventoryConfig } from "../../src/interfaces";
+import { Deposit, InventoryConfig, L1Token } from "../../src/interfaces";
 import { BundleDataClient, HubPoolClient, InventoryClient, Rebalance, TokenClient } from "../../src/clients";
 import { AdapterManager, CrossChainTransferClient } from "../../src/clients/bridges";
-import { BigNumber, bnZero } from "../../src/utils";
+import { BigNumber } from "../../src/utils";
 import winston from "winston";
 
+type TokenMapping = { [l1Token: string]: { [chainId: number]: string } };
 export class MockInventoryClient extends InventoryClient {
   possibleRebalances: Rebalance[] = [];
-  balanceOnChain: BigNumber | undefined = bnZero;
+  balanceOnChain: BigNumber | undefined = undefined;
   excessRunningBalancePcts: { [l1Token: string]: { [chainId: number]: BigNumber } } = {};
+  l1Token: string | undefined = undefined;
+  tokenMappings: TokenMapping | undefined = undefined;
 
   constructor(
     relayer: string | null = null,
@@ -18,7 +21,9 @@ export class MockInventoryClient extends InventoryClient {
     hubPoolClient: HubPoolClient | null = null,
     bundleDataClient: BundleDataClient | null = null,
     adapterManager: AdapterManager | null = null,
-    crossChainTransferClient: CrossChainTransferClient | null = null
+    crossChainTransferClient: CrossChainTransferClient | null = null,
+    simMode = false,
+    prioritizeLpUtilization = false
   ) {
     super(
       relayer, // relayer
@@ -29,7 +34,9 @@ export class MockInventoryClient extends InventoryClient {
       hubPoolClient, // hubPoolClient
       bundleDataClient, // bundleDataClient
       adapterManager, // adapter manager
-      crossChainTransferClient
+      crossChainTransferClient,
+      simMode, // sim mode
+      prioritizeLpUtilization // prioritize lp utilization
     );
   }
 
@@ -64,5 +71,33 @@ export class MockInventoryClient extends InventoryClient {
 
   override getBalanceOnChain(chainId: number, l1Token: string, l2Token?: string): BigNumber {
     return this.balanceOnChain ?? super.getBalanceOnChain(chainId, l1Token, l2Token);
+  }
+
+  setTokenMapping(tokenMapping: TokenMapping): void {
+    this.tokenMappings = tokenMapping;
+  }
+
+  override getRemoteTokenForL1Token(l1Token: string, chainId: number | string): string | undefined {
+    if (this.tokenMappings) {
+      const tokenMapping = Object.values(this.tokenMappings).find((mapping) => mapping[l1Token]);
+      if (tokenMapping) {
+        return tokenMapping[l1Token][chainId];
+      }
+    }
+    return super.getRemoteTokenForL1Token(l1Token, chainId);
+  }
+
+  override getL1TokenInfo(l2Token: string, chainId: number): L1Token {
+    if (this.tokenMappings) {
+      const tokenMapping = Object.entries(this.tokenMappings).find(([, mapping]) => mapping[chainId] === l2Token);
+      if (tokenMapping) {
+        return {
+          address: tokenMapping[0],
+          symbol: "TEST",
+          decimals: 18,
+        };
+      }
+    }
+    return super.getL1TokenInfo(l2Token, chainId);
   }
 }

--- a/test/mocks/MockTokenClient.ts
+++ b/test/mocks/MockTokenClient.ts
@@ -55,12 +55,19 @@ export class MockTokenClient extends TokenClient {
 
 export class SimpleMockTokenClient extends TokenClient {
   private tokenContracts: Contract[] | undefined = undefined;
+  private remoteTokenContracts: { [chainId: number]: Contract[] } | undefined = {};
 
-  setRemoteTokens(tokens: Contract[]): void {
+  setRemoteTokens(tokens: Contract[], remoteTokenContracts?: { [chainId: number]: Contract[] }): void {
     this.tokenContracts = tokens;
+    if (remoteTokenContracts) {
+      this.remoteTokenContracts = remoteTokenContracts;
+    }
   }
 
   resolveRemoteTokens(chainId: number, hubPoolTokens: L1Token[]): Contract[] {
+    if (this.remoteTokenContracts?.[chainId]) {
+      return this.remoteTokenContracts[chainId];
+    }
     if (this.tokenContracts) {
       return this.tokenContracts;
     }

--- a/test/mocks/MockTokenClient.ts
+++ b/test/mocks/MockTokenClient.ts
@@ -1,5 +1,6 @@
-import { BigNumber, toBN } from "../../src/utils";
+import { BigNumber, Contract, toBN } from "../../src/utils";
 import { TokenClient } from "../../src/clients";
+import { L1Token } from "../../src/interfaces";
 
 export class MockTokenClient extends TokenClient {
   public override tokenData: { [chainId: number]: { [token: string]: { balance: BigNumber; allowance: BigNumber } } } =
@@ -49,5 +50,20 @@ export class MockTokenClient extends TokenClient {
       this.tokenData[chainId][token] = { balance: toBN(0), allowance: toBN(0) };
     }
     this.tokenData[chainId][token].balance = this.tokenData[chainId][token].balance.sub(amount);
+  }
+}
+
+export class SimpleMockTokenClient extends TokenClient {
+  private tokenContracts: Contract[] | undefined = undefined;
+
+  setRemoteTokens(tokens: Contract[]): void {
+    this.tokenContracts = tokens;
+  }
+
+  resolveRemoteTokens(chainId: number, hubPoolTokens: L1Token[]): Contract[] {
+    if (this.tokenContracts) {
+      return this.tokenContracts;
+    }
+    return super.resolveRemoteTokens(chainId, hubPoolTokens);
   }
 }


### PR DESCRIPTION
## Relayer and InventoryClient changes

If a deposit's inputToken is not mapped to a PoolRebalanceRoute mapping then the fill must take repayment on origin chain, which is similar to a lite chain deposit.

There is a lot of logic in the Relayer and InventoryClient that deals with lite chain deposits that should therefore also apply to these "forced origin chain repayment" deposits.

## Replacing token equivalency mapping lookups

Additionally, this PR replaces more token matching lookups via PoolRebalanceRoute events with looking up in the TOKEN_SYMBOLS_MAP constants file. This is required to make all bots be able to support deposited tokens that do not map to any L1 token via PoolRebalanceRoutes
