### PR TITLE
refactor: allow L2 withdraw transaction construction to be async

### DIFF
--- a/src/adapter/BaseChainAdapter.ts
+++ b/src/adapter/BaseChainAdapter.ts
@@ -195,7 +195,12 @@ export class BaseChainAdapter {
     if (!this.isSupportedL2Bridge(l1TokenInfo.address)) {
       return [];
     }
-    const txnsToSend = this.l2Bridges[l1TokenInfo.address].constructWithdrawToL1Txns(address, l2Token, l1Token, amount);
+    const txnsToSend = await this.l2Bridges[l1TokenInfo.address].constructWithdrawToL1Txns(
+      address,
+      l2Token,
+      l1Token,
+      amount
+    );
     const multicallerClient = new MultiCallerClient(this.logger);
     txnsToSend.forEach((txn) => multicallerClient.enqueueTransaction(txn));
     const txnReceipts = await multicallerClient.executeTxnQueues(simMode);

--- a/src/adapter/l2Bridges/ArbitrumOrbitBridge.ts
+++ b/src/adapter/l2Bridges/ArbitrumOrbitBridge.ts
@@ -47,7 +47,7 @@ export class ArbitrumOrbitBridge extends BaseL2BridgeAdapter {
     l2Token: EvmAddress,
     _l1Token: EvmAddress,
     amount: BigNumber
-  ): AugmentedTransaction[] {
+  ): Promise<AugmentedTransaction[]> {
     const l1TokenInfo = getL1TokenInfo(l2Token.toAddress(), this.l2chainId);
     const formatter = createFormatFunction(2, 4, false, l1TokenInfo.decimals);
     const withdrawTxn: AugmentedTransaction = {
@@ -66,7 +66,7 @@ export class ArbitrumOrbitBridge extends BaseL2BridgeAdapter {
         this.l2chainId
       )} to L1`,
     };
-    return [withdrawTxn];
+    return Promise.resolve([withdrawTxn]);
   }
 
   async getL2PendingWithdrawalAmount(

--- a/src/adapter/l2Bridges/BaseL2BridgeAdapter.ts
+++ b/src/adapter/l2Bridges/BaseL2BridgeAdapter.ts
@@ -18,7 +18,7 @@ export abstract class BaseL2BridgeAdapter {
     l2Token: Address,
     l1Token: EvmAddress,
     amount: BigNumber
-  ): AugmentedTransaction[];
+  ): Promise<AugmentedTransaction[]>;
 
   abstract getL2PendingWithdrawalAmount(
     l2EventSearchConfig: EventSearchConfig,

--- a/src/adapter/l2Bridges/OpStackBridge.ts
+++ b/src/adapter/l2Bridges/OpStackBridge.ts
@@ -38,7 +38,7 @@ export class OpStackBridge extends BaseL2BridgeAdapter {
     l2Token: EvmAddress,
     l1Token: EvmAddress,
     amount: BigNumber
-  ): AugmentedTransaction[] {
+  ): Promise<AugmentedTransaction[]> {
     const l1TokenInfo = getL1TokenInfo(l2Token.toAddress(), this.l2chainId);
     const formatter = createFormatFunction(2, 4, false, l1TokenInfo.decimals);
     const withdrawTxn: AugmentedTransaction = {
@@ -60,7 +60,7 @@ export class OpStackBridge extends BaseL2BridgeAdapter {
       message: "🎰 Withdrew OpStack ERC20 to L1",
       mrkdwn: `Withdrew ${formatter(amount.toString())} ${l1TokenInfo.symbol} ${getNetworkName(this.l2chainId)} to L1`,
     };
-    return [withdrawTxn];
+    return Promise.resolve([withdrawTxn]);
   }
 
   async getL2PendingWithdrawalAmount(

--- a/src/adapter/l2Bridges/OpStackWethBridge.ts
+++ b/src/adapter/l2Bridges/OpStackWethBridge.ts
@@ -39,7 +39,7 @@ export class OpStackWethBridge extends BaseL2BridgeAdapter {
     l2Token: EvmAddress,
     _l1Token: EvmAddress,
     amount: BigNumber
-  ): AugmentedTransaction[] {
+  ): Promise<AugmentedTransaction[]> {
     const weth = new Contract(l2Token.toAddress(), WETH_ABI, this.l2Signer);
     const l1TokenInfo = getL1TokenInfo(l2Token.toAddress(), this.l2chainId);
     const formatter = createFormatFunction(2, 4, false, l1TokenInfo.decimals);
@@ -72,7 +72,7 @@ export class OpStackWethBridge extends BaseL2BridgeAdapter {
         this.l2chainId
       )} to L1`,
     };
-    return [unwrapTxn, withdrawTxn];
+    return Promise.resolve([unwrapTxn, withdrawTxn]);
   }
 
   async getL2PendingWithdrawalAmount(


### PR DESCRIPTION
Small refactor to the `BaseL2Bridge` interface to have `constructWithdrawToL1Txns` return a promise, which allows the function to be async. It needs to be async since the Binance L2 bridge will need to first query an API to get a withdrawal address.