### PR TITLE
feat(MulticallerClient): Allow caller to use PermissionedMulticaller

### DIFF
--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -26,6 +26,8 @@ export interface AugmentedTransaction {
   value?: BigNumber;
   unpermissioned?: boolean; // If false, the transaction must be sent from the enqueuer of the method.
   // If true, then can be sent from the MakerDAO multisender contract.
+  sendThroughPermissionedMulticall?: boolean;
+  // If true, then should be sent through the permissioned multisender contract.
   canFailInSimulation?: boolean;
   // Optional batch ID to use to group transactions
   groupId?: string;

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -294,8 +294,8 @@ export async function finalize(
         hubChainId,
         ...configuredChainIds,
       ]).map(
-        async (chainId) =>
-          [chainId, await getMultisender(chainId, spokePoolClients[chainId].spokePool.signer)] as [number, Contract]
+        (chainId) =>
+          [chainId, getMultisender(chainId, spokePoolClients[chainId].spokePool.signer)] as [number, Contract]
       )
     )
   );

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -53,8 +53,12 @@ export function getNetworkError(err: unknown): string {
   return isEthersError(err) ? err.reason : isError(err) ? err.message : "unknown error";
 }
 
-export async function getMultisender(chainId: number, baseSigner: Signer): Promise<Contract | undefined> {
+export function getMultisender(chainId: number, baseSigner: Signer): Contract | undefined {
   return sdkUtils.getMulticall3(chainId, baseSigner);
+}
+
+export function getPermissionedMultisender(chainId: number, baseSigner: Signer): Contract | undefined {
+  return sdkUtils.getPermissionedMulticall3(chainId, baseSigner);
 }
 
 // Note that this function will throw if the call to the contract on method for given args reverts. Implementers


### PR DESCRIPTION
Can be used to batch txns to contracts that whitelist the msg.sender

Depends on https://github.com/across-protocol/sdk/pull/1017