### PR TITLE
Revert "feat(TransactionUtils): Do not send `error` level log in `run…

### DIFF
--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -49,14 +49,8 @@ export class TransactionClient {
     return willSucceed(txn);
   }
 
-  /**
-   * @notice Simulates transactions and returns the simulation results. Should not crash if any of the transactions fail
-   * and instead return the simulation results as either successful or failed results.
-   * @dev Each transaction is simulated in isolation; but on-chain execution may produce different
-   * results due to execution sequence or intermediate changes in on-chain state.
-   * @param txns - The transactions to simulate.
-   * @returns The simulation results.
-   */
+  // Each transaction is simulated in isolation; but on-chain execution may produce different
+  // results due to execution sequence or intermediate changes in on-chain state.
   simulate(txns: AugmentedTransaction[]): Promise<TransactionSimulationResult[]> {
     return Promise.all(txns.map((txn: AugmentedTransaction) => this._simulate(txn)));
   }
@@ -66,16 +60,6 @@ export class TransactionClient {
     return runTransaction(this.logger, contract, method, args, value, gasLimit, nonce);
   }
 
-  /**
-   * @notice This function submits transactions and returns the transaction responses. This should not
-   * crash if any of the transactions fail and instead return the transaction responses as either successful or failed
-   * responses.
-   * @dev The caller should call simulate() first and handle the error, otherwise this function might crash silently
-   * unexpectedly.
-   * @param chainId - The chain ID to submit the transactions to.
-   * @param txns - The transactions to submit.
-   * @returns The transaction responses.
-   */
   async submit(chainId: number, txns: AugmentedTransaction[]): Promise<TransactionResponse[]> {
     const networkName = getNetworkName(chainId);
     const txnResponses: TransactionResponse[] = [];
@@ -114,9 +98,7 @@ export class TransactionClient {
         response = await this._submit(txn, nonce);
       } catch (error) {
         delete this.nonces[chainId];
-        // If the transaction can fail in simulation, then we do want to log an error if the following transaction
-        // fails, because otherwise the caller might not know that the transaction failed in a previous simulation step.
-        this.logger[txn.canFailInSimulation ? "error" : "info"]({
+        this.logger.info({
           at: "TransactionClient#submit",
           message: `Transaction ${idx + 1} submission on ${networkName} failed or timed out.`,
           mrkdwn,

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -65,6 +65,18 @@ const txnRetryable = (error?: unknown): boolean => {
   return expectedRpcErrorMessages.has((error as Error)?.message);
 };
 
+const isFillRelayError = (error: unknown): boolean => {
+  const fillRelaySelector = "0xdeff4b24"; // keccak256("fillRelay()")[:4]
+  const multicallSelector = "0xac9650d8"; // keccak256("multicall()")[:4]
+
+  const errorStack = (error as Error).stack;
+  const isFillRelayError = errorStack?.includes(fillRelaySelector);
+  const isMulticallError = errorStack?.includes(multicallSelector);
+  const isFillRelayInMulticallError = isMulticallError && errorStack?.includes(fillRelaySelector);
+
+  return isFillRelayError && isFillRelayInMulticallError;
+};
+
 export function getNetworkError(err: unknown): string {
   return isEthersError(err) ? err.reason : isError(err) ? err.message : "unknown error";
 }
@@ -187,12 +199,12 @@ export async function runTransaction(
           ethersErrors.push({ reason: topError.reason, err: topError.error as EthersError });
           topError = topError.error as EthersError;
         }
-        logger["warn"]({
+        logger[ethersErrors.some((e) => txnRetryable(e.err)) ? "warn" : "error"]({
           ...commonFields,
           errorReasons: ethersErrors.map((e, i) => `\t ${i}: ${e.reason}`).join("\n"),
         });
       } else {
-        logger["warn"]({
+        logger[txnRetryable(error) || isFillRelayError(error) ? "warn" : "error"]({
           ...commonFields,
           error: stringifyThrownValue(error),
         });


### PR DESCRIPTION
This reverts commit 4a9fe99c9dc96e9400ad300ed46d920044b0a84b.

The reason is that this is accidentally suppressing errors like `maxPriorityFee > maxFeePerGas` which are legitimate issues caused by the relayer's config where the simulated calldata can pass but the on-chain submission can repeatedly fail