### PR TITLE
fix: query svm balance in BalanceAllocator

### DIFF
--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -1,4 +1,4 @@
-import { arch, utils as sdkUtils } from "@across-protocol/sdk";
+import { utils as sdkUtils } from "@across-protocol/sdk";
 import { HubPoolClient, SpokePoolClient } from ".";
 import { CachingMechanismInterface, L1Token, Deposit } from "../interfaces";
 import {
@@ -32,6 +32,7 @@ import {
   SVMProvider,
   EvmAddress,
   convertRelayDataParamsToBytes32,
+  getSolanaTokenBalance,
 } from "../utils";
 
 export type TokenDataType = { [chainId: number]: { [token: string]: { balance: BigNumber; allowance: BigNumber } } };
@@ -454,37 +455,7 @@ export class TokenClient {
     walletAddress: SvmAddress,
     tokenMint: SvmAddress
   ): Promise<BigNumber> {
-    // Convert addresses to the correct format for SVM provider
-    const ownerPubkey = arch.svm.toAddress(walletAddress);
-    const mintPubkey = arch.svm.toAddress(tokenMint);
-
-    // Get token accounts owned by the wallet for this specific mint
-    const tokenAccountsByOwner = await provider
-      .getTokenAccountsByOwner(
-        ownerPubkey,
-        {
-          mint: mintPubkey,
-        },
-        {
-          encoding: "jsonParsed",
-        }
-      )
-      .send();
-
-    const response = tokenAccountsByOwner;
-    if (!response.value || response.value.length === 0) {
-      // No token account found for this mint, balance is 0
-      return toBN(0);
-    }
-
-    // For SPL tokens, there should typically be only one token account per mint per owner
-    // Sum all balances in case there are multiple accounts (rare but possible)
-    const totalBalance = response.value.reduce((acc, accountInfo) => {
-      const balance = accountInfo?.account?.data?.parsed?.info?.tokenAmount?.amount;
-      return balance ? acc.add(toBN(balance)) : acc;
-    }, toBN(0));
-
-    return totalBalance;
+    return getSolanaTokenBalance(provider, walletAddress, tokenMint);
   }
 
   protected async getRedis(): Promise<CachingMechanismInterface | undefined> {

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { Contract, utils as ethersUtils } from "ethers";
-import { utils as sdkUtils } from "@across-protocol/sdk";
+import { utils as sdkUtils, arch } from "@across-protocol/sdk";
 import {
   bnZero,
   winston,
@@ -2437,11 +2437,14 @@ export class Dataworker {
           }
           const refundSum = leaf.refundAmounts.reduce((acc, curr) => acc.add(curr), BigNumber.from(0));
           const totalSent = refundSum.add(leaf.amountToReturn.gte(0) ? leaf.amountToReturn : BigNumber.from(0));
+          const holder = chainIsSvm(leaf.chainId)
+            ? SvmAddress.from(await getStatePda(arch.svm.toAddress(client.spokePoolAddress)))
+            : client.spokePoolAddress;
           const balanceRequestsToQuery = [
             {
               chainId: leaf.chainId,
               tokens: l2TokensToCountTowardsSpokePoolLeafExecutionCapital(leaf.l2TokenAddress, leaf.chainId),
-              holder: client.spokePoolAddress,
+              holder,
               amount: totalSent,
             },
           ];

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -45,6 +45,7 @@ import {
   convertFillParamsToBytes32,
   mapAsync,
   getAccountMeta,
+  chainIsSvm,
 } from "../utils";
 import {
   ProposedRootBundle,
@@ -2612,6 +2613,9 @@ export class Dataworker {
     token: Address,
     holder: Address
   ): Promise<BigNumber> {
+    if (chainIsSvm(chainId)) {
+      return Promise.resolve(bnZero);
+    }
     return sdkUtils.reduceAsync(
       l2TokensToCountTowardsSpokePoolLeafExecutionCapital(token, chainId),
       async (acc, token) => acc.add(await balanceAllocator.getBalanceSubUsed(chainId, token, holder)),

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2616,9 +2616,6 @@ export class Dataworker {
     token: Address,
     holder: Address
   ): Promise<BigNumber> {
-    if (chainIsSvm(chainId)) {
-      return Promise.resolve(bnZero);
-    }
     return sdkUtils.reduceAsync(
       l2TokensToCountTowardsSpokePoolLeafExecutionCapital(token, chainId),
       async (acc, token) => acc.add(await balanceAllocator.getBalanceSubUsed(chainId, token, holder)),

--- a/src/utils/TokenUtils.ts
+++ b/src/utils/TokenUtils.ts
@@ -1,10 +1,10 @@
 import { TOKEN_EQUIVALENCE_REMAPPING, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
-import { constants, utils } from "@across-protocol/sdk";
+import { constants, utils, arch } from "@across-protocol/sdk";
 import { CONTRACT_ADDRESSES } from "../common";
-import { BigNumberish } from "./BNUtils";
+import { BigNumberish, BigNumber } from "./BNUtils";
 import { formatUnits } from "./SDKUtils";
 import { isDefined } from "./TypeGuards";
-import { Address, toAddressType, EvmAddress } from "./";
+import { Address, toAddressType, EvmAddress, SvmAddress, SVMProvider, toBN } from "./";
 
 const { ZERO_ADDRESS } = constants;
 
@@ -53,4 +53,49 @@ export function getWrappedNativeTokenAddress(chainId: number): Address {
 export function formatUnitsForToken(symbol: string, amount: BigNumberish): string {
   const decimals = (TOKEN_SYMBOLS_MAP[symbol]?.decimals as number) ?? 18;
   return formatUnits(amount, decimals);
+}
+
+/**
+ * Format the given amount of tokens to the correct number of decimals for the given token symbol.
+ * @param provider An SVM provider.
+ * @param tokenMint The address of the Solana token.
+ * @param walletAddress The address of the wallet to query.
+ * @returns The wallet's balance of the input token.
+ */
+export async function getSolanaTokenBalance(
+  provider: SVMProvider,
+  tokenMint: SvmAddress,
+  walletAddress: SvmAddress
+): Promise<BigNumber> {
+  // Convert addresses to the correct format for SVM provider
+  const ownerPubkey = arch.svm.toAddress(walletAddress);
+  const mintPubkey = arch.svm.toAddress(tokenMint);
+
+  // Get token accounts owned by the wallet for this specific mint
+  const tokenAccountsByOwner = await provider
+    .getTokenAccountsByOwner(
+      ownerPubkey,
+      {
+        mint: mintPubkey,
+      },
+      {
+        encoding: "jsonParsed",
+      }
+    )
+    .send();
+
+  const response = tokenAccountsByOwner;
+  if (!response.value || response.value.length === 0) {
+    // No token account found for this mint, balance is 0
+    return toBN(0);
+  }
+
+  // For SPL tokens, there should typically be only one token account per mint per owner
+  // Sum all balances in case there are multiple accounts (rare but possible)
+  const totalBalance = response.value.reduce((acc, accountInfo) => {
+    const balance = accountInfo?.account?.data?.parsed?.info?.tokenAmount?.amount;
+    return balance ? acc.add(toBN(balance)) : acc;
+  }, toBN(0));
+
+  return totalBalance;
 }


### PR DESCRIPTION
We need the balance allocator to work for relayer refund leaf tokens on Solana. A natural way to get this to work is to reuse the TokenClient's logic. 