### PR TITLE
feat: retrieve binance keys from gckms and avoid unnecesary binance queries

### DIFF
--- a/src/adapter/bridges/BinanceCEXBridge.ts
+++ b/src/adapter/bridges/BinanceCEXBridge.ts
@@ -20,7 +20,9 @@ import { BaseBridgeAdapter, BridgeTransactionDetails, BridgeEvents } from "./Bas
 import ERC20_ABI from "../../common/abi/MinimalERC20.json";
 
 export class BinanceCEXBridge extends BaseBridgeAdapter {
-  protected readonly binanceApiClient;
+  // Only store the promise in the constructor and evaluate the promise in async blocks.
+  protected readonly binanceApiClientPromise;
+  protected binanceApiClient;
   protected tokenSymbol: string;
 
   constructor(
@@ -53,6 +55,7 @@ export class BinanceCEXBridge extends BaseBridgeAdapter {
     _l2Token: EvmAddress,
     amount: BigNumber
   ): Promise<BridgeTransactionDetails> {
+    this.binanceApiClient ??= await this.binanceApiClientPromise;
     assert(l1Token.toAddress() === this.getL1Bridge().address);
     // Fetch the deposit address from the binance API.
 
@@ -74,6 +77,7 @@ export class BinanceCEXBridge extends BaseBridgeAdapter {
     _toAddress: EvmAddress,
     eventConfig: EventSearchConfig
   ): Promise<BridgeEvents> {
+    this.binanceApiClient ??= await this.binanceApiClientPromise;
     assert(l1Token.toAddress() === this.getL1Bridge().address);
     const fromTimestamp = (await getTimestampForBlock(this.getL1Bridge().provider, eventConfig.fromBlock)) * 1_000; // Convert timestamp to ms.
 
@@ -119,6 +123,7 @@ export class BinanceCEXBridge extends BaseBridgeAdapter {
     toAddress: EvmAddress,
     eventConfig: EventSearchConfig
   ): Promise<BridgeEvents> {
+    this.binanceApiClient ??= await this.binanceApiClientPromise;
     // We must typecast the l2 signer or provider into specifically an ethers Provider type so we can call `getTransactionReceipt` and `getBlockByNumber` on it.
     const l2Provider =
       this.l2SignerOrProvider instanceof ethers.providers.Provider

--- a/src/adapter/bridges/BinanceCEXNativeBridge.ts
+++ b/src/adapter/bridges/BinanceCEXNativeBridge.ts
@@ -35,11 +35,11 @@ export class BinanceCEXNativeBridge extends BinanceCEXBridge {
     _l2Token: EvmAddress,
     amount: BigNumber
   ): Promise<BridgeTransactionDetails> {
-    this.binanceApiClient ??= await this.binanceApiClientPromise;
     assert(l1Token.toAddress() === this.getL1Bridge().address);
     // Fetch the deposit address from the binance API.
 
-    const depositAddress = await this.binanceApiClient.depositAddress({
+    const binanceApiClient = await this.getBinanceClient();
+    const depositAddress = await binanceApiClient.depositAddress({
       coin: this.tokenSymbol,
       network: "ETH",
     });

--- a/src/adapter/bridges/BinanceCEXNativeBridge.ts
+++ b/src/adapter/bridges/BinanceCEXNativeBridge.ts
@@ -35,6 +35,7 @@ export class BinanceCEXNativeBridge extends BinanceCEXBridge {
     _l2Token: EvmAddress,
     amount: BigNumber
   ): Promise<BridgeTransactionDetails> {
+    this.binanceApiClient ??= await this.binanceApiClientPromise;
     assert(l1Token.toAddress() === this.getL1Bridge().address);
     // Fetch the deposit address from the binance API.
 

--- a/src/adapter/l2Bridges/BinanceCEXBridge.ts
+++ b/src/adapter/l2Bridges/BinanceCEXBridge.ts
@@ -59,9 +59,9 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
     _l1Token: EvmAddress,
     amount: BigNumber
   ): Promise<AugmentedTransaction[]> {
-    this.binanceApiClient ??= await this.binanceApiClientPromise;
+    const binanceApiClient = await this.getBinanceClient();
     const l2TokenInfo = getTokenInfo(l2Token.toAddress(), this.l2chainId);
-    const depositAddress = await this.binanceApiClient.depositAddress({
+    const depositAddress = await binanceApiClient.depositAddress({
       coin: this.l1TokenInfo.symbol,
       network: "BSC",
     });
@@ -91,15 +91,15 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
     fromAddress: EvmAddress,
     l2Token: EvmAddress
   ): Promise<BigNumber> {
-    this.binanceApiClient ??= await this.binanceApiClientPromise;
+    const binanceApiClient = await this.getBinanceClient();
     const l2TokenInfo = getTokenInfo(l2Token.toAddress(), this.l2chainId);
     const fromTimestamp = (await getTimestampForBlock(this.l2Bridge.provider, l2EventConfig.fromBlock)) * 1_000;
     const [_depositHistory, _withdrawHistory] = await Promise.all([
-      this.binanceApiClient.depositHistory({
+      binanceApiClient.depositHistory({
         coin: this.l1TokenInfo.symbol,
         startTime: fromTimestamp,
       }),
-      this.binanceApiClient.withdrawHistory({
+      binanceApiClient.withdrawHistory({
         coin: this.l1TokenInfo.symbol,
         startTime: fromTimestamp,
       }),
@@ -138,5 +138,9 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
     );
     const diff = totalDepositAmountForAddress.sub(totalWithdrawalAmountForAddress);
     return diff.gt(bnZero) ? diff : bnZero;
+  }
+
+  protected async getBinanceClient() {
+    return (this.binanceApiClient ??= await this.binanceApiClientPromise);
   }
 }

--- a/src/adapter/l2Bridges/BinanceCEXBridge.ts
+++ b/src/adapter/l2Bridges/BinanceCEXBridge.ts
@@ -24,7 +24,9 @@ import ERC20_ABI from "../../common/abi/MinimalERC20.json";
 import { AugmentedTransaction } from "../../clients/TransactionClient";
 
 export class BinanceCEXBridge extends BaseL2BridgeAdapter {
-  protected readonly binanceApiClient;
+  // Store the promise to be evaluated when needed so that we can construct the bridge synchronously.
+  protected readonly binanceApiClientPromise;
+  protected binanceApiClient;
   // Store the token info for the bridge so we can reference the L1 decimals and L1 token symbol.
   protected l1TokenInfo: L1Token;
 
@@ -48,7 +50,7 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
       symbol: l1TokenInfo.symbol === "WETH" ? "ETH" : l1TokenInfo.symbol,
     };
 
-    this.binanceApiClient = getBinanceApiClient(process.env["BINANCE_API_BASE"]);
+    this.binanceApiClientPromise = getBinanceApiClient(process.env["BINANCE_API_BASE"]);
   }
 
   async constructWithdrawToL1Txns(
@@ -57,6 +59,7 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
     _l1Token: EvmAddress,
     amount: BigNumber
   ): Promise<AugmentedTransaction[]> {
+    this.binanceApiClient ??= await this.binanceApiClientPromise;
     const l2TokenInfo = getTokenInfo(l2Token.toAddress(), this.l2chainId);
     const depositAddress = await this.binanceApiClient.depositAddress({
       coin: this.l1TokenInfo.symbol,
@@ -88,6 +91,7 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
     fromAddress: EvmAddress,
     l2Token: EvmAddress
   ): Promise<BigNumber> {
+    this.binanceApiClient ??= await this.binanceApiClientPromise;
     const l2TokenInfo = getTokenInfo(l2Token.toAddress(), this.l2chainId);
     const fromTimestamp = (await getTimestampForBlock(this.l2Bridge.provider, l2EventConfig.fromBlock)) * 1_000;
     const [_depositHistory, _withdrawHistory] = await Promise.all([

--- a/src/finalizer/utils/binance/l1ToL2.ts
+++ b/src/finalizer/utils/binance/l1ToL2.ts
@@ -33,7 +33,7 @@ export async function binanceL1ToL2Finalizer(
   const hubChainId = l1SpokePoolClient.chainId;
   const l1EventSearchConfig = l1SpokePoolClient.eventSearchConfig;
 
-  const binanceApi = getBinanceApiClient(process.env["BINANCE_API_BASE"]);
+  const binanceApi = await getBinanceApiClient(process.env["BINANCE_API_BASE"]);
   const fromTimestamp = (await getTimestampForBlock(hubSigner.provider, l1EventSearchConfig.fromBlock)) * 1_000;
 
   const [binanceDeposits, accountCoins] = await Promise.all([

--- a/src/finalizer/utils/binance/l1ToL2.ts
+++ b/src/finalizer/utils/binance/l1ToL2.ts
@@ -139,8 +139,8 @@ export async function binanceL1ToL2Finalizer(
       }
     });
   });
-  return Promise.resolve({
+  return {
     callData: [],
     crossChainMessages: [],
-  });
+  };
 }

--- a/src/finalizer/utils/binance/l2ToL1.ts
+++ b/src/finalizer/utils/binance/l2ToL1.ts
@@ -33,7 +33,7 @@ export async function binanceL2ToL1Finalizer(
   const hubChainId = l1SpokePoolClient.chainId;
   const l1EventSearchConfig = l1SpokePoolClient.eventSearchConfig;
 
-  const binanceApi = getBinanceApiClient(process.env["BINANCE_API_BASE"]);
+  const binanceApi = await getBinanceApiClient(process.env["BINANCE_API_BASE"]);
   const fromTimestamp = (await getTimestampForBlock(hubSigner.provider, l1EventSearchConfig.fromBlock)) * 1_000;
 
   const [binanceDeposits, accountCoins] = await Promise.all([

--- a/src/finalizer/utils/binance/l2ToL1.ts
+++ b/src/finalizer/utils/binance/l2ToL1.ts
@@ -139,8 +139,8 @@ export async function binanceL2ToL1Finalizer(
       }
     });
   });
-  return Promise.resolve({
+  return {
     callData: [],
     crossChainMessages: [],
-  });
+  };
 }

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -1,0 +1,48 @@
+import Binance from "binance-api-node";
+import minimist from "minimist";
+import { getGckmsConfig, retrieveGckmsKeys, isDefined, assert } from "./";
+
+// Store global promises on Gckms key retrievel actions so that we don't retrieve the same key multiple times.
+let binanceSecretKeyPromise = undefined;
+
+/**
+ * Returns an API client to interface with Binance
+ * @param url The base HTTP url to use to connect to Binance.
+ * @returns A Binance client from `binance-api-node`.
+ */
+export async function getBinanceApiClient(url = "https://api.binance.com") {
+  const apiKey = process.env["BINANCE_API_KEY"];
+  const secretKey = (await getBinanceSecretKey()) ?? process.env["BINANCE_HMAC_KEY"];
+  assert(isDefined(apiKey) && isDefined(secretKey), "Binance client cannot be constructed due to missing keys.");
+  return Binance({
+    apiKey,
+    apiSecret: secretKey,
+    httpBase: url,
+  });
+}
+
+/**
+ * Retrieves a Binance API secret key from GCKMS if the key is stored in GCKMS.
+ * @returns A base64 encoded secret key, or undefined if the key is not present in GCKMS.
+ */
+async function getBinanceSecretKey(): Promise<string | undefined> {
+  binanceSecretKeyPromise ??= retrieveBinanceSecretKeyFromCLIArgs();
+  return binanceSecretKeyPromise;
+}
+
+/**
+ * Retrieves a Binance HMAC secret key based on CLI args.
+ * @returns A Binance API secret key if present in the arguments, or otherwise `undefined`.
+ */
+async function retrieveBinanceSecretKeyFromCLIArgs(): Promise<string | undefined> {
+  const opts = {
+    string: ["binanceSecretKey"],
+  };
+  const args = minimist(process.argv.slice(2), opts);
+  const binanceKeys = await retrieveGckmsKeys(getGckmsConfig(args.binanceSecretKey ?? []));
+  if (binanceKeys.length === 0) {
+    return undefined;
+  }
+  const buffer = Buffer.from(binanceKeys[0].slice(2), "hex");
+  return buffer.toString("base64");
+}

--- a/src/utils/CLIUtils.ts
+++ b/src/utils/CLIUtils.ts
@@ -3,7 +3,6 @@ import { Signer } from "ethers";
 import { constants as sdkConsts } from "@across-protocol/sdk";
 import { SignerOptions, getSigner } from "./SignerUtils";
 import { isDefined } from "./TypeGuards";
-import { getGckmsConfig, retrieveGckmsKeys } from "./GckmsUtils";
 
 const keyTypes = ["secret", "mnemonic", "privateKey", "gckms", "void"];
 
@@ -39,23 +38,6 @@ export function retrieveSignerFromCLIArgs(): Promise<Signer> {
 
   // Return the signer.
   return getSigner(signerOptions);
-}
-
-/**
- * Retrieves a Binance HMAC secret key based on CLI args.
- * @returns A Binance API secret key if present in the arguments, or otherwise `undefined`.
- */
-export async function retrieveBinanceSecretKeyFromCLIArgs(): Promise<string | undefined> {
-  const opts = {
-    string: ["binanceSecretKey"],
-  };
-  const args = minimist(process.argv.slice(2), opts);
-  const binanceKeys = await retrieveGckmsKeys(getGckmsConfig(args.binanceSecretKey ?? []));
-  if (binanceKeys.length === 0) {
-    return undefined;
-  }
-  const buffer = Buffer.from(binanceKeys[0].slice(2), "hex");
-  return buffer.toString("base64");
 }
 
 /**

--- a/src/utils/CLIUtils.ts
+++ b/src/utils/CLIUtils.ts
@@ -3,6 +3,7 @@ import { Signer } from "ethers";
 import { constants as sdkConsts } from "@across-protocol/sdk";
 import { SignerOptions, getSigner } from "./SignerUtils";
 import { isDefined } from "./TypeGuards";
+import { getGckmsConfig, retrieveGckmsKeys } from "./GckmsUtils";
 
 const keyTypes = ["secret", "mnemonic", "privateKey", "gckms", "void"];
 
@@ -38,6 +39,23 @@ export function retrieveSignerFromCLIArgs(): Promise<Signer> {
 
   // Return the signer.
   return getSigner(signerOptions);
+}
+
+/**
+ * Retrieves a Binance HMAC secret key based on CLI args.
+ * @returns A Binance API secret key if present in the arguments, or otherwise `undefined`.
+ */
+export async function retrieveBinanceSecretKeyFromCLIArgs(): Promise<string | undefined> {
+  const opts = {
+    string: ["binanceSecretKey"],
+  };
+  const args = minimist(process.argv.slice(2), opts);
+  const binanceKeys = await retrieveGckmsKeys(getGckmsConfig(args.binanceSecretKey ?? []));
+  if (binanceKeys.length === 0) {
+    return undefined;
+  }
+  const buffer = Buffer.from(binanceKeys[0].slice(2), "hex");
+  return buffer.toString("base64");
 }
 
 /**

--- a/src/utils/NetworkUtils.ts
+++ b/src/utils/NetworkUtils.ts
@@ -1,6 +1,4 @@
-import Binance from "binance-api-node";
 import { utils as sdkUtils } from "@across-protocol/sdk";
-import { isDefined, assert, retrieveBinanceSecretKeyFromCLIArgs } from "./";
 
 export const { getNetworkName, getNativeTokenSymbol } = sdkUtils;
 
@@ -15,20 +13,4 @@ export function getOriginFromURL(url: string): string {
   } catch (e) {
     return "UNKNOWN";
   }
-}
-
-/**
- * Returns an API client to interface with Binance
- * @param url The base HTTP url to use to connect to Binance.
- * @returns A Binance client from `binance-api-node`.
- */
-export async function getBinanceApiClient(url = "https://api.binance.com") {
-  const apiKey = process.env["BINANCE_API_KEY"];
-  const secretKey = (await retrieveBinanceSecretKeyFromCLIArgs()) ?? process.env["BINANCE_HMAC_KEY"];
-  assert(isDefined(apiKey) && isDefined(secretKey), "Binance client cannot be constructed due to missing keys.");
-  return Binance({
-    apiKey,
-    apiSecret: secretKey,
-    httpBase: url,
-  });
 }

--- a/src/utils/NetworkUtils.ts
+++ b/src/utils/NetworkUtils.ts
@@ -1,6 +1,6 @@
 import Binance from "binance-api-node";
 import { utils as sdkUtils } from "@across-protocol/sdk";
-import { isDefined, assert } from "./";
+import { isDefined, assert, retrieveBinanceSecretKeyFromCLIArgs } from "./";
 
 export const { getNetworkName, getNativeTokenSymbol } = sdkUtils;
 
@@ -22,9 +22,9 @@ export function getOriginFromURL(url: string): string {
  * @param url The base HTTP url to use to connect to Binance.
  * @returns A Binance client from `binance-api-node`.
  */
-export function getBinanceApiClient(url = "https://api.binance.com") {
+export async function getBinanceApiClient(url = "https://api.binance.com") {
   const apiKey = process.env["BINANCE_API_KEY"];
-  const secretKey = process.env["BINANCE_HMAC_KEY"];
+  const secretKey = (await retrieveBinanceSecretKeyFromCLIArgs()) ?? process.env["BINANCE_HMAC_KEY"];
   assert(isDefined(apiKey) && isDefined(secretKey), "Binance client cannot be constructed due to missing keys.");
   return Binance({
     apiKey,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -76,3 +76,4 @@ export * from "./CLIUtils";
 export * from "./BNUtils";
 export * from "./CCTPUtils";
 export * from "./RetryUtils";
+export * from "./BinanceUtils";


### PR DESCRIPTION
We should be able to retrieve Binance secret keys from GCKMS and not the environment.

Also, in order to avoid being rate-limited by the Binance API, we should only query it when it makes sense to do so, i.e. when the address we are querying for is an EOA and not a contract (since the API should never be used to transfer contract funds, anyways).