### PR TITLE
feat: solana balance monitoring

### DIFF
--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -324,6 +324,9 @@ export const CONTRACT_ADDRESSES: {
     cctpMessageTransmitter: {
       address: "CCTPmbSD7gX1bxKPAmg77w8oFzNFpaQiQUWD43TKaecd",
     },
+    nativeToken: {
+      address: "So11111111111111111111111111111111111111112",
+    },
   },
   [CHAIN_IDs.SONEIUM]: {
     opUSDCBridge: {

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -1456,8 +1456,6 @@ export class Monitor {
           this.balanceCache[chainId][token.toBytes32()][account.toBytes32()] = balance;
           return balance;
         }
-        console.log(token);
-        console.log(account);
         // Assert balance request has solana types.
         assert(isSVMSpokePoolClient(spokePoolClient));
         assert(token.isSVM());

--- a/src/monitor/MonitorConfig.ts
+++ b/src/monitor/MonitorConfig.ts
@@ -185,10 +185,10 @@ export class MonitorConfig extends CommonConfig {
 
           const isNativeToken = !token || token === getNativeTokenAddressForChain(chainId);
           return {
-            token: isNativeToken ? getNativeTokenAddressForChain(chainId) : EvmAddress.from(token),
+            token: isNativeToken ? getNativeTokenAddressForChain(chainId) : toAddressType(token, chainId),
             errorThreshold: parsedErrorThreshold,
             warnThreshold: parsedWarnThreshold,
-            account: EvmAddress.from(ethers.utils.getAddress(account)),
+            account: toAddressType(account, chainId),
             chainId: parseInt(chainId),
           };
         }

--- a/src/monitor/MonitorConfig.ts
+++ b/src/monitor/MonitorConfig.ts
@@ -8,7 +8,6 @@ import {
   TOKEN_SYMBOLS_MAP,
   Address,
   toAddressType,
-  EvmAddress,
 } from "../utils";
 
 // Set modes to true that you want to enable in the AcrossMonitor bot.

--- a/src/utils/SDKUtils.ts
+++ b/src/utils/SDKUtils.ts
@@ -79,7 +79,7 @@ export const {
   blockExplorerLink,
   isContractDeployedToAddress,
   blockExplorerLinks,
-  createShortHexString: shortenHexString,
+  createShortenedString: shortenHexString,
   compareAddresses,
   compareAddressesSimple,
   getL1TokenAddress,


### PR DESCRIPTION
Here's an example:
```
2025-08-13 14:08:21 [error]: {
  "at": "Monitor",
  "message": "Balance(s) below threshold",
  "mrkdwn": "Some balance(s) are below the configured threshold!\n  Solana SOL balance for <> is 0.0. Threshold: 2",
  "bot-identifier": "bennett-test",
  "run-identifier": "13f73103-0a09-4280-a2a4-fe32690dcc40"
}
```
Obviously this still needs an sdk bump to fix this block explorer URL formatting. See https://github.com/across-protocol/sdk/pull/1191