### PR TITLE
refactor: combine the proposer and l1 executor

### DIFF
--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -7,8 +7,8 @@ import {
   startupLogLevel,
   Signer,
   disconnectRedisClients,
-  isDefined,
   Profiler,
+  isDefined,
   getSvmSignerFromEvmSigner,
 } from "../utils";
 import { spokePoolClientsToProviders } from "../common";
@@ -21,7 +21,7 @@ import {
   DataworkerClients,
 } from "./DataworkerClientHelper";
 import { BalanceAllocator } from "../clients/BalanceAllocator";
-import { PendingRootBundle, BundleData } from "../interfaces";
+import { PendingRootBundle } from "../interfaces";
 
 config();
 let logger: winston.Logger;
@@ -73,7 +73,6 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
   );
 
   await config.update(logger); // Update address filter.
-  let proposedBundleData: BundleData | undefined = undefined;
   let poolRebalanceLeafExecutionCount = 0;
   try {
     // Explicitly don't log addressFilter because it can be huge and can overwhelm log transports.
@@ -158,43 +157,33 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
       }
 
       // Bundle data is defined if and only if there is a new bundle proposal transaction enqueued.
-      proposedBundleData = await dataworker.proposeRootBundle(
+      const proposeRootBundleReturnData = await dataworker.proposeRootBundle(
         spokePoolClients,
         config.rootBundleExecutionThreshold,
         config.sendingTransactionsEnabled,
         fromBlocks
       );
+      poolRebalanceLeafExecutionCount = isDefined(proposeRootBundleReturnData) ? proposeRootBundleReturnData[1] : 0;
     } else {
       logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Proposer disabled" });
     }
 
-    if (config.l2ExecutorEnabled || config.l1ExecutorEnabled) {
+    if (config.l2ExecutorEnabled) {
       const balanceAllocator = new BalanceAllocator(spokePoolClientsToProviders(spokePoolClients));
 
-      if (config.l1ExecutorEnabled) {
-        poolRebalanceLeafExecutionCount = await dataworker.executePoolRebalanceLeaves(
-          spokePoolClients,
-          balanceAllocator,
-          config.sendingTransactionsEnabled,
-          fromBlocks
-        );
-      }
-
-      if (config.l2ExecutorEnabled) {
-        // Execute slow relays before relayer refunds to give them priority for any L2 funds.
-        await dataworker.executeSlowRelayLeaves(
-          spokePoolClients,
-          balanceAllocator,
-          config.sendingTransactionsEnabled,
-          fromBlocks
-        );
-        await dataworker.executeRelayerRefundLeaves(
-          spokePoolClients,
-          balanceAllocator,
-          config.sendingTransactionsEnabled,
-          fromBlocks
-        );
-      }
+      // Execute slow relays before relayer refunds to give them priority for any L2 funds.
+      await dataworker.executeSlowRelayLeaves(
+        spokePoolClients,
+        balanceAllocator,
+        config.sendingTransactionsEnabled,
+        fromBlocks
+      );
+      await dataworker.executeRelayerRefundLeaves(
+        spokePoolClients,
+        balanceAllocator,
+        config.sendingTransactionsEnabled,
+        fromBlocks
+      );
     } else {
       logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Executor disabled" });
     }
@@ -204,7 +193,6 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
     // leaves to be executed but the proposed bundle was already executed, then exit early.
     const pendingProposal: PendingRootBundle = await clients.hubPoolClient.hubPool.rootBundleProposal();
 
-    const proposalCollision = isDefined(proposedBundleData) && pendingProposal.unclaimedPoolRebalanceLeafCount > 0;
     // The pending root bundle that we want to execute has already been executed if its unclaimed leaf count
     // does not match the number of leaves the executor wants to execute, or the pending root bundle's
     // challenge period timestamp is in the future. This latter case is rarer but it can
@@ -213,12 +201,10 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
       poolRebalanceLeafExecutionCount > 0 &&
       (pendingProposal.unclaimedPoolRebalanceLeafCount !== poolRebalanceLeafExecutionCount ||
         pendingProposal.challengePeriodEndTimestamp > clients.hubPoolClient.currentTime);
-    if (proposalCollision || executorCollision) {
+    if (executorCollision) {
       logger[startupLogLevel(config)]({
         at: "Dataworker#index",
         message: "Exiting early due to dataworker function collision",
-        proposalCollision,
-        proposedBundleDataDefined: isDefined(proposedBundleData),
         executorCollision,
         poolRebalanceLeafExecutionCount,
         unclaimedPoolRebalanceLeafCount: pendingProposal.unclaimedPoolRebalanceLeafCount,


### PR DESCRIPTION
`executePoolRebalanceLeaves` is called only by the l1 executor to execute a root bundle on mainnet after finalization. Since we need to execute the root bundle out of the hub pool before proposing another root bundle, it makes sense to swap the order and instead run the l1 executor before the proposer.

For expediency, the two processes have been combined here. This means we are loading data from the BundleDataClient in parallel, so to avoid potential race conditions, we clone the bundle data client when calculating bundle data for the pending root bundle and the upcoming root bundle.