### PR TITLE
fix: CCTP v2 attestation index

### DIFF
--- a/src/utils/CCTPUtils.ts
+++ b/src/utils/CCTPUtils.ts
@@ -424,5 +424,10 @@ async function _generateCCTPV2AttestationProof(
       isMainnet ? "" : "-sandbox"
     }.circle.com/v2/messages/${sourceDomainId}?transactionHash=${transactionHash}`
   );
-  return httpResponse.data;
+  // Only leave v2 attestations in the response
+  const filteredMessages = httpResponse.data.messages.filter((message) => message.cctpVersion === 2);
+  return {
+    ...httpResponse.data,
+    messages: filteredMessages,
+  };
 }

--- a/src/utils/CCTPUtils.ts
+++ b/src/utils/CCTPUtils.ts
@@ -427,7 +427,6 @@ async function _generateCCTPV2AttestationProof(
   // Only leave v2 attestations in the response
   const filteredMessages = httpResponse.data.messages.filter((message) => message.cctpVersion === 2);
   return {
-    ...httpResponse.data,
     messages: filteredMessages,
   };
 }


### PR DESCRIPTION
When getting an attestation from Circle's api by index [here](https://github.com/across-protocol/relayer/blob/6fbe3eaf6742ff5b23c52cf9b4248e949fbc2f53/src/utils/CCTPUtils.ts#L300), we didn't account for the fact that one message can contain both L1 and L2 attestations.

As a result, our `count` variable only knows about v2 messages, but trying to get an attestation by index from an array of both v1 and v2 messages.

Solution: filter L1 messages from an array.

✅ Tested locally, fixes finalizer error and simulates a batch on Linea successfully.