### PR TITLE
refactor(dataworker): Drop bundle volume computation

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -398,7 +398,6 @@ export class Dataworker {
    */
   async proposeRootBundle(
     spokePoolClients: { [chainId: number]: SpokePoolClient },
-    usdThresholdToSubmitNewBundle?: BigNumber,
     submitProposals = true,
     earliestBlocksInSpokePoolClients: { [chainId: number]: number } = {}
   ): Promise<BundleData> {
@@ -432,38 +431,6 @@ export class Dataworker {
       false, // Don't load data from arweave when proposing.
       logData
     );
-
-    if (usdThresholdToSubmitNewBundle !== undefined) {
-      // Exit early if volume of pool rebalance leaves exceeds USD threshold. Volume includes netSendAmounts only since
-      // that is the actual amount sent over bridges. This also mitigates the chance that a RelayerRefundLeaf is
-      // published but its refund currency isn't sent over the bridge in a PoolRebalanceLeaf.
-      const totalUsdRefund = await PoolRebalanceUtils.computePoolRebalanceUsdVolume(
-        rootBundleData.poolRebalanceLeaves,
-        this.clients
-      );
-      if (totalUsdRefund.lt(usdThresholdToSubmitNewBundle)) {
-        this.logger.debug({
-          at: "Dataworker",
-          message: "Root bundle USD volume does not exceed threshold, exiting early 🟡",
-          usdThresholdToSubmitNewBundle,
-          totalUsdRefund,
-          leaves: rootBundleData.poolRebalanceLeaves.map((leaf) => {
-            return {
-              ...leaf,
-              l1Tokens: leaf.l1Tokens.map((l1Token) => l1Token.toNative()),
-            };
-          }),
-        });
-        return;
-      } else {
-        this.logger.debug({
-          at: "Dataworker",
-          message: "Root bundle USD volume exceeds threshold! 💚",
-          usdThresholdToSubmitNewBundle,
-          totalUsdRefund,
-        });
-      }
-    }
 
     // TODO: Validate running balances in potential new bundle and make sure that important invariants
     // are not violated, such as a token balance being lower than the amount necessary to pay out all refunds,

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -5,7 +5,6 @@ export class DataworkerConfig extends CommonConfig {
   readonly minChallengeLeadTime: number;
   readonly maxPoolRebalanceLeafSizeOverride: number;
   readonly maxRelayerRepaymentLeafSizeOverride: number;
-  readonly rootBundleExecutionThreshold: BigNumber;
   readonly spokeRootsLookbackCount: number; // Consider making this configurable per chain ID.
 
   // These variables can be toggled to choose whether the bot will go through the dataworker logic.
@@ -40,7 +39,6 @@ export class DataworkerConfig extends CommonConfig {
 
   constructor(env: ProcessEnv) {
     const {
-      ROOT_BUNDLE_EXECUTION_THRESHOLD,
       MAX_POOL_REBALANCE_LEAF_SIZE_OVERRIDE,
       MAX_RELAYER_REPAYMENT_LEAF_SIZE_OVERRIDE,
       DISPUTER_ENABLED,
@@ -77,9 +75,6 @@ export class DataworkerConfig extends CommonConfig {
     if (this.maxRelayerRepaymentLeafSizeOverride !== undefined) {
       assert(this.maxRelayerRepaymentLeafSizeOverride > 0, "Max leaf count set to 0");
     }
-    this.rootBundleExecutionThreshold = ROOT_BUNDLE_EXECUTION_THRESHOLD
-      ? toBNWei(ROOT_BUNDLE_EXECUTION_THRESHOLD)
-      : toBNWei("500000");
     this.disputerEnabled = DISPUTER_ENABLED === "true";
     this.proposerEnabled = PROPOSER_ENABLED === "true";
     this.l2ExecutorEnabled = L2_EXECUTOR_ENABLED === "true";

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -22,43 +22,6 @@ import {
 } from "../utils";
 import { DataworkerClients } from "./DataworkerClientHelper";
 
-// TODO: Is summing up absolute values really the best way to compute a root bundle's "volume"? Said another way,
-// how do we measure a root bundle's "impact" or importance?
-export async function computePoolRebalanceUsdVolume(
-  leaves: PoolRebalanceLeaf[],
-  clients: DataworkerClients
-): Promise<BigNumber> {
-  // Fetch the set of unique token addresses from the array of PoolRebalanceLeave objects.
-  // Map the resulting HubPool token addresses to symbol, decimals, and price.
-  const hubPoolTokens = Object.fromEntries(
-    Array.from(new Set(leaves.map(({ l1Tokens }) => l1Tokens).flat()))
-      .map((address) => clients.hubPoolClient.getTokenInfoForL1Token(address))
-      .map(({ symbol, decimals, address }) => [address, { symbol, decimals, price: bnZero }])
-  );
-
-  // Fetch all relevant token prices.
-  const prices = await clients.priceClient.getPricesByAddress(
-    Object.keys(hubPoolTokens).map((address) => address),
-    "usd"
-  );
-
-  // Scale token price to 18 decimals.
-  prices.forEach(({ address, price }) => (hubPoolTokens[address].price = toBNWei(price)));
-
-  const bn10 = toBN(10);
-  return leaves.reduce((result: BigNumber, poolRebalanceLeaf) => {
-    return poolRebalanceLeaf.l1Tokens.reduce((sum: BigNumber, l1Token: EvmAddress, index: number) => {
-      const { decimals, price: usdTokenPrice } = hubPoolTokens[l1Token.toEvmAddress()];
-
-      const netSendAmount = poolRebalanceLeaf.netSendAmounts[index];
-      const volume = netSendAmount.abs().mul(bn10.pow(18 - decimals)); // Scale volume to 18 decimals.
-
-      const usdVolume = volume.mul(usdTokenPrice).div(fixedPoint);
-      return sum.add(usdVolume);
-    }, result);
-  }, bnZero);
-}
-
 export function generateMarkdownForDisputeInvalidBundleBlocks(
   chainIdListForBundleEvaluationBlockNumbers: number[],
   pendingRootBundle: PendingRootBundle,

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -202,7 +202,6 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
       // Bundle data is defined if and only if there is a new bundle proposal transaction enqueued.
       proposedBundleData = await dataworker.proposeRootBundle(
         spokePoolClients,
-        config.rootBundleExecutionThreshold,
         config.sendingTransactionsEnabled,
         fromBlocks
       );


### PR DESCRIPTION
This isn't required in the dataworker anymore.