### PR TITLE
improve(relayer): Catch IPC failures

### DIFF
--- a/src/libexec/RelayerSpokePoolListener.ts
+++ b/src/libexec/RelayerSpokePoolListener.ts
@@ -110,7 +110,9 @@ async function listen(eventMgr: EventManager, spokePool: Contract, eventNames: s
     }
     const [blockNumber, currentTime] = [parseInt(block.number.toString()), parseInt(block.timestamp.toString())];
     const events = eventMgr.tick();
-    postEvents(blockNumber, currentTime, events);
+    if (!postEvents(blockNumber, currentTime, events)) {
+      stop = true;
+    }
   };
 
   const blockError = (error: Error, provider: string) => {

--- a/src/libexec/RelayerSpokePoolListenerHTTPS.ts
+++ b/src/libexec/RelayerSpokePoolListenerHTTPS.ts
@@ -127,7 +127,9 @@ async function listen(eventMgr: EventManager, spokePool: Contract, eventNames: s
 
           const events = eventMgr.tick();
           const { blockNumber } = events.at(-1);
-          postEvents(blockNumber, getCurrentTime(), events);
+          if (!postEvents(blockNumber, getCurrentTime(), events)) {
+            stop = true;
+          }
         },
       });
     });

--- a/src/libexec/util/ipc.ts
+++ b/src/libexec/util/ipc.ts
@@ -22,8 +22,10 @@ export function postEvents(blockNumber: number, currentTime: number, events: Log
     nEvents: events.length,
     data: JSON.stringify(events, sdkUtils.jsonReplacerWithBigNumbers),
   };
+
+  const msg = JSON.stringify(message);
   try {
-    process.send(JSON.stringify(message));
+    process.send(msg);
   } catch {
     return false;
   }

--- a/src/libexec/util/ipc.ts
+++ b/src/libexec/util/ipc.ts
@@ -10,9 +10,9 @@ import { Log, SpokePoolClientMessage } from "./../types";
  * @param events An array of Log objects to be submitted.
  * @returns void
  */
-export function postEvents(blockNumber: number, currentTime: number, events: Log[]): void {
+export function postEvents(blockNumber: number, currentTime: number, events: Log[]): boolean {
   if (!isDefined(process.send)) {
-    return;
+    return true; // Process may have been started standalone.
   }
 
   events = sortEventsAscending(events);
@@ -22,7 +22,13 @@ export function postEvents(blockNumber: number, currentTime: number, events: Log
     nEvents: events.length,
     data: JSON.stringify(events, sdkUtils.jsonReplacerWithBigNumbers),
   };
-  process.send(JSON.stringify(message));
+  try {
+    process.send(JSON.stringify(message));
+  } catch {
+    return false;
+  }
+
+  return true;
 }
 
 /**

--- a/src/libexec/util/ipc.ts
+++ b/src/libexec/util/ipc.ts
@@ -12,7 +12,9 @@ import { Log, SpokePoolClientMessage } from "./../types";
  */
 export function postEvents(blockNumber: number, currentTime: number, events: Log[]): boolean {
   if (!isDefined(process.send)) {
-    return true; // Process may have been started standalone.
+    // Process was probably started standalone.
+    // https://nodejs.org/api/process.html#processsendmessage-sendhandle-options-callback
+    return true;
   }
 
   events = sortEventsAscending(events);


### PR DESCRIPTION
I'd previously (mis)understood that process.send() should be actively set undefined if the IPC has been closed, but this is not the documented behaviour, nor what is observed in practice.

I think this was previously OK when ethers websocket transports were used, but viem seems to suppress the exception so that the process continues to run despite being an orphan.