### PR TITLE
feat(ProfitClient): Allow Relayer to set min relayer fee just for single destination chain

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -346,12 +346,11 @@ export class ProfitClient {
 
     const tokenKey = `MIN_RELAYER_FEE_PCT_${effectiveSymbol}`;
     const routeKey = `${tokenKey}_${srcChainId}_${dstChainId}`;
-    const destinationChainKey = `${dstChainId}`;
-    let minRelayerFeePct =
-      this.minRelayerFees[routeKey] ?? this.minRelayerFees[destinationChainKey] ?? this.minRelayerFees[tokenKey];
+    const destinationChainKey = `MIN_RELAYER_FEE_PCT_${dstChainId}`;
+    let minRelayerFeePct = this.minRelayerFees[routeKey] ?? this.minRelayerFees[tokenKey];
 
     if (!minRelayerFeePct) {
-      const _minRelayerFeePct = process.env[routeKey] ?? process.env[tokenKey];
+      const _minRelayerFeePct = process.env[routeKey] ?? process.env[destinationChainKey] ?? process.env[tokenKey];
       minRelayerFeePct = _minRelayerFeePct ? toBNWei(_minRelayerFeePct) : this.defaultMinRelayerFeePct;
 
       // Save the route for next time.

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -346,7 +346,9 @@ export class ProfitClient {
 
     const tokenKey = `MIN_RELAYER_FEE_PCT_${effectiveSymbol}`;
     const routeKey = `${tokenKey}_${srcChainId}_${dstChainId}`;
-    let minRelayerFeePct = this.minRelayerFees[routeKey] ?? this.minRelayerFees[tokenKey];
+    const destinationChainKey = `${dstChainId}`;
+    let minRelayerFeePct =
+      this.minRelayerFees[routeKey] ?? this.minRelayerFees[destinationChainKey] ?? this.minRelayerFees[tokenKey];
 
     if (!minRelayerFeePct) {
       const _minRelayerFeePct = process.env[routeKey] ?? process.env[tokenKey];


### PR DESCRIPTION
Can be used when there is a gas spike on a specific chain. Is lower in precedence than the more specific `routeKey` but higher than more general `tokenKey`
