### PR TITLE
patch(ProviderUtils): Change getSvmProvider to sync

### DIFF
--- a/src/clients/BalanceAllocator.ts
+++ b/src/clients/BalanceAllocator.ts
@@ -178,7 +178,7 @@ export class BalanceAllocator {
     } else {
       assert(token.isSVM());
       assert(holder.isSVM());
-      return getSolanaTokenBalance(await getSvmProvider(), token, holder);
+      return getSolanaTokenBalance(getSvmProvider(), token, holder);
     }
   }
 }

--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -363,7 +363,7 @@ export class TokenClient {
     const spokePoolClient = this.spokePoolClients[chainId];
     assert(isSVMSpokePoolClient(spokePoolClient));
 
-    const provider = await getSvmProvider();
+    const provider = getSvmProvider();
     const solanaTokens = this.resolveSolanaTokens(chainId, hubPoolTokens);
 
     const tokenData = Object.fromEntries(

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -319,7 +319,7 @@ export async function getSpokePoolClientsForContract(
         chainId,
         BigInt(registrationBlock),
         spokePoolClientSearchSettings,
-        await getSvmProvider()
+        getSvmProvider()
       );
     }
   });

--- a/src/libexec/RelayerSpokePoolListenerSVM.ts
+++ b/src/libexec/RelayerSpokePoolListenerSVM.ts
@@ -171,7 +171,7 @@ async function run(argv: string[]): Promise<void> {
 
   chain = getNetworkName(chainId);
 
-  const provider = await getSvmProvider();
+  const provider = getSvmProvider();
   const blockFinder = undefined;
   const { slot: latestSlot } = await arch.svm.getNearestSlotTime(provider);
 
@@ -214,7 +214,7 @@ async function run(argv: string[]): Promise<void> {
     abortController.abort();
   });
 
-  const eventsClient = await arch.svm.SvmCpiEventsClient.create(await getSvmProvider());
+  const eventsClient = await arch.svm.SvmCpiEventsClient.create(getSvmProvider());
   if (latestSlot > startSlot) {
     const events = ["FundsDeposited", "FilledRelay", "RelayedRootBundle", "ExecutedRelayerRefundRoot"];
     await scrapeEvents(eventsClient, events, { ...opts, to: latestSlot });

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -83,7 +83,7 @@ async function indexedSpokePoolClient(
     spokePoolClient.init(opts);
     return spokePoolClient;
   } else {
-    const provider = await getSvmProvider();
+    const provider = getSvmProvider();
     const svmEventsClient = await arch.svm.SvmCpiEventsClient.create(provider);
     const programId = svmEventsClient.getProgramAddress();
     const statePda = await arch.svm.getStatePda(programId);
@@ -233,7 +233,7 @@ export async function constructRelayerClients(
   }
   const svmFillerClient =
     svmChainIds.length === 1
-      ? await SvmFillerClient.from(baseSigner, await getSvmProvider(), svmChainIds[0], logger)
+      ? await SvmFillerClient.from(baseSigner, getSvmProvider(), svmChainIds[0], logger)
       : undefined;
 
   return {

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -26,7 +26,7 @@ export async function getBlockFinder(chainId: number): Promise<utils.BlockFinder
     evmBlockFinders[chainId] ??= new EVMBlockFinder(await getProvider(chainId));
     return evmBlockFinders[chainId];
   }
-  const provider = await getSvmProvider();
+  const provider = getSvmProvider();
   svmBlockFinder ??= new SVMBlockFinder(provider);
   return svmBlockFinder;
 }

--- a/src/utils/CCTPUtils.ts
+++ b/src/utils/CCTPUtils.ts
@@ -813,7 +813,7 @@ async function _getCCTPDepositEventsSvm(
   sourceEventSearchConfig: EventSearchConfig
 ): Promise<AttestedCCTPDeposit[]> {
   // Get the `DepositForBurn` events on Solana.
-  const provider = await getSvmProvider();
+  const provider = getSvmProvider();
   const { address } = getCctpTokenMessenger(l2ChainId, sourceChainId);
 
   const eventClient = await SvmCpiEventsClient.createFor(provider, address, TokenMessengerMinterIdl);

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -271,20 +271,16 @@ export function getWSProviders(chainId: number, quorum?: number): ethers.provide
 /**
  * @notice Returns a cached SVMProvider.
  */
-export async function getSvmProvider(
-  logger: winston.Logger = Logger,
-  chainId = MAINNET_CHAIN_IDs.SOLANA
-): Promise<SVMProvider> {
+export function getSvmProvider(logger: winston.Logger = Logger, chainId = MAINNET_CHAIN_IDs.SOLANA): SVMProvider {
   const nodeUrlList = getNodeUrlList(chainId);
   const namespace = process.env["NODE_PROVIDER_CACHE_NAMESPACE"] ?? "default_svm_provider";
   const maxConcurrency = getMaxConcurrency(chainId);
-  // @dev: We are not using a redis client for the SVMProvider because it doesn't seem to work currently.
-  // const redisClient = await getRedisCache(logger);
   const pctRpcCallsLogged = getPctRpcCallsLogged(chainId);
   const { retries, retryDelay } = getRetryParams(chainId);
   const providerFactory = new sdkProviders.CachedSolanaRpcFactory(
     namespace,
     undefined, // redisClient
+    // @dev: We are not using a redis client for the SVMProvider because it doesn't seem to work currently.
     retries,
     retryDelay,
     maxConcurrency,


### PR DESCRIPTION
async is no longer necessary since we're not using the Redis cache, and for some reason this fixes some bug where getSvmProvider is hanging somewhere in constructSpokePoolClients()
