### PR TITLE
feat(finalizer): Remove individual txn client simulation

### DIFF
--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -3,7 +3,7 @@ import assert from "assert";
 import { Contract, ethers } from "ethers";
 import { getAddress } from "ethers/lib/utils";
 import { groupBy, uniq } from "lodash";
-import { AugmentedTransaction, HubPoolClient, MultiCallerClient, TransactionClient } from "../clients";
+import { AugmentedTransaction, HubPoolClient, MultiCallerClient } from "../clients";
 import {
   CONTRACT_ADDRESSES,
   Clients,
@@ -16,8 +16,6 @@ import {
 import { DataworkerConfig } from "../dataworker/DataworkerConfig";
 import { SpokePoolClientsByChain } from "../interfaces";
 import {
-  BigNumber,
-  bnZero,
   Signer,
   blockExplorerLink,
   config,
@@ -307,158 +305,96 @@ export async function finalize(
       .map(([k]) => k)}`
   );
 
-  const txnClient = new TransactionClient(logger);
+  // @dev use multicaller client to execute batched txn to take advantage of its native txn simulation
+  // safety features. This only works because we assume all finalizer transactions are
+  // unpermissioned (i.e. msg.sender can be anyone). If this is not true for any chain then we'd need to use
+  // the TransactionClient.
+  const multicallerClient = new MultiCallerClient(logger);
+  let txnRefLookup: Record<number, string[]> = {};
+  try {
+    const finalizationsByChain = groupBy(
+      finalizerResponseTxns,
+      ({ crossChainMessage }) => crossChainMessage.destinationChainId
+    );
 
-  let gasEstimation = bnZero;
-  const batchGasLimit = BigNumber.from(10_000_000);
-  // @dev To avoid running into block gas limit in case the # of finalizations gets too high, keep a running
-  // counter of the approximate gas estimation and cut off the list of finalizations if it gets too high.
+    // @dev Here, we enqueueTransaction individual transactions right away, and we batch all multicalls into `multicallTxns` to enqueue as a single tx right after
+    for (const [chainId, finalizations] of Object.entries(finalizationsByChain)) {
+      const multicallTxns: Multicall2Call[] = [];
 
-  // Ensure each transaction would succeed in isolation.
-  const finalizations = await sdkUtils.filterAsync(finalizerResponseTxns, async ({ txn: _txn, crossChainMessage }) => {
-    let simErrorReason: string;
-    if (!isAugmentedTransaction(_txn)) {
-      // Multicall transaction simulation flow
-      const txnToSubmit: AugmentedTransaction = {
-        contract: multicall2Lookup[crossChainMessage.destinationChainId],
-        chainId: crossChainMessage.destinationChainId,
-        method: "aggregate",
-        // aggregate() takes an array of tuples: [calldata: bytes, target: address].
-        args: [[_txn]],
-      };
-      const [{ reason, succeed, transaction }] = await txnClient.simulate([txnToSubmit]);
-
-      if (succeed) {
-        // Increase running counter of estimated gas cost for batch finalization.
-        // gasLimit should be defined if succeed is True.
-        const updatedGasEstimation = gasEstimation.add(transaction.gasLimit);
-        if (updatedGasEstimation.lt(batchGasLimit)) {
-          gasEstimation = updatedGasEstimation;
-          return true;
+      finalizations.forEach(({ txn }) => {
+        if (isAugmentedTransaction(txn)) {
+          // It's an AugmentedTransaction, enqueue directly
+          txn.nonMulticall = true; // cautiously enforce an invariant that should already be present
+          multicallerClient.enqueueTransaction(txn);
         } else {
-          return false;
+          // It's a Multicall2Call, collect for batching
+          multicallTxns.push(txn);
         }
-      } else {
-        simErrorReason = reason;
-      }
-    } else {
-      // Individual transaction simulation flow
-      const [{ reason, succeed }] = await txnClient.simulate([_txn]);
-      if (succeed) {
-        return true;
-      } else {
-        simErrorReason = reason;
-      }
-    }
-
-    // Simulation failed, log the reason and continue.
-    let message: string;
-    if (isDefined(crossChainMessage)) {
-      const { originationChainId, destinationChainId, type, l1TokenSymbol, amount } = crossChainMessage;
-      const originationNetwork = getNetworkName(originationChainId);
-      const destinationNetwork = getNetworkName(destinationChainId);
-      message = `Failed to estimate gas for ${originationNetwork} -> ${destinationNetwork} ${amount} ${l1TokenSymbol} ${type}.`;
-    } else {
-      // @dev Likely to be the 2nd part of a 2-stage withdrawal (i.e. retrieve() on the Polygon bridge adapter).
-      message = "Unknown finalizer simulation failure.";
-    }
-    logger.warn({ at: "finalizer", message, simErrorReason, txn: _txn });
-    return false;
-  });
-
-  if (finalizations.length > 0) {
-    // @dev use multicaller client to execute batched txn to take advantage of its native txn simulation
-    // safety features. This only works because we assume all finalizer transactions are
-    // unpermissioned (i.e. msg.sender can be anyone). If this is not true for any chain then we'd need to use
-    // the TransactionClient.
-    const multicallerClient = new MultiCallerClient(logger);
-    let txnRefLookup: Record<number, string[]> = {};
-    try {
-      const finalizationsByChain = groupBy(
-        finalizations,
-        ({ crossChainMessage }) => crossChainMessage.destinationChainId
-      );
-
-      // @dev Here, we enqueueTransaction individual transactions right away, and we batch all multicalls into `multicallTxns` to enqueue as a single tx right after
-      for (const [chainId, finalizations] of Object.entries(finalizationsByChain)) {
-        const multicallTxns: Multicall2Call[] = [];
-
-        finalizations.forEach(({ txn }) => {
-          if (isAugmentedTransaction(txn)) {
-            // It's an AugmentedTransaction, enqueue directly
-            txn.nonMulticall = true; // cautiously enforce an invariant that should already be present
-            multicallerClient.enqueueTransaction(txn);
-          } else {
-            // It's a Multicall2Call, collect for batching
-            multicallTxns.push(txn);
-          }
-        });
-
-        if (multicallTxns.length > 0) {
-          const txnToSubmit: AugmentedTransaction = {
-            contract: multicall2Lookup[Number(chainId)],
-            chainId: Number(chainId),
-            method: "aggregate",
-            args: [multicallTxns],
-            gasLimit: gasEstimation,
-            gasLimitMultiplier: 2,
-            unpermissioned: true,
-            message: `Batch finalized ${multicallTxns.length} txns`,
-            mrkdwn: `Batch finalized ${multicallTxns.length} txns`,
-          };
-          multicallerClient.enqueueTransaction(txnToSubmit);
-        }
-      }
-      txnRefLookup = await multicallerClient.executeTxnQueues(!submitFinalizationTransactions);
-    } catch (_error) {
-      const error = _error as Error;
-      logger.warn({
-        at: "Finalizer",
-        message: "Error creating aggregateTx",
-        reason: error.stack || error.message || error.toString(),
-        notificationPath: "across-error",
-        finalizations,
       });
+
+      if (multicallTxns.length > 0) {
+        const txnToSubmit: AugmentedTransaction = {
+          contract: multicall2Lookup[Number(chainId)],
+          chainId: Number(chainId),
+          method: "aggregate",
+          args: [multicallTxns],
+          gasLimitMultiplier: 2,
+          unpermissioned: true,
+          message: `Batch finalized ${multicallTxns.length} txns`,
+          mrkdwn: `Batch finalized ${multicallTxns.length} txns`,
+        };
+        multicallerClient.enqueueTransaction(txnToSubmit);
+      }
+    }
+    txnRefLookup = await multicallerClient.executeTxnQueues(!submitFinalizationTransactions);
+  } catch (_error) {
+    const error = _error as Error;
+    logger.warn({
+      at: "Finalizer",
+      message: "Error creating aggregateTx",
+      reason: error.stack || error.message || error.toString(),
+      notificationPath: "across-error",
+      finalizations: finalizerResponseTxns,
+    });
+    return;
+  }
+
+  const { transfers = [], misc = [] } = groupBy(
+    finalizerResponseTxns.filter(({ crossChainMessage }) => isDefined(crossChainMessage)),
+    ({ crossChainMessage: { type } }) => {
+      return type === "misc" ? "misc" : "transfers";
+    }
+  );
+
+  misc.forEach(({ crossChainMessage }) => {
+    const { originationChainId, destinationChainId, amount, l1TokenSymbol: symbol, type } = crossChainMessage;
+    // Required for tsc to be happy.
+    if (type !== "misc") {
       return;
     }
-
-    const { transfers = [], misc = [] } = groupBy(
-      finalizations.filter(({ crossChainMessage }) => isDefined(crossChainMessage)),
-      ({ crossChainMessage: { type } }) => {
-        return type === "misc" ? "misc" : "transfers";
-      }
-    );
-
-    misc.forEach(({ crossChainMessage }) => {
-      const { originationChainId, destinationChainId, amount, l1TokenSymbol: symbol, type } = crossChainMessage;
-      // Required for tsc to be happy.
-      if (type !== "misc") {
-        return;
-      }
-      const { miscReason } = crossChainMessage;
+    const { miscReason } = crossChainMessage;
+    const originationNetwork = getNetworkName(originationChainId);
+    const destinationNetwork = getNetworkName(destinationChainId);
+    const infoLogMessage =
+      amount && symbol ? `to support a ${originationNetwork} withdrawal of ${amount} ${symbol} 🔜` : "";
+    logger.info({
+      at: "Finalizer",
+      message: `Submitted ${miscReason} on ${destinationNetwork}`,
+      infoLogMessage,
+      txnRefList: txnRefLookup[destinationChainId]?.map((txnRef) => blockExplorerLink(txnRef, destinationChainId)),
+    });
+  });
+  transfers.forEach(
+    ({ crossChainMessage: { originationChainId, destinationChainId, type, amount, l1TokenSymbol: symbol } }) => {
       const originationNetwork = getNetworkName(originationChainId);
       const destinationNetwork = getNetworkName(destinationChainId);
-      const infoLogMessage =
-        amount && symbol ? `to support a ${originationNetwork} withdrawal of ${amount} ${symbol} 🔜` : "";
       logger.info({
         at: "Finalizer",
-        message: `Submitted ${miscReason} on ${destinationNetwork}`,
-        infoLogMessage,
+        message: `Finalized ${originationNetwork} ${type} on ${destinationNetwork} for ${amount} ${symbol} 🪃`,
         txnRefList: txnRefLookup[destinationChainId]?.map((txnRef) => blockExplorerLink(txnRef, destinationChainId)),
       });
-    });
-    transfers.forEach(
-      ({ crossChainMessage: { originationChainId, destinationChainId, type, amount, l1TokenSymbol: symbol } }) => {
-        const originationNetwork = getNetworkName(originationChainId);
-        const destinationNetwork = getNetworkName(destinationChainId);
-        logger.info({
-          at: "Finalizer",
-          message: `Finalized ${originationNetwork} ${type} on ${destinationNetwork} for ${amount} ${symbol} 🪃`,
-          txnRefList: txnRefLookup[destinationChainId]?.map((txnRef) => blockExplorerLink(txnRef, destinationChainId)),
-        });
-      }
-    );
-  }
+    }
+  );
 }
 
 export async function constructFinalizerClients(


### PR DESCRIPTION
We should rely on the multicaller client's transaction simulation logic rather than directly call the transaction client to simulate finalization txns invidually. This code is leftover from legacy code before we used to submit finalization txns to the multicaller client.

Replaces https://github.com/across-protocol/relayer/pull/2218