### PR TITLE
fix(ZkStackBridge): Fix getOutstandingTransfers

### DIFF
--- a/src/adapter/bridges/ZKStackBridge.ts
+++ b/src/adapter/bridges/ZKStackBridge.ts
@@ -169,6 +169,13 @@ export class ZKStackBridge extends BaseBridgeAdapter {
               compareAddressesSimple(e.args.l1Token, l1Token.toAddress())
           )
           .map((e) => processEvent(e, "amount"));
+      } else if (toAddress.toAddress() === this.hubPool.address) {
+        // If the recipient is not an L2 contract, then we should ignore any events where the sender is the HubPool,
+        // because the only deposits that we care about that send to a contract are from the HubPool, and we're
+        // already tracking that above in the `isL2Contract` case. This case is important because we know the monitor
+        // might set the from and to addresses to the same address, and we don't want to double count Hub->Spoke
+        // transfers.
+        processedEvents = [];
       } else {
         const rawEvents = await paginatedEventQuery(
           this.sharedBridge,
@@ -200,17 +207,11 @@ export class ZKStackBridge extends BaseBridgeAdapter {
       if (assetId === ZERO_BYTES) {
         throw new Error(`Undefined assetId for L2 token ${l2Token}`);
       }
-      const events = isSpokePool
-        ? await paginatedEventQuery(
-            this.getL2Bridge(),
-            this.getL2Bridge().filters.BridgeMint(this.hubChainId, assetId),
-            eventConfig
-          )
-        : await paginatedEventQuery(
-            this.getL2Bridge(),
-            this.getL2Bridge().filters.BridgeMint(this.hubChainId, assetId),
-            eventConfig
-          );
+      const events = await paginatedEventQuery(
+        this.getL2Bridge(),
+        this.getL2Bridge().filters.BridgeMint(this.hubChainId, assetId),
+        eventConfig
+      );
       processedEvents = events
         .filter((event) => compareAddressesSimple(event.args.receiver, toAddress.toAddress()))
         .map((event) => processEvent(event, "amount"));


### PR DESCRIPTION
We are double counting Hub->Spoke transfers because of the way the monitor works.

The `BaseChainAdapter` queries L1 and L2 events for each address passed into it by setting the `fromAddress` and `toAddress` [equal to each other](https://github.com/across-protocol/relayer/blob/0e8b9c143a477d409191c72ccfb8cf9314d03a65/src/adapter/BaseChainAdapter.ts#L356). This works great when tracking EOA transfers but not when sending transfers from Hub to Spoke.

Therefore, each adapter must handle this case and not double count such transfers. The ZkStackBridge is correctly tracking when the `from` and `to` addresses are set to the SpokePool, but not when they are set to the HubPool. When the `from` and `to` address is set to the HubPool, then `queryL1BridgeInitiationEvents` is returning some events but `queryL2BridgeFinalizationEvents` is returning nothing, leading the monitor to think there are outstanding transfers.
