### PR TITLE
improve(zkSyncFinalizer): Catch error where Log Proof doesn't exist yet on ZkSync

### DIFF
--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -148,10 +148,16 @@ async function filterMessageLogs(
     return { ...tokenBridged, withdrawalIdx: logIndexesForMessage[i] };
   });
 
-  const ready = await sdkUtils.filterAsync(
-    withdrawals,
-    async ({ txnRef, withdrawalIdx }) => !(await wallet.isWithdrawalFinalized(txnRef, withdrawalIdx))
-  );
+  const ready = await sdkUtils.filterAsync(withdrawals, async ({ txnRef, withdrawalIdx }) => {
+    try {
+      return !(await wallet.isWithdrawalFinalized(txnRef, withdrawalIdx));
+    } catch (error: unknown) {
+      if (error instanceof Error && error.message.includes("Log proof not found")) {
+        return false;
+      }
+      throw error;
+    }
+  });
 
   return ready;
 }


### PR DESCRIPTION
This error can occur if the L2 provider is missing an event, and it is thrown by the SDK
