### PR TITLE
Feat: Use SpokePoolManager instead of SpokePoolClients

### DIFF
--- a/src/adapter/BaseChainAdapter.ts
+++ b/src/adapter/BaseChainAdapter.ts
@@ -1,4 +1,4 @@
-import { MultiCallerClient, SpokePoolClient } from "../clients";
+import { MultiCallerClient, SpokePoolClient, SpokePoolManager } from "../clients";
 import {
   AnyObject,
   BigNumber,
@@ -55,9 +55,10 @@ export class BaseChainAdapter {
   protected baseL1SearchConfig: MakeOptional<EventSearchConfig, "to">;
   protected baseL2SearchConfig: MakeOptional<EventSearchConfig, "to">;
   private transactionClient: TransactionClient;
+  protected spokePoolClientManager: SpokePoolManager;
 
   constructor(
-    protected readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
+    spokePoolClients: { [chainId: number]: SpokePoolClient },
     protected readonly chainId: number,
     protected readonly hubChainId: number,
     protected readonly monitoredAddresses: Address[],
@@ -67,6 +68,7 @@ export class BaseChainAdapter {
     protected readonly l2Bridges: { [l1Token: string]: BaseL2BridgeAdapter },
     protected readonly gasMultiplier: number
   ) {
+    this.spokePoolClientManager = new SpokePoolManager(logger, spokePoolClients);
     this.baseL1SearchConfig = { ...this.getSearchConfig(this.hubChainId) };
     this.baseL2SearchConfig = { ...this.getSearchConfig(this.chainId) };
     this.transactionClient = new TransactionClient(logger);
@@ -82,19 +84,25 @@ export class BaseChainAdapter {
   }
 
   protected getSearchConfig(chainId: number): MakeOptional<EventSearchConfig, "to"> {
-    return { ...this.spokePoolClients[chainId].eventSearchConfig };
+    const spokePoolClient = this.spokePoolClientManager.getClient(chainId);
+    return spokePoolClient ? { ...spokePoolClient.eventSearchConfig } : undefined;
   }
 
   protected getSigner(chainId: number): Signer {
-    const spokePoolClient = this.spokePoolClients[chainId];
+    const spokePoolClient = this.spokePoolClientManager.getClient(chainId);
+    assert(isDefined(spokePoolClient), `SpokePoolClient not found for chainId ${chainId}`);
     assert(isEVMSpokePoolClient(spokePoolClient));
     return spokePoolClient.spokePool.signer;
   }
 
   // Note: this must be called after the SpokePoolClients are updated.
   public getUpdatedSearchConfigs(): { l1SearchConfig: EventSearchConfig; l2SearchConfig: EventSearchConfig } {
-    const l1LatestBlock = this.spokePoolClients[this.hubChainId].latestHeightSearched;
-    const l2LatestBlock = this.spokePoolClients[this.chainId].latestHeightSearched;
+    const l1SpokePoolClient = this.spokePoolClientManager.getClient(this.hubChainId);
+    const l2SpokePoolClient = this.spokePoolClientManager.getClient(this.chainId);
+    assert(isDefined(l1SpokePoolClient), `SpokePoolClient not found for chainId ${this.hubChainId}`);
+    assert(isDefined(l2SpokePoolClient), `SpokePoolClient not found for chainId ${this.chainId}`);
+    const l1LatestBlock = l1SpokePoolClient.latestHeightSearched;
+    const l2LatestBlock = l2SpokePoolClient.latestHeightSearched;
     if (l1LatestBlock === 0 || l2LatestBlock === 0) {
       throw new Error("One or more SpokePoolClients have not been updated");
     }

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -1128,7 +1128,7 @@ export class InventoryClient {
           .filter(isDefined)
           // This map adds the ETH balance to the object.
           .map(async (chainInfo) => {
-            const spokePoolClient = this.tokenClient.spokePoolClients[chainInfo.chainId];
+            const spokePoolClient = this.tokenClient.spokePoolClientManager.getClient(chainInfo.chainId);
             assert(isEVMSpokePoolClient(spokePoolClient));
             return {
               ...chainInfo,
@@ -1467,7 +1467,7 @@ export class InventoryClient {
   }
 
   _unwrapWeth(chainId: number, _l2Weth: string, amount: BigNumber): Promise<TransactionResponse> {
-    const spokePoolClient = this.tokenClient.spokePoolClients[chainId];
+    const spokePoolClient = this.tokenClient.spokePoolClientManager.getClient(chainId);
     assert(isEVMSpokePoolClient(spokePoolClient));
     const l2Signer = spokePoolClient.spokePool.signer;
     const l2Weth = new Contract(_l2Weth, WETH_ABI, l2Signer);

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -1,10 +1,11 @@
 import { clients } from "@across-protocol/sdk";
 
 export type SpokePoolClient = clients.SpokePoolClient;
+export type SpokePoolManager = clients.SpokePoolManager;
 export type EVMSpokePoolClient = clients.EVMSpokePoolClient;
 export type SVMSpokePoolClient = clients.SVMSpokePoolClient;
 export type SpokePoolUpdate = clients.SpokePoolUpdate;
-export const { EVMSpokePoolClient, SpokePoolClient, SVMSpokePoolClient } = clients;
+export const { EVMSpokePoolClient, SpokePoolClient, SVMSpokePoolClient, SpokePoolManager } = clients;
 
 export { SpokeListener, SpokePoolClientMessage } from "./SpokePoolClient";
 export class BundleDataClient extends clients.BundleDataClient.BundleDataClient {}

--- a/test/generic-adapters/Linea.ts
+++ b/test/generic-adapters/Linea.ts
@@ -298,8 +298,10 @@ class MockBaseChainAdapter extends BaseChainAdapter {
   async updateSpokePoolClients() {
     // Since we are simulating getting outstanding transfers, we need to manually overwrite the config in
     // the adapter so that getOutstandingCrossChainTransfers won't throw an error.
-    const blockNumber = await this.spokePoolClients[this.hubChainId].spokePool.provider.getBlockNumber();
-    this.spokePoolClients[this.hubChainId].latestHeightSearched = blockNumber;
-    this.spokePoolClients[this.chainId].latestHeightSearched = blockNumber;
+    const blockNumber = await this.spokePoolClientManager
+      .getClient(this.hubChainId)
+      ?.spokePool.provider.getBlockNumber();
+    this.spokePoolClientManager.getClient(this.hubChainId).latestHeightSearched = blockNumber;
+    this.spokePoolClientManager.getClient(this.chainId).latestHeightSearched = blockNumber;
   }
 }

--- a/test/generic-adapters/Polygon.ts
+++ b/test/generic-adapters/Polygon.ts
@@ -174,7 +174,11 @@ describe("Cross Chain Adapter: Polygon", async function () {
 
     it("Matches L1 and L2 events: EOA", async function () {
       // There should be no pre-existing outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       let transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Weth)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -224,7 +228,11 @@ describe("Cross Chain Adapter: Polygon", async function () {
       expect(receipts[l2Weth].length).to.equal(0);
 
       // There should be 1 outstanding transfer.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Weth)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -265,7 +273,11 @@ describe("Cross Chain Adapter: Polygon", async function () {
       expect(receipts[l2Weth].length).to.equal(1);
 
       // There should be no outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Weth)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -332,7 +344,11 @@ describe("Cross Chain Adapter: Polygon", async function () {
 
     it("Matches L1 and L2 events: HubPool", async function () {
       // There should be no pre-existing outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       let transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Weth)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -382,7 +398,11 @@ describe("Cross Chain Adapter: Polygon", async function () {
       expect(receipts[l2Weth].length).to.equal(0);
 
       // There should be 1 outstanding transfer.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Weth)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -423,7 +443,11 @@ describe("Cross Chain Adapter: Polygon", async function () {
       expect(receipts[l2Weth].length).to.equal(1);
 
       // There should be no outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Weth)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -517,7 +541,11 @@ describe("Cross Chain Adapter: Polygon", async function () {
 
     it("Matches l1 deposits and l2 receipts: EOA", async function () {
       // There should be no pre-existing outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       let transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -567,7 +595,11 @@ describe("Cross Chain Adapter: Polygon", async function () {
       expect(receipts[l2Token].length).to.equal(0);
 
       // There should be 1 outstanding transfer.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -608,7 +640,11 @@ describe("Cross Chain Adapter: Polygon", async function () {
       expect(receipts[l2Token].length).to.equal(1);
 
       // There should be no outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -707,7 +743,11 @@ describe("Cross Chain Adapter: Polygon", async function () {
 
     it("Matches l1 deposits and l2 receipts: HubPool", async function () {
       // There should be no pre-existing outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       let transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -757,7 +797,11 @@ describe("Cross Chain Adapter: Polygon", async function () {
       expect(receipts[l2Token].length).to.equal(0);
 
       // There should be 1 outstanding transfer.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -798,7 +842,11 @@ describe("Cross Chain Adapter: Polygon", async function () {
       expect(receipts[l2Token].length).to.equal(1);
 
       // There should be no outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {

--- a/test/generic-adapters/Scroll.ts
+++ b/test/generic-adapters/Scroll.ts
@@ -248,8 +248,10 @@ class MockBaseChainAdapter extends BaseChainAdapter {
   async updateSpokePoolClients() {
     // Since we are simulating getting outstanding transfers, we need to manually overwrite the config in
     // the adapter so that getOutstandingCrossChainTransfers won't throw an error.
-    const blockNumber = await this.spokePoolClients[this.hubChainId].spokePool.provider.getBlockNumber();
-    this.spokePoolClients[this.hubChainId].latestHeightSearched = blockNumber;
-    this.spokePoolClients[this.chainId].latestHeightSearched = blockNumber;
+    const blockNumber = await this.spokePoolClientManager
+      .getClient(this.hubChainId)
+      ?.spokePool.provider.getBlockNumber();
+    this.spokePoolClientManager.getClient(this.hubChainId).latestHeightSearched = blockNumber;
+    this.spokePoolClientManager.getClient(this.chainId).latestHeightSearched = blockNumber;
   }
 }

--- a/test/generic-adapters/zkSync.ts
+++ b/test/generic-adapters/zkSync.ts
@@ -165,6 +165,16 @@ describe("Cross Chain Adapter: zkSync", async function () {
       1
     );
 
+    // Ensure SpokePoolClients are properly initialized
+    await l1SpokePoolClient.update();
+    await l2SpokePoolClient.update();
+
+    // Verify that the SpokePoolManager has the correct clients
+    const clients = adapter.spokePoolClientManager.getSpokePoolClients();
+    if (!clients[MAINNET] || !clients[ZK_SYNC]) {
+      throw new Error(`SpokePoolManager missing required clients. Available: ${Object.keys(clients)}`);
+    }
+
     // Point the adapter to the proper bridges.
     l1Bridge = await (await getContractFactory("zkSync_L1Bridge", depositor)).deploy();
     l2Bridge = await (await getContractFactory("zkSync_L2Bridge", depositor)).deploy();
@@ -227,7 +237,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
     // See https://github.com/across-protocol/relayer/blob/f42853e28747010111941073e54d3d9d8a3f3a09/src/clients/bridges/ZKSyncAdapter.ts#L72
     it("Matches L1 and L2 events: EOA", async function () {
       // There should be no pre-existing outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       let transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Weth)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -269,7 +283,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
       expect(receipts[l2Weth.address].length).to.equal(0);
 
       // There should be 1 outstanding transfer.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Weth)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -303,7 +321,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
       expect(receipts[l2Weth.address].length).to.equal(1);
 
       // There should be no outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Weth)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -363,7 +385,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
 
     it("Matches L1 and L2 events: HubPool", async function () {
       // There should be no pre-existing outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       let transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Weth)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -405,7 +431,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
       expect(receipts[l2Weth.address].length).to.equal(0);
 
       // There should be 1 outstanding transfer.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Weth)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -438,7 +468,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
       expect(receipts[l2Weth.address].length).to.equal(1);
 
       // There should be no outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Weth)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -462,7 +496,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
 
     it("Correctly makes l1 deposits", async function () {
       // There should be no pre-existing outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       let transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Weth)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -500,7 +538,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
       expect(deposits[l2Weth.address].length).to.equal(1);
 
       // There should be 1 outstanding transfer.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Weth)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -599,7 +641,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
 
     it("Matches l1 deposits and l2 receipts: EOA", async function () {
       // There should be no pre-existing outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       let transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -649,7 +695,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
       expect(receipts[l2Token].length).to.equal(0);
 
       // There should be 1 outstanding transfer.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -690,7 +740,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
       expect(receipts[l2Token].length).to.equal(1);
 
       // There should be no outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -801,7 +855,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
 
     it("Matches l1 deposits and l2 receipts: HubPool", async function () {
       // There should be no pre-existing outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       let transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -858,7 +916,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
       expect(receipts[l2Token].length).to.equal(0);
 
       // There should be 1 outstanding transfer.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -899,7 +961,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
       expect(receipts[l2Token].length).to.equal(1);
 
       // There should be no outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -931,7 +997,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
 
     it("Correctly makes l1 deposits", async function () {
       // There should be no pre-existing outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       let transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -978,7 +1048,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
       expect(deposits[l2Token].length).to.equal(1);
 
       // There should be 1 outstanding transfer.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -1036,12 +1110,18 @@ describe("Cross Chain Adapter: zkSync", async function () {
       const lensSpokePoolClient = new EVMSpokePoolClient(logger, spokePool, hubPoolClient, LENS, deploymentBlock, {
         from: deploymentBlock,
       });
+      const l1SpokePoolClient = new EVMSpokePoolClient(logger, spokePool, hubPoolClient, MAINNET, deploymentBlock, {
+        from: deploymentBlock,
+      });
 
-      const l1Signer = adapter.spokePoolClients[MAINNET].spokePool.signer;
+      const l1Signer = adapter.spokePoolClientManager.getClient(MAINNET)?.spokePool.signer;
       const l2Signer = lensSpokePoolClient.spokePool.signer;
 
       adapter = new TestBaseChainAdapter(
-        { ...adapter.spokePoolClients, [LENS]: lensSpokePoolClient },
+        {
+          [MAINNET]: l1SpokePoolClient,
+          [LENS]: lensSpokePoolClient,
+        },
         LENS,
         MAINNET,
         [toAddress(monitoredEoa), toAddress(hubPool.address), toAddress(spokePool.address)],
@@ -1055,6 +1135,10 @@ describe("Cross Chain Adapter: zkSync", async function () {
       adapter.setSharedBridge(l1Token, l1Bridge);
       adapter.setL1USDCBridge(l1Token, l1Bridge);
       adapter.setL2Bridge(l1Token, l2Bridge);
+
+      // Ensure SpokePoolClients are properly initialized
+      await l1SpokePoolClient.update();
+      await lensSpokePoolClient.update();
     });
 
     it("Get L1 deposits: EOA", async function () {
@@ -1124,7 +1208,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
 
     it("Matches l1 deposits and l2 receipts: EOA", async function () {
       // There should be no pre-existing outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       let transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -1174,7 +1262,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
       expect(receipts[l2Token].length).to.equal(0);
 
       // There should be 1 outstanding transfer.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -1215,7 +1307,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
       expect(receipts[l2Token].length).to.equal(1);
 
       // There should be no outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -1317,7 +1413,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
 
     it("Matches l1 deposits and l2 receipts: HubPool", async function () {
       // There should be no pre-existing outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       let transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -1367,7 +1467,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
       expect(receipts[l2Token].length).to.equal(0);
 
       // There should be 1 outstanding transfer.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -1408,7 +1512,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
       expect(receipts[l2Token].length).to.equal(1);
 
       // There should be no outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -1440,7 +1548,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
 
     it("Correctly makes l1 deposits", async function () {
       // There should be no pre-existing outstanding transfers.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       let transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {
@@ -1487,7 +1599,11 @@ describe("Cross Chain Adapter: zkSync", async function () {
       expect(deposits[l2Token].length).to.equal(1);
 
       // There should be 1 outstanding transfer.
-      await Promise.all(Object.values(adapter.spokePoolClients).map((spokePoolClient) => spokePoolClient.update()));
+      await Promise.all(
+        Object.values(adapter.spokePoolClientManager.getSpokePoolClients()).map((spokePoolClient) =>
+          spokePoolClient.update()
+        )
+      );
       transfers = await adapter.getOutstandingCrossChainTransfers([toAddress(l1Token)]);
       expect(transfers).to.deep.equal({
         [monitoredEoa]: {


### PR DESCRIPTION
Use SpokePoolManager instead of SpokePoolClients object to enforce devs to handle wrong/incorrect chainIds.