### PR TITLE
feat: support small message relays in the relayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.68",
     "@across-protocol/contracts": "^4.1.0",
-    "@across-protocol/sdk": "4.3.31",
+    "@across-protocol/sdk": "4.3.32-alpha.1",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@coral-xyz/anchor": "^0.31.1",

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -118,7 +118,8 @@ export class ProfitClient {
     readonly hubPoolClient: HubPoolClient,
     spokePoolClients: SpokePoolClientsByChain,
     readonly enabledChainIds: number[],
-    readonly relayerAddress: Address,
+    readonly relayerAddress: EvmAddress,
+    readonly relayerAddressSvm: SvmAddress,
     readonly defaultMinRelayerFeePct = toBNWei(constants.RELAYER_MIN_FEE_PCT),
     readonly debugProfitability = false,
     protected gasMultiplier = toBNWei(constants.DEFAULT_RELAYER_GAS_MULTIPLIER),
@@ -273,7 +274,8 @@ export class ProfitClient {
       return this.totalGasCosts[chainId];
     }
 
-    return this._getTotalGasCost(deposit, this.relayerAddress);
+    const relayer = chainIsEvm(deposit.destinationChainId) ? this.relayerAddress : this.relayerAddressSvm;
+    return this._getTotalGasCost(deposit, relayer);
   }
 
   getGasCostsForChain(chainId: number): TransactionCostEstimate {

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -164,10 +164,11 @@ export async function constructRelayerClients(
   ]);
 
   const svmSigner = getSvmSignerFromEvmSigner(baseSigner);
+  const relayerSvmAddress = SvmAddress.from(svmSigner.publicKey.toBase58());
   const tokenClient = new TokenClient(
     logger,
     signerAddr,
-    SvmAddress.from(svmSigner.publicKey.toBase58()),
+    relayerSvmAddress,
     spokePoolClients,
     hubPoolClient,
     relayerTokens
@@ -185,6 +186,7 @@ export async function constructRelayerClients(
     spokePoolClients,
     enabledChainIds,
     signerAddr,
+    relayerSvmAddress,
     config.minRelayerFeePct,
     config.debugProfitability,
     config.relayerGasMultiplier,

--- a/src/utils/SDKUtils.ts
+++ b/src/utils/SDKUtils.ts
@@ -34,6 +34,7 @@ export const {
   getEventAuthority,
   getClaimAccountPda,
   createDefaultTransaction,
+  toSvmRelayData,
 } = sdk.arch.svm;
 export type SVMProvider = sdk.arch.svm.SVMProvider;
 

--- a/src/utils/TypeUtils.ts
+++ b/src/utils/TypeUtils.ts
@@ -1,5 +1,5 @@
-import { SlowFillLeaf, RelayData, RelayerRefundLeaf } from "../interfaces";
-import { ethers } from "./";
+import { SlowFillLeaf, RelayerRefundLeaf } from "../interfaces";
+import { toSvmRelayData } from "./";
 import { address } from "@solana/kit";
 import { SvmSpokeClient } from "@across-protocol/contracts";
 
@@ -12,23 +12,6 @@ export function toSvmSlowFillLeaf(slowFillLeaf: SlowFillLeaf): SvmSpokeClient.Sl
     relayData: toSvmRelayData(slowFillLeaf.relayData),
     chainId: BigInt(slowFillLeaf.chainId),
     updatedOutputAmount: slowFillLeaf.updatedOutputAmount.toBigInt(),
-  };
-}
-
-export function toSvmRelayData(relayData: RelayData): SvmSpokeClient.RelayData {
-  return {
-    originChainId: BigInt(relayData.originChainId),
-    depositor: address(relayData.depositor.toBase58()),
-    recipient: address(relayData.recipient.toBase58()),
-    depositId: ethers.utils.arrayify(ethers.utils.hexZeroPad(relayData.depositId.toHexString(), 32)),
-    inputToken: address(relayData.inputToken.toBase58()),
-    outputToken: address(relayData.outputToken.toBase58()),
-    inputAmount: ethers.utils.arrayify(ethers.utils.hexZeroPad(relayData.inputAmount.toHexString(), 32)),
-    outputAmount: relayData.outputAmount.toBigInt(),
-    message: Uint8Array.from(Buffer.from(relayData.message.slice(2), "hex")),
-    fillDeadline: relayData.fillDeadline,
-    exclusiveRelayer: address(relayData.exclusiveRelayer.toBase58()),
-    exclusivityDeadline: relayData.exclusivityDeadline,
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,10 +92,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@4.3.31":
-  version "4.3.31"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.31.tgz#e5cd672ed7a74886fe8bc5fa5b3a44dfec5e4c32"
-  integrity sha512-dHbn+iDmGsGFeiBNpyfoPqpd/dVZqXgMz5oi/QMvImb004s7osJoMCDsLZFyR+r+DKTJ4uv+AbgRG5l6rsfMVg==
+"@across-protocol/sdk@4.3.32-alpha.1":
+  version "4.3.32-alpha.1"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.32-alpha.1.tgz#b0ff07eb279d8ba4805680bc8a7c86f0479454af"
+  integrity sha512-cvk17vly47I10yfUl+PfHaosFUfsYo6IRIlP83VWnOQJnwMkNU/ymFTua1ShaYzuMVi3hWbFZs68UuqOSs7I9w==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.71"


### PR DESCRIPTION
Associated SDK PR: https://github.com/across-protocol/sdk/pull/1170

The way we will be able to support larger message relays is by filling large relays with the `instruction_params` PDA. This is still a todo.