### PR TITLE
improve: Replace hubPoolClient.getL1TokenInfo calls where input is not a guaranteed LP token

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -20,6 +20,7 @@ import {
   _buildPoolRebalanceRoot,
   ERC20,
   getL1TokenInfo,
+  getTokenInfo,
 } from "../utils";
 import {
   ProposedRootBundle,
@@ -2185,7 +2186,7 @@ export class Dataworker {
 
   protected getL1TokenInfo(l2Token: string, chainId: number): L1Token {
     return chainId === this.clients.hubPoolClient.chainId
-      ? this.clients.hubPoolClient.getTokenInfoForL1Token(l2Token)
+      ? getTokenInfo(l2Token, chainId)
       : getL1TokenInfo(l2Token, chainId);
   }
 

--- a/src/finalizer/utils/linea/common.ts
+++ b/src/finalizer/utils/linea/common.ts
@@ -14,6 +14,7 @@ import {
   getRedisCache,
   paginatedEventQuery,
   CHAIN_IDs,
+  getTokenInfo,
 } from "../../../utils";
 import { HubPoolClient } from "../../../clients";
 import { CONTRACT_ADDRESSES } from "../../../common";
@@ -226,7 +227,7 @@ export function determineMessageType(
     );
     const decoded = contractInterface.decodeFunctionData("completeBridging", _calldata);
     // If we've made it this far, then the calldata is a valid TokenBridge calldata.
-    const token = hubPoolClient.getTokenInfoForL1Token(decoded._nativeToken);
+    const token = getTokenInfo(decoded._nativeToken, hubPoolClient.chainId);
     return {
       type: "bridge",
       l1TokenSymbol: token.symbol,

--- a/src/finalizer/utils/linea/l1ToL2.ts
+++ b/src/finalizer/utils/linea/l1ToL2.ts
@@ -4,7 +4,16 @@ import { Contract } from "ethers";
 import { groupBy } from "lodash";
 import { HubPoolClient, SpokePoolClient } from "../../../clients";
 import { CONTRACT_ADDRESSES } from "../../../common";
-import { EventSearchConfig, Signer, convertFromWei, winston, CHAIN_IDs, ethers, BigNumber, getTokenInfo } from "../../../utils";
+import {
+  EventSearchConfig,
+  Signer,
+  convertFromWei,
+  winston,
+  CHAIN_IDs,
+  ethers,
+  BigNumber,
+  getTokenInfo,
+} from "../../../utils";
 import { CrossChainMessage, FinalizerPromise } from "../../types";
 import {
   determineMessageType,

--- a/src/finalizer/utils/linea/l1ToL2.ts
+++ b/src/finalizer/utils/linea/l1ToL2.ts
@@ -4,7 +4,7 @@ import { Contract } from "ethers";
 import { groupBy } from "lodash";
 import { HubPoolClient, SpokePoolClient } from "../../../clients";
 import { CONTRACT_ADDRESSES } from "../../../common";
-import { EventSearchConfig, Signer, convertFromWei, winston, CHAIN_IDs, ethers, BigNumber } from "../../../utils";
+import { EventSearchConfig, Signer, convertFromWei, winston, CHAIN_IDs, ethers, BigNumber, getTokenInfo } from "../../../utils";
 import { CrossChainMessage, FinalizerPromise } from "../../types";
 import {
   determineMessageType,
@@ -144,7 +144,7 @@ export async function lineaL1ToL2Finalizer(
         miscReason: "lineaClaim:relayMessage",
       };
     } else {
-      const { decimals, symbol: l1TokenSymbol } = hubPoolClient.getTokenInfoForL1Token(messageType.l1TokenAddress);
+      const { decimals, symbol: l1TokenSymbol } = getTokenInfo(messageType.l1TokenAddress, l1ChainId);
       const amountFromWei = convertFromWei(messageType.amount.toString(), decimals);
       crossChainCall = {
         originationChainId: l1ChainId,

--- a/src/finalizer/utils/scroll.ts
+++ b/src/finalizer/utils/scroll.ts
@@ -12,6 +12,7 @@ import {
   Multicall2Call,
   winston,
   convertFromWei,
+  getTokenInfo,
 } from "../../utils";
 import { FinalizerPromise, CrossChainMessage } from "../types";
 
@@ -172,7 +173,7 @@ function populateClaimWithdrawal(
   l2ChainId: number,
   hubPoolClient: HubPoolClient
 ): CrossChainMessage {
-  const l1Token = hubPoolClient.getTokenInfoForL1Token(claim.l1Token);
+  const l1Token = getTokenInfo(claim.l1Token, hubPoolClient.chainId);
   return {
     originationChainId: l2ChainId,
     l1TokenSymbol: l1Token.symbol,


### PR DESCRIPTION


follow up to https://github.com/across-protocol/relayer/pull/2209/files