### PR TITLE
feat(InventoryClient): Add ability to withdraw USDC over CCTP from L2 to L1

### DIFF
--- a/src/adapter/l2Bridges/ArbitrumOrbitBridge.ts
+++ b/src/adapter/l2Bridges/ArbitrumOrbitBridge.ts
@@ -96,6 +96,9 @@ export class ArbitrumOrbitBridge extends BaseL2BridgeAdapter {
     ]);
     const counted = new Set<number>();
     const withdrawalAmount = withdrawalInitiatedEvents.reduce((totalAmount, { args: l2Args }) => {
+      if (l2Args.l1Token !== l1Token) {
+        return totalAmount;
+      }
       const received = withdrawalFinalizedEvents.find(({ args: l1Args }, idx) => {
         // Protect against double-counting the same l1 withdrawal events.
         // @dev: If we begin to send "fast-finalized" messages via CCTP V2 then the amounts will not exactly match

--- a/src/adapter/l2Bridges/ArbitrumOrbitBridge.ts
+++ b/src/adapter/l2Bridges/ArbitrumOrbitBridge.ts
@@ -94,17 +94,23 @@ export class ArbitrumOrbitBridge extends BaseL2BridgeAdapter {
         l1EventConfig
       ),
     ]);
-    const withdrawalAmount = withdrawalInitiatedEvents.reduce((totalAmount, event) => {
-      if (event.args.l1Token === l1Token) {
-        const matchingFinalizedEvent = withdrawalFinalizedEvents.find((e) =>
-          toBN(e.args._amount.toString()).eq(toBN(event.args._amount.toString()))
-        );
-        if (!isDefined(matchingFinalizedEvent)) {
-          return totalAmount.add(event.args._amount);
+    const counted = new Set<number>();
+    const withdrawalAmount = withdrawalInitiatedEvents.reduce((totalAmount, { args: l2Args }) => {
+      const received = withdrawalFinalizedEvents.find(({ args: l1Args }, idx) => {
+        // Protect against double-counting the same l1 withdrawal events.
+        // @dev: If we begin to send "fast-finalized" messages via CCTP V2 then the amounts will not exactly match
+        // and we will need to adjust this logic.
+        if (counted.has(idx) || !toBN(l1Args._amount.toString()).eq(toBN(l2Args._amount.toString()))) {
+          return false;
         }
-      }
-      return totalAmount;
+
+        counted.add(idx);
+        return true;
+      });
+
+      return isDefined(received) ? totalAmount : totalAmount.add(l2Args._amount);
     }, bnZero);
+
     return withdrawalAmount;
   }
 }

--- a/src/adapter/l2Bridges/OpStackBridge.ts
+++ b/src/adapter/l2Bridges/OpStackBridge.ts
@@ -89,14 +89,21 @@ export class OpStackBridge extends BaseL2BridgeAdapter {
         l1EventConfig
       ),
     ]);
-    const withdrawalAmount = withdrawalInitiatedEvents.reduce((totalAmount, event) => {
-      const matchingFinalizedEvent = withdrawalFinalizedEvents.find((e) =>
-        toBN(e.args.amount.toString()).eq(toBN(event.args.amount.toString()))
-      );
-      if (!isDefined(matchingFinalizedEvent)) {
-        return totalAmount.add(event.args.amount);
-      }
-      return totalAmount;
+    const counted = new Set<number>();
+    const withdrawalAmount = withdrawalInitiatedEvents.reduce((totalAmount, { args: l2Args }) => {
+      const received = withdrawalFinalizedEvents.find(({ args: l1Args }, idx) => {
+        // Protect against double-counting the same l1 withdrawal events.
+        // @dev: If we begin to send "fast-finalized" messages via CCTP V2 then the amounts will not exactly match
+        // and we will need to adjust this logic.
+        if (counted.has(idx) || !toBN(l1Args.amount.toString()).eq(toBN(l2Args.amount.toString()))) {
+          return false;
+        }
+
+        counted.add(idx);
+        return true;
+      });
+
+      return isDefined(received) ? totalAmount : totalAmount.add(l2Args.amount);
     }, bnZero);
     return withdrawalAmount;
   }

--- a/src/adapter/l2Bridges/OpStackUSDCBridge.ts
+++ b/src/adapter/l2Bridges/OpStackUSDCBridge.ts
@@ -15,6 +15,7 @@ import {
   Signer,
   EvmAddress,
   getTokenInfo,
+  toBN,
 } from "../../utils";
 import { BaseL2BridgeAdapter } from "./BaseL2BridgeAdapter";
 
@@ -102,7 +103,9 @@ export class OpStackUSDCBridge extends BaseL2BridgeAdapter {
     const withdrawalAmount = l2Events.reduce((totalAmount, { args: l2Args }) => {
       const received = l1Events.find(({ args: l1Args }, idx) => {
         // Protect against double-counting the same l1 withdrawal events.
-        if (counted.has(idx) || l1Args._amount.ne(l2Args._amount)) {
+        // @dev: If we begin to send "fast-finalized" messages via CCTP V2 then the amounts will not exactly match
+        // and we will need to adjust this logic.
+        if (counted.has(idx) || !toBN(l1Args._amount.toString()).eq(toBN(l2Args._amount.toString()))) {
           return false;
         }
 

--- a/src/adapter/l2Bridges/OpStackWethBridge.ts
+++ b/src/adapter/l2Bridges/OpStackWethBridge.ts
@@ -96,15 +96,22 @@ export class OpStackWethBridge extends BaseL2BridgeAdapter {
         l1EventConfig
       ),
     ]);
-    const withdrawalAmount = withdrawalInitiatedEvents.reduce((totalAmount, event) => {
-      const matchingFinalizedEvent = withdrawalFinalizedEvents.find((e) =>
-        toBN(e.args.amount.toString()).eq(toBN(event.args.amount.toString()))
-      );
-      if (!isDefined(matchingFinalizedEvent)) {
-        return totalAmount.add(event.args.amount);
-      }
-      return totalAmount;
-    }, bnZero);
+    const counted = new Set<number>();
+    const withdrawalAmount = withdrawalInitiatedEvents.reduce((totalAmount, { args: l2Args }) => {
+      const received = withdrawalFinalizedEvents.find(({ args: l1Args }, idx) => {
+        // Protect against double-counting the same l1 withdrawal events.
+        // @dev: If we begin to send "fast-finalized" messages via CCTP V2 then the amounts will not exactly match
+        // and we will need to adjust this logic.
+        if (counted.has(idx) || !toBN(l1Args.amount.toString()).eq(toBN(l2Args.amount.toString()))) {
+          return false;
+        }
+
+        counted.add(idx);
+        return true;
+      });
+
+      return isDefined(received) ? totalAmount : totalAmount.add(l2Args.amount);
+    }, bnZero);    
     return withdrawalAmount;
   }
 }

--- a/src/adapter/l2Bridges/OpStackWethBridge.ts
+++ b/src/adapter/l2Bridges/OpStackWethBridge.ts
@@ -111,7 +111,7 @@ export class OpStackWethBridge extends BaseL2BridgeAdapter {
       });
 
       return isDefined(received) ? totalAmount : totalAmount.add(l2Args.amount);
-    }, bnZero);    
+    }, bnZero);
     return withdrawalAmount;
   }
 }

