### PR TITLE
improve(proposer): Guard early exit in proposer/executor

### DIFF
--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -87,6 +87,8 @@ async function getChallengeRemaining(chainId: number): Promise<number> {
 }
 
 export async function runDataworker(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
+  const { RUN_IDENTIFIER: runIdentifier } = process.env;
+
   const profiler = new Profiler({
     at: "Dataworker#index",
     logger: _logger,
@@ -97,7 +99,11 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
   const personality = resolvePersonality(config);
   const challengeRemaining = await getChallengeRemaining(config.hubPoolChainId);
 
-  if (challengeRemaining > config.minChallengeLeadTime && (config.proposerEnabled || config.l1ExecutorEnabled)) {
+  if (
+    !isDefined(runIdentifier) &&
+    challengeRemaining > config.minChallengeLeadTime &&
+    ((config.proposerEnabled && !config.forcePropose) || config.l1ExecutorEnabled)
+  ) {
     logger[startupLogLevel(config)]({
       at: "Dataworker#index",
       message: `${personality} aborting (not ready)`,

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -30,8 +30,6 @@ import { PendingRootBundle, BundleData } from "../interfaces";
 config();
 let logger: winston.Logger;
 
-const { RUN_IDENTIFIER: runIdentifier, BOT_IDENTIFIER: botIdentifier = "across-dataworker" } = process.env;
-
 export async function createDataworker(
   _logger: winston.Logger,
   baseSigner: Signer,
@@ -91,7 +89,7 @@ async function getChallengeRemaining(chainId: number): Promise<number> {
 }
 
 export async function runDataworker(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
-  const { RUN_IDENTIFIER: runIdentifier } = process.env;
+  const { RUN_IDENTIFIER: runIdentifier, BOT_IDENTIFIER: botIdentifier = "across-dataworker" } = process.env;
 
   const profiler = new Profiler({
     at: "Dataworker#index",
@@ -104,7 +102,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
   const challengeRemaining = await getChallengeRemaining(config.hubPoolChainId);
 
   if (
-    !isDefined(runIdentifier) &&
+    isDefined(runIdentifier) &&
     challengeRemaining > config.minChallengeLeadTime &&
     ((config.proposerEnabled && !config.forcePropose) || config.l1ExecutorEnabled)
   ) {


### PR DESCRIPTION
tldr this restores the existing proposer & executor behaviour (when run 
locally) from before the recent change to bail early.

RUN_IDENTIFIER is typically only defined in production and it has 
previously been used in the relayer to infer whether the bot is running
in a production environment.

Also, irrespective of environment, the proposer should run if both the 
propser is enabled and FORCE_PROPOSE is set.