### PR TITLE
chore: Enforce number type on process exit()

### DIFF
--- a/src/libexec/RelayerSpokePoolListener.ts
+++ b/src/libexec/RelayerSpokePoolListener.ts
@@ -280,6 +280,6 @@ if (require.main === module) {
     .finally(async () => {
       await disconnectRedisClients();
       logger.debug({ at: "RelayerSpokePoolListener", message: `Exiting ${chain} listener.` });
-      exit(process.exitCode);
+      exit(Number(process.exitCode));
     });
 }

--- a/src/libexec/RelayerSpokePoolListenerHTTPS.ts
+++ b/src/libexec/RelayerSpokePoolListenerHTTPS.ts
@@ -248,6 +248,6 @@ if (require.main === module) {
     .finally(async () => {
       await disconnectRedisClients();
       logger.debug({ at: "RelayerSpokePoolListener", message: `Exiting ${chain} listener.` });
-      exit(process.exitCode);
+      exit(Number(process.exitCode));
     });
 }


### PR DESCRIPTION
process.exitCode is unconditionally a number in the implementation, but its type also permits string. Identified by @fusmanii in PR #2284.