### PR TITLE
improve: use `Address` in the finalizer

### DIFF
--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -33,6 +33,8 @@ import {
   stringifyThrownValue,
   isEVMSpokePoolClient,
   chainIsEvm,
+  EvmAddress,
+  Address,
 } from "../utils";
 import { ChainFinalizer, CrossChainMessage, isAugmentedTransaction } from "./types";
 import {
@@ -248,12 +250,12 @@ export async function finalize(
     const userSpecifiedAddresses: string[] = process.env.FINALIZER_WITHDRAWAL_TO_ADDRESSES
       ? JSON.parse(process.env.FINALIZER_WITHDRAWAL_TO_ADDRESSES).map((address) => ethers.utils.getAddress(address))
       : [];
-    const addressesToFinalize = [
+    const addressesToFinalize: Address[] = [
       hubPoolClient.hubPool.address,
-      spokePoolClients[chainId].spokePoolAddress.toEvmAddress(),
       CONTRACT_ADDRESSES[hubChainId]?.atomicDepositor?.address,
       ...userSpecifiedAddresses,
-    ].map(getAddress);
+    ].map((address) => EvmAddress.from(getAddress(address)));
+    addressesToFinalize.push(spokePoolClients[chainId].spokePoolAddress);
 
     // We can subloop through the finalizers for each chain, and then execute the finalizer. For now, the
     // main reason for this is related to CCTP finalizations. We want to run the CCTP finalizer AND the

--- a/src/finalizer/types.ts
+++ b/src/finalizer/types.ts
@@ -1,6 +1,6 @@
 import { Signer } from "ethers";
 import { AugmentedTransaction, HubPoolClient, SpokePoolClient } from "../clients";
-import { Multicall2Call, winston } from "../utils";
+import { Multicall2Call, winston, Address } from "../utils";
 
 /**
  * A cross-chain message is a message sent from one chain to another. This can be a token withdrawal from L2 to L1,
@@ -40,7 +40,7 @@ export interface ChainFinalizer {
     hubPoolClient: HubPoolClient,
     l2SpokePoolClient: SpokePoolClient,
     l1SpokePoolClient: SpokePoolClient,
-    l1ToL2AddressesToFinalize: string[]
+    l1ToL2AddressesToFinalize: Address[]
   ): Promise<FinalizerPromise>;
 }
 

--- a/src/finalizer/utils/arbStack.ts
+++ b/src/finalizer/utils/arbStack.ts
@@ -28,6 +28,7 @@ import {
   assert,
   isEVMSpokePoolClient,
   EvmAddress,
+  Address,
 } from "../../utils";
 import { TokensBridged } from "../../interfaces";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
@@ -82,9 +83,11 @@ export async function arbStackFinalizer(
   hubPoolClient: HubPoolClient,
   spokePoolClient: SpokePoolClient,
   _l1SpokePoolClient: SpokePoolClient,
-  recipientAddresses: string[]
+  _recipientAddresses: Address[]
 ): Promise<FinalizerPromise> {
   assert(isEVMSpokePoolClient(spokePoolClient));
+  // Recipient addresses are just used to query events.
+  const recipientAddresses = _recipientAddresses.map((address) => address.toEvmAddress());
   LATEST_MAINNET_BLOCK = hubPoolClient.latestHeightSearched;
   const hubPoolProvider = await getProvider(hubPoolClient.chainId, logger);
   MAINNET_BLOCK_TIME = (await arch.evm.averageBlockTime(hubPoolProvider)).average;

--- a/src/finalizer/utils/binance.ts
+++ b/src/finalizer/utils/binance.ts
@@ -17,6 +17,7 @@ import {
   isEVMSpokePoolClient,
   assert,
   EvmAddress,
+  Address,
 } from "../../utils";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
 import { FinalizerPromise } from "../types";
@@ -85,9 +86,10 @@ export async function binanceFinalizer(
   _hubPoolClient: HubPoolClient,
   l2SpokePoolClient: SpokePoolClient,
   l1SpokePoolClient: SpokePoolClient,
-  senderAddresses: string[]
+  _senderAddresses: Address[]
 ): Promise<FinalizerPromise> {
   assert(isEVMSpokePoolClient(l1SpokePoolClient) && isEVMSpokePoolClient(l2SpokePoolClient));
+  const senderAddresses = _senderAddresses.map((address) => address.toEvmAddress());
   const chainId = l2SpokePoolClient.chainId;
   const hubChainId = l1SpokePoolClient.chainId;
   const l1EventSearchConfig = l1SpokePoolClient.eventSearchConfig;

--- a/src/finalizer/utils/cctp/l1ToL2.ts
+++ b/src/finalizer/utils/cctp/l1ToL2.ts
@@ -33,6 +33,7 @@ import {
   toBuffer,
   isSVMSpokePoolClient,
   getTypedAnchorProgram,
+  Address,
 } from "../../../utils";
 import {
   AttestedCCTPMessage,
@@ -49,7 +50,7 @@ export async function cctpL1toL2Finalizer(
   hubPoolClient: HubPoolClient,
   l2SpokePoolClient: SpokePoolClient,
   l1SpokePoolClient: SpokePoolClient,
-  senderAddresses: string[]
+  senderAddresses: Address[]
 ): Promise<FinalizerPromise> {
   assert(isEVMSpokePoolClient(l1SpokePoolClient));
   const searchConfig: EventSearchConfig = {

--- a/src/finalizer/utils/cctp/l2ToL1.ts
+++ b/src/finalizer/utils/cctp/l2ToL1.ts
@@ -15,10 +15,10 @@ import {
   SvmAddress,
   toPublicKey,
   chainIsSvm,
+  Address,
 } from "../../../utils";
 import {
   AttestedCCTPDeposit,
-  cctpBytes32ToAddress,
   CCTPMessageStatus,
   getAttestedCCTPDeposits,
   getCctpMessageTransmitter,
@@ -32,7 +32,7 @@ export async function cctpL2toL1Finalizer(
   hubPoolClient: HubPoolClient,
   spokePoolClient: SpokePoolClient,
   _l1SpokePoolClient: SpokePoolClient,
-  senderAddresses: string[]
+  senderAddresses: Address[]
 ): Promise<FinalizerPromise> {
   const searchConfig: EventSearchConfig = {
     from: spokePoolClient.eventSearchConfig.from,
@@ -132,18 +132,18 @@ async function generateWithdrawalData(
  */
 // TODO: this function is fragile, because it assumes the format of `senderAddresses` and how it gets populated
 // TODO: When we fully move to using the `Address` class, this problem should be alleviated by using `Address.eq` instead
-function augmentSendersListForSolana(senderAddresses: string[], spokePoolClient: SpokePoolClient) {
+function augmentSendersListForSolana(senderAddresses: Address[], spokePoolClient: SpokePoolClient): Address[] {
   const spokeAddress = spokePoolClient.spokePoolAddress;
   // This format is taken from `src/finalizer/index.ts`
-  if (senderAddresses.includes(spokeAddress.toEvmAddress())) {
+  if (senderAddresses.some((address) => address.eq(spokeAddress))) {
     const seed = new BN("0"); // Seed is always 0 for the state account PDA in public networks.
-    const [statePda] = web3.PublicKey.findProgramAddressSync(
+    const [_statePda] = web3.PublicKey.findProgramAddressSync(
       [Buffer.from("state"), seed.toArrayLike(Buffer, "le", 8)],
       toPublicKey(spokeAddress.toBase58())
     );
     // This format has to match format in CCTPUtils.ts >
-    const trimmedStatePda = cctpBytes32ToAddress(SvmAddress.from(statePda.toBase58(), "base58").toBytes32());
-    return [...senderAddresses, trimmedStatePda];
+    const statePda = SvmAddress.from(_statePda.toBase58(), "base58");
+    return [...senderAddresses, statePda];
   } else {
     return senderAddresses;
   }

--- a/src/finalizer/utils/cctp/l2ToL1.ts
+++ b/src/finalizer/utils/cctp/l2ToL1.ts
@@ -130,8 +130,6 @@ async function generateWithdrawalData(
  * to have SpokePool address in the `senderAddresses`. We instead need SpokePool's `statePda` in there, because that is
  * what gets recorded as `depositor` in the `DepositForBurn` event
  */
-// TODO: this function is fragile, because it assumes the format of `senderAddresses` and how it gets populated
-// TODO: When we fully move to using the `Address` class, this problem should be alleviated by using `Address.eq` instead
 function augmentSendersListForSolana(senderAddresses: Address[], spokePoolClient: SpokePoolClient): Address[] {
   const spokeAddress = spokePoolClient.spokePoolAddress;
   // This format is taken from `src/finalizer/index.ts`

--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -10,6 +10,7 @@ import {
   groupObjectCountsByProp,
   isEVMSpokePoolClient,
   assert,
+  Address,
 } from "../../utils";
 import { spreadEventWithBlockNumber } from "../../utils/EventUtils";
 import { FinalizerPromise, CrossChainMessage } from "../types";
@@ -62,7 +63,7 @@ export async function heliosL1toL2Finalizer(
   l2SpokePoolClient: SpokePoolClient,
   l1SpokePoolClient: SpokePoolClient,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _senderAddresses: string[]
+  _senderAddresses: Address[]
 ): Promise<FinalizerPromise> {
   assert(
     isEVMSpokePoolClient(l2SpokePoolClient) && isEVMSpokePoolClient(l1SpokePoolClient),

--- a/src/finalizer/utils/linea/l1ToL2.ts
+++ b/src/finalizer/utils/linea/l1ToL2.ts
@@ -16,6 +16,7 @@ import {
   assert,
   isEVMSpokePoolClient,
   EvmAddress,
+  Address,
 } from "../../../utils";
 import { CrossChainMessage, FinalizerPromise } from "../../types";
 import {
@@ -51,9 +52,10 @@ export async function lineaL1ToL2Finalizer(
   hubPoolClient: HubPoolClient,
   l2SpokePoolClient: SpokePoolClient,
   l1SpokePoolClient: SpokePoolClient,
-  senderAddresses: string[]
+  _senderAddresses: Address[]
 ): Promise<FinalizerPromise> {
   assert(isEVMSpokePoolClient(l1SpokePoolClient) && isEVMSpokePoolClient(l2SpokePoolClient));
+  const senderAddresses = _senderAddresses.map((address) => address.toEvmAddress());
   const [l1ChainId] = [hubPoolClient.chainId, hubPoolClient.hubPool.address];
   if (l1ChainId !== CHAIN_IDs.MAINNET) {
     throw new Error("Finalizations for Linea testnet is not supported.");

--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -44,6 +44,7 @@ import {
   isEVMSpokePoolClient,
   EvmAddress,
   ZERO_ADDRESS,
+  Address,
 } from "../../utils";
 import { CONTRACT_ADDRESSES, OPSTACK_CONTRACT_OVERRIDES } from "../../common";
 import OPStackPortalL1 from "../../common/abi/OpStackPortalL1.json";
@@ -106,7 +107,7 @@ export async function opStackFinalizer(
   hubPoolClient: HubPoolClient,
   spokePoolClient: SpokePoolClient,
   _l1SpokePoolClient: SpokePoolClient,
-  senderAddresses: string[]
+  senderAddresses: Address[]
 ): Promise<FinalizerPromise> {
   assert(isEVMSpokePoolClient(spokePoolClient));
   const { chainId, latestHeightSearched: to, spokePool } = spokePoolClient;
@@ -145,7 +146,9 @@ export async function opStackFinalizer(
   // and because they are lite chains, our only way to withdraw them is to initiate a manual bridge from the
   // the lite chain to Ethereum via the canonical OVM standard bridge.
   // Filter out SpokePool as sender since we query for it previously using the TokensBridged event query.
-  const ovmFromAddresses = senderAddresses.filter((sender) => sender !== spokePool.address);
+  const ovmFromAddresses = senderAddresses
+    .map((sender) => sender.toEvmAddress())
+    .filter((sender) => sender !== spokePool.address);
   const searchConfig = { ...spokePoolClient.eventSearchConfig, to };
   const withdrawalEvents = await Promise.all([
     getOVMStdEvents(logger, spokePool.provider, ovmFromAddresses, searchConfig),

--- a/src/utils/CCTPUtils.ts
+++ b/src/utils/CCTPUtils.ts
@@ -13,6 +13,8 @@ import {
   SvmAddress,
   mapAsync,
   chainIsProd,
+  Address,
+  EvmAddress,
 } from "./SDKUtils";
 import { isDefined } from "./TypeGuards";
 import { getCachedProvider, getSvmProvider } from "./ProviderUtils";
@@ -215,10 +217,12 @@ async function getRelevantCCTPTxHashes(
   sourceChainId: number,
   destinationChainId: number,
   l2ChainId: number,
-  senderAddresses: string[],
+  _senderAddresses: EvmAddress[],
   sourceEventSearchConfig: EventSearchConfig,
   isSourceHubChain: boolean
 ): Promise<Set<string>> {
+  // At this point, all sender addresses should be EVM.
+  const senderAddresses = _senderAddresses.map((address) => address.toNative());
   const txHashesFromHubPool: string[] = [];
 
   if (isSourceHubChain) {
@@ -281,13 +285,18 @@ async function getRelevantCCTPTxHashes(
  * @returns An array of `CCTPMessageEvent` objects.
  */
 async function getCCTPMessageEvents(
-  senderAddresses: string[],
+  _senderAddresses: Address[],
   sourceChainId: number,
   destinationChainId: number,
   l2ChainId: number,
   sourceEventSearchConfig: EventSearchConfig,
   isSourceHubChain: boolean
 ): Promise<CCTPMessageEvent[]> {
+  // At this point, we are going from EVM to EVM _or_ we are going from and EVM L1 to an SVM L2. Either way, we need to ensure that all
+  // `senderAddresses` are EVM.
+  const senderAddresses: EvmAddress[] = _senderAddresses
+    .map((address) => (address.isEVM() ? address : undefined))
+    .filter(isDefined);
   const isCctpV2 = isCctpV2L2ChainId(l2ChainId);
   const { tokenMessengerInterface, messageTransmitterInterface } = getContractInterfaces(
     l2ChainId,
@@ -426,8 +435,9 @@ function getRelevantCCTPEventsFromReceipt(
   sourceDomainId: number,
   destinationDomainId: number,
   usdcAddress: string,
-  senderAddresses: string[]
+  _senderAddresses: EvmAddress[]
 ): CCTPMessageEvent[] {
+  const senderAddresses = _senderAddresses.map((address) => address.toNative());
   const relevantEvents: CCTPMessageEvent[] = [];
 
   /*
@@ -503,7 +513,7 @@ function getRelevantCCTPEventsFromReceipt(
 }
 
 async function getCCTPMessagesWithStatus(
-  senderAddresses: string[],
+  senderAddresses: Address[],
   sourceChainId: number,
   destinationChainId: number,
   l2ChainId: number,
@@ -570,7 +580,7 @@ async function getCCTPMessagesWithStatus(
  * @returns A promise that resolves to an array of `AttestedCCTPDeposit` objects.
  */
 export async function getAttestedCCTPDeposits(
-  senderAddresses: string[],
+  senderAddresses: Address[],
   sourceChainId: number,
   destinationChainId: number,
   l2ChainId: number,
@@ -609,7 +619,7 @@ export async function getAttestedCCTPDeposits(
  * @returns A promise that resolves to an array of `AttestedCCTPMessage` objects. These can be `AttestedCCTPDeposit` or common `AttestedCCTPMessage` types.
  */
 export async function getAttestedCCTPMessages(
-  senderAddresses: string[],
+  senderAddresses: Address[],
   sourceChainId: number,
   destinationChainId: number,
   l2ChainId: number,
@@ -796,7 +806,7 @@ async function _hasCCTPMessageBeenProcessedSvm(nonce: number, sourceDomain: numb
 }
 
 async function _getCCTPDepositEventsSvm(
-  senderAddresses: string[],
+  senderAddresses: Address[],
   sourceChainId: number,
   destinationChainId: number,
   l2ChainId: number,
@@ -822,11 +832,13 @@ async function _getCCTPDepositEventsSvm(
   // Return undefined if we need to filter out the deposit event.
   const _depositsWithAttestations = await mapAsync(depositForBurnEvents, async (event) => {
     const eventData = event.data as MinimalSvmDepositForBurnData;
-    const trimmedDepositor = cctpBytes32ToAddress(SvmAddress.from(eventData.depositor, "base58").toBytes32());
+    const depositor = SvmAddress.from(eventData.depositor, "base58");
     const destinationDomain = eventData.destinationDomain;
 
     if (
-      !senderAddresses.some((addr) => compareAddressesSimple(addr, trimmedDepositor)) ||
+      !senderAddresses.some((addr) =>
+        compareAddressesSimple(addr.truncateToBytes20(), depositor.truncateToBytes20())
+      ) ||
       getCctpDomainForChainId(destinationChainId) !== destinationDomain
     ) {
       return undefined;
@@ -836,7 +848,7 @@ async function _getCCTPDepositEventsSvm(
     return await mapAsync(attestation.messages, async (data) => {
       const decodedMessage = _decodeDepositForBurnMessageDataV1({ data: data.message }, true);
       if (
-        !senderAddresses.includes(cctpBytes32ToAddress(decodedMessage.sender)) ||
+        !senderAddresses.some((addr) => compareAddressesSimple(addr.toBytes32(), decodedMessage.sender)) ||
         getCctpDomainForChainId(destinationChainId) !== decodedMessage.destinationDomain
       ) {
         return undefined;

--- a/src/utils/CCTPUtils.ts
+++ b/src/utils/CCTPUtils.ts
@@ -836,9 +836,7 @@ async function _getCCTPDepositEventsSvm(
     const destinationDomain = eventData.destinationDomain;
 
     if (
-      !senderAddresses.some((addr) =>
-        compareAddressesSimple(addr.truncateToBytes20(), depositor.truncateToBytes20())
-      ) ||
+      !senderAddresses.some((addr) => addr.eq(depositor)) ||
       getCctpDomainForChainId(destinationChainId) !== destinationDomain
     ) {
       return undefined;


### PR DESCRIPTION
We need to be able to distinguish between svm and evm addresses in the finalizer.