### PR TITLE
fix: wait for a block after creation of ALT

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2934,6 +2934,7 @@ export class Dataworker {
       (tx) => appendTransactionMessageInstructions([lookupTableIx], tx)
     );
     txSignature = await sendAndConfirmSolanaTransaction(createLookupTableTx, kitKeypair, provider);
+    await waitForNewSolanaBlock(provider, 1);
 
     this.logger.debug({
       at: "Dataworker#executeRelayerRefundLeafSvm",


### PR DESCRIPTION
It's possible that the time between the ALT to being confirmed to the time of the extend ALT transaction is less than the time it takes for a new solana block to be added, so wait after creating the ALT to guarantee that the extend transaction will not fail in simulation. 

For all ALT transactions, we need to wait a block for them to "activate": https://solana.com/developers/courses/program-optimization/lookup-tables#6-modify-main-to-use-lookup-tables