### PR TITLE
chore: Bump SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.68",
     "@across-protocol/contracts": "^4.1.0",
-    "@across-protocol/sdk": "4.3.34",
+    "@across-protocol/sdk": "4.3.35",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.2.1",
     "@coral-xyz/anchor": "^0.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,10 +92,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@4.3.34":
-  version "4.3.34"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.34.tgz#007c34728a1b17857d1b300ce311a325440c41a7"
-  integrity sha512-vwWqoZljtI3XCkv1K5XdIkY6AktPE7D+odQjFJLFTN3cOkeF8C21fhR8sdiX4/Ebx8ibHyjB2VI4oZH0UN/luA==
+"@across-protocol/sdk@4.3.35":
+  version "4.3.35"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.35.tgz#e400578ec059e69b6cda5c4abf0ee8401bda1b81"
+  integrity sha512-mo8kSALMuAc30XIjzBntuhty/JzvV92oM5VbqA8UzxIxabLkBrJHeXT73qfDiQxeFbfEYtlI0ZXV3UaTvx8mxQ==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.71"


### PR DESCRIPTION
For updates to the QuickNode provider adapter (including Arbitrum and WorldChain fixes).