### PR TITLE
fix: do not evaluate destination profitability if token has no route

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1248,7 +1248,8 @@ export class Relayer {
     if (
       !isDefined(preferredChain) &&
       !preferredChainIds.includes(destinationChainId) &&
-      !depositForcesOriginChainRepayment(deposit, this.clients.hubPoolClient)
+      !depositForcesOriginChainRepayment(deposit, this.clients.hubPoolClient) &&
+      this.clients.hubPoolClient.l2TokenHasPoolRebalanceRoute(deposit.outputToken, deposit.destinationChainId)
     ) {
       this.logger.debug({
         at: "Relayer::resolveRepaymentChain",


### PR DESCRIPTION
We are trying to check if a token which has no pool rebalance route has an LP fee, which it won't ever have due to changes made in the inventory client.