### PR TITLE
improve: add periodic KeepAlive messages for SP1Helios

### DIFF
--- a/src/common/abi/SP1Helios.json
+++ b/src/common/abi/SP1Helios.json
@@ -11,6 +11,25 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "slot",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "root",
+        "type": "bytes32"
+      }
+    ],
+    "name": "HeadUpdate",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "head",
     "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],

--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -7,9 +7,9 @@ import {
   compareAddressesSimple,
   ethers,
   BigNumber,
+  groupObjectCountsByProp,
 } from "../../utils";
 import { spreadEventWithBlockNumber } from "../../utils/EventUtils";
-import { groupObjectCountsByProp } from "@across-protocol/sdk/src/utils/ObjectUtils";
 import { FinalizerPromise, CrossChainMessage } from "../types";
 import axios from "axios";
 import UNIVERSAL_SPOKE_ABI from "../../common/abi/Universal_SpokePool.json";

--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -10,7 +10,6 @@ import {
 } from "../../utils";
 import { spreadEventWithBlockNumber } from "../../utils/EventUtils";
 import { FinalizerPromise, CrossChainMessage } from "../types";
-import { CONTRACT_ADDRESSES } from "../../common";
 import axios from "axios";
 import UNIVERSAL_SPOKE_ABI from "../../common/abi/Universal_SpokePool.json";
 import { RelayedCallDataEvent, StoredCallDataEvent } from "../../interfaces/Universal";
@@ -20,23 +19,35 @@ import { calculateProofId, decodeProofOutputs } from "../../utils/ZkApiUtils";
 import { calculateHubPoolStoreStorageSlot, getHubPoolStoreContract } from "../../utils/UniversalUtils";
 import { stringifyThrownValue } from "../../utils/LogUtils";
 import { getSp1HeliosContract } from "../../utils/HeliosUtils";
+import { getBlockFinder, getBlockForTimestamp } from "../../utils/BlockUtils";
 
-type CrossChainMessageStatus = "NeedsProofAndExecution" | "NeedsExecutionOnly";
+// --- Helios Action Types ---
+type HeliosActionType = "NeedsProofAndExecution" | "NeedsExecutionOnly" | "KeepSP1HeliosAlive";
 
-interface PendingCrosschainMessage {
-  l1Event: StoredCallDataEvent; // The original HubPoolStore event triggering the flow
-  status: CrossChainMessageStatus;
-  verifiedHead?: ethers.BigNumber; // Head from the StorageSlotVerified event, only present if status is NeedsExecutionOnly
+interface BaseHeliosAction {
+  type: HeliosActionType;
 }
-// ---------------------------------------
 
-// Type for successful proof data, augmented with HubPoolStore event info.
-type SuccessfulProof = {
-  proofData: SP1HeliosProofData;
-  sourceNonce: ethers.BigNumber;
-  target: string;
-  sourceMessageData: string;
-};
+export interface HeliosProofAndExecuteAction extends BaseHeliosAction {
+  type: "NeedsProofAndExecution";
+  l1Event: StoredCallDataEvent;
+  zkProofData?: SP1HeliosProofData;
+}
+
+export interface HeliosExecuteOnlyAction extends BaseHeliosAction {
+  type: "NeedsExecutionOnly";
+  l1Event: StoredCallDataEvent;
+  // @dev `head` from `StorageSlotVerified` event on `SP1Helios`. Required for `executeMessage` on `Universal_SpokePool`
+  verifiedSlotHead: ethers.BigNumber;
+}
+
+export interface HeliosKeepAliveAction extends BaseHeliosAction {
+  type: "KeepSP1HeliosAlive";
+  zkProofData?: SP1HeliosProofData;
+}
+
+export type HeliosAction = HeliosProofAndExecuteAction | HeliosExecuteOnlyAction | HeliosKeepAliveAction;
+// ---------------------------------------
 
 export async function heliosL1toL2Finalizer(
   logger: winston.Logger,
@@ -49,88 +60,90 @@ export async function heliosL1toL2Finalizer(
 ): Promise<FinalizerPromise> {
   const l1ChainId = hubPoolClient.chainId;
   const l2ChainId = l2SpokePoolClient.chainId;
+  const { sp1HeliosHead, sp1HeliosHeader } = await getSp1HeliosHeadData(l2SpokePoolClient);
 
-  // --- Step 1: Identify Pending Messages ---
-  const pendingMessages = await identifyPendingHeliosMessages(
+  // --- Step 1: Identify all actions needed (pending L1 -> L2 messages to finalize & keep-alive) ---
+  const actions = await identifyRequiredActions(
     logger,
     hubPoolClient,
     l1SpokePoolClient,
     l2SpokePoolClient,
     l1ChainId,
-    l2ChainId
+    l2ChainId,
+    sp1HeliosHead
   );
-
-  if (pendingMessages.length === 0) {
-    logger.debug({
-      at: `Finalizer#heliosL1toL2Finalizer:${l2ChainId}`,
-      message: "No pending Helios messages found requiring action.",
-    });
-    return { callData: [], crossChainMessages: [] };
-  }
-
-  // Separate messages based on required action
-  const needsProofAndExecution = pendingMessages.filter((m) => m.status === "NeedsProofAndExecution");
-  const needsExecutionOnly = pendingMessages.filter((m) => m.status === "NeedsExecutionOnly");
 
   logger.debug({
     at: `Finalizer#heliosL1toL2Finalizer:${l2ChainId}`,
-    message: `Identified ${pendingMessages.length} total pending messages.`,
-    counts: {
-      needsProofAndExecution: needsProofAndExecution.length,
-      needsExecutionOnly: needsExecutionOnly.length,
-    },
-    needsExecutionNonces: needsExecutionOnly.map((m) => m.l1Event.nonce.toString()), // Log nonces needing only execution
+    message: `Identified ${actions.length} total Helios actions.`,
+    actionCounts: actions.reduce((acc, action) => {
+      acc[action.type] = (acc[action.type] || 0) + 1;
+      return acc;
+    }, {} as Record<HeliosActionType, number>),
   });
 
-  // --- Step 2: Get Proofs for Messages Needing Full Finalization ---
-  let proofsToSubmit: SuccessfulProof[] = [];
-  if (needsProofAndExecution.length > 0) {
-    // Pass only the messages that need proofs
-    proofsToSubmit = await processUnfinalizedHeliosMessages(
-      logger,
-      needsProofAndExecution, // Pass PendingHeliosMessage[] here
-      l2SpokePoolClient,
-      l1ChainId
-    );
-    if (proofsToSubmit.length === 0) {
-      logger.debug({
-        at: `Finalizer#heliosL1toL2Finalizer:${l2ChainId}`,
-        message: "No successful proofs retrieved for messages needing full finalization.",
-      });
-      // Don't return yet, might still have needsExecutionOnly messages
-    }
+  if (actions.length === 0) {
+    return { callData: [], crossChainMessages: [] };
   }
 
-  // --- Step 3: Generate Multicall Data from Proofs and Partially Finalized Messages ---
-  if (proofsToSubmit.length === 0 && needsExecutionOnly.length === 0) {
+  // --- Step 2: Enrich actions with ZK proofs. Return messages that are ready to submit on-chain ---
+  const readyActions = await enrichHeliosActions(
+    logger,
+    actions,
+    l2SpokePoolClient,
+    l1SpokePoolClient,
+    sp1HeliosHead,
+    sp1HeliosHeader
+  );
+
+  if (readyActions.length === 0) {
     logger.debug({
       at: `Finalizer#heliosL1toL2Finalizer:${l2ChainId}`,
-      message: "No proofs obtained and no messages need execution only. Nothing to submit.",
+      message: "No Helios actions are ready for submission after enrichment phase.",
     });
     return { callData: [], crossChainMessages: [] };
   }
 
-  return generateHeliosTxns(logger, proofsToSubmit, needsExecutionOnly, l1ChainId, l2ChainId, l2SpokePoolClient);
+  // --- Step 3: Generate transactions from ready-to-submit actions ---
+  return generateTxnsForHeliosActions(logger, readyActions, l1ChainId, l2ChainId, l2SpokePoolClient);
 }
 
 // ==================================
 // Step-by-step Helper Functions
 // ==================================
 
-/** --- Step 1 ---
- * Identifies messages stored on L1 HubPoolStore that require action on L2.
- * Fetches L1 StoredCallData events, L2 StorageSlotVerified events, and L2 RelayedCallData events.
- * Determines if a message needs both proof+execution or just execution or no actions.
- */
-async function identifyPendingHeliosMessages(
+interface Sp1HeliosHeadData {
+  sp1HeliosHead: number;
+  sp1HeliosHeader: string;
+}
+
+async function getSp1HeliosHeadData(l2SpokePoolClient: SpokePoolClient): Promise<Sp1HeliosHeadData> {
+  const sp1HeliosL2 = getSp1HeliosContract(l2SpokePoolClient.chainId, l2SpokePoolClient.spokePool.provider);
+  const sp1HeliosHeadBn: ethers.BigNumber = await sp1HeliosL2.head();
+  const sp1HeliosHead = sp1HeliosHeadBn.toNumber();
+  const sp1HeliosHeader = await sp1HeliosL2.headers(sp1HeliosHeadBn);
+  if (!sp1HeliosHeader || sp1HeliosHeader === ethers.constants.HashZero) {
+    throw new Error(
+      `Invalid or zero header found for SP1Helios head ${sp1HeliosHead}. Cannot proceed with proof generation.`
+    );
+  }
+
+  return {
+    sp1HeliosHead,
+    sp1HeliosHeader,
+  };
+}
+
+async function identifyRequiredActions(
   logger: winston.Logger,
   hubPoolClient: HubPoolClient,
   l1SpokePoolClient: SpokePoolClient,
   l2SpokePoolClient: SpokePoolClient,
   l1ChainId: number,
-  l2ChainId: number
-): Promise<PendingCrosschainMessage[]> {
-  // --- Substep 1: Query and Filter L1 Events ---
+  l2ChainId: number,
+  currentL2HeliosHeadNumber: number
+): Promise<HeliosAction[]> {
+  // --- Substep 1: Query and Filter L1 Events (similar to getRelevantL1Events) ---
   const relevantStoredCallDataEvents = await getRelevantL1Events(
     logger,
     hubPoolClient,
@@ -140,75 +153,237 @@ async function identifyPendingHeliosMessages(
     l2SpokePoolClient.spokePool.address
   );
 
-  if (relevantStoredCallDataEvents.length === 0) {
-    logger.debug({
-      at: `Finalizer#identifyPendingHeliosMessages:${l2ChainId}`,
-      message: "No relevant StoredCallData events found on L1.",
-    });
-    return [];
-  }
-
   // --- Substep 2: Query L2 Verification Events (StorageSlotVerified) ---
   const verifiedSlotsMap = await getL2VerifiedSlotsMap(l2SpokePoolClient, l2ChainId);
 
   // --- Substep 3: Query L2 Execution Events (RelayedCallData) ---
   const relayedNonces = await getL2RelayedNonces(l2SpokePoolClient);
 
+  const actions: HeliosAction[] = [];
+
   // --- Determine Status for each L1 Event ---
-  const pendingMessages: PendingCrosschainMessage[] = [];
   for (const l1Event of relevantStoredCallDataEvents) {
     const expectedStorageSlot = calculateHubPoolStoreStorageSlot(l1Event.nonce);
     const nonce = l1Event.nonce;
+    const isExecuted = relayedNonces.has(nonce.toString());
 
-    const isExecuted = relayedNonces.has(nonce.toString()); // Use nonce string as key
-
-    if (!isExecuted) {
-      if (verifiedSlotsMap.has(expectedStorageSlot) /* isVerified */) {
-        // Verified but not executed -> Needs Execution Only
-        const verifiedEvent = verifiedSlotsMap.get(expectedStorageSlot);
-        pendingMessages.push({
-          l1Event: l1Event,
-          status: "NeedsExecutionOnly",
-          verifiedHead: verifiedEvent.head, // set verifiedHead as it's needed for execution
-        });
-        // Log a warning for partially finalized messages
-        logger.warn({
-          at: `Finalizer#identifyPendingHeliosMessages:${l2ChainId}`,
-          message:
-            "Message requires execution only (already verified in SP1Helios). Will generate SpokePool.executeMessage tx.",
-          l1TxRef: l1Event.txnRef,
-          nonce: nonce.toString(),
-          storageSlot: expectedStorageSlot,
-          verifiedOnL2TxnRef: verifiedEvent.txnRef,
-          verifiedHead: verifiedEvent.head.toString(),
-        });
-      } else {
-        // Not verified and not executed -> Needs Proof and Execution
-        pendingMessages.push({
-          l1Event: l1Event,
-          status: "NeedsProofAndExecution",
-          // verifiedHead is undefined here
-        });
-      }
+    if (isExecuted) {
+      // Nothing to do for already executed events
+      continue;
     }
-    // If `isExecuted` is true, the message is fully finalized, do nothing.
+
+    if (verifiedSlotsMap.has(expectedStorageSlot) /* isVerified */) {
+      const verifiedEvent = verifiedSlotsMap.get(expectedStorageSlot);
+      actions.push({
+        type: "NeedsExecutionOnly",
+        l1Event: l1Event,
+        verifiedSlotHead: verifiedEvent.head,
+      });
+      // Warn about a half-finished finalization
+      logger.warn({
+        at: `Finalizer#getHeliosActions:${l2ChainId}`,
+        message:
+          "Message requires execution only (already verified in SP1Helios). Will generate SpokePool.executeMessage tx.",
+        l1TxRef: l1Event.txnRef,
+        nonce: nonce.toString(),
+      });
+    } else {
+      actions.push({
+        type: "NeedsProofAndExecution",
+        l1Event: l1Event,
+      });
+    }
+  }
+
+  // --- Substep 4: Check if Keep-Alive action is needed and push to actions if yes ---
+  if (
+    await shouldGenerateKeepAliveAction(logger, hubPoolClient, l2SpokePoolClient, currentL2HeliosHeadNumber, l2ChainId)
+  ) {
+    actions.push({
+      type: "KeepSP1HeliosAlive",
+    });
   }
 
   logger.debug({
-    at: `Finalizer#identifyPendingHeliosMessages:${l2ChainId}`,
-    message: "Finished identifying pending messages.",
+    at: `Finalizer#getHeliosActions:${l2ChainId}`,
+    message: "Finished identifying Helios actions.",
     totalL1StoredCallData: relevantStoredCallDataEvents.length,
     totalL2VerifiedSlots: verifiedSlotsMap.size,
     totalL2RelayedNonces: relayedNonces.size,
-    pendingMessagesCount: pendingMessages.length,
-    needsProofCount: pendingMessages.filter((m) => m.status === "NeedsProofAndExecution").length,
-    needsExecutionOnlyCount: pendingMessages.filter((m) => m.status === "NeedsExecutionOnly").length,
+    actionsCount: actions.length,
+    actionBreakdown: actions.reduce((acc, action) => {
+      acc[action.type] = (acc[action.type] || 0) + 1;
+      return acc;
+    }, {} as Record<HeliosActionType, number>),
   });
 
-  return pendingMessages;
+  return actions;
 }
 
-/** Query and Filter L1 Events */
+async function shouldGenerateKeepAliveAction(
+  logger: winston.Logger,
+  hubPoolClient: HubPoolClient,
+  l2SpokePoolClient: SpokePoolClient,
+  currentL2HeliosHeadNumber: number,
+  l2ChainId: number
+): Promise<boolean> {
+  const twentyFourHoursInSeconds = 24 * 60 * 60;
+  const timestamp24hAgo = Math.floor(Date.now() / 1000) - twentyFourHoursInSeconds;
+
+  /**
+   * @dev Exact check that happens in SP1Helios that we're protecting against:
+   * require(block.timestamp - slotTimestamp(fromHead) <= MAX_SLOT_AGE, PreviousHeadTooOld(fromHead));
+   * where MAX_SLOT_AGE = 1 week.
+   */
+  const l1ChainId = hubPoolClient.chainId;
+  const l1BlockFinder = await getBlockFinder(l1ChainId);
+  const l1Block24hAgo = await getBlockForTimestamp(l1ChainId, timestamp24hAgo, l1BlockFinder);
+
+  if (currentL2HeliosHeadNumber < l1Block24hAgo) {
+    // todo: perhaps change to warn? This should be a rare-ish log
+    logger.info({
+      at: "Finalizer#shouldGenerateKeepAliveAction",
+      message: "SP1Helios head is older than 24 hours (L1 block time). Should generate keep-alive.",
+      currentL2HeliosHeadNumber,
+      l1Block24hAgo,
+      l2ChainId,
+    });
+    return true;
+  }
+  return false;
+}
+
+// returns helios messages ready for on-chain execution enriched with proof data
+async function enrichHeliosActions(
+  logger: winston.Logger,
+  actions: HeliosAction[],
+  l2SpokePoolClient: SpokePoolClient,
+  l1SpokePoolClient: SpokePoolClient,
+  currentL2HeliosHeadNumber: number,
+  currentL2HeliosHeader: string
+): Promise<HeliosAction[]> {
+  const l2ChainId = l2SpokePoolClient.chainId;
+  const apiBaseUrl = process.env.HELIOS_PROOF_API_URL;
+  if (!apiBaseUrl) {
+    throw new Error("[enrichHeliosActions] HELIOS_PROOF_API_URL environment variable not set.");
+  }
+  const hubPoolStoreAddress = getHubPoolStoreContract(
+    l1SpokePoolClient.chainId,
+    l1SpokePoolClient.spokePool.provider
+  ).address;
+
+  const readyActions: HeliosAction[] = [];
+  for (const action of actions) {
+    let apiRequest: ApiProofRequest;
+    let logContext: any;
+    switch (action.type) {
+      case "NeedsExecutionOnly":
+        // ExecutionOnly messages can be executed right away without a proof, so we add them to `readyActions` and continue
+        readyActions.push(action);
+        continue;
+      case "NeedsProofAndExecution":
+        logContext = {
+          at: `Finalizer#heliosL1toL2Finalizer:enrichHeliosActions:${l2ChainId}`,
+          messageType: "NeedsProofAndExecution",
+          l1TxHash: action.l1Event.txnRef,
+          nonce: action.l1Event.nonce.toString(),
+          target: action.l1Event.target,
+        };
+        apiRequest = {
+          src_chain_contract_address: hubPoolStoreAddress,
+          src_chain_storage_slots: [calculateHubPoolStoreStorageSlot(action.l1Event.nonce)],
+          src_chain_block_number: action.l1Event.blockNumber,
+          dst_chain_contract_from_head: currentL2HeliosHeadNumber,
+          dst_chain_contract_from_header: currentL2HeliosHeader,
+        };
+        break;
+      case "KeepSP1HeliosAlive":
+        logContext = {
+          at: `Finalizer#heliosL1toL2Finalizer:enrichHeliosActions:${l2ChainId}`,
+          messageType: "KeepSP1HeliosAlive",
+        };
+        apiRequest = {
+          src_chain_contract_address: ethers.constants.AddressZero,
+          src_chain_storage_slots: [],
+          src_chain_block_number: 0,
+          dst_chain_contract_from_head: currentL2HeliosHeadNumber,
+          dst_chain_contract_from_header: currentL2HeliosHeader,
+        };
+        break;
+      default: {
+        throw new Error(`[enrichHeliosActions] Unhandled action type ${action}`);
+      }
+    }
+
+    const proofId = calculateProofId(apiRequest);
+    const getProofUrl = `${apiBaseUrl}/api/proofs/${proofId}`;
+
+    logger.debug({ ...logContext, message: "Attempting to get proof", proofId, getProofUrl });
+
+    let proofState: ProofStateResponse | null = null;
+
+    // @dev We need try - catch here because of how API responds to non-existing proofs: with NotFound status
+    let getError: any = null;
+    try {
+      const response = await axios.get<ProofStateResponse>(getProofUrl);
+      proofState = response.data;
+      logger.debug({ ...logContext, message: "Proof state received", proofId, status: proofState.status });
+    } catch (error: any) {
+      getError = error;
+    }
+
+    // Axios error. Handle based on whether was a NOTFOUND or another error
+    if (getError) {
+      const isNotFoundError = axios.isAxiosError(getError) && getError.response?.status === 404;
+      if (isNotFoundError) {
+        // NOTFOUND error -> Request proof
+        logger.debug({ ...logContext, message: "Proof not found (404), requesting...", proofId });
+        await axios.post(`${apiBaseUrl}/api/proofs`, apiRequest);
+        logger.debug({ ...logContext, message: "Proof requested successfully.", proofId });
+        continue;
+      } else {
+        // If other error is returned -- throw and alert PD; this shouldn't happen
+        throw new Error(`Failed to get proof state for proofId ${proofId}: ${stringifyThrownValue(getError)}`);
+      }
+    }
+
+    // No axios error, process `proofState`
+    switch (proofState.status) {
+      case "pending":
+        // If proof generation is pending -- there's nothing for us to do yet. Will check this proof next run
+        logger.debug({ ...logContext, message: "Proof generation is pending.", proofId });
+        break;
+      case "errored":
+        // Proof generation errored on the API side. This is concerning, so we log an error. But nothing to do for us other than to re-request
+        logger.error({
+          ...logContext,
+          message: "Proof generation errored on ZK API side. Requesting again.",
+          proofId,
+          errorMessage: proofState.error_message,
+        });
+
+        await axios.post(`${apiBaseUrl}/api/proofs`, apiRequest);
+        logger.debug({ ...logContext, message: "Errored proof requested again successfully.", proofId });
+        break;
+      case "success":
+        if (!proofState.update_calldata) {
+          throw new Error(`Proof status is success but update_calldata is missing for proofId ${proofId}`);
+        }
+        logger.debug({ ...logContext, message: "Proof successfully retrieved.", proofId });
+        // Proof generation succeeded. Insert `update_calldata` into action. It's now ready to execute
+        action.zkProofData = proofState.update_calldata;
+        readyActions.push(action);
+        break;
+      default:
+        throw new Error(`Received unexpected proof status for proof ${proofId}`);
+    }
+    // end loop over actions
+  }
+
+  return readyActions;
+}
+
+// --- Helper: Query and Filter L1 Events ---
 async function getRelevantL1Events(
   _logger: winston.Logger,
   hubPoolClient: HubPoolClient,
@@ -307,150 +482,10 @@ async function getL2RelayedNonces(l2SpokePoolClient: SpokePoolClient): Promise<S
   return new Set<string>(events.map((event) => event.nonce.toString()));
 }
 
-/**
- * --- Get Proofs for Unfinalized Messages ---
- * Processes messages needing proof+execution by interacting with the ZK Proof API.
- * Returns a list of successfully retrieved proofs.
- */
-async function processUnfinalizedHeliosMessages(
-  logger: winston.Logger,
-  messagesToProcess: PendingCrosschainMessage[],
-  l2SpokePoolClient: SpokePoolClient,
-  l1ChainId: number
-): Promise<SuccessfulProof[]> {
-  // Filter within the function just in case, though the caller should have already filtered
-  const unfinalizedMessages = messagesToProcess.filter((m) => m.status === "NeedsProofAndExecution");
-  if (unfinalizedMessages.length === 0) {
-    return [];
-  }
-
-  const l2ChainId = l2SpokePoolClient.chainId;
-  const l2Provider = l2SpokePoolClient.spokePool.provider;
-  const apiBaseUrl = process.env.HELIOS_PROOF_API_URL;
-
-  if (!apiBaseUrl) {
-    logger.error({
-      at: `Finalizer#heliosL1toL2Finalizer:processUnfinalizedHeliosMessages:${l2ChainId}`,
-      message: "HELIOS_PROOF_API_URL environment variable not set. Cannot process Helios messages.",
-    });
-    return [];
-  }
-
-  const hubPoolStoreInfo = CONTRACT_ADDRESSES[l1ChainId]?.hubPoolStore;
-  if (!hubPoolStoreInfo?.address) {
-    throw new Error(`HubPoolStore address not available for chain: ${l1ChainId}. Cannot process Helios messages.`);
-  }
-  const hubPoolStoreAddress = hubPoolStoreInfo.address;
-  const sp1HeliosContract = getSp1HeliosContract(l2ChainId, l2Provider);
-
-  const headBn: ethers.BigNumber = await sp1HeliosContract.head();
-  // todo: well, currently we're taking currentHead to use as prevHead in our ZK proof. There's a particular scenario where we could speed up proofs
-  // todo: (by not making them to wait for finality longer than needed) if our blockNumber that we need a proved slot for is older than this head.
-  const currentHead = headBn.toNumber();
-  const currentHeader = await sp1HeliosContract.headers(headBn);
-  if (!currentHeader || currentHeader === ethers.constants.HashZero) {
-    throw new Error(`Invalid header found for head ${currentHead}`);
-  }
-
-  const successfulProofs: SuccessfulProof[] = [];
-
-  // todo? Can use Promise.All if we really want to
-  // Process messages one by one
-  for (const pendingMessage of unfinalizedMessages) {
-    const l1Event = pendingMessage.l1Event; // Extract the L1 event
-    const logContext = {
-      at: `Finalizer#heliosL1toL2Finalizer:processUnfinalizedHeliosMessages:${l2ChainId}`,
-      l1TxHash: l1Event.txnRef,
-      nonce: l1Event.nonce.toString(),
-      target: l1Event.target,
-    };
-
-    const storageSlot = calculateHubPoolStoreStorageSlot(l1Event.nonce);
-
-    const apiRequest: ApiProofRequest = {
-      src_chain_contract_address: hubPoolStoreAddress,
-      src_chain_storage_slots: [storageSlot],
-      src_chain_block_number: l1Event.blockNumber, // Use block number from L1 event
-      dst_chain_contract_from_head: currentHead,
-      dst_chain_contract_from_header: currentHeader,
-    };
-
-    const proofId = calculateProofId(apiRequest);
-    const getProofUrl = `${apiBaseUrl}/api/proofs/${proofId}`;
-
-    logger.debug({ ...logContext, message: "Attempting to get proof", proofId, getProofUrl, storageSlot });
-
-    let proofState: ProofStateResponse | null = null;
-
-    // @dev We need try - catch here because of how API responds to non-existing proofs: with NotFound status
-    let getError: any = null;
-    try {
-      const response = await axios.get<ProofStateResponse>(getProofUrl);
-      proofState = response.data;
-      logger.debug({ ...logContext, message: "Proof state received", proofId, status: proofState.status });
-    } catch (error: any) {
-      getError = error;
-    }
-
-    // Axios error. Handle based on whether was a NOTFOUND or another error
-    if (getError) {
-      const isNotFoundError = axios.isAxiosError(getError) && getError.response?.status === 404;
-      if (isNotFoundError) {
-        // NOTFOUND error -> Request proof
-        logger.debug({ ...logContext, message: "Proof not found (404), requesting...", proofId });
-        await axios.post(`${apiBaseUrl}/api/proofs`, apiRequest);
-        logger.debug({ ...logContext, message: "Proof requested successfully.", proofId });
-        continue;
-      } else {
-        // If other error is returned -- throw and alert PD; this shouldn't happen
-        throw new Error(`Failed to get proof state for proofId ${proofId}: ${stringifyThrownValue(getError)}`);
-      }
-    }
-
-    // No axios error, process `proofState`
-    switch (proofState.status) {
-      case "pending":
-        // If proof generation is pending -- there's nothing for us to do yet. Will check this proof next run
-        logger.debug({ ...logContext, message: "Proof generation is pending.", proofId });
-        break;
-      case "errored":
-        // Proof generation errored on the API side. This is concerning, so we log an error. But nothing to do for us other than to re-request
-        logger.error({
-          ...logContext,
-          message: "Proof generation errored on ZK API side. Requesting again.",
-          proofId,
-          errorMessage: proofState.error_message,
-        });
-
-        await axios.post(`${apiBaseUrl}/api/proofs`, apiRequest);
-        logger.debug({ ...logContext, message: "Errored proof requested again successfully.", proofId });
-        break;
-      case "success":
-        if (!proofState.update_calldata) {
-          throw new Error(`Proof status is success but update_calldata is missing for proofId ${proofId}`);
-        }
-        logger.debug({ ...logContext, message: "Proof successfully retrieved.", proofId });
-        successfulProofs.push({
-          // @dev `proofData` should exist if proofState.status is "success"
-          proofData: proofState.update_calldata,
-          sourceNonce: l1Event.nonce,
-          target: l1Event.target,
-          sourceMessageData: l1Event.data,
-        });
-        break;
-      default:
-        throw new Error(`Received unexpected proof status for proof ${proofId}`);
-    }
-  } // end loop over messages
-
-  return successfulProofs;
-}
-
 /** --- Generate Multicall Data --- */
-async function generateHeliosTxns(
+async function generateTxnsForHeliosActions(
   logger: winston.Logger,
-  successfulProofs: SuccessfulProof[],
-  needsExecutionOnlyMessages: PendingCrosschainMessage[],
+  readyActions: HeliosAction[],
   l1ChainId: number,
   l2ChainId: number,
   l2SpokePoolClient: SpokePoolClient
@@ -459,124 +494,223 @@ async function generateHeliosTxns(
   const crossChainMessages: CrossChainMessage[] = [];
 
   const sp1HeliosContract = getSp1HeliosContract(l2ChainId, l2SpokePoolClient.spokePool.signer);
-  const spokePoolAddress = l2SpokePoolClient.spokePool.address;
   const universalSpokePoolContract = new ethers.Contract(
-    spokePoolAddress,
+    l2SpokePoolClient.spokePool.address,
     [...UNIVERSAL_SPOKE_ABI],
     l2SpokePoolClient.spokePool.signer
   );
 
-  // --- Process messages needing only execution ---
-  for (const message of needsExecutionOnlyMessages) {
-    const { l1Event, verifiedHead } = message;
-    const nonce = l1Event.nonce;
-    const l1Target = l1Event.target; // Get target from L1 event
-    const l1Data = l1Event.data; // Get data from L1 event
+  for (const action of readyActions) {
+    switch (action.type) {
+      case "NeedsExecutionOnly":
+        updateTxnArraysExecutionOnly(
+          logger,
+          l1ChainId,
+          l2ChainId,
+          transactions,
+          crossChainMessages,
+          universalSpokePoolContract,
+          action
+        );
+        break;
 
-    if (!verifiedHead) {
-      // @dev This shouldn't happen. If it does, there's a bug that needs fixing.
-      throw new Error(`Logic error: Message ${nonce.toString()} needs execution only but verifiedHead is missing.`);
+      case "NeedsProofAndExecution":
+        updateTxnArraysProofAndExecution(
+          l1ChainId,
+          l2ChainId,
+          transactions,
+          crossChainMessages,
+          sp1HeliosContract,
+          universalSpokePoolContract,
+          action
+        );
+        break;
+
+      case "KeepSP1HeliosAlive":
+        updateTxnArraysKeepAlive(l1ChainId, l2ChainId, transactions, crossChainMessages, sp1HeliosContract, action);
+        break;
+
+      default:
+        throw new Error("unhandled action type in generateTxnsForHeliosActions");
     }
-
-    // @dev Warn about messages that require only half of finalization. Means that either a tx from prev. run got stuck or failed or something else weird happened
-    logger.warn({
-      at: `Finalizer#heliosL1toL2Finalizer:generateTxnItem:${l2ChainId}`,
-      message: "Generating SpokePool.executeMessage ONLY for partially finalized message.",
-      nonce: nonce.toString(),
-      l1TxHash: l1Event.txnRef,
-      verifiedHead: verifiedHead.toString(),
-    });
-
-    // --- Encode the message parameter ---
-    const encodedMessage = ethers.utils.defaultAbiCoder.encode(["address", "bytes"], [l1Target, l1Data]);
-    // ------------------------------------
-
-    const executeArgs = [nonce, encodedMessage, verifiedHead]; // Use encodedMessage
-    const executeTx: AugmentedTransaction = {
-      contract: universalSpokePoolContract,
-      chainId: l2ChainId,
-      method: "executeMessage",
-      args: executeArgs,
-      unpermissioned: true,
-      canFailInSimulation: true,
-      message: `Finalize Helios msg (HubPoolStore nonce ${nonce.toString()}) - Step 2 ONLY: Execute on SpokePool`,
-    };
-    transactions.push(executeTx);
-    crossChainMessages.push({
-      type: "misc",
-      miscReason: "ZK bridge finalization (Execute Message Only)",
-      originationChainId: l1ChainId,
-      destinationChainId: l2ChainId,
-    });
   }
 
-  // --- Process messages needing proof and execution ---
-  for (const proof of successfulProofs) {
-    // Ensure the hex strings have the '0x' prefix, adding it only if missing.
-    const proofBytes = proof.proofData.proof.startsWith("0x") ? proof.proofData.proof : "0x" + proof.proofData.proof;
-    const publicValuesBytes = proof.proofData.public_values.startsWith("0x")
-      ? proof.proofData.public_values
-      : "0x" + proof.proofData.public_values;
+  const summary = readyActions.reduce((acc, r) => {
+    acc[r.type] = (acc[r.type] || 0) + 1;
+    if (r.type === "NeedsProofAndExecution") {
+      acc.proofNonces = [...(acc.proofNonces || []), r.l1Event.nonce.toString()];
+    }
+    if (r.type === "NeedsExecutionOnly") {
+      acc.execOnlyNonces = [...(acc.execOnlyNonces || []), r.l1Event.nonce.toString()];
+    }
+    if (r.type === "KeepSP1HeliosAlive" && r.zkProofData) {
+      acc.keepAliveProofs = (acc.keepAliveProofs || 0) + 1;
+    }
+    return acc;
+  }, {} as Record<string, any>);
 
-    // @dev Will throw on decode errors here.
-    const decodedOutputs: ProofOutputs = decodeProofOutputs(publicValuesBytes);
-
-    // 1. SP1Helios.update transaction
-    const updateArgs = [proofBytes, publicValuesBytes];
-    const updateTx: AugmentedTransaction = {
-      contract: sp1HeliosContract,
-      chainId: l2ChainId,
-      method: "update",
-      args: updateArgs,
-      unpermissioned: false,
-      canFailInSimulation: false,
-      nonMulticall: true,
-      message: `Finalize Helios msg (HubPoolStore nonce ${proof.sourceNonce.toString()}) - Step 1: Update SP1Helios`,
-    };
-    transactions.push(updateTx);
-    crossChainMessages.push({
-      type: "misc",
-      miscReason: "ZK bridge finalization (Helios Update)",
-      originationChainId: l1ChainId,
-      destinationChainId: l2ChainId,
-    });
-
-    // 2. SpokePool.executeMessage transaction
-    // --- Encode the message parameter ---
-    const l1Target = proof.target; // Get target from SuccessfulProof
-    const l1Data = proof.sourceMessageData; // Get data from SuccessfulProof
-    const encodedMessage = ethers.utils.defaultAbiCoder.encode(["address", "bytes"], [l1Target, l1Data]);
-    // ------------------------------------
-
-    const executeArgs = [proof.sourceNonce, encodedMessage, decodedOutputs.newHead]; // Use encodedMessage
-    const executeTx: AugmentedTransaction = {
-      contract: universalSpokePoolContract,
-      chainId: l2ChainId,
-      method: "executeMessage",
-      args: executeArgs,
-      unpermissioned: true,
-      // @dev Simulation of `executeMessage` depends on prior state update via SP1Helios.update
-      canFailInSimulation: true,
-      // todo? this hardcoded gas limit of 2 mil could be improved if we were able to simulate this tx on top of blockchain state created by the tx above
-      gasLimit: BigNumber.from(2000000),
-      message: `Finalize Helios msg (HubPoolStore nonce ${proof.sourceNonce.toString()}) - Step 2: Execute on SpokePool`,
-    };
-    transactions.push(executeTx);
-    crossChainMessages.push({
-      type: "misc",
-      miscReason: "ZK bridge finalization (Execute Message)",
-      originationChainId: l1ChainId,
-      destinationChainId: l2ChainId,
-    });
-  }
-
-  const totalFinalizations = successfulProofs.length + needsExecutionOnlyMessages.length;
   logger.debug({
-    at: `Finalizer#heliosL1toL2Finalizer:generateHeliosTxns:${l2ChainId}`,
-    message: `Generated ${transactions.length} transactions for ${totalFinalizations} finalizations (${successfulProofs.length} full, ${needsExecutionOnlyMessages.length} exec only).`,
-    proofNoncesFinalized: successfulProofs.map((p) => p.sourceNonce.toString()),
-    execOnlyNoncesFinalized: needsExecutionOnlyMessages.map((m) => m.l1Event.nonce.toString()),
+    at: `Finalizer#generateHeliosTxns:${l2ChainId}`,
+    message: `Generated ${transactions.length} transactions for ${readyActions.length} ready actions.`,
+    summary,
   });
 
   return { callData: transactions, crossChainMessages: crossChainMessages };
+}
+
+function updateTxnArraysExecutionOnly(
+  logger: winston.Logger,
+  l1ChainId: number,
+  l2ChainId: number,
+  transactions: AugmentedTransaction[],
+  crossChainMessages: CrossChainMessage[],
+  universalSpokePoolContract: ethers.Contract,
+  action: HeliosExecuteOnlyAction
+) {
+  const { l1Event, verifiedSlotHead } = action;
+
+  if (!verifiedSlotHead) {
+    throw new Error("Logic error: verifiedSlotHead missing from HeliosExecuteOnlyAction");
+  }
+
+  logger.warn({
+    at: `Finalizer#generateHeliosTxns:${l2ChainId}`,
+    message: "Generating SpokePool.executeMessage ONLY for partially finalized message.",
+    nonce: l1Event.nonce.toString(),
+    l1TxHash: l1Event.txnRef,
+    verifiedHead: verifiedSlotHead.toString(),
+  });
+
+  const encodedMessage = ethers.utils.defaultAbiCoder.encode(["address", "bytes"], [l1Event.target, l1Event.data]);
+  const executeArgs = [l1Event.nonce, encodedMessage, verifiedSlotHead];
+  const executeTx: AugmentedTransaction = {
+    contract: universalSpokePoolContract,
+    chainId: l2ChainId,
+    method: "executeMessage",
+    args: executeArgs,
+    unpermissioned: true,
+    canFailInSimulation: false,
+    message: `Finalize Helios msg (HubPoolStore nonce ${action.l1Event.nonce.toString()}) - Step 2 ONLY: Execute on SpokePool`,
+  };
+  transactions.push(executeTx);
+  crossChainMessages.push({
+    type: "misc",
+    miscReason: "ZK bridge finalization (Execute Message Only)",
+    originationChainId: l1ChainId,
+    destinationChainId: l2ChainId,
+  });
+}
+
+function updateTxnArraysProofAndExecution(
+  l1ChainId: number,
+  l2ChainId: number,
+  transactions: AugmentedTransaction[],
+  crossChainMessages: CrossChainMessage[],
+  sp1HeliosContract: ethers.Contract,
+  universalSpokePoolContract: ethers.Contract,
+  action: HeliosProofAndExecuteAction
+) {
+  const { l1Event, zkProofData } = action;
+
+  if (!zkProofData) {
+    throw new Error(
+      "[updateTxnArraysProofAndExecution] Logic error: zkProofData missing from HeliosProofAndExecuteAction"
+    );
+  }
+
+  // Ensure the hex strings have the '0x' prefix, adding it only if missing.
+  const proofBytes = zkProofData.proof.startsWith("0x") ? zkProofData.proof : "0x" + zkProofData.proof;
+  const publicValuesBytes = zkProofData.public_values.startsWith("0x")
+    ? zkProofData.public_values
+    : "0x" + zkProofData.public_values;
+
+  // @dev Will throw on decode errors here.
+  const decodedOutputs: ProofOutputs = decodeProofOutputs(publicValuesBytes);
+
+  // 1. SP1Helios.update transaction
+  const updateArgs = [proofBytes, publicValuesBytes];
+  const updateTx: AugmentedTransaction = {
+    contract: sp1HeliosContract,
+    chainId: l2ChainId,
+    method: "update",
+    args: updateArgs,
+    unpermissioned: false,
+    canFailInSimulation: false,
+    nonMulticall: true,
+    message: `Finalize Helios msg (HubPoolStore nonce ${l1Event.nonce.toString()}) - Step 1: Update SP1Helios`,
+  };
+  transactions.push(updateTx);
+  crossChainMessages.push({
+    type: "misc",
+    miscReason: "ZK bridge finalization (Helios Update)",
+    originationChainId: l1ChainId,
+    destinationChainId: l2ChainId,
+  });
+
+  // 2. SpokePool.executeMessage transaction
+  const encodedMessage = ethers.utils.defaultAbiCoder.encode(["address", "bytes"], [l1Event.target, l1Event.data]);
+  const executeArgs = [l1Event.nonce, encodedMessage, decodedOutputs.newHead];
+  const executeTx: AugmentedTransaction = {
+    contract: universalSpokePoolContract,
+    chainId: l2ChainId,
+    method: "executeMessage",
+    args: executeArgs,
+    unpermissioned: true,
+    // @dev Simulation of `executeMessage` depends on prior state update via SP1Helios.update
+    canFailInSimulation: true,
+    // todo? this hardcoded gas limit of 2 mil could be improved if we were able to simulate this tx on top of blockchain state created by the tx above
+    gasLimit: BigNumber.from(2000000),
+    message: `Finalize Helios msg (HubPoolStore nonce ${l1Event.nonce.toString()}) - Step 2: Execute on SpokePool`,
+  };
+  transactions.push(executeTx);
+  crossChainMessages.push({
+    type: "misc",
+    miscReason: "ZK bridge finalization (Execute Message)",
+    originationChainId: l1ChainId,
+    destinationChainId: l2ChainId,
+  });
+}
+
+function updateTxnArraysKeepAlive(
+  l1ChainId: number,
+  l2ChainId: number,
+  transactions: AugmentedTransaction[],
+  crossChainMessages: CrossChainMessage[],
+  sp1HeliosContract: ethers.Contract,
+  action: HeliosKeepAliveAction
+) {
+  const { zkProofData } = action;
+
+  if (!zkProofData) {
+    throw new Error("[updateTxnArraysKeepAlive] Logic error: zkProofData missing from HeliosKeepAliveAction");
+  }
+
+  // Ensure the hex strings have the '0x' prefix, adding it only if missing.
+  const proofBytes = zkProofData.proof.startsWith("0x") ? zkProofData.proof : "0x" + zkProofData.proof;
+  const publicValuesBytes = zkProofData.public_values.startsWith("0x")
+    ? zkProofData.public_values
+    : "0x" + zkProofData.public_values;
+
+  // @dev Will throw on decode errors here.
+  const decodedOutputs: ProofOutputs = decodeProofOutputs(publicValuesBytes);
+
+  // 1. SP1Helios.update transaction
+  const updateArgs = [proofBytes, publicValuesBytes];
+  const updateTx: AugmentedTransaction = {
+    contract: sp1HeliosContract,
+    chainId: l2ChainId,
+    method: "update",
+    args: updateArgs,
+    unpermissioned: false,
+    canFailInSimulation: false,
+    nonMulticall: true,
+    message: `KeepAlive msg for SP1Helios: updating to a newer head ${decodedOutputs.prevHead} -> ${decodedOutputs.newHead}`,
+  };
+  transactions.push(updateTx);
+  crossChainMessages.push({
+    type: "misc",
+    miscReason: "ZK bridge finalization (Helios Update)",
+    originationChainId: l1ChainId,
+    destinationChainId: l2ChainId,
+  });
 }

--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -9,6 +9,7 @@ import {
   BigNumber,
 } from "../../utils";
 import { spreadEventWithBlockNumber } from "../../utils/EventUtils";
+import { groupObjectCountsByProp } from "@across-protocol/sdk/src/utils/ObjectUtils";
 import { FinalizerPromise, CrossChainMessage } from "../types";
 import axios from "axios";
 import UNIVERSAL_SPOKE_ABI from "../../common/abi/Universal_SpokePool.json";
@@ -78,10 +79,7 @@ export async function heliosL1toL2Finalizer(
   logger.debug({
     at: `Finalizer#heliosL1toL2Finalizer:${l2ChainId}`,
     message: `Identified ${actions.length} total Helios actions.`,
-    actionCounts: actions.reduce((acc, action) => {
-      acc[action.type] = (acc[action.type] || 0) + 1;
-      return acc;
-    }, {} as Record<HeliosActionType, number>),
+    actionCounts: groupObjectCountsByProp(actions, (action) => action.type),
   });
 
   if (actions.length === 0) {
@@ -210,10 +208,7 @@ async function identifyRequiredActions(
     totalL2VerifiedSlots: verifiedSlotsMap.size,
     totalL2RelayedNonces: relayedNonces.size,
     actionsCount: actions.length,
-    actionBreakdown: actions.reduce((acc, action) => {
-      acc[action.type] = (acc[action.type] || 0) + 1;
-      return acc;
-    }, {} as Record<HeliosActionType, number>),
+    actionBreakdown: groupObjectCountsByProp(actions, (action) => action.type),
   });
 
   return actions;

--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -176,8 +176,8 @@ async function identifyRequiredActions(
         l1Event: l1Event,
         verifiedSlotHead: verifiedEvent.head,
       });
-      // Warn about a half-finished finalization
-      logger.warn({
+      // Report half-finished finalization from prev. run
+      logger.debug({
         at: `Finalizer#identifyRequiredActions:${l2ChainId}`,
         message:
           "Message requires execution only (already verified in SP1Helios). Will generate SpokePool.executeMessage tx.",

--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -184,7 +184,7 @@ async function identifyRequiredActions(
       });
       // Warn about a half-finished finalization
       logger.warn({
-        at: `Finalizer#getHeliosActions:${l2ChainId}`,
+        at: `Finalizer#identifyRequiredActions:${l2ChainId}`,
         message:
           "Message requires execution only (already verified in SP1Helios). Will generate SpokePool.executeMessage tx.",
         l1TxRef: l1Event.txnRef,
@@ -208,7 +208,7 @@ async function identifyRequiredActions(
   }
 
   logger.debug({
-    at: `Finalizer#getHeliosActions:${l2ChainId}`,
+    at: `Finalizer#identifyRequiredActions:${l2ChainId}`,
     message: "Finished identifying Helios actions.",
     totalL1StoredCallData: relevantStoredCallDataEvents.length,
     totalL2VerifiedSlots: verifiedSlotsMap.size,
@@ -553,7 +553,7 @@ async function generateTxnsForHeliosActions(
   }, {} as Record<string, any>);
 
   logger.debug({
-    at: `Finalizer#generateHeliosTxns:${l2ChainId}`,
+    at: `Finalizer#generateTxnsForHeliosActions:${l2ChainId}`,
     message: `Generated ${transactions.length} transactions for ${readyActions.length} ready actions.`,
     summary,
   });
@@ -577,7 +577,7 @@ function addExecuteOnlyTxn(
   }
 
   logger.warn({
-    at: `Finalizer#generateHeliosTxns:${l2ChainId}`,
+    at: `Finalizer#addExecuteOnlyTxn:${l2ChainId}`,
     message: "Generating SpokePool.executeMessage ONLY for partially finalized message.",
     nonce: l1Event.nonce.toString(),
     l1TxHash: l1Event.txnRef,

--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -122,10 +122,8 @@ async function getSp1HeliosHeadData(l2SpokePoolClient: SpokePoolClient): Promise
   const sp1HeliosHeadBn: ethers.BigNumber = await sp1HeliosL2.head();
   const sp1HeliosHead = sp1HeliosHeadBn.toNumber();
   const sp1HeliosHeader = await sp1HeliosL2.headers(sp1HeliosHeadBn);
-  if (!sp1HeliosHeader || sp1HeliosHeader === ethers.constants.HashZero) {
-    throw new Error(
-      `Invalid or zero header found for SP1Helios head ${sp1HeliosHead}. Cannot proceed with proof generation.`
-    );
+  if (sp1HeliosHeader === ethers.constants.HashZero) {
+    throw new Error(`Zero header found for SP1Helios head ${sp1HeliosHead}. Cannot proceed with proof generation.`);
   }
 
   return {

--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -369,7 +369,7 @@ async function processUnfinalizedHeliosMessages(
 
     const apiRequest: ApiProofRequest = {
       src_chain_contract_address: hubPoolStoreAddress,
-      src_chain_storage_slot: storageSlot,
+      src_chain_storage_slots: [storageSlot],
       src_chain_block_number: l1Event.blockNumber, // Use block number from L1 event
       dst_chain_contract_from_head: currentHead,
       dst_chain_contract_from_header: currentHeader,

--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -319,7 +319,7 @@ async function enrichHeliosActions(
     }
 
     const proofId = calculateProofId(apiRequest);
-    const getProofUrl = `${apiBaseUrl}/api/proofs/${proofId}`;
+    const getProofUrl = `${apiBaseUrl}/v1/api/proofs/${proofId}`;
 
     logger.debug({ ...logContext, message: "Attempting to get proof", proofId, getProofUrl });
 
@@ -341,7 +341,7 @@ async function enrichHeliosActions(
       if (isNotFoundError) {
         // NOTFOUND error -> Request proof
         logger.debug({ ...logContext, message: "Proof not found (404), requesting...", proofId });
-        await axios.post(`${apiBaseUrl}/api/proofs`, apiRequest);
+        await axios.post(`${apiBaseUrl}/v1/api/proofs`, apiRequest);
         logger.debug({ ...logContext, message: "Proof requested successfully.", proofId });
         continue;
       } else {
@@ -365,7 +365,7 @@ async function enrichHeliosActions(
           errorMessage: proofState.error_message,
         });
 
-        await axios.post(`${apiBaseUrl}/api/proofs`, apiRequest);
+        await axios.post(`${apiBaseUrl}/v1/api/proofs`, apiRequest);
         logger.debug({ ...logContext, message: "Errored proof requested again successfully.", proofId });
         break;
       case "success":

--- a/src/interfaces/Helios.ts
+++ b/src/interfaces/Helios.ts
@@ -3,15 +3,14 @@ import { BigNumber } from "../utils";
 
 // Event type for Sp1Helios used in v4 messaging (Flattened)
 export interface StorageSlotVerifiedEvent extends SortableEvent {
-  key: string; // bytes32 indexed key
-  value: string; // bytes32 value
-  head: BigNumber; // uint256 indexed head (beacon chain slot number)
-  // contractAddress will also be present due to spreadEventWithBlockNumber
+  key: string; // bytes32 indexed (storage slot key)
+  value: string; // bytes32 (value at storage slot key)
+  head: BigNumber; // uint256 (beacon chain slot number)
+  contractAddress: string; // address
 }
 
 // Flattened SP1Helios Event for HeadUpdate
 export interface HeadUpdateEvent extends SortableEvent {
-  slot: BigNumber; // uint256 indexed slot
-  root: string; // bytes32 indexed root
-  // contractAddress will also be present due to spreadEventWithBlockNumber
+  slot: BigNumber; // uint256
+  root: string; // bytes32
 }

--- a/src/interfaces/Helios.ts
+++ b/src/interfaces/Helios.ts
@@ -3,8 +3,15 @@ import { BigNumber } from "../utils";
 
 // Event type for Sp1Helios used in v4 messaging (Flattened)
 export interface StorageSlotVerifiedEvent extends SortableEvent {
-  head: BigNumber;
-  key: string; // bytes32
-  value: string; // bytes32
-  contractAddress: string;
+  key: string; // bytes32 indexed key
+  value: string; // bytes32 value
+  head: BigNumber; // uint256 indexed head (beacon chain slot number)
+  // contractAddress will also be present due to spreadEventWithBlockNumber
+}
+
+// Flattened SP1Helios Event for HeadUpdate
+export interface HeadUpdateEvent extends SortableEvent {
+  slot: BigNumber; // uint256 indexed slot
+  root: string; // bytes32 indexed root
+  // contractAddress will also be present due to spreadEventWithBlockNumber
 }

--- a/src/interfaces/ZkApi.ts
+++ b/src/interfaces/ZkApi.ts
@@ -3,7 +3,7 @@ import { BigNumber } from "../utils";
 // --- API Interaction Types ---
 export interface ApiProofRequest {
   src_chain_contract_address: string;
-  src_chain_storage_slot: string;
+  src_chain_storage_slots: string[];
   src_chain_block_number: number; // u64 on Rust API side
   dst_chain_contract_from_head: number; // u64 on Rust API side
   dst_chain_contract_from_header: string;

--- a/src/utils/ZkApiUtils.ts
+++ b/src/utils/ZkApiUtils.ts
@@ -6,11 +6,18 @@ import { ApiProofRequest, PROOF_OUTPUTS_ABI_TUPLE, ProofOutputs } from "../inter
  * Matches the Rust implementation using RLP encoding and Keccak256.
  */
 export function calculateProofId(request: ApiProofRequest): string {
+  // RLP spec: integer values should be minimal big-endian; zero is empty string
+  const blockNumberHex = BigNumber.from(request.src_chain_block_number).isZero()
+    ? "0x"
+    : BigNumber.from(request.src_chain_block_number).toHexString();
+  const headHex = BigNumber.from(request.dst_chain_contract_from_head).isZero()
+    ? "0x"
+    : BigNumber.from(request.dst_chain_contract_from_head).toHexString();
   const encoded = ethers.utils.RLP.encode([
     request.src_chain_contract_address,
     request.src_chain_storage_slots,
-    BigNumber.from(request.src_chain_block_number).toHexString(), // Ensure block number is hex encoded for RLP
-    BigNumber.from(request.dst_chain_contract_from_head).toHexString(), // Ensure head is hex encoded for RLP
+    blockNumberHex,
+    headHex,
     request.dst_chain_contract_from_header,
   ]);
   return ethers.utils.keccak256(encoded);

--- a/src/utils/ZkApiUtils.ts
+++ b/src/utils/ZkApiUtils.ts
@@ -8,7 +8,7 @@ import { ApiProofRequest, PROOF_OUTPUTS_ABI_TUPLE, ProofOutputs } from "../inter
 export function calculateProofId(request: ApiProofRequest): string {
   const encoded = ethers.utils.RLP.encode([
     request.src_chain_contract_address,
-    request.src_chain_storage_slot,
+    request.src_chain_storage_slots,
     BigNumber.from(request.src_chain_block_number).toHexString(), // Ensure block number is hex encoded for RLP
     BigNumber.from(request.dst_chain_contract_from_head).toHexString(), // Ensure head is hex encoded for RLP
     request.dst_chain_contract_from_header,


### PR DESCRIPTION
If SP1Helios.head is left unupdated for > 1 WEEK, the contract gets bricked. We let 24hrs go by with no updates, but after then we call .update() even if there are no new messages to finalize (by requesting a new ZK proof with empty storage slots to prove).

This turned out to be a large refactor. IMO, the current flow is nice though:

we identify required HeliosActions
try to enrich them with ZK proof data
for all the actions that are "ready", generate on-chain txs
Closes ACX-4075