### PR TITLE
improve: use token symbols map over hub pool client for rebalancing

### DIFF
--- a/src/clients/bridges/AdapterManager.ts
+++ b/src/clients/bridges/AdapterManager.ts
@@ -22,6 +22,7 @@ import {
   toAddressType,
   TOKEN_EQUIVALENCE_REMAPPING,
   getRemoteTokenForL1Token,
+  getTokenInfo,
 } from "../../utils";
 import { SpokePoolClient, HubPoolClient } from "../";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
@@ -134,7 +135,7 @@ export class AdapterManager {
     const adapter = this.adapters[chainId];
     // @dev The adapter should filter out tokens that are not supported by the adapter, but we do it here as well.
     const adapterSupportedL1Tokens = l1Tokens.filter((token) => {
-      const tokenSymbol = this.hubPoolClient.getTokenInfoForL1Token(token).symbol;
+      const tokenSymbol = getTokenInfo(token, this.hubPoolClient.chainId).symbol;
       return (
         adapter.supportedTokens.includes(tokenSymbol) ||
         adapter.supportedTokens.includes(TOKEN_EQUIVALENCE_REMAPPING[tokenSymbol])

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -20,6 +20,7 @@ import {
   _buildPoolRebalanceRoot,
   ERC20,
   getL1TokenInfo,
+  getTokenInfo,
 } from "../utils";
 import {
   ProposedRootBundle,
@@ -2185,7 +2186,7 @@ export class Dataworker {
 
   protected getL1TokenInfo(l2Token: string, chainId: number): L1Token {
     return chainId === this.clients.hubPoolClient.chainId
-      ? this.clients.hubPoolClient.getTokenInfoForL1Token(l2Token)
+      ? getTokenInfo(l2Token, chainId)
       : getL1TokenInfo(l2Token, chainId);
   }
 

--- a/src/finalizer/utils/linea/common.ts
+++ b/src/finalizer/utils/linea/common.ts
@@ -14,6 +14,7 @@ import {
   getRedisCache,
   paginatedEventQuery,
   CHAIN_IDs,
+  getTokenInfo,
 } from "../../../utils";
 import { HubPoolClient } from "../../../clients";
 import { CONTRACT_ADDRESSES } from "../../../common";
@@ -226,7 +227,7 @@ export function determineMessageType(
     );
     const decoded = contractInterface.decodeFunctionData("completeBridging", _calldata);
     // If we've made it this far, then the calldata is a valid TokenBridge calldata.
-    const token = hubPoolClient.getTokenInfoForL1Token(decoded._nativeToken);
+    const token = getTokenInfo(decoded._nativeToken, hubPoolClient.chainId);
     return {
       type: "bridge",
       l1TokenSymbol: token.symbol,

--- a/src/finalizer/utils/linea/l1ToL2.ts
+++ b/src/finalizer/utils/linea/l1ToL2.ts
@@ -4,7 +4,16 @@ import { Contract } from "ethers";
 import { groupBy } from "lodash";
 import { HubPoolClient, SpokePoolClient } from "../../../clients";
 import { CONTRACT_ADDRESSES } from "../../../common";
-import { EventSearchConfig, Signer, convertFromWei, winston, CHAIN_IDs, ethers, BigNumber } from "../../../utils";
+import {
+  EventSearchConfig,
+  Signer,
+  convertFromWei,
+  winston,
+  CHAIN_IDs,
+  ethers,
+  BigNumber,
+  getTokenInfo,
+} from "../../../utils";
 import { CrossChainMessage, FinalizerPromise } from "../../types";
 import {
   determineMessageType,
@@ -144,7 +153,7 @@ export async function lineaL1ToL2Finalizer(
         miscReason: "lineaClaim:relayMessage",
       };
     } else {
-      const { decimals, symbol: l1TokenSymbol } = hubPoolClient.getTokenInfoForL1Token(messageType.l1TokenAddress);
+      const { decimals, symbol: l1TokenSymbol } = getTokenInfo(messageType.l1TokenAddress, l1ChainId);
       const amountFromWei = convertFromWei(messageType.amount.toString(), decimals);
       crossChainCall = {
         originationChainId: l1ChainId,

--- a/src/finalizer/utils/scroll.ts
+++ b/src/finalizer/utils/scroll.ts
@@ -12,6 +12,7 @@ import {
   Multicall2Call,
   winston,
   convertFromWei,
+  getTokenInfo,
 } from "../../utils";
 import { FinalizerPromise, CrossChainMessage } from "../types";
 
@@ -172,7 +173,7 @@ function populateClaimWithdrawal(
   l2ChainId: number,
   hubPoolClient: HubPoolClient
 ): CrossChainMessage {
-  const l1Token = hubPoolClient.getTokenInfoForL1Token(claim.l1Token);
+  const l1Token = getTokenInfo(claim.l1Token, hubPoolClient.chainId);
   return {
     originationChainId: l2ChainId,
     l1TokenSymbol: l1Token.symbol,

--- a/src/utils/SDKUtils.ts
+++ b/src/utils/SDKUtils.ts
@@ -68,6 +68,7 @@ export const {
   toBytes32,
   validateFillForDeposit,
   toAddressType,
+  getTokenInfo,
 } = sdk.utils;
 
 export const {


### PR DESCRIPTION
We will need to rebalance tokens which are not enabled for liquidity provision, so the inventory client and adapter manager should not use the hub pool client to resolve L1 token information. They should instead use `TOKEN_SYMBOLS_MAP.` This is safe since all calls use an L1 token as input, and `getTokenInfo` has a specific block of code [here](https://github.com/across-protocol/sdk/blob/4b856bdd2cf4020ea1dde286048afe83d2d1648a/src/utils/TokenUtils.ts#L114) which ensures that if there are many L1 definitions for a token, we will use the remapped symbol when resolving token information. 