### PR TITLE
fix: simulate all solana fills

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -269,7 +269,11 @@ export class ProfitClient {
 
     // If there's no attached message, gas consumption from previous fills can be used in most cases.
     // @todo: Simulate this per-token in future, because some ERC20s consume more gas.
-    if (isMessageEmpty(resolveDepositMessage(deposit)) && isDefined(this.totalGasCosts[chainId])) {
+    if (
+      isMessageEmpty(resolveDepositMessage(deposit)) &&
+      isDefined(this.totalGasCosts[chainId]) &&
+      chainIsEvm(chainId)
+    ) {
       return this.totalGasCosts[chainId];
     }
 


### PR DESCRIPTION
We are using cached gas prices for relays with no messages. This doesn't work for Solana since we also need to know whether the recipient has an ATA.