### PR TITLE
chore: Fix typo and assertion text

### DIFF
--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -99,7 +99,7 @@ export async function runScript(baseSigner: Signer): Promise<void> {
   // being sent to L2s. Clients will load events from the endblocks set in `oldestBundleToLookupEventsFor`.
   const BUNDLE_LOOKBACK = 8; // The number of prior bundles to look back for when attempting to reconstruct
   const PAGE_SIZE = Number(process.env.PAGE_SIZE ?? bundlesToValidate);
-  assert(PAGE_SIZE <= bundlesToValidate, "PAGE_SIZE must be less than BUNDLES_COUNT");
+  assert(PAGE_SIZE <= bundlesToValidate, "PAGE_SIZE must be less than or equal to BUNDLES_COUNT");
   const PAGE = Number(process.env.PAGE ?? 0);
   assert(PAGE * PAGE_SIZE < bundlesToValidate, "PAGE * PAGE_SIZE must be less than BUNDLES_COUNT");
   // bundle data for arbitrary bundle. For example, setting this to 8 ensures that we'll be validating a bundle X

--- a/src/utils/CCTPUtils.ts
+++ b/src/utils/CCTPUtils.ts
@@ -35,7 +35,7 @@ type CommonMessageData = {
   nonce: number; // This nonce makes sense only for v1 events, as it's emitted on src chain send
   nonceHash: string;
 };
-// Common data + auxilary data from depositForBurn event
+// Common data + auxiliary data from depositForBurn event
 type DepositForBurnMessageData = CommonMessageData & { amount: string; mintRecipient: string; burnToken: string };
 type CommonMessageEvent = CommonMessageData & { log: Log };
 type DepositForBurnMessageEvent = DepositForBurnMessageData & { log: Log };


### PR DESCRIPTION
## Summary

Fix a comment typo and make an assertion message accurately reflect its boundary condition. No functional changes.

## Changes

 - Correct “auxilary” → “auxiliary”
 - Update assertion message to match the actual check PAGE_SIZE <= bundlesToValidate:
from “PAGE_SIZE must be less than BUNDLES_COUNT” to “PAGE_SIZE must be less than or equal to BUNDLES_COUNT”.