--- a/src/adapter/l2Bridges/UsdcCCTPBridge.ts
+++ b/src/adapter/l2Bridges/UsdcCCTPBridge.ts
@@ -1,0 +1,128 @@
+import {
+  BigNumber,
+  bnZero,
+  Contract,
+  EventSearchConfig,
+  getNetworkName,
+  isDefined,
+  paginatedEventQuery,
+  Provider,
+  Signer,
+  toBN,
+  EvmAddress,
+  getCctpTokenMessenger,
+  isCctpV2L2ChainId,
+  getCctpDomainForChainId,
+  TOKEN_SYMBOLS_MAP,
+  ethers,
+  assert,
+  createFormatFunction,
+  getTokenInfo,
+} from "../../utils";
+import { BaseL2BridgeAdapter } from "./BaseL2BridgeAdapter";
+import { AugmentedTransaction } from "../../clients/TransactionClient";
+
+export class UsdcCCTPBridge extends BaseL2BridgeAdapter {
+  private CCTP_MAX_SEND_AMOUNT = toBN(1_000_000_000_000); // 1MM USDC.
+  private IS_CCTP_V2 = false;
+  private readonly l1UsdcTokenAddress: EvmAddress;
+  private readonly l2UsdcTokenAddress: EvmAddress;
+
+  constructor(
+    l2chainId: number,
+    hubChainId: number,
+    l2Signer: Signer,
+    l1Provider: Provider | Signer,
+    l1Token: EvmAddress
+  ) {
+    super(l2chainId, hubChainId, l2Signer, l1Provider, l1Token);
+    this.IS_CCTP_V2 = isCctpV2L2ChainId(l2chainId);
+
+    const { address: l2TokenMessengerAddress, abi: l2TokenMessengerAbi } = getCctpTokenMessenger(l2chainId, l2chainId);
+    this.l2Bridge = new Contract(l2TokenMessengerAddress, l2TokenMessengerAbi, l2Signer);
+
+    const { address: l1TokenMessengerAddress, abi: l1Abi } = getCctpTokenMessenger(l2chainId, hubChainId);
+    this.l1Bridge = new Contract(l1TokenMessengerAddress, l1Abi, l1Provider);
+
+    this.l1UsdcTokenAddress = EvmAddress.from(TOKEN_SYMBOLS_MAP.USDC.addresses[this.hubChainId]);
+    this.l2UsdcTokenAddress = EvmAddress.from(TOKEN_SYMBOLS_MAP.USDC.addresses[this.l2chainId]);
+  }
+
+  private get l1DestinationDomain(): number {
+    return getCctpDomainForChainId(this.hubChainId);
+  }
+
+  constructWithdrawToL1Txns(
+    toAddress: EvmAddress,
+    l2Token: EvmAddress,
+    l1Token: EvmAddress,
+    amount: BigNumber
+  ): Promise<AugmentedTransaction[]> {
+    assert(l1Token.eq(this.l1UsdcTokenAddress));
+    assert(l2Token.eq(this.l2UsdcTokenAddress));
+    const { decimals } = getTokenInfo(l2Token, this.l2chainId);
+    const formatter = createFormatFunction(2, 4, false, decimals);
+
+    amount = amount.gt(this.CCTP_MAX_SEND_AMOUNT) ? this.CCTP_MAX_SEND_AMOUNT : amount;
+    return Promise.resolve([
+      {
+        contract: this.l2Bridge,
+        chainId: this.l2chainId,
+        method: "depositForBurn",
+        nonMulticall: true,
+        message: "🎰 Withdrew CCTP USDC to L1",
+        mrkdwn: `Withdrew ${formatter(amount.toString())} USDC from ${getNetworkName(this.l2chainId)} to L1 via CCTP`,
+        args: this.IS_CCTP_V2
+          ? [
+              amount,
+              this.l1DestinationDomain,
+              toAddress.toBytes32(),
+              this.l2UsdcTokenAddress.toNative(),
+              ethers.constants.HashZero, // Anyone can finalize the message on domain when this is set to bytes32(0)
+              0, // maxFee set to 0 so this will be a "standard" speed transfer
+              2000, // Hardcoded minFinalityThreshold value for standard transfer
+            ]
+          : [amount, this.l1DestinationDomain, toAddress.toBytes32(), this.l2UsdcTokenAddress.toNative()],
+      },
+    ]);
+  }
+
+  async getL2PendingWithdrawalAmount(
+    l2EventConfig: EventSearchConfig,
+    l1EventConfig: EventSearchConfig,
+    fromAddress: EvmAddress,
+    l2Token: EvmAddress
+  ): Promise<BigNumber> {
+    assert(l2Token.eq(this.l2UsdcTokenAddress));
+
+    const l2EventFilterArgs = this.IS_CCTP_V2
+      ? [this.l2UsdcTokenAddress.toNative(), undefined, fromAddress.toNative()]
+      : [undefined, this.l2UsdcTokenAddress.toNative(), undefined, fromAddress.toNative()];
+    // @dev: First parameter in MintAndWithdraw is mintRecipient, this should be the same as the fromAddress
+    // for all use cases of this adapter.
+    const l1EventFilterArgs = [fromAddress.toNative(), undefined, this.l1UsdcTokenAddress.toNative()];
+    const [withdrawalInitiatedEvents, withdrawalFinalizedEvents] = await Promise.all([
+      paginatedEventQuery(this.l2Bridge, this.l2Bridge.filters.DepositForBurn(...l2EventFilterArgs), l2EventConfig),
+      paginatedEventQuery(this.l1Bridge, this.l1Bridge.filters.MintAndWithdraw(...l1EventFilterArgs), l1EventConfig),
+    ]);
+    const withdrawalAmount = withdrawalInitiatedEvents.reduce((totalAmount, event) => {
+      const matchingFinalizedEvent = withdrawalFinalizedEvents.find((e) =>
+        toBN(e.args.amount.toString()).eq(toBN(event.args.amount.toString()))
+      );
+      if (!isDefined(matchingFinalizedEvent)) {
+        return totalAmount.add(event.args.amount);
+      }
+      return totalAmount;
+    }, bnZero);
+    return withdrawalAmount;
+  }
+
+  public override requiredTokenApprovals(): { token: EvmAddress; bridge: EvmAddress }[] {
+    return [
+      {
+        token: this.l2UsdcTokenAddress,
+        bridge: EvmAddress.from(this.l2Bridge.address),
+      },
+    ];
+  }
+}

