### PR TITLE
fix(finalizer): Filter out not-completely-ready attestations

### DIFF
--- a/src/finalizer/utils/cctp/l1ToL2.ts
+++ b/src/finalizer/utils/cctp/l1ToL2.ts
@@ -41,7 +41,7 @@ export async function cctpL1toL2Finalizer(
     l2SpokePoolClient.chainId,
     searchConfig
   );
-  const unprocessedMessages = outstandingDeposits.filter((message) => message.status === "ready");
+  const unprocessedMessages = outstandingDeposits.filter((message) => message.status === "ready" && message.attestation !== "PENDING");
   const statusesGrouped = groupObjectCountsByProp(
     outstandingDeposits,
     (message: { status: CCTPMessageStatus }) => message.status
@@ -75,7 +75,7 @@ async function generateMultiCallData(
   messageTransmitter: Contract,
   messages: Pick<AttestedCCTPDepositEvent, "attestation" | "messageBytes">[]
 ): Promise<Multicall2Call[]> {
-  assert(messages.every((message) => isDefined(message.attestation)));
+  assert(messages.every(({ attestation }) => isDefined(attestation) && attestation !== "PENDING"));
   return Promise.all(
     messages.map(async (message) => {
       const txn = (await messageTransmitter.populateTransaction.receiveMessage(


### PR DESCRIPTION
Observed on CCTPv2 when a deposit is very recent on mainnet; the finalizer tries and fails to submit a transaction because the message attestation is "PENDING".