### PR TITLE
fix: add `allowance` to MinimalERC20 json

### DIFF
--- a/src/common/abi/MinimalERC20.json
+++ b/src/common/abi/MinimalERC20.json
@@ -71,5 +71,28 @@
     ],
     "stateMutability": "nonpayable",
     "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
   }
 ]


### PR DESCRIPTION
This fixes an error in the rebalancer
```
TypeError: erc20.allowance is not a function
   at OpStackUSDCBridge.constructWithdrawToL1Txns (/across-relayer/dist/src/adapter/l2Bridges/OpStackUSDCBridge.js:30:39)
   at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
   at async BaseChainAdapter.withdrawTokenFromL2 (/across-relayer/dist/src/adapter/BaseChainAdapter.js:204:26)
   at async /across-relayer/dist/src/clients/InventoryClient.js:1064:32
   at async Promise.all (index 0)
```