### PR TITLE
improve(InventoryClient): Don't skip BSC deposits

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -30,6 +30,7 @@ import {
   getRemoteTokenForL1Token,
   getTokenInfo,
   isEVMSpokePoolClient,
+  repaymentChainCanBeQuicklyRebalanced,
 } from "../utils";
 import { HubPoolClient, TokenClient, BundleDataClient } from ".";
 import { Deposit, ProposedRootBundle } from "../interfaces";
@@ -494,9 +495,11 @@ export class InventoryClient {
       );
     }
 
-    // The hub chain is magical; don't fumble repayment based on perceived over-allocation.
-    if (forceOriginRepayment && deposit.originChainId === hubChainId) {
-      return [hubChainId];
+    // If the deposit forces origin chain repayment but the origin chain is one we can easily rebalance inventory from,
+    // then don't ignore this deposit based on perceived over-allocation. For example, the hub chain and chains connected
+    // to the user's Binance API are easy to move inventory from so we should never skip filling these deposits.
+    if (forceOriginRepayment && repaymentChainCanBeQuicklyRebalanced(deposit, this.hubPoolClient)) {
+      return [deposit.originChainId];
     }
 
     l1Token ??= this.getL1TokenAddress(inputToken, originChainId);

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -1,6 +1,6 @@
 import { HubPoolClient } from "../clients";
 import { Fill, FillStatus, SpokePoolClientsByChain, DepositWithBlock } from "../interfaces";
-import { bnZero } from "../utils";
+import { bnZero, CHAIN_IDs } from "../utils";
 
 export type RelayerUnfilledDeposit = {
   deposit: DepositWithBlock;
@@ -49,6 +49,18 @@ export function depositForcesOriginChainRepayment(
   return (
     deposit.fromLiteChain || !hubPoolClient.l2TokenHasPoolRebalanceRoute(deposit.inputToken, deposit.originChainId)
   );
+}
+
+/**
+ * @notice Returns true if after filling this deposit, the repayment can be quickly rebalanced to a different chain.
+ * @dev This function can be used by the InventoryClient and Relayer to help determine whether a deposit should
+ * be filled or ignored given current inventory allocation levels.
+ */
+export function repaymentChainCanBeQuicklyRebalanced(
+  deposit: Pick<DepositWithBlock, "originChainId">,
+  hubPoolClient: HubPoolClient
+): boolean {
+  return [hubPoolClient.chainId, CHAIN_IDs.BSC].includes(deposit.originChainId);
 }
 
 export function getAllUnfilledDeposits(

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -31,8 +31,8 @@ import {
 import { utils as sdkUtils } from "@across-protocol/sdk";
 
 describe("InventoryClient: Refund chain selection", async function () {
-  const { MAINNET, OPTIMISM, POLYGON, ARBITRUM } = CHAIN_IDs;
-  const enabledChainIds = [MAINNET, OPTIMISM, POLYGON, ARBITRUM];
+  const { MAINNET, OPTIMISM, POLYGON, ARBITRUM, BSC } = CHAIN_IDs;
+  const enabledChainIds = [MAINNET, OPTIMISM, POLYGON, ARBITRUM, BSC];
   const mainnetWeth = TOKEN_SYMBOLS_MAP.WETH.addresses[MAINNET];
   const mainnetUsdc = TOKEN_SYMBOLS_MAP.USDC.addresses[MAINNET];
 
@@ -50,7 +50,11 @@ describe("InventoryClient: Refund chain selection", async function () {
     .filter((chainId) => chainId !== MAINNET)
     .forEach((chainId) => {
       l2TokensForWeth[chainId] = TOKEN_SYMBOLS_MAP.WETH.addresses[chainId];
-      l2TokensForUsdc[chainId] = TOKEN_SYMBOLS_MAP["USDC.e"].addresses[chainId];
+      if (chainId !== BSC) {
+        l2TokensForUsdc[chainId] = TOKEN_SYMBOLS_MAP["USDC.e"].addresses[chainId];
+      } else {
+        l2TokensForUsdc[chainId] = TOKEN_SYMBOLS_MAP["USDC-BNB"].addresses[chainId];
+      }
     });
 
   const toMegaWei = (num: string | number | BigNumber) => parseUnits(num.toString(), 6);
@@ -66,11 +70,13 @@ describe("InventoryClient: Refund chain selection", async function () {
         [OPTIMISM]: { targetPct: toWei(0.12), thresholdPct: toWei(0.1), targetOverageBuffer },
         [POLYGON]: { targetPct: toWei(0.07), thresholdPct: toWei(0.05), targetOverageBuffer },
         [ARBITRUM]: { targetPct: toWei(0.07), thresholdPct: toWei(0.05), targetOverageBuffer },
+        [BSC]: { targetPct: toWei(0.07), thresholdPct: toWei(0.05), targetOverageBuffer },
       },
       [mainnetUsdc]: {
         [OPTIMISM]: { targetPct: toWei(0.12), thresholdPct: toWei(0.1), targetOverageBuffer },
         [POLYGON]: { targetPct: toWei(0.07), thresholdPct: toWei(0.05), targetOverageBuffer },
         [ARBITRUM]: { targetPct: toWei(0.07), thresholdPct: toWei(0.05), targetOverageBuffer },
+        [BSC]: { targetPct: toWei(0.07), thresholdPct: toWei(0.05), targetOverageBuffer },
       },
     },
   };
@@ -81,12 +87,14 @@ describe("InventoryClient: Refund chain selection", async function () {
     [OPTIMISM]: { [mainnetWeth]: toWei(20), [mainnetUsdc]: toMegaWei(2000) }, // seed 20 WETH and 2000 USDC on Optimism
     [POLYGON]: { [mainnetWeth]: toWei(10), [mainnetUsdc]: toMegaWei(1000) }, // seed 10 WETH and 1000 USDC on Polygon
     [ARBITRUM]: { [mainnetWeth]: toWei(10), [mainnetUsdc]: toMegaWei(1000) }, // seed 10 WETH and 1000 USDC on Arbitrum
+    // [BSC]: { [mainnetWeth]: toWei(10), [mainnetUsdc]: toMegaWei(1000) }, // seed 10 WETH and 1000 USDC on BSC
   };
 
   const seedMocks = (seedBalances: { [chainId: string]: { [token: string]: BigNumber } }) => {
     hubPoolClient.addL1Token({ address: mainnetWeth, decimals: 18, symbol: "WETH" });
     hubPoolClient.addL1Token({ address: mainnetUsdc, decimals: 6, symbol: "USDC" });
-    enabledChainIds.forEach((chainId) => {
+    Object.keys(seedBalances).forEach((_chainId) => {
+      const chainId = Number(_chainId);
       adapterManager.setMockedOutstandingCrossChainTransfers(chainId, owner.address, mainnetWeth, bnZero);
       adapterManager.setMockedOutstandingCrossChainTransfers(chainId, owner.address, mainnetUsdc, bnZero);
       tokenClient.setTokenData(chainId, l2TokensForWeth[chainId], seedBalances[chainId][mainnetWeth]);
@@ -140,12 +148,14 @@ describe("InventoryClient: Refund chain selection", async function () {
         [OPTIMISM]: l2TokensForWeth[OPTIMISM],
         [POLYGON]: l2TokensForWeth[POLYGON],
         [ARBITRUM]: l2TokensForWeth[ARBITRUM],
+        [BSC]: l2TokensForWeth[BSC],
       },
       [mainnetUsdc]: {
         [MAINNET]: mainnetUsdc,
         [OPTIMISM]: l2TokensForUsdc[OPTIMISM],
         [POLYGON]: l2TokensForUsdc[POLYGON],
         [ARBITRUM]: l2TokensForUsdc[ARBITRUM],
+        [BSC]: l2TokensForUsdc[BSC],
       },
     });
 
@@ -628,6 +638,16 @@ describe("InventoryClient: Refund chain selection", async function () {
       tokenClient.setTokenData(POLYGON, l2TokensForWeth[POLYGON], toWei(10));
       const refundChains = await inventoryClient.determineRefundChainId(sampleDepositData);
       expect(refundChains.length).to.equal(0);
+    });
+    it("returns origin chain even if it is over allocated if origin chain is a quick rebalance source", async function () {
+      sampleDepositData.originChainId = BSC;
+      sampleDepositData.inputToken = l2TokensForWeth[BSC];
+      seedMocks({
+        [BSC]: { [mainnetWeth]: toWei(10), [mainnetUsdc]: toMegaWei(1000) },
+      });
+      tokenClient.setTokenData(BSC, l2TokensForWeth[BSC], toWei(10));
+      const refundChains = await inventoryClient.determineRefundChainId(sampleDepositData);
+      expect(refundChains).to.deep.equal([BSC]);
     });
   });
 

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -87,7 +87,6 @@ describe("InventoryClient: Refund chain selection", async function () {
     [OPTIMISM]: { [mainnetWeth]: toWei(20), [mainnetUsdc]: toMegaWei(2000) }, // seed 20 WETH and 2000 USDC on Optimism
     [POLYGON]: { [mainnetWeth]: toWei(10), [mainnetUsdc]: toMegaWei(1000) }, // seed 10 WETH and 1000 USDC on Polygon
     [ARBITRUM]: { [mainnetWeth]: toWei(10), [mainnetUsdc]: toMegaWei(1000) }, // seed 10 WETH and 1000 USDC on Arbitrum
-    // [BSC]: { [mainnetWeth]: toWei(10), [mainnetUsdc]: toMegaWei(1000) }, // seed 10 WETH and 1000 USDC on BSC
   };
 
   const seedMocks = (seedBalances: { [chainId: string]: { [token: string]: BigNumber } }) => {


### PR DESCRIPTION
The current IM logic will return zero possible repayment chains if the deposit forces origin chain repayment and the origin chain is over allocated. This lets us avoid accruing too much balance on these chains, typically lite chains, that force origin chain repayment.

However, BSC Is now included as one of these chains since it does force origin chain repayment. However, BSC is relatively easy to rebalance tokens out of--so we shouldn't impose the same constraints.

This PR therefore allows the IM to return the origin chain as a possible repayment chain if the origin chain is BSC.