### PR TITLE
fix: swap argument ordering of getSolanaTokenBalance

### DIFF
--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -455,7 +455,7 @@ export class TokenClient {
     walletAddress: SvmAddress,
     tokenMint: SvmAddress
   ): Promise<BigNumber> {
-    return getSolanaTokenBalance(provider, walletAddress, tokenMint);
+    return getSolanaTokenBalance(provider, tokenMint, walletAddress);
   }
 
   protected async getRedis(): Promise<CachingMechanismInterface | undefined> {


### PR DESCRIPTION
This PR https://github.com/across-protocol/relayer/pull/2355 mistakenly swapped the ordering of the call to `getSolanaTokenBalance` in the TokenClient. 