### PR TITLE
improve(relayer): Skip benevolent repayment for fast routes

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -1624,10 +1624,11 @@ export class InventoryClient {
     return SLOW_WITHDRAWAL_CHAINS.filter((repaymentChainId) => {
       let fastWithdrawal = isUSDC && sdkUtils.chainIsCCTPEnabled(repaymentChainId);
       fastWithdrawal ||= isUSDT && repaymentChainId === CHAIN_IDs.ARBITRUM;
-      return;
-      !fastWithdrawal &&
+      return (
+        !fastWithdrawal &&
         this._l1TokenEnabledForChain(l1Token, repaymentChainId) &&
-        this.hubPoolClient.l2TokenEnabledForL1Token(l1Token, repaymentChainId);
+        this.hubPoolClient.l2TokenEnabledForL1Token(l1Token, repaymentChainId)
+      );
     });
   }
 

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -3,6 +3,7 @@ import WETH_ABI from "../common/abi/Weth.json";
 import {
   bnZero,
   BigNumber,
+  CHAIN_IDs,
   winston,
   toBN,
   getNetworkName,
@@ -1608,16 +1609,26 @@ export class InventoryClient {
   /**
    * @notice Return possible repayment chains for L1 token that have "slow withdrawals" from L2 to L1, so
    * taking repayment on these chains would be done to reduce HubPool utilization and keep funds out of the
-   * slow withdrawal canonical bridges.
+   * slow withdrawal canonical bridges. Explicitly skip chains with fast rebalancing options because it doesn't
+   * help with utilisation issues.
    * @param l1Token
    * @returns list of chains for l1Token that have a token config enabled and have pool rebalance routes set.
    */
   getSlowWithdrawalRepaymentChains(l1Token: EvmAddress): number[] {
-    return SLOW_WITHDRAWAL_CHAINS.filter(
-      (chainId) =>
-        this._l1TokenEnabledForChain(l1Token, Number(chainId)) &&
-        this.hubPoolClient.l2TokenEnabledForL1Token(l1Token, Number(chainId))
-    );
+    const { hubPoolClient } = this;
+    const { USDC, USDT } = TOKEN_SYMBOLS_MAP;
+    const l1TokenStr = l1Token.toNative();
+    const isUSDC = USDC.addresses[hubPoolClient.chainId] === l1TokenStr;
+    const isUSDT = !isUSDC && USDT.addresses[hubPoolClient.chainId] === l1TokenStr;
+
+    return SLOW_WITHDRAWAL_CHAINS.filter((repaymentChainId) => {
+      let fastWithdrawal = isUSDC && sdkUtils.chainIsCCTPEnabled(repaymentChainId);
+      fastWithdrawal ||= isUSDT && repaymentChainId === CHAIN_IDs.ARBITRUM;
+      return;
+      !fastWithdrawal &&
+        this._l1TokenEnabledForChain(l1Token, repaymentChainId) &&
+        this.hubPoolClient.l2TokenEnabledForL1Token(l1Token, repaymentChainId);
+    });
   }
 
   log(message: string, data?: AnyObject, level: DefaultLogLevels = "debug"): void {

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -654,7 +654,13 @@ export const ARWEAVE_TAG_BYTE_LIMIT = 2048;
 // This does not include all 7-day withdrawal chains because we don't necessarily prefer being repaid on some of these 7-day chains, like Mode.
 // This list should generally exclude Lite chains because the relayer ignores HubPool liquidity in that case which could cause the
 // relayer to unintentionally overdraw the HubPool's available reserves.
-export const SLOW_WITHDRAWAL_CHAINS = [CHAIN_IDs.ARBITRUM, CHAIN_IDs.BASE, CHAIN_IDs.OPTIMISM, CHAIN_IDs.BLAST];
+export const SLOW_WITHDRAWAL_CHAINS = [
+  CHAIN_IDs.ARBITRUM,
+  CHAIN_IDs.BASE,
+  CHAIN_IDs.OPTIMISM,
+  CHAIN_IDs.BLAST,
+  CHAIN_IDs.UNICHAIN,
+];
 
 // Arbitrum Orbit chains may have custom gateways for certain tokens. These gateways need to be specified since token approvals are directed at the
 // gateway, while function calls are directed at the gateway router.

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -651,14 +651,16 @@ export const DEFAULT_ARWEAVE_GATEWAY = { url: "arweave.net", port: 443, protocol
 export const ARWEAVE_TAG_BYTE_LIMIT = 2048;
 
 // Chains with slow (> 2 day liveness) canonical L2-->L1 bridges that we prioritize taking repayment on.
-// This does not include all 7-day withdrawal chains because we don't necessarily prefer being repaid on some of these 7-day chains, like Mode.
+// This does not include all 7-day withdrawal chains because we don't necessarily prefer being repaid on some of these 7-day chains.
 // This list should generally exclude Lite chains because the relayer ignores HubPool liquidity in that case which could cause the
 // relayer to unintentionally overdraw the HubPool's available reserves.
 export const SLOW_WITHDRAWAL_CHAINS = [
   CHAIN_IDs.ARBITRUM,
   CHAIN_IDs.BASE,
-  CHAIN_IDs.OPTIMISM,
   CHAIN_IDs.BLAST,
+  CHAIN_IDs.INK,
+  CHAIN_IDs.OPTIMISM,
+  CHAIN_IDs.SONEIUM,
   CHAIN_IDs.UNICHAIN,
 ];
 


### PR DESCRIPTION
Avoid taking repayment on 7 day withdrawal chains where a fast rebalance route is available for the given token (i.e. USDC on CCTP chains, USDT on OFT chains). This increases the chance of taking repayment on a chain where it would actually make a difference for HubPool utilisation.

Additionally, add Unichain as a slow withdrawal chain. It has a lot of activity so it's generally fine to prioritise taking repayments there.