### PR TITLE
improve(HubPoolClient): Optimize update speed

### DIFF
--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -24,7 +24,13 @@ export async function constructDataworkerClients(
   config: DataworkerConfig,
   baseSigner: Signer
 ): Promise<DataworkerClients> {
-  const commonClients = await constructClients(logger, config, baseSigner);
+  // Set hubPoolLookback conservatively to be equal to one month of blocks. If the config.dataworkerFastLookbackCount
+  // exceeds ~720 then we'll just use the gensis block since in that case, this dataworker is being used for
+  // non-production circumstances (i.e. to execute a very old leaf). 720 is chosen because it's roughly equal to
+  // one month worth of bundles assuming 1 bundle an hour.
+  const BUNDLES_PER_MONTH = 720;
+  const hubPoolLookback = config.dataworkerFastLookbackCount > BUNDLES_PER_MONTH ? undefined : 3600 * 24 * 30;
+  const commonClients = await constructClients(logger, config, baseSigner, hubPoolLookback);
   const { hubPoolClient, configStoreClient } = commonClients;
 
   await updateClients(commonClients, config, logger);

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -178,10 +178,6 @@ export class Monitor {
       this.hubPoolStartingBlock,
       this.hubPoolEndingBlock
     );
-    const cancelledBundles = this.clients.hubPoolClient.getCancelledRootBundlesInBlockRange(
-      this.hubPoolStartingBlock,
-      this.hubPoolEndingBlock
-    );
     const disputedBundles = this.clients.hubPoolClient.getDisputedRootBundlesInBlockRange(
       this.hubPoolStartingBlock,
       this.hubPoolEndingBlock
@@ -189,9 +185,6 @@ export class Monitor {
 
     for (const event of proposedBundles) {
       this.notifyIfUnknownCaller(event.proposer.toEvmAddress(), BundleAction.PROPOSED, event.txnRef);
-    }
-    for (const event of cancelledBundles) {
-      this.notifyIfUnknownCaller(event.disputer, BundleAction.CANCELED, event.txnRef);
     }
     for (const event of disputedBundles) {
       this.notifyIfUnknownCaller(event.disputer, BundleAction.DISPUTED, event.txnRef);

--- a/src/monitor/MonitorClientHelper.ts
+++ b/src/monitor/MonitorClientHelper.ts
@@ -25,7 +25,11 @@ export async function constructMonitorClients(
   baseSigner: Signer
 ): Promise<MonitorClients> {
   const signerAddr = await baseSigner.getAddress();
-  const commonClients = await constructClients(logger, config, baseSigner);
+  // Set hubPoolLookback conservatively to be equal to one month of blocks. If the config.maxRelayerLookBack
+  // exceeds half a month, then we'll just use the gensis block since in that case, this monitor is being used
+  // for non-production circumstances.
+  const hubPoolLookback = config.maxRelayerLookBack > 3600 * 24 * 15 ? undefined : 3600 * 24 * 30;
+  const commonClients = await constructClients(logger, config, baseSigner, hubPoolLookback);
   const { hubPoolClient, configStoreClient } = commonClients;
 
   await updateClients(commonClients, config, logger);


### PR DESCRIPTION
Two optimizations, the first is a bigger help:

1) Limit HubPoolClient's default event lookback to 30 days, unless the `dataworkerFastLookbackCount` is set very high in which case default to the current settings which sets this to the genesis block. Apply similar settings to the Monitor

2) Remove RootBundleCancelled event query, this is basically unused except by the monitor which we also don't really need