### PR TITLE
fix: avoid exiting early on binance finalizer

### DIFF
--- a/src/finalizer/utils/binance.ts
+++ b/src/finalizer/utils/binance.ts
@@ -148,7 +148,7 @@ export async function binanceFinalizer(
           at: "BinanceFinalizer",
           message: `No finalizable deposits found for ${address}`,
         });
-        return;
+        continue;
       }
 
       // Start by finalizing L1 -> L2, then go to L2 -> L1.


### PR DESCRIPTION
Since this is no longer in a Promise.all, we need to `continue` and not `return`.