### PR TITLE
fix(Monitor): Convert decimals properly for L2 token balances and support additional L1 token reporting

### DIFF
--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -39,6 +39,7 @@ import {
   resolveTokenDecimals,
   sortEventsDescending,
   getWidestPossibleExpectedBlockRange,
+  utils,
   _buildPoolRebalanceRoot,
   getRemoteTokenForL1Token,
   getTokenInfo,

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -373,13 +373,14 @@ export class Monitor {
         );
 
         for (let i = 0; i < l2TokenAddresses.length; i++) {
+          const decimalConverter = this.l2TokenAmountToL1TokenAmountConverter(l2TokenAddresses[i], chainId);
           const { symbol } = l2ToL1Tokens[l2TokenAddresses[i]];
           this.updateRelayerBalanceTable(
             relayerBalanceReport[relayer],
             symbol,
             getNetworkName(chainId),
             BalanceType.CURRENT,
-            tokenBalances[i]
+            decimalConverter(tokenBalances[i])
           );
         }
       }
@@ -1248,7 +1249,6 @@ export class Monitor {
         if (this.balanceCache[chainId]?.[token]?.[account]) {
           return this.balanceCache[chainId][token][account];
         }
-        const decimalConverter = this.l2TokenAmountToL1TokenAmountConverter(token, chainId);
         const gasTokenAddressForChain = getNativeTokenAddressForChain(chainId);
         const balance =
           token === gasTokenAddressForChain
@@ -1261,15 +1261,14 @@ export class Monitor {
                 account,
                 { blockTag: this.clients.spokePoolClients[chainId].latestBlockSearched }
               );
-        const convertedBalance = decimalConverter(balance);
         if (!this.balanceCache[chainId]) {
           this.balanceCache[chainId] = {};
         }
         if (!this.balanceCache[chainId][token]) {
           this.balanceCache[chainId][token] = {};
         }
-        this.balanceCache[chainId][token][account] = convertedBalance;
-        return convertedBalance;
+        this.balanceCache[chainId][token][account] = balance;
+        return balance;
       })
     );
   }

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -39,9 +39,11 @@ import {
   resolveTokenDecimals,
   sortEventsDescending,
   getWidestPossibleExpectedBlockRange,
-  utils,
   _buildPoolRebalanceRoot,
   getRemoteTokenForL1Token,
+  getTokenInfo,
+  ConvertDecimals,
+  getL1TokenInfo,
 } from "../utils";
 import { MonitorClients, updateMonitorClients } from "./MonitorClientHelper";
 import { MonitorConfig } from "./MonitorConfig";
@@ -72,6 +74,7 @@ export class Monitor {
   private spokePoolsBlocks: Record<number, { startingBlock: number | undefined; endingBlock: number | undefined }> = {};
   private balanceCache: { [chainId: number]: { [token: string]: { [account: string]: BigNumber } } } = {};
   private decimals: { [chainId: number]: { [token: string]: number } } = {};
+  private additionalL1Tokens: string[] = [];
   private balanceAllocator: BalanceAllocator;
   // Chains for each spoke pool client.
   public monitorChains: number[];
@@ -96,6 +99,7 @@ export class Monitor {
       crossChainAdapterSupportedChains: this.crossChainAdapterSupportedChains,
     });
     this.balanceAllocator = new BalanceAllocator(spokePoolClientsToProviders(clients.spokePoolClients));
+    this.additionalL1Tokens = this.monitorConfig.additionalL1NonLpTokens;
   }
 
   public async update(): Promise<void> {
@@ -236,14 +240,29 @@ export class Monitor {
     }
   }
 
+  l2TokenAmountToL1TokenAmountConverter(l2Token: string, chainId: number): (BigNumber) => BigNumber {
+    // Step 1: Get l1 token address equivalent of L2 token
+    const l1Token = (
+      chainId === this.clients.hubPoolClient.chainId ? getTokenInfo(l2Token, chainId) : getL1TokenInfo(l2Token, chainId)
+    ).address;
+    const l1TokenDecimals = getTokenInfo(l1Token, this.clients.hubPoolClient.chainId).decimals;
+    const l2TokenDecimals = getTokenInfo(l2Token, chainId).decimals;
+    return ConvertDecimals(l2TokenDecimals, l1TokenDecimals);
+  }
+
   getL1TokensForRelayerBalancesReport(): L1Token[] {
-    const allL1Tokens = [...this.clients.hubPoolClient.getL1Tokens()].map(({ symbol, ...tokenInfo }) => {
-      return {
-        ...tokenInfo,
-        // Remap symbols so that we're using a symbol available to us in TOKEN_SYMBOLS_MAP.
-        symbol: TOKEN_EQUIVALENCE_REMAPPING[symbol] ?? symbol,
-      };
-    });
+    const additionalL1Tokens = this.additionalL1Tokens.map((l1Token) =>
+      getTokenInfo(l1Token, this.clients.hubPoolClient.chainId)
+    );
+    const allL1Tokens = [...this.clients.hubPoolClient.getL1Tokens(), ...additionalL1Tokens].map(
+      ({ symbol, ...tokenInfo }) => {
+        return {
+          ...tokenInfo,
+          // Remap symbols so that we're using a symbol available to us in TOKEN_SYMBOLS_MAP.
+          symbol: TOKEN_EQUIVALENCE_REMAPPING[symbol] ?? symbol,
+        };
+      }
+    );
     // @dev Handle special case for L1 USDC which is mapped to two L2 tokens on some chains, so we can more easily
     // see L2 Bridged USDC balance versus Native USDC. Add USDC.e right after the USDC element.
     const indexOfUsdc = allL1Tokens.findIndex(({ symbol }) => symbol === "USDC");
@@ -1084,6 +1103,7 @@ export class Monitor {
       }
 
       for (const tokenAddress of Object.keys(fillsToRefund)) {
+        const decimalConverter = this.l2TokenAmountToL1TokenAmountConverter(tokenAddress, chainId);
         // Skip token if there are no refunds (although there are valid fills).
         // This is an edge case that shouldn't usually happen.
         if (fillsToRefund[tokenAddress] === undefined || l2ToL1Tokens[tokenAddress] === undefined) {
@@ -1092,7 +1112,7 @@ export class Monitor {
 
         const totalRefundAmount = fillsToRefund[tokenAddress][relayer];
         const { symbol } = l2ToL1Tokens[tokenAddress];
-        const amount = totalRefundAmount ?? bnZero;
+        const amount = decimalConverter(totalRefundAmount ?? bnZero);
         this.updateRelayerBalanceTable(relayerBalanceTable, symbol, getNetworkName(chainId), balanceType, amount);
       }
     }
@@ -1228,6 +1248,7 @@ export class Monitor {
         if (this.balanceCache[chainId]?.[token]?.[account]) {
           return this.balanceCache[chainId][token][account];
         }
+        const decimalConverter = this.l2TokenAmountToL1TokenAmountConverter(token, chainId);
         const gasTokenAddressForChain = getNativeTokenAddressForChain(chainId);
         const balance =
           token === gasTokenAddressForChain
@@ -1240,14 +1261,15 @@ export class Monitor {
                 account,
                 { blockTag: this.clients.spokePoolClients[chainId].latestBlockSearched }
               );
+        const convertedBalance = decimalConverter(balance);
         if (!this.balanceCache[chainId]) {
           this.balanceCache[chainId] = {};
         }
         if (!this.balanceCache[chainId][token]) {
           this.balanceCache[chainId][token] = {};
         }
-        this.balanceCache[chainId][token][account] = balance;
-        return balance;
+        this.balanceCache[chainId][token][account] = convertedBalance;
+        return convertedBalance;
       })
     );
   }

--- a/src/monitor/MonitorConfig.ts
+++ b/src/monitor/MonitorConfig.ts
@@ -1,6 +1,6 @@
 import winston from "winston";
 import { CommonConfig, ProcessEnv } from "../common";
-import { ethers, getNativeTokenAddressForChain, isDefined } from "../utils";
+import { CHAIN_IDs, ethers, getNativeTokenAddressForChain, isDefined, TOKEN_SYMBOLS_MAP } from "../utils";
 
 // Set modes to true that you want to enable in the AcrossMonitor bot.
 export interface BotModes {
@@ -43,6 +43,7 @@ export class MonitorConfig extends CommonConfig {
     account: string;
     token: string;
   }[] = [];
+  readonly additionalL1NonLpTokens: string[] = [];
 
   // TODO: Remove this config once we fully migrate to generic adapters.
   readonly useGenericAdapter: boolean;
@@ -69,6 +70,7 @@ export class MonitorConfig extends CommonConfig {
       REPORT_SPOKE_POOL_BALANCES,
       MONITORED_SPOKE_POOL_CHAINS,
       MONITORED_TOKEN_SYMBOLS,
+      MONITOR_REPORT_NON_LP_TOKENS,
       BUNDLES_COUNT,
     } = env;
 
@@ -92,6 +94,11 @@ export class MonitorConfig extends CommonConfig {
     this.monitoredSpokePoolChains = JSON.parse(MONITORED_SPOKE_POOL_CHAINS ?? "[]");
     this.monitoredTokenSymbols = JSON.parse(MONITORED_TOKEN_SYMBOLS ?? "[]");
     this.bundlesCount = Number(BUNDLES_COUNT ?? 4);
+    this.additionalL1NonLpTokens = JSON.parse(MONITOR_REPORT_NON_LP_TOKENS ?? "[]").map((token) => {
+      if (TOKEN_SYMBOLS_MAP[token]?.addresses?.[CHAIN_IDs.MAINNET]) {
+        return TOKEN_SYMBOLS_MAP[token]?.addresses?.[CHAIN_IDs.MAINNET];
+      }
+    });
 
     // Used to send tokens if available in wallet to balances under target balances.
     if (REFILL_BALANCES) {

--- a/test/Monitor.ts
+++ b/test/Monitor.ts
@@ -45,12 +45,6 @@ class TestMonitor extends Monitor {
     return this.overriddenTokenMap[chainId] ?? super.getL2ToL1TokenMap(l1Tokens, chainId);
   }
 
-  getL1TokenInfo(l2Token: string, chainId: number): L1Token {
-    return this.overriddenTokenMap[chainId]
-      ? this.overriddenTokenMap[chainId]?.[l2Token]
-      : super.getL1TokenInfo(l2Token, chainId);
-  }
-
   getRemoteTokenForL1Token(l1Token: string, chainId: number | string): string | undefined {
     Object.values(this.overriddenTokenMap).forEach((tokenMap: TokenMap) => {
       const matchedToken = Object.entries(tokenMap).find(([, l1TokenObject]) => l1TokenObject.address === l1Token);
@@ -59,6 +53,10 @@ class TestMonitor extends Monitor {
       }
     });
     return super.getRemoteTokenForL1Token(l1Token, chainId);
+  }
+
+  l2TokenAmountToL1TokenAmountConverter(): (BigNumber) => BigNumber {
+    return (amount: BigNumber) => amount;
   }
 }
 


### PR DESCRIPTION
1. L2 token balances are all converted to L1 token decimals to normalize reporting cross chain relayer balances

2. Allows Monitor constructor to specify additional L1 tokens to report cross chain relayer balances for
