### PR TITLE
fix(Dataworker): Make sure that each spoke pool client start-search timestamp is > maxFillDeadlineHours earlier than lowest bundle start block timestamp

### DIFF
--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -74,7 +74,7 @@ export async function blockRangesAreInvalidForSpokeClients(
       },
       {
         timestamp: Object.values(startBlockTimestamps)[0],
-        chainId: -1,
+        chainId: Object.keys(startBlockTimestamps)[0],
       }
     );
   }

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -29,7 +29,6 @@ import {
   winston,
   getNativeTokenSymbol,
   getWrappedNativeTokenAddress,
-  MAX_UINT_VAL,
 } from "../utils";
 import { DataworkerClients } from "./DataworkerClientHelper";
 import {

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -74,7 +74,7 @@ export async function blockRangesAreInvalidForSpokeClients(
       },
       {
         timestamp: Object.values(startBlockTimestamps)[0],
-        chainId: Object.keys(startBlockTimestamps)[0],
+        chainId: Number(Object.keys(startBlockTimestamps)[0]),
       }
     );
   }

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -52,25 +52,25 @@ export async function getBlockForTimestamp(
   return utils.getCachedBlockForTimestamp(chainId, timestamp, blockFinder, redisCache, hints);
 }
 
-export async function getTimestampsForBundleEndBlocks(
+export async function getTimestampsForBundleStartBlocks(
   spokePoolClients: SpokePoolClientsByChain,
   blockRanges: number[][],
   chainIdListForBundleEvaluationBlockNumbers: number[]
 ): Promise<{ [chainId: number]: number }> {
   return Object.fromEntries(
     (
-      await utils.mapAsync(blockRanges, async ([, endBlock], index) => {
+      await utils.mapAsync(blockRanges, async ([startBlock], index) => {
         const chainId = chainIdListForBundleEvaluationBlockNumbers[index];
         const spokePoolClient = spokePoolClients[chainId];
         if (spokePoolClient === undefined) {
           return;
         }
         if (isEVMSpokePoolClient(spokePoolClient)) {
-          return [chainId, (await spokePoolClient.spokePool.getCurrentTime({ blockTag: endBlock })).toNumber()];
+          return [chainId, (await spokePoolClient.spokePool.getCurrentTime({ blockTag: startBlock })).toNumber()];
         } else if (isSVMSpokePoolClient(spokePoolClient)) {
           return [
             chainId,
-            Number(await spokePoolClient.svmEventsClient.getRpc().getBlockTime(BigInt(endBlock)).send()),
+            Number(await spokePoolClient.svmEventsClient.getRpc().getBlockTime(BigInt(startBlock)).send()),
           ];
         }
       })


### PR DESCRIPTION
This will ensure the Dataworker throws whenever a single chain halts for a long time, causing the subsequent bundle block ranges to show a very early start timestamp for this newly unhalted chain, relative to other chains.

For now, the user will have to manually reset DATAWORKER_FAST_LOOKBACK_COUNT to a higher value to overcome this hurdle but at least an invalid proposal won't be submitted