### PR TITLE
chore: reduce bsc finalizer log level

### DIFF
--- a/src/finalizer/utils/binance/l1ToL2.ts
+++ b/src/finalizer/utils/binance/l1ToL2.ts
@@ -109,7 +109,7 @@ export async function binanceL1ToL2Finalizer(
       // Binance also takes fees from withdrawals. Since we are bundling together multiple deposits, it is possible that the amount we are trying to withdraw is slightly greater than our free balance
       // (since a prior withdrawal's fees were paid for in part from the current withdrawal's balance). In this case, set `amountToFinalize` as `min(amountToFinalize, accountBalance)`.
       if (amountToFinalize > Number(coin.balance)) {
-        logger.warn({
+        logger.debug({
           at: "BinanceL1ToL2Finalizer",
           message:
             "Need to reduce the amount to finalize since hot wallet balance is less than desired withdrawal amount",

--- a/src/finalizer/utils/binance/l2ToL1.ts
+++ b/src/finalizer/utils/binance/l2ToL1.ts
@@ -108,7 +108,7 @@ export async function binanceL2ToL1Finalizer(
       // Binance also takes fees from withdrawals. Since we are bundling together multiple deposits, it is possible that the amount we are trying to withdraw is slightly greater than our free balance
       // (since a prior withdrawal's fees were paid for in part from the current withdrawal's balance). In this case, set `amountToFinalize` as `min(amountToFinalize, accountBalance)`.
       if (amountToFinalize > Number(coin.balance)) {
-        logger.warn({
+        logger.debug({
           at: "BinanceL2ToL1Finalizer",
           message:
             "Need to reduce the amount to finalize since hot wallet balance is less than desired withdrawal amount",


### PR DESCRIPTION
In practice this log happens often since there are diffs between deposit amounts and withdrawal amounts due to withdrawal fees.