### PR TITLE
fix(Monitor): Report should unify ETH balances under WETH

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -552,7 +552,7 @@ export class ProfitClient {
     // Note: we should batch these up and log them all at once to avoid spamming the logs.
     const unknownTokens = this.hubPoolClient
       .getL1Tokens()
-      .filter(({ symbol }) => !isDefined(TOKEN_SYMBOLS_MAP[symbol]));
+      .filter(({ symbol }) => !isDefined(TOKEN_SYMBOLS_MAP[symbol]) && !isDefined(TOKEN_EQUIVALENCE_REMAPPING[symbol]));
     if (unknownTokens.length > 0) {
       this.logger.debug({
         at: "ProfitClient#updateTokenPrices",


### PR DESCRIPTION
See comment in PR explaining the fix:

```
 // WETH is the symbol that `getL1TokenInfo()` will return for WETH on Mainnet but ETH is what
// it will return for a non-Mainnet chain, so unify the symbols. This is because TOKEN_SYMBOLS_MAP
// defines both an ETH and WETH mapping that both reference "WETH" addresses but the ETH mapping comes first.
```

The issue stems from 1b0bed4dae8303b93bd43865d6f379e8d22657e4 where we now load token infos from the TOKEN_SYMBOLS_MAP for all L2 tokens or via the HubPoolClient for L1 tokens. This is necessary because L2 tokens might share the same L1 token despite having different symbols and decimals so we opt to read symbol and decimals for L1 tokens directly from on-chain. This does mean that whereas an L2 token address can load the "ETH" mapping from TOKEN_SYMBOLS_MAP, we are loading the equivalent "WETH" symbol from on-chain.
