### PR TITLE
refactor Permit early exit in HubPool proposer/executor

### DIFF
--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -2,6 +2,7 @@ import { CommonConfig, ProcessEnv } from "../common";
 import { BigNumber, assert, getArweaveJWKSigner, toBNWei } from "../utils";
 
 export class DataworkerConfig extends CommonConfig {
+  readonly minChallengeLeadTime: number;
   readonly maxPoolRebalanceLeafSizeOverride: number;
   readonly maxRelayerRepaymentLeafSizeOverride: number;
   readonly rootBundleExecutionThreshold: BigNumber;
@@ -55,8 +56,11 @@ export class DataworkerConfig extends CommonConfig {
       FORCE_PROPOSAL_BUNDLE_RANGE,
       PERSIST_BUNDLES_TO_ARWEAVE,
       EXECUTOR_IGNORE_CHAINS,
+      MIN_CHALLENGE_LEAD_TIME = "600"
     } = env;
     super(env);
+
+    this.minChallengeLeadTime = Number(MIN_CHALLENGE_LEAD_TIME);
 
     this.bufferToPropose = BUFFER_TO_PROPOSE ? Number(BUFFER_TO_PROPOSE) : (20 * 60) / 15; // 20 mins of blocks;
     // Should we assert that the leaf count caps are > 0?

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -56,7 +56,7 @@ export class DataworkerConfig extends CommonConfig {
       FORCE_PROPOSAL_BUNDLE_RANGE,
       PERSIST_BUNDLES_TO_ARWEAVE,
       EXECUTOR_IGNORE_CHAINS,
-      MIN_CHALLENGE_LEAD_TIME = "600"
+      MIN_CHALLENGE_LEAD_TIME = "600",
     } = env;
     super(env);
 

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -1,4 +1,3 @@
-import { Contract } from "ethers";
 import { TokenClient } from "../clients";
 import {
   EvmAddress,

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -122,7 +122,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
   try {
     // Explicitly don't log addressFilter because it can be huge and can overwhelm log transports.
     const { addressFilter: _addressFilter, ...loggedConfig } = config;
-    logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Dataworker started 👩‍🔬", loggedConfig });
+    logger[startupLogLevel(config)]({ at: "Dataworker#index", message: `${personality} started 👩‍🔬`, loggedConfig });
 
     profiler.mark("loopStart");
     // Determine the spoke client's lookback:

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -32,7 +32,7 @@ let logger: winston.Logger;
 export async function createDataworker(
   _logger: winston.Logger,
   baseSigner: Signer,
-  config?: DataworkerConfig,
+  config?: DataworkerConfig
 ): Promise<{
   config: DataworkerConfig;
   clients: DataworkerClients;
@@ -63,9 +63,7 @@ export async function createDataworker(
 
 function resolvePersonality(config: DataworkerConfig): string {
   if (config.proposerEnabled) {
-    return config.l1ExecutorEnabled
-      ? "Proposer/Executor"
-      : "Proposer";
+    return config.l1ExecutorEnabled ? "Proposer/Executor" : "Proposer";
   }
 
   if (config.l1ExecutorEnabled || config.l2ExecutorEnabled) {
@@ -83,13 +81,10 @@ async function getChallengeRemaining(chainId: number): Promise<number> {
   const provider = await getProvider(chainId);
   const hubPool = getDeployedContract("HubPool", chainId).connect(provider);
 
-  const [proposal, currentTime] = await Promise.all([
-    hubPool.rootBundleProposal(),
-    hubPool.getCurrentTime(),
-  ]);
+  const [proposal, currentTime] = await Promise.all([hubPool.rootBundleProposal(), hubPool.getCurrentTime()]);
   const { challengePeriodEndTimestamp } = proposal;
 
-  return Math.max(challengePeriodEndTimestamp  - currentTime, 0);
+  return Math.max(challengePeriodEndTimestamp - currentTime, 0);
 }
 
 export async function runDataworker(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
@@ -104,7 +99,11 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
 
   const personality = resolvePersonality(config);
   if (challengeRemaining > 600 && (config.proposerEnabled || config.l1ExecutorEnabled)) {
-    logger[startupLogLevel(config)]({ at: "Dataworker#index", message: `${personality} aborting (not ready)`, challengeRemaining });
+    logger[startupLogLevel(config)]({
+      at: "Dataworker#index",
+      message: `${personality} aborting (not ready)`,
+      challengeRemaining,
+    });
     return;
   }
 

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -94,10 +94,10 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
   logger = _logger;
 
   const config = new DataworkerConfig(process.env);
+  const personality = resolvePersonality(config);
   const challengeRemaining = await getChallengeRemaining(config.hubPoolChainId);
 
-  const personality = resolvePersonality(config);
-  if (challengeRemaining > 600 && (config.proposerEnabled || config.l1ExecutorEnabled)) {
+  if (challengeRemaining > config.minChallengeLeadTime && (config.proposerEnabled || config.l1ExecutorEnabled)) {
     logger[startupLogLevel(config)]({
       at: "Dataworker#index",
       message: `${personality} aborting (not ready)`,


### PR DESCRIPTION
There are cases where the proposer & executor are unable to do anthing. This can be detected well in advance of doing a HubPoolClient update, which is otherwise a quite heavy procedure.