### PR TITLE
refactor(dataworker): Drop common dependency on TokenClient

### DIFF
--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -13,20 +13,16 @@ import {
   acrossApi,
   coingecko,
   defiLlama,
-  EvmAddress,
   Signer,
   getArweaveJWKSigner,
-  SvmAddress,
-  getSvmSignerFromEvmSigner,
 } from "../utils";
-import { BundleDataClient, HubPoolClient, TokenClient } from "../clients";
+import { BundleDataClient, HubPoolClient } from "../clients";
 import { getBlockForChain } from "./DataworkerUtils";
 import { Dataworker } from "./Dataworker";
 import { ProposedRootBundle, SpokePoolClientsByChain } from "../interfaces";
 import { caching } from "@across-protocol/sdk";
 
 export interface DataworkerClients extends Clients {
-  tokenClient: TokenClient;
   bundleDataClient: BundleDataClient;
   priceClient?: PriceClient;
 }
@@ -36,28 +32,11 @@ export async function constructDataworkerClients(
   config: DataworkerConfig,
   baseSigner: Signer
 ): Promise<DataworkerClients> {
-  const signerAddr = await baseSigner.getAddress();
   const commonClients = await constructClients(logger, config, baseSigner);
   const { hubPoolClient, configStoreClient } = commonClients;
 
   await updateClients(commonClients, config, logger);
   await hubPoolClient.update();
-
-  const svmSigner = getSvmSignerFromEvmSigner(baseSigner);
-
-  // We don't pass any spoke pool clients to token client since data worker doesn't need to set approvals for L2 tokens.
-  const tokenClient = new TokenClient(
-    logger,
-    EvmAddress.from(signerAddr),
-    SvmAddress.from(svmSigner.publicKey.toBase58()),
-    {},
-    hubPoolClient
-  );
-  await tokenClient.update();
-  // Run approval on hub pool.
-  if (config.sendingTransactionsEnabled) {
-    await tokenClient.setBondTokenAllowance();
-  }
 
   // TODO: Remove need to pass in spokePoolClients into BundleDataClient since we pass in empty {} here and pass in
   // clients for each class level call we make. Its more of a static class.
@@ -90,7 +69,6 @@ export async function constructDataworkerClients(
   return {
     ...commonClients,
     bundleDataClient,
-    tokenClient,
     priceClient,
     arweaveClient,
   };

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -14,7 +14,7 @@ import {
   sinon,
 } from "../utils";
 import * as clients from "../../src/clients";
-import { PriceClient, acrossApi, coingecko, defiLlama, SvmAddress, EvmAddress } from "../../src/utils";
+import { PriceClient, acrossApi, coingecko, defiLlama } from "../../src/utils";
 import {
   amountToLp,
   destinationChainId as defaultDestinationChainId,
@@ -25,7 +25,7 @@ import {
 } from "../constants";
 
 import { Dataworker } from "../../src/dataworker/Dataworker"; // Tested
-import { BundleDataClient, TokenClient } from "../../src/clients";
+import { BundleDataClient } from "../../src/clients";
 import { DataworkerConfig } from "../../src/dataworker/DataworkerConfig";
 import { DataworkerClients } from "../../src/dataworker/DataworkerClientHelper";
 import { MockConfigStoreClient, MockedMultiCallerClient, SimpleMockHubPoolClient } from "../mocks";
@@ -193,11 +193,6 @@ export async function setupDataworker(
       spokePoolDeploymentBlocks
     );
 
-  // Tests use non-Wallet signers, so hardcode SVM address
-  const svmAddress = SvmAddress.from("11111111111111111111111111111111");
-
-  const tokenClient = new TokenClient(spyLogger, EvmAddress.from(relayer.address), svmAddress, {}, hubPoolClient);
-
   // This client dictionary can be conveniently passed in root builder functions that expect mapping of clients to
   // load events from. Dataworker needs a client mapped to every chain ID set in testChainIdList.
   const spokePoolClients = {
@@ -227,7 +222,6 @@ export async function setupDataworker(
 
   const dataworkerClients: DataworkerClients = {
     bundleDataClient,
-    tokenClient,
     hubPoolClient,
     multiCallerClient,
     configStoreClient: configStoreClient as unknown as sdkClients.AcrossConfigStoreClient,


### PR DESCRIPTION
The TokenClient is only used by the proposer, so relegate it to that specific scenario. This simplifies Dataworker instantiation for other use cases.