### PR TITLE
chore: do not log encoded accounts

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2832,7 +2832,7 @@ export class Dataworker {
       this.logger.debug({
         at: "Dataworker#executeRelayerRefundLeafSvm",
         message: "Need to close existing instruction params account",
-        instructionParamsAccount,
+        instructionParamsAccount: instructionParamsAccount.address,
       });
       closeInstructionParamsIx = SvmSpokeClient.getCloseInstructionParamsInstruction({
         signer: kitKeypair,
@@ -2931,7 +2931,7 @@ export class Dataworker {
       at: "Dataworker#executeRelayerRefundLeafSvm",
       message: "Created relayer refund address lookup table",
       txSignature,
-      lookupTable,
+      lookupTable: lookupTablePda,
     });
 
     // Add logic to deactivate the LUT. The LUT should be deactivated whether or not the relayer refund execution fails.


### PR DESCRIPTION
I believe we cannot handle logging encoded accounts in some environments, so instead of logging the entire account, just log the address.