--- a/src/adapter/l2Bridges/index.ts
+++ b/src/adapter/l2Bridges/index.ts
@@ -4,3 +4,4 @@ export * from "./BinanceCEXBridge";
 export * from "./OpStackBridge";
 export * from "./OpStackUSDCBridge";
 export * from "./OpStackWethBridge";
+export * from "./UsdcCCTPBridge";

--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -77,7 +77,7 @@ export class AcrossApiClient {
       at: "AcrossAPIClient",
       message: "Querying /liquid-reserves",
       timeout: this.timeout,
-      tokens,
+      tokens: tokens.map((token) => token.toEvmAddress()),
       endpoint: this.endpoint,
     });
     this.updatedLimits = false;

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -1311,8 +1311,8 @@ export class InventoryClient {
               shouldWithdrawExcess ? "HAS EXCESS ✅" : "NO EXCESS ❌"
             }`,
             {
-              l1Token,
-              l2Token,
+              l1Token: l1Token.toEvmAddress(),
+              l2Token: l2Token.toEvmAddress(),
               cumulativeBalance: formatter(cumulativeBalance),
               currentAllocPct: formatUnits(currentAllocPct, 18),
               excessWithdrawThresholdPct: formatUnits(excessWithdrawThresholdPct, 18),
@@ -1378,7 +1378,19 @@ export class InventoryClient {
       this.log("No excess balances to withdraw");
       return;
     } else {
-      this.log("Excess balances to withdraw", { withdrawalsRequired });
+      this.log("Excess balances to withdraw", {
+        withdrawalsRequired: Object.entries(withdrawalsRequired).map(([chainIds, withdrawals]) => {
+          return [
+            chainIds,
+            withdrawals.map((withdrawal) => {
+              return {
+                ...withdrawal,
+                l2Token: withdrawal.l2Token.toEvmAddress(),
+              };
+            }),
+          ];
+        }),
+      });
     }
 
     // Now, go through each chain and submit transactions. We cannot batch them unfortunately since the bridges
@@ -1503,7 +1515,7 @@ export class InventoryClient {
       return;
     }
     const l1Tokens = this.getL1Tokens();
-    this.log("Checking token approvals", { l1Tokens });
+    this.log("Checking token approvals", { l1Tokens: l1Tokens.map((token) => token.toEvmAddress()) });
 
     await this.adapterManager.setL1TokenApprovals(l1Tokens);
   }

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -43,6 +43,7 @@ import {
   ArbitrumOrbitBridge as L2ArbitrumOrbitBridge,
   OpStackBridge as L2OpStackBridge,
   BinanceCEXBridge as L2BinanceCEXBridge,
+  UsdcCCTPBridge as L2UsdcCCTPBridge,
 } from "../adapter/l2Bridges";
 import { CONTRACT_ADDRESSES } from "./ContractAddresses";
 import { HyperlaneXERC20Bridge } from "../adapter/bridges/HyperlaneXERC20Bridge";
@@ -597,30 +598,39 @@ export const CUSTOM_L2_BRIDGE: {
   },
   [CHAIN_IDs.OPTIMISM]: {
     [TOKEN_SYMBOLS_MAP.ezETH.addresses[CHAIN_IDs.MAINNET]]: HyperlaneXERC20BridgeL2,
+    [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: L2UsdcCCTPBridge,
   },
   [CHAIN_IDs.ARBITRUM]: {
     [TOKEN_SYMBOLS_MAP.ezETH.addresses[CHAIN_IDs.MAINNET]]: HyperlaneXERC20BridgeL2,
+    [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: L2UsdcCCTPBridge,
   },
   [CHAIN_IDs.MODE]: {
     [TOKEN_SYMBOLS_MAP.ezETH.addresses[CHAIN_IDs.MAINNET]]: HyperlaneXERC20BridgeL2,
   },
   [CHAIN_IDs.LINEA]: {
     [TOKEN_SYMBOLS_MAP.ezETH.addresses[CHAIN_IDs.MAINNET]]: HyperlaneXERC20BridgeL2,
+    [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: L2UsdcCCTPBridge,
   },
   [CHAIN_IDs.BLAST]: {
     [TOKEN_SYMBOLS_MAP.ezETH.addresses[CHAIN_IDs.MAINNET]]: HyperlaneXERC20BridgeL2,
   },
   [CHAIN_IDs.BASE]: {
     [TOKEN_SYMBOLS_MAP.ezETH.addresses[CHAIN_IDs.MAINNET]]: HyperlaneXERC20BridgeL2,
+    [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: L2UsdcCCTPBridge,
   },
   [CHAIN_IDs.UNICHAIN]: {
     [TOKEN_SYMBOLS_MAP.ezETH.addresses[CHAIN_IDs.MAINNET]]: HyperlaneXERC20BridgeL2,
+    [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: L2UsdcCCTPBridge,
+  },
+  [CHAIN_IDs.POLYGON]: {
+    [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: L2UsdcCCTPBridge,
   },
   [CHAIN_IDs.BSC]: {
     [TOKEN_SYMBOLS_MAP.ezETH.addresses[CHAIN_IDs.MAINNET]]: HyperlaneXERC20BridgeL2,
   },
   [CHAIN_IDs.WORLD_CHAIN]: {
     [TOKEN_SYMBOLS_MAP.ezETH.addresses[CHAIN_IDs.MAINNET]]: HyperlaneXERC20BridgeL2,
+    [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: L2UsdcCCTPBridge,
   },
 };
 


### PR DESCRIPTION
This will unlock more USDC capital efficiency. The finalizer doesn't need any changes to support finalizing these USDC withdrawals.

## Integration tests:
1. [Base withdrawal](https://basescan.org/tx/0x82ced92aff24d903256ca43c79f6a999ee01265e41bd0eccb5dfa4478732dae4#eventlog)

```
# Run 1
2025-07-17 21:18:28 [debug]: {
  "at": "InventoryClient",
  "message": "Evaluated withdrawing excess balance on Base for token USDC: HAS EXCESS ✅",
  "l1Token": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
  "l2Token": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
  "cumulativeBalance": "755.10",
  "currentAllocPct": "0.400835260824695875",
  "excessWithdrawThresholdPct": "0.285",
  "targetPct": "0.2",
  "withdrawalParams": {
    "withdrawPct": "0.200835260824695875",
    "desiredWithdrawalAmount": "151.65"
  },
  "bot-identifier": "nick-local",
  "run-identifier": "5c354d9b-7ae5-4b16-b8b0-4dc8252eff16"
}

# Run 2
2025-07-17 21:19:04 [debug]: {
  "at": "InventoryClient",
  "message": "Evaluated withdrawing excess balance on Base for token USDC: NO EXCESS ❌",
  "l1Token": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
  "l2Token": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
  "cumulativeBalance": "603.44",
  "currentAllocPct": "0.250261293058660819",
  "excessWithdrawThresholdPct": "0.285",
  "targetPct": "0.2",
  "bot-identifier": "nick-local",
  "run-identifier": "aa7ac77e-34f3-4156-83ef-d58fb4be51d1"
}
```

2. Make sure we can read pending withdrawal amounts

```
2025-07-17 21:34:05 [debug]: {
  "at": "InventoryClient",
  "message": "Total withdrawal volume for the last 3600 seconds is OVER the limit of 25.64 for USDC on Base, cannot withdraw 90.67.",
  "excessWithdrawThresholdPct": "0.1425",
  "targetPct": "0.1",
  "maximumWithdrawalPct": "0.0425",
  "maximumWithdrawalAmount": "25.64",
  "pendingWithdrawalAmount": "151.65",
  "bot-identifier": "nick-local",
  "run-identifier": "32b6dc79-1be1-41d5-a8d7-2f6022b8082d"
}
```

3. Base finalizer running untouched finalizer code [txn](https://etherscan.io/tx/0x1796ac33c9eaf8496d576df27823c0b71860efabef05a5947ef103cf827e3dde)

4. Polygon [withdrawal](https://polygonscan.com/tx/0xf047d91b8e782c4726530c75f5d46c5abe5b7bb8f512614061d7a575f7c48079)

```
2025-07-17 21:42:29 [debug]: {
  "at": "MultiCallerClient#executeChainTxnQueue",
  "message": "Successfully simulated Polygon transaction batch!",
  "batchTxn": {
    "contract": "0x9daF8c91AEFAE50b9c0E69629D3F6Ca40cA3B3FE",
    "chainId": 137,
    "method": "depositForBurn",
    "nonMulticall": true,
    "message": "🎰 Withdrew CCTP USDC to L1",
    "mrkdwn": "Withdrew 57.94 USDC from Polygon to L1 via CCTP",
    "args": {
      "0": "57944287",
      "1": 0,
      "2": "0x0000000000000000000000009a8f92a830a5cb89a3816e3d267cb7791c16b04d",
      "3": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
    },
    "gasLimit": "111753"
  },
  "bot-identifier": "nick-local",
  "run-identifier": "c01a655a-1d0e-4b9c-89ed-7197e7bdf5ef"
}
```

5. Linea [withdrawal]

```
2025-07-17 21:38:47 [debug]: {
  "at": "TxUtil",
  "message": "Send tx",
  "target": {
    "targetAddress": "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d"
  },
  "method": "depositForBurn",
  "args": {
    "0": "23918468",
    "1": 0,
    "2": "0x0000000000000000000000009a8f92a830a5cb89a3816e3d267cb7791c16b04d",
    "3": "0x176211869cA2b568f2A7D4EE941E073a821EE1ff",
    "4": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "5": 0,
    "6": 2000
  },
  "value": "0",
  "nonce": 839,
  "gas": {
    "maxFeePerGas": "51499897",
    "maxPriorityFeePerGas": "51499890"
  },
  "gasLimit": "140083",
  "bot-identifier": "nick-local",
  "run-identifier": "30744a2d-51f1-47f8-b0a6-72e04e2032ce"
}
```
