### PR TITLE
fix: properly initialize headers object in getProviderHeaders

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -64,14 +64,14 @@ export function getChainQuorum(chainId: number): number {
  * RPC_PROVIDER_<provider>_<chainId>_HEADER_AUTH=xxx-auth-header
  */
 export function getProviderHeaders(provider: string, chainId: number): { [header: string]: string } | undefined {
-  let headers: { [k: string]: string };
+  const headers: { [k: string]: string } = {};
   const _headers = process.env[`RPC_PROVIDER_${provider}_${chainId}_HEADERS`];
+
   _headers?.split(",").forEach((header) => {
-    headers ??= {};
     headers[header] = process.env[`RPC_PROVIDER_${provider}_${chainId}_HEADER_${header.toUpperCase()}`];
   });
 
-  return headers;
+  return Object.keys(headers).length > 0 ? headers : undefined;
 }
 
 function getMaxConcurrency(chainId: number): number {


### PR DESCRIPTION
Squashed a sneaky bug in getProviderHeaders where headers could be undefined when accessed. Now properly initializing as empty object and returning undefined when no headers exist. This prevents potential "Cannot set property of undefined" runtime errors that would be hard to debug in production. Small change, big impact for reliability