### PR TITLE
fix: distinguish solana/evm relayers in profit client

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -118,7 +118,8 @@ export class ProfitClient {
     readonly hubPoolClient: HubPoolClient,
     spokePoolClients: SpokePoolClientsByChain,
     readonly enabledChainIds: number[],
-    readonly relayerAddress: Address,
+    readonly relayerAddressEvm: EvmAddress,
+    readonly relayerAddressSvm: SvmAddress,
     readonly defaultMinRelayerFeePct = toBNWei(constants.RELAYER_MIN_FEE_PCT),
     readonly debugProfitability = false,
     protected gasMultiplier = toBNWei(constants.DEFAULT_RELAYER_GAS_MULTIPLIER),
@@ -277,7 +278,8 @@ export class ProfitClient {
       return this.totalGasCosts[chainId];
     }
 
-    return this._getTotalGasCost(deposit, this.relayerAddress);
+    const relayer = chainIsEvm(chainId) ? this.relayerAddressEvm : this.relayerAddressSvm;
+    return this._getTotalGasCost(deposit, relayer);
   }
 
   getGasCostsForChain(chainId: number): TransactionCostEstimate {

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -164,14 +164,8 @@ export async function constructRelayerClients(
   ]);
 
   const svmSigner = getSvmSignerFromEvmSigner(baseSigner);
-  const tokenClient = new TokenClient(
-    logger,
-    signerAddr,
-    SvmAddress.from(svmSigner.publicKey.toBase58()),
-    spokePoolClients,
-    hubPoolClient,
-    relayerTokens
-  );
+  const svmAddress = SvmAddress.from(svmSigner.publicKey.toBase58());
+  const tokenClient = new TokenClient(logger, signerAddr, svmAddress, spokePoolClients, hubPoolClient, relayerTokens);
 
   // If `relayerDestinationChains` is a non-empty array, then copy its value, otherwise default to all chains.
   const enabledChainIds = (
@@ -185,6 +179,7 @@ export async function constructRelayerClients(
     spokePoolClients,
     enabledChainIds,
     signerAddr,
+    svmAddress,
     config.minRelayerFeePct,
     config.debugProfitability,
     config.relayerGasMultiplier,

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -17,6 +17,9 @@ import {
   toGWei,
   TOKEN_SYMBOLS_MAP,
   toAddressType,
+  EvmAddress,
+  SvmAddress,
+  ZERO_BYTES,
 } from "../src/utils";
 import { MockHubPoolClient, MockProfitClient } from "./mocks";
 import { originChainId, destinationChainId, ZERO_ADDRESS } from "./constants";
@@ -173,7 +176,8 @@ describe("ProfitClient: Consider relay profit", () => {
       hubPoolClient,
       spokePoolClients,
       [],
-      randomAddress(),
+      EvmAddress.from(randomAddress()),
+      SvmAddress.from(ZERO_BYTES),
       minRelayerFeePct,
       debugProfitability
     );

--- a/test/ProfitClient.PriceRetrieval.ts
+++ b/test/ProfitClient.PriceRetrieval.ts
@@ -46,7 +46,15 @@ describe("ProfitClient: Price Retrieval", async () => {
 
     mainnetTokens.forEach((token) => hubPoolClient.addL1Token(token));
     const relayerAddress = toAddressType(randomAddress(), hubPoolClient.chainId);
-    profitClient = new ProfitClientWithMockPriceClient(spyLogger, hubPoolClient, {}, [], relayerAddress, bnZero);
+    profitClient = new ProfitClientWithMockPriceClient(
+      spyLogger,
+      hubPoolClient,
+      {},
+      [],
+      relayerAddress,
+      relayerAddress,
+      bnZero
+    );
   });
 
   it("Correctly fetches token prices", async () => {

--- a/test/mocks/MockProfitClient.ts
+++ b/test/mocks/MockProfitClient.ts
@@ -2,7 +2,7 @@ import { Contract } from "ethers";
 import { utils as sdkUtils } from "@across-protocol/sdk";
 import { ProfitClient } from "../../src/clients";
 import { SpokePoolClientsByChain } from "../../src/interfaces";
-import { bnOne, isDefined, TOKEN_SYMBOLS_MAP } from "../../src/utils";
+import { bnOne, isDefined, TOKEN_SYMBOLS_MAP, EvmAddress, SvmAddress } from "../../src/utils";
 import { BigNumber, toBN, toBNWei, winston } from "../utils";
 import { MockHubPoolClient } from "./MockHubPoolClient";
 
@@ -17,7 +17,8 @@ export class MockProfitClient extends ProfitClient {
     hubPoolClient: HubPoolClient | MockHubPoolClient,
     spokePoolClients: SpokePoolClientsByChain,
     enabledChainIds: number[],
-    relayerAddress: string,
+    relayerAddressEvm: EvmAddress,
+    relayerAddressSvm: SvmAddress,
     defaultMinRelayerFeePct?: BigNumber,
     debugProfitability?: boolean,
     gasMultiplier = toBNWei("1"),
@@ -29,7 +30,8 @@ export class MockProfitClient extends ProfitClient {
       hubPoolClient,
       spokePoolClients,
       enabledChainIds,
-      relayerAddress,
+      relayerAddressEvm,
+      relayerAddressSvm,
       defaultMinRelayerFeePct,
       debugProfitability,
       gasMultiplier,


### PR DESCRIPTION
This change was added in this PR https://github.com/across-protocol/relayer/pull/2439, but is needed now since we no longer cache gas prices for empty message relays destined for Solana.