### PR TITLE
feat(TransactionUtils): Move MIN_PRIORITY_FEE_PER_GAS_ into runTransaction

### DIFF
--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -19,6 +19,7 @@ import {
   CHAIN_IDs,
   EvmGasPriceEstimate,
   SVMProvider,
+  parseUnits,
 } from "../utils";
 import {
   CompilableTransactionMessage,
@@ -126,9 +127,13 @@ export async function runTransaction(
         : await contract.populateTransaction[method](...(args as Array<unknown>), { value })
     );
 
+    const flooredPriorityFeePerGas = parseUnits(process.env[`MIN_PRIORITY_FEE_PER_GAS_${chainId}`] || "0", 9);
+
     // Check if the chain requires legacy transactions
     if (LEGACY_TRANSACTION_CHAINS.includes(chainId)) {
-      gas = { gasPrice: gas.maxFeePerGas };
+      gas = { gasPrice: gas.maxFeePerGas.lt(flooredPriorityFeePerGas) ? flooredPriorityFeePerGas : gas.maxFeePerGas };
+    } else {
+      gas.maxPriorityFeePerGas = (gas.maxPriorityFeePerGas.lt(flooredPriorityFeePerGas) ? flooredPriorityFeePerGas : gas.maxPriorityFeePerGas);
     }
 
     logger.debug({
@@ -140,6 +145,7 @@ export async function runTransaction(
       value,
       nonce,
       gas,
+      flooredPriorityFeePerGas,
       gasLimit,
       sendRawTxn: sendRawTransaction,
     });


### PR DESCRIPTION
This is currently used in the SDK [here](https://github.com/across-protocol/sdk/blob/d645111b70eded4c3f38f384e27f5b7d2a6c977c/src/gasPriceOracle/adapters/ethereum.ts#L41) but that means its used to both submit transactions with a floored priority fee AND estimate gas prices, which can cause issues if the API quoting gas prices hasn't set this same variable.

This variable is mostly intended to be used by the caller to boost the gas price temporarily to get transactions submitted on-chain, even at cost, so this PR makes this variable safer to use by not putting it in the gas price estimation path.
