### PR TITLE
feat: Prepare bundleRefundsPromise on init of InventoryClient

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -332,6 +332,12 @@ export class InventoryClient {
     return refunds;
   }
 
+  async init(): Promise<void> {
+    await this.setTokenApprovals();
+    this.prepareBundleRefundsPromise();
+    await this.bundleRefundsPromise;
+  }
+
   public prepareBundleRefundsPromise(): void {
     if (!isDefined(this.bundleRefundsPromise)) {
       this.bundleRefundsPromise = this.getAllBundleRefunds();
@@ -1576,9 +1582,7 @@ export class InventoryClient {
       return;
     }
 
-    await this.crossChainTransferClient.update(this.getL1Tokens(), chainIds);
-    this.prepareBundleRefundsPromise();
-    await this.bundleRefundsPromise;
+    return this.crossChainTransferClient.update(this.getL1Tokens(), chainIds);
   }
 
   isInventoryManagementEnabled(): boolean {

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -332,9 +332,9 @@ export class InventoryClient {
     return refunds;
   }
 
-  async executeBundleRefundsPromise(): Promise<void> {
+  async executeBundleRefundsPromise(): Promise<CombinedRefunds[]> {
     this.prepareBundleRefundsPromise();
-    await this.bundleRefundsPromise;
+    return this.bundleRefundsPromise;
   }
 
   public prepareBundleRefundsPromise(): void {
@@ -353,8 +353,7 @@ export class InventoryClient {
     // Increase virtual balance by pending relayer refunds from the latest valid bundle and the
     // upcoming bundle. We can assume that all refunds from the second latest valid bundle have already
     // been executed.
-    this.prepareBundleRefundsPromise();
-    refundsToConsider = lodash.cloneDeep(await this.bundleRefundsPromise);
+    refundsToConsider = lodash.cloneDeep(await this.executeBundleRefundsPromise());
     const totalRefundsPerChain = this.getEnabledChains().reduce(
       (refunds: { [chainId: string]: BigNumber }, chainId) => {
         const destinationToken = this.getRemoteTokenForL1Token(l1Token, chainId);

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -332,8 +332,7 @@ export class InventoryClient {
     return refunds;
   }
 
-  async init(): Promise<void> {
-    await this.setTokenApprovals();
+  async executeBundleRefundsPromise(): Promise<void> {
     this.prepareBundleRefundsPromise();
     await this.bundleRefundsPromise;
   }
@@ -1577,7 +1576,7 @@ export class InventoryClient {
     await this.adapterManager.wrapNativeTokenIfAboveThreshold(this.inventoryConfig, this.simMode);
   }
 
-  async update(chainIds?: number[]): Promise<void> {
+  update(chainIds?: number[]): Promise<void> {
     if (!this.isInventoryManagementEnabled()) {
       return;
     }

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -300,6 +300,7 @@ export class InventoryClient {
   }
 
   async getAllBundleRefunds(): Promise<CombinedRefunds[]> {
+    const mark = this.profiler.start("bundleRefunds");
     const refunds: CombinedRefunds[] = [];
     const [pendingRefunds, nextBundleRefunds] = await Promise.all([
       this.bundleDataClient.getPendingRefundsFromValidBundles(),
@@ -329,20 +330,18 @@ export class InventoryClient {
         refunds: nextBundleRefunds[0],
       });
     }
+
+    mark.stop({
+      message: "Time to calculate total refunds per chain",
+    });
     return refunds;
   }
 
   async executeBundleRefundsPromise(): Promise<CombinedRefunds[]> {
-    let mark: ReturnType<typeof this.profiler.start>;
     if (!isDefined(this.bundleRefundsPromise)) {
       this.bundleRefundsPromise = this.getAllBundleRefunds();
-      mark = this.profiler.start("bundleRefunds");
     }
-    const result = this.bundleRefundsPromise;
-    mark?.stop({
-      message: "Time to calculate total refunds per chain",
-    });
-    return result;
+    return this.bundleRefundsPromise;
   }
 
   // Return the upcoming refunds (in pending and next bundles) on each chain.

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -105,8 +105,7 @@ export class Relayer {
     }
 
     if (this.config.sendingRebalancesEnabled && this.config.sendingTransactionsEnabled) {
-      await inventoryClient.setTokenApprovals();
-      await inventoryClient.update();
+      await inventoryClient.init();
     }
 
     this.logger.debug({

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -106,6 +106,7 @@ export class Relayer {
 
     if (this.config.sendingRebalancesEnabled && this.config.sendingTransactionsEnabled) {
       await inventoryClient.setTokenApprovals();
+      await inventoryClient.update();
     }
 
     this.logger.debug({

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -105,7 +105,7 @@ export class Relayer {
     }
 
     if (this.config.sendingRebalancesEnabled && this.config.sendingTransactionsEnabled) {
-      await inventoryClient.init();
+      await inventoryClient.setTokenApprovals();
     }
 
     this.logger.debug({

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -55,9 +55,11 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
   const relayer = new Relayer(await baseSigner.getAddress(), logger, relayerClients, config);
   await relayer.init();
 
-  const { spokePoolClients } = relayerClients;
+  const { spokePoolClients, inventoryClient } = relayerClients;
   const simulate = !config.sendingTransactionsEnabled || !config.sendingRelaysEnabled;
   let txnReceipts: { [chainId: number]: Promise<string[]> } = {};
+  const inventoryManagement = inventoryClient.isInventoryManagementEnabled();
+  let inventoryInit = false;
 
   try {
     for (let run = 1; !stop; ++run) {
@@ -85,7 +87,10 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
         throw new Error(`Unable to start relayer due to chains ${badChains.join(", ")}`);
       }
       // Execute bundleRefundsPromise only after all spokePoolClients are updated.
-      await relayer.clients.inventoryClient.executeBundleRefundsPromise();
+      if (!inventoryInit && inventoryManagement) {
+        await inventoryClient.executeBundleRefundsPromise();
+        inventoryInit = true;
+      }
 
       // Signal to any existing relayer that a handover is underway, or alternatively
       // check for handover initiated by another (newer) relayer instance.

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -84,6 +84,8 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
           .map(({ chainId }) => getNetworkName(chainId));
         throw new Error(`Unable to start relayer due to chains ${badChains.join(", ")}`);
       }
+      // Execute bundleRefundsPromise only after all spokePoolClients are updated.
+      await relayer.clients.inventoryClient.executeBundleRefundsPromise();
 
       // Signal to any existing relayer that a handover is underway, or alternatively
       // check for handover initiated by another (newer) relayer instance.


### PR DESCRIPTION
Prepare bundleRefundsPromise on init of InventoryClient. This will speed up the relayers bcs, during the relayer handover, it will load bundleRefunds into a relayer so the relayer doesn't need to wait for it when it wants to fill the deposit.