### PR TITLE
fix(finalizer): Enable CCTP withdrawals on World Chain

### DIFF
--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -137,7 +137,7 @@ const chainFinalizers: { [chainId: number]: { finalizeOnL2: ChainFinalizer[]; fi
     finalizeOnL2: [],
   },
   [CHAIN_IDs.WORLD_CHAIN]: {
-    finalizeOnL1: [opStackFinalizer],
+    finalizeOnL1: [opStackFinalizer, cctpL2toL1Finalizer],
     finalizeOnL2: [cctpL1toL2Finalizer],
   },
   [CHAIN_IDs.INK]: {


### PR DESCRIPTION
Identified after Dylan queried abnormally high USDC utilization.