### PR TITLE
fix(Dataworker): Produce leaves for chains with no running balances

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.63",
     "@across-protocol/contracts": "^4.0.9",
-    "@across-protocol/sdk": "4.1.56",
+    "@across-protocol/sdk": "4.1.58-beta.3",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.63",
     "@across-protocol/contracts": "^4.0.9",
-    "@across-protocol/sdk": "4.1.58-beta.3",
+    "@across-protocol/sdk": "4.1.58",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,10 +59,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@4.1.58-beta.3":
-  version "4.1.58-beta.3"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.58-beta.3.tgz#27465cd2efc9019fb29ffbc6b3a29745a6822d38"
-  integrity sha512-VDfYm+HVNUSWTQVlzQ6cEozhJ1hynG2/1rERALPEpsdd+TM6I9ng68N9BpEyWPFj2fFsW3sGjErMcHZnEq29mA==
+"@across-protocol/sdk@4.1.58":
+  version "4.1.58"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.58.tgz#cc224bf67ddbc8c3ccce13a2f17bae13e98714ba"
+  integrity sha512-E5SsRCJG3sVGjv0dgwmJo+3A/UQWLXf2JwxQGeHRiQEIdFUL8Fwc3GAAQQnDwfPq9dJNMmOB6C5nVy5Jcv64ZA==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.64"

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,10 +59,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@4.1.56":
-  version "4.1.56"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.56.tgz#bcb83f6380d50b1cafcd6b7c9d8330fbc621dea0"
-  integrity sha512-82MOqQe2UZs11bTaBTqKF3Yyzcs6k7EDFUmb5+vcYJMAydo69WFe55OeQPiW5D+L4H3hdscWDhFkTifCDNEfCQ==
+"@across-protocol/sdk@4.1.58-beta.3":
+  version "4.1.58-beta.3"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.1.58-beta.3.tgz#27465cd2efc9019fb29ffbc6b3a29745a6822d38"
+  integrity sha512-VDfYm+HVNUSWTQVlzQ6cEozhJ1hynG2/1rERALPEpsdd+TM6I9ng68N9BpEyWPFj2fFsW3sGjErMcHZnEq29mA==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.64"


### PR DESCRIPTION
If a chain has no running balances but has refunds, then we should still produce an empty pool rebalance leaf for it