### PR TITLE
refactor: allow arbitrary arguments to bridge adapters

### DIFF
--- a/src/adapter/bridges/ArbitrumOrbitBridge.ts
+++ b/src/adapter/bridges/ArbitrumOrbitBridge.ts
@@ -57,7 +57,7 @@ export class ArbitrumOrbitBridge extends BaseBridgeAdapter {
     const l1Abi = CONTRACT_ADDRESSES[hubChainId][`orbitErc20Gateway_${l2chainId}`].abi;
     const l2Abi = ARBITRUM_ERC20_GATEWAY_L2_ABI;
 
-    super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, [EvmAddress.from(l1Address)]);
+    super(l2chainId, hubChainId, l1Signer, [EvmAddress.from(l1Address)]);
 
     const nativeToken = PUBLIC_NETWORKS[l2chainId].nativeToken;
     // Only set nonstandard gas tokens.

--- a/src/adapter/bridges/BaseBridgeAdapter.ts
+++ b/src/adapter/bridges/BaseBridgeAdapter.ts
@@ -3,7 +3,6 @@ import {
   BigNumber,
   EventSearchConfig,
   Signer,
-  Provider,
   getTranslatedTokenAddress,
   assert,
   isDefined,
@@ -34,7 +33,6 @@ export abstract class BaseBridgeAdapter {
     protected l2chainId: number,
     protected hubChainId: number,
     protected l1Signer: Signer,
-    protected l2SignerOrProvider: Signer | Provider,
     public l1Gateways: EvmAddress[]
   ) {}
 

--- a/src/adapter/bridges/BinanceCEXBridge.ts
+++ b/src/adapter/bridges/BinanceCEXBridge.ts
@@ -10,7 +10,6 @@ import {
   isDefined,
   getTimestampForBlock,
   mapAsync,
-  ethers,
   getBinanceApiClient,
   floatToBN,
   CHAIN_IDs,
@@ -25,6 +24,7 @@ export class BinanceCEXBridge extends BaseBridgeAdapter {
   protected readonly binanceApiClientPromise;
   protected binanceApiClient;
   protected tokenSymbol: string;
+  protected l2Provider: Provider;
 
   constructor(
     l2chainId: number,
@@ -37,7 +37,7 @@ export class BinanceCEXBridge extends BaseBridgeAdapter {
       throw new Error("Cannot define a binance CEX bridge on a non-production network");
     }
     // No L1 gateways needed since no L1 bridge transfers tokens from the EOA.
-    super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, []);
+    super(l2chainId, hubChainId, l1Signer, []);
     // Pull the binance API key from environment and throw if we cannot instantiate this bridge.
     this.binanceApiClientPromise = getBinanceApiClient(process.env["BINANCE_API_BASE"]);
 
@@ -48,6 +48,13 @@ export class BinanceCEXBridge extends BaseBridgeAdapter {
     const _tokenSymbol = getTokenInfo(l1Token.toAddress(), this.hubChainId).symbol;
     // Handle the special case for when we are bridging WBNB to BNB on L2.
     this.tokenSymbol = _tokenSymbol === "WBNB" ? "BNB" : _tokenSymbol;
+
+    // Cast the input Signer | Provider to a Provider.
+    if (l2SignerOrProvider instanceof Signer) {
+      this.l2Provider = l2SignerOrProvider.provider;
+    } else {
+      this.l2Provider = l2SignerOrProvider;
+    }
   }
 
   async constructL1ToL2Txn(
@@ -137,12 +144,8 @@ export class BinanceCEXBridge extends BaseBridgeAdapter {
       return {};
     }
     // We must typecast the l2 signer or provider into specifically an ethers Provider type so we can call `getTransactionReceipt` and `getBlockByNumber` on it.
-    const l2Provider =
-      this.l2SignerOrProvider instanceof ethers.providers.Provider
-        ? (this.l2SignerOrProvider as ethers.providers.Provider)
-        : (this.l2SignerOrProvider as ethers.Signer).provider;
     assert(l1Token.toAddress() === this.getL1Bridge().address);
-    const fromTimestamp = (await getTimestampForBlock(l2Provider, eventConfig.fromBlock)) * 1_000; // Convert timestamp to ms.
+    const fromTimestamp = (await getTimestampForBlock(this.l2Provider, eventConfig.fromBlock)) * 1_000; // Convert timestamp to ms.
 
     const binanceApiClient = await this.getBinanceClient();
     // Fetch the deposit address from the binance API.
@@ -156,7 +159,7 @@ export class BinanceCEXBridge extends BaseBridgeAdapter {
     );
     const withdrawalTxReceipts = await mapAsync(
       withdrawalHistory.map((withdrawal) => withdrawal.txId as string),
-      async (transactionHash) => l2Provider.getTransactionReceipt(transactionHash as string)
+      async (transactionHash) => this.l2Provider.getTransactionReceipt(transactionHash as string)
     );
     const { decimals: l1Decimals } = getTokenInfo(l1Token.toAddress(), this.hubChainId);
 
@@ -177,13 +180,9 @@ export class BinanceCEXBridge extends BaseBridgeAdapter {
   }
 
   private async isL1OrL2Contract(address: EvmAddress): Promise<boolean> {
-    const l2Provider =
-      this.l2SignerOrProvider instanceof ethers.providers.Provider
-        ? (this.l2SignerOrProvider as ethers.providers.Provider)
-        : (this.l2SignerOrProvider.provider as ethers.providers.Provider);
     const [isL1Contract, isL2Contract] = await Promise.all([
       isContractDeployedToAddress(address.toAddress(), this.l1Signer.provider),
-      isContractDeployedToAddress(address.toAddress(), l2Provider),
+      isContractDeployedToAddress(address.toAddress(), this.l2Provider),
     ]);
     return isL1Contract || isL2Contract;
   }

--- a/src/adapter/bridges/BlastBridge.ts
+++ b/src/adapter/bridges/BlastBridge.ts
@@ -9,7 +9,7 @@ export class BlastBridge extends BaseBridgeAdapter {
   constructor(l2chainId: number, hubChainId: number, l1Signer: Signer, l2SignerOrProvider: Signer | Provider) {
     const { address: l1Address, abi: l1Abi } = CONTRACT_ADDRESSES[hubChainId].blastBridge;
     const { address: l2Address, abi: l2Abi } = CONTRACT_ADDRESSES[l2chainId].blastBridge;
-    super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, [EvmAddress.from(l1Address)]);
+    super(l2chainId, hubChainId, l1Signer, [EvmAddress.from(l1Address)]);
 
     this.l1Bridge = new Contract(l1Address, l1Abi, l1Signer);
     this.l2Bridge = new Contract(l2Address, l2Abi, l2SignerOrProvider);

--- a/src/adapter/bridges/LineaBridge.ts
+++ b/src/adapter/bridges/LineaBridge.ts
@@ -7,7 +7,7 @@ export class LineaBridge extends BaseBridgeAdapter {
   constructor(l2chainId: number, hubChainId: number, l1Signer: Signer, l2SignerOrProvider: Signer | Provider) {
     const { address: l1Address, abi: l1Abi } = CONTRACT_ADDRESSES[hubChainId].lineaL1TokenBridge;
     const { address: l2Address, abi: l2Abi } = CONTRACT_ADDRESSES[l2chainId].lineaL2TokenBridge;
-    super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, [EvmAddress.from(l1Address)]);
+    super(l2chainId, hubChainId, l1Signer, [EvmAddress.from(l1Address)]);
 
     this.l1Bridge = new Contract(l1Address, l1Abi, l1Signer);
     this.l2Bridge = new Contract(l2Address, l2Abi, l2SignerOrProvider);

--- a/src/adapter/bridges/LineaWethBridge.ts
+++ b/src/adapter/bridges/LineaWethBridge.ts
@@ -26,7 +26,7 @@ export class LineaWethBridge extends BaseBridgeAdapter {
     const { address: l1Address, abi: l1Abi } = CONTRACT_ADDRESSES[hubChainId].lineaMessageService;
     const { address: l2Address, abi: l2Abi } = CONTRACT_ADDRESSES[l2chainId].l2MessageService;
     const { address: atomicDepositorAddress, abi: atomicDepositorAbi } = CONTRACT_ADDRESSES[hubChainId].atomicDepositor;
-    super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, [EvmAddress.from(atomicDepositorAddress)]);
+    super(l2chainId, hubChainId, l1Signer, [EvmAddress.from(atomicDepositorAddress)]);
 
     this.atomicDepositor = new Contract(atomicDepositorAddress, atomicDepositorAbi, l1Signer);
     this.l1Bridge = new Contract(l1Address, l1Abi, l1Signer);

--- a/src/adapter/bridges/OpStackDefaultErc20Bridge.ts
+++ b/src/adapter/bridges/OpStackDefaultErc20Bridge.ts
@@ -7,7 +7,7 @@ export class OpStackDefaultERC20Bridge extends BaseBridgeAdapter {
   private readonly l2Gas = 200000;
 
   constructor(l2chainId: number, hubChainId: number, l1Signer: Signer, l2SignerOrProvider: Signer | Provider) {
-    super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, [
+    super(l2chainId, hubChainId, l1Signer, [
       EvmAddress.from(CONTRACT_ADDRESSES[hubChainId][`ovmStandardBridge_${l2chainId}`].address),
     ]);
 

--- a/src/adapter/bridges/OpStackUSDCBridge.ts
+++ b/src/adapter/bridges/OpStackUSDCBridge.ts
@@ -9,7 +9,7 @@ export class OpStackUSDCBridge extends BaseBridgeAdapter {
   constructor(l2chainId: number, hubChainId: number, l1Signer: Signer, l2SignerOrProvider: Signer | Provider) {
     const { address: l1Address, abi: l1Abi } = CONTRACT_ADDRESSES[hubChainId][`opUSDCBridge_${l2chainId}`];
     const { address: l2Address, abi: l2Abi } = CONTRACT_ADDRESSES[l2chainId].opUSDCBridge;
-    super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, [EvmAddress.from(l1Address)]);
+    super(l2chainId, hubChainId, l1Signer, [EvmAddress.from(l1Address)]);
 
     this.l1Bridge = new Contract(l1Address, l1Abi, l1Signer);
     this.l2Bridge = new Contract(l2Address, l2Abi, l2SignerOrProvider);

--- a/src/adapter/bridges/OpStackWethBridge.ts
+++ b/src/adapter/bridges/OpStackWethBridge.ts
@@ -30,7 +30,6 @@ export class OpStackWethBridge extends BaseBridgeAdapter {
       l2chainId,
       hubChainId,
       l1Signer,
-      l2SignerOrProvider,
       // To keep existing logic, we should use atomic depositor as the l1 bridge
       [EvmAddress.from(CONTRACT_ADDRESSES[hubChainId].atomicDepositor.address)]
     );

--- a/src/adapter/bridges/PolygonERC20Bridge.ts
+++ b/src/adapter/bridges/PolygonERC20Bridge.ts
@@ -33,7 +33,7 @@ export class PolygonERC20Bridge extends BaseBridgeAdapter {
     // up-to-date.
     const { address: l1Address, abi: l1Abi } = CONTRACT_ADDRESSES[hubChainId].polygonBridge;
     const { address: l1GatewayAddress, abi: l1GatewayAbi } = CONTRACT_ADDRESSES[hubChainId].polygonRootChainManager;
-    super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, [EvmAddress.from(l1Address)]);
+    super(l2chainId, hubChainId, l1Signer, [EvmAddress.from(l1Address)]);
 
     this.l1Bridge = new Contract(l1Address, l1Abi, l1Signer);
     this.l1Gateway = new Contract(l1GatewayAddress, l1GatewayAbi, l1Signer);

--- a/src/adapter/bridges/PolygonWethBridge.ts
+++ b/src/adapter/bridges/PolygonWethBridge.ts
@@ -38,7 +38,7 @@ export class PolygonWethBridge extends BaseBridgeAdapter {
     const { address: atomicDepositorAddress, abi: atomicDepositorAbi } = CONTRACT_ADDRESSES[hubChainId].atomicDepositor;
     const { address: rootChainManagerAddress, abi: rootChainManagerAbi } =
       CONTRACT_ADDRESSES[hubChainId].polygonRootChainManager;
-    super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, [EvmAddress.from(atomicDepositorAddress)]);
+    super(l2chainId, hubChainId, l1Signer, [EvmAddress.from(atomicDepositorAddress)]);
 
     this.l1Bridge = new Contract(l1Address, l1Abi, l1Signer);
     this.atomicDepositor = new Contract(atomicDepositorAddress, atomicDepositorAbi, l1Signer);

--- a/src/adapter/bridges/ScrollERC20Bridge.ts
+++ b/src/adapter/bridges/ScrollERC20Bridge.ts
@@ -44,7 +44,7 @@ export class ScrollERC20Bridge extends BaseBridgeAdapter {
 
     const { address: gasPriceOracleAddress, abi: gasPriceOracleAbi } =
       CONTRACT_ADDRESSES[hubChainId].scrollGasPriceOracle;
-    super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, [EvmAddress.from(l1Address)]);
+    super(l2chainId, hubChainId, l1Signer, [EvmAddress.from(l1Address)]);
 
     this.l1Bridge = new Contract(l1BridgeAddress, l1Abi, l1Signer);
     this.l2Bridge = new Contract(l2BridgeAddress, l2Abi, l2SignerOrProvider);

--- a/src/adapter/bridges/SnxOptimismBridge.ts
+++ b/src/adapter/bridges/SnxOptimismBridge.ts
@@ -14,9 +14,7 @@ import { processEvent } from "../utils";
 
 export class SnxOptimismBridge extends BaseBridgeAdapter {
   constructor(l2chainId: number, hubChainId: number, l1Signer: Signer, l2SignerOrProvider: Signer | Provider) {
-    super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, [
-      EvmAddress.from(CONTRACT_ADDRESSES[hubChainId].snxOptimismBridge.address),
-    ]);
+    super(l2chainId, hubChainId, l1Signer, [EvmAddress.from(CONTRACT_ADDRESSES[hubChainId].snxOptimismBridge.address)]);
 
     const { address: l1Address, abi: l1Abi } = CONTRACT_ADDRESSES[hubChainId].snxOptimismBridge;
     this.l1Bridge = new Contract(l1Address, l1Abi, l1Signer);

--- a/src/adapter/bridges/UsdcCCTPBridge.ts
+++ b/src/adapter/bridges/UsdcCCTPBridge.ts
@@ -24,9 +24,7 @@ export class UsdcCCTPBridge extends BaseBridgeAdapter {
   private readonly l1UsdcTokenAddress: EvmAddress;
 
   constructor(l2chainId: number, hubChainId: number, l1Signer: Signer, l2SignerOrProvider: Signer | Provider) {
-    super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, [
-      EvmAddress.from(getCctpTokenMessenger(l2chainId, hubChainId).address),
-    ]);
+    super(l2chainId, hubChainId, l1Signer, [EvmAddress.from(getCctpTokenMessenger(l2chainId, hubChainId).address)]);
     assert(
       getCctpDomainForChainId(l2chainId) !== CCTP_NO_DOMAIN && getCctpDomainForChainId(hubChainId) !== CCTP_NO_DOMAIN,
       "Unknown CCTP domain ID"

--- a/src/adapter/bridges/UsdcTokenSplitterBridge.ts
+++ b/src/adapter/bridges/UsdcTokenSplitterBridge.ts
@@ -32,7 +32,7 @@ export class UsdcTokenSplitterBridge extends BaseBridgeAdapter {
       l1Token
     );
 
-    super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, [
+    super(l2chainId, hubChainId, l1Signer, [
       EvmAddress.from(CONTRACT_ADDRESSES[hubChainId].cctpTokenMessenger.address),
       canonicalBridge.l1Gateways[0], // Canonical Bridge should have a single L1 Gateway.
     ]);

--- a/src/adapter/bridges/ZKStackBridge.ts
+++ b/src/adapter/bridges/ZKStackBridge.ts
@@ -50,7 +50,7 @@ export class ZKStackBridge extends BaseBridgeAdapter {
     _l1Token: EvmAddress
   ) {
     const { address: sharedBridgeAddress, abi: sharedBridgeAbi } = CONTRACT_ADDRESSES[hubChainId].zkStackSharedBridge;
-    super(l2chainId, hubChainId, l1Signer, l2SignerOrProvider, [EvmAddress.from(sharedBridgeAddress)]);
+    super(l2chainId, hubChainId, l1Signer, [EvmAddress.from(sharedBridgeAddress)]);
     this.sharedBridge = new Contract(sharedBridgeAddress, sharedBridgeAbi, l1Signer);
 
     const nativeToken = PUBLIC_NETWORKS[l2chainId].nativeToken;

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -376,19 +376,12 @@ export const TOKEN_APPROVALS_TO_FIRST_ZERO: Record<number, string[]> = {
   ],
 };
 
+// Type alias for a function which takes in arbitrary arguments and outputs a BaseBridgeAdapter class.
+type L1BridgeConstructor<T extends BaseBridgeAdapter> = new (...args: any[]) => T;
+
 // Map of chain IDs to all "canonical bridges" for the given chain. Canonical is loosely defined -- in this
 // case, it is the default bridge for the given chain.
-export const CANONICAL_BRIDGE: {
-  [chainId: number]: {
-    new (
-      l2chainId: number,
-      hubChainId: number,
-      l1Signer: Signer,
-      l2SignerOrProvider: Signer | Provider,
-      l1Token?: EvmAddress
-    ): BaseBridgeAdapter;
-  };
-} = {
+export const CANONICAL_BRIDGE: Record<number, L1BridgeConstructor<BaseBridgeAdapter>> = {
   [CHAIN_IDs.ALEPH_ZERO]: ArbitrumOrbitBridge,
   [CHAIN_IDs.ARBITRUM]: ArbitrumOrbitBridge,
   [CHAIN_IDs.BASE]: OpStackDefaultERC20Bridge,
@@ -442,19 +435,7 @@ export const CANONICAL_L2_BRIDGE: {
 
 // Custom Bridges are all bridges between chains which only support a small number (typically one) of tokens.
 // In addition to mapping a chain to the custom bridges, we also need to specify which token the bridge supports.
-export const CUSTOM_BRIDGE: {
-  [chainId: number]: {
-    [tokenAddress: string]: {
-      new (
-        l2chainId: number,
-        hubChainId: number,
-        l1Signer: Signer,
-        l2SignerOrProvider: Signer | Provider,
-        l1Token?: EvmAddress
-      ): BaseBridgeAdapter;
-    };
-  };
-} = {
+export const CUSTOM_BRIDGE: Record<number, Record<string, L1BridgeConstructor<BaseBridgeAdapter>>> = {
   [CHAIN_IDs.ARBITRUM]: {
     [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: UsdcTokenSplitterBridge,
   },


### PR DESCRIPTION
There are two changes to the bridge adapters here:
1. We no longer define `l2SignerOrProvider` on the interface level of the bridge adapters. We didn't really even use this anywhere, so it's good to cut off for the sake of contravariance, but we need this relaxation anyways since the Solana bridge will require a different l2 provider type entirely, so it will be incompatible with a BaseBridgeAdapter given its current state.
2. The `CUSTOM_BRIDGE`/`CANONICAL_BRIDGE` maps now let us take an arbitrary set of arguments. Our "contract" is that we will supply some extension of the BaseBridgeAdapter, but the inputs we need to get there are no longer explicit. This means we no longer require each extension of BaseBridgeAdapter to have the same constructor arguments, meaning that we can pass in an `SVMProvider` in the future to these values. This comes at the cost of not getting type checking at compilation time. I think this is OK, since these bridge adapters implement a known interface, so we really only need to be more careful [here](https://github.com/across-protocol/relayer/blob/302b2ea9ef8cff08a9357494528f025fb11c2156/src/clients/bridges/AdapterManager.ts#L73) when defining the arguments to pass into each bridge.