### PR TITLE
fix: re-map BNB in the finalizer, not in the adapter

### DIFF
--- a/src/adapter/bridges/BinanceCEXBridge.ts
+++ b/src/adapter/bridges/BinanceCEXBridge.ts
@@ -22,7 +22,6 @@ import ERC20_ABI from "../../common/abi/MinimalERC20.json";
 export class BinanceCEXBridge extends BaseBridgeAdapter {
   private readonly binanceApiClient;
   private readonly tokenSymbol: string;
-  private readonly tokenDecimals: number;
 
   constructor(
     l2chainId: number,

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -329,7 +329,7 @@ export const SUPPORTED_TOKENS: { [chainId: number]: string[] } = {
   [CHAIN_IDs.ARBITRUM]: ["USDC", "USDT", "WETH", "DAI", "WBTC", "UMA", "BAL", "ACX", "POOL"],
   [CHAIN_IDs.BASE]: ["BAL", "DAI", "ETH", "WETH", "USDC", "POOL"],
   [CHAIN_IDs.BLAST]: ["DAI", "WBTC", "WETH"],
-  [CHAIN_IDs.BSC]: ["CAKE", "BNB", "USDC", "USDT"],
+  [CHAIN_IDs.BSC]: ["CAKE", "WBNB", "USDC", "USDT"],
   [CHAIN_IDs.UNICHAIN]: ["ETH", "WETH", "USDC"],
   [CHAIN_IDs.INK]: ["ETH", "WETH"],
   [CHAIN_IDs.LENS]: ["WETH", "WGHO"],

--- a/src/finalizer/utils/binance/l1ToL2.ts
+++ b/src/finalizer/utils/binance/l1ToL2.ts
@@ -62,7 +62,9 @@ export async function binanceL1ToL2Finalizer(
     }
 
     // The inner loop finalizes all deposits for all supported tokens for the address.
-    await mapAsync(SUPPORTED_TOKENS[chainId], async (symbol) => {
+    await mapAsync(SUPPORTED_TOKENS[chainId], async (_symbol) => {
+      // An exception for L1 to L2 is WBNB, which we must re-map to BNB.
+      const symbol = _symbol === "WBNB" ? "BNB" : _symbol;
       const coin = accountCoins.find((coin) => coin.symbol === symbol);
       const networkLimits = coin.networkList.find((network) => network.name === "BSC");
       const l1Token = TOKEN_SYMBOLS_MAP[symbol].addresses[hubChainId];


### PR DESCRIPTION
The BaseChainAdapter will not get outstanding transfers if the L1Token to query is not in `SUPPORTED_TOKENS` (see `SUPPORTED_TOKENS`[here](https://github.com/across-protocol/relayer/blob/8dc44a1600d51920e8bfa5eef61d6d172743bcf4/src/adapter/BaseChainAdapter.ts#L107 ). Our `SUPPORTED_TOKENS` had a `BNB` [entry](https://github.com/across-protocol/relayer/blob/8dc44a1600d51920e8bfa5eef61d6d172743bcf4/src/common/Constants.ts#L332) which was resolving to `WBNB` when fetching its token symbol, meaning we were not getting outstanding transfers for BNB rebalances properly. From Binance's perspective, these are deposits of BNB, not WBNB, so both the adapter and the finalizer must re-map this to BNB.