### PR TITLE
Chore: Remove compareAddresses function from relayer and start using one from SDK

### DIFF
--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -1,5 +1,5 @@
 import { TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
-import { BigNumber, compareAddressesSimple, ethers, getRemoteTokenForL1Token, isDefined } from ".";
+import { compareAddressesSimple, ethers, getRemoteTokenForL1Token, isDefined } from ".";
 
 export function includesAddressSimple(address: string | undefined, list: string[]): boolean {
   if (!isDefined(address)) {

--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -1,20 +1,6 @@
 import { TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
 import { BigNumber, compareAddressesSimple, ethers, getRemoteTokenForL1Token, isDefined } from ".";
 
-export function compareAddresses(addressA: string, addressB: string): 1 | -1 | 0 {
-  // Convert address strings to BigNumbers and then sort numerical value of the BigNumber, which sorts the addresses
-  // effectively by their hex value.
-  const bnAddressA = BigNumber.from(addressA);
-  const bnAddressB = BigNumber.from(addressB);
-  if (bnAddressA.gt(bnAddressB)) {
-    return 1;
-  } else if (bnAddressA.lt(bnAddressB)) {
-    return -1;
-  } else {
-    return 0;
-  }
-}
-
 export function includesAddressSimple(address: string | undefined, list: string[]): boolean {
   if (!isDefined(address)) {
     return false;

--- a/src/utils/SDKUtils.ts
+++ b/src/utils/SDKUtils.ts
@@ -67,6 +67,7 @@ export const {
   isContractDeployedToAddress,
   blockExplorerLinks,
   createShortHexString: shortenHexString,
+  compareAddresses,
   compareAddressesSimple,
   getL1TokenAddress,
   getUsdcSymbol,


### PR DESCRIPTION
Remove redundant util function compareAddresses from relayer, and start using the same function from SDK.