### PR TITLE
feat(InventoryClient): Take repayment on origin chain if we can quickly rebalance

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -516,7 +516,12 @@ export class InventoryClient {
     // If the deposit forces origin chain repayment but the origin chain is one we can easily rebalance inventory from,
     // then don't ignore this deposit based on perceived over-allocation. For example, the hub chain and chains connected
     // to the user's Binance API are easy to move inventory from so we should never skip filling these deposits.
-    if (forceOriginRepayment && repaymentChainCanBeQuicklyRebalanced(deposit, this.hubPoolClient)) {
+    // If the relayer wants to prioritize LP utilization, then we should always take repayment on the origin chain
+    // if it is a quick rebalance source.
+    if (
+      (this.prioritizeLpUtilization || forceOriginRepayment) &&
+      repaymentChainCanBeQuicklyRebalanced(deposit, this.hubPoolClient)
+    ) {
       return [deposit.originChainId];
     }
 
@@ -703,7 +708,7 @@ export class InventoryClient {
 
     // Always add hubChain as a fallback option if inventory management is enabled and origin chain is not a lite chain.
     // If none of the chainsToEvaluate were selected, then this function will return just the hub chain as a fallback option.
-    if (!depositForcesOriginChainRepayment(deposit, this.hubPoolClient) && !eligibleRefundChains.includes(hubChainId)) {
+    if (!forceOriginRepayment && !eligibleRefundChains.includes(hubChainId)) {
       eligibleRefundChains.push(hubChainId);
     }
     return eligibleRefundChains;

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -17,7 +17,7 @@ import {
   randomAddress,
 } from "./utils";
 
-import { ConfigStoreClient, InventoryClient } from "../src/clients"; // Tested
+import { ConfigStoreClient, HubPoolClient, InventoryClient } from "../src/clients"; // Tested
 import { CrossChainTransferClient } from "../src/clients/bridges";
 import { Deposit, InventoryConfig } from "../src/interfaces";
 import {
@@ -28,6 +28,7 @@ import {
   parseUnits,
   TOKEN_SYMBOLS_MAP,
   toAddressType,
+  depositForcesOriginChainRepayment,
 } from "../src/utils";
 import {
   MockAdapterManager,
@@ -187,18 +188,18 @@ describe("InventoryClient: Refund chain selection", async function () {
     seedMocks(initialAllocation);
   });
 
-  describe("origin chain is equal to hub chain", function () {
+  describe("Decimal precision and miscellaneous tests", function () {
     beforeEach(async function () {
       const inputAmount = toBNWei(1);
       sampleDepositData = {
         depositId: bnZero,
         fromLiteChain: false,
         toLiteChain: false,
-        originChainId: MAINNET,
+        originChainId: ARBITRUM,
         destinationChainId: OPTIMISM,
-        depositor: toAddressType(owner.address, MAINNET),
-        recipient: toAddressType(owner.address, MAINNET),
-        inputToken: toAddressType(mainnetWeth, MAINNET),
+        depositor: toAddressType(owner.address, ARBITRUM),
+        recipient: toAddressType(owner.address, ARBITRUM),
+        inputToken: toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM),
         inputAmount,
         outputToken: toAddressType(l2TokensForWeth[OPTIMISM], OPTIMISM),
         outputAmount: inputAmount,
@@ -207,39 +208,10 @@ describe("InventoryClient: Refund chain selection", async function () {
         quoteTimestamp: hubPoolClient.currentTime!,
         fillDeadline: 0,
         exclusivityDeadline: 0,
-        exclusiveRelayer: toAddressType(ZERO_ADDRESS, MAINNET),
+        exclusiveRelayer: toAddressType(ZERO_ADDRESS, ARBITRUM),
       };
     });
-    it("Correctly decides when to refund based on relay size", async function () {
-      // The repayment amount should be added to the numerator in the case where the repayment chain choice is not
-      // equal to the destination chain, and otherwise it should have no affect. The repayment amount should not
-      // affect the allocation percentage computation, which intuitively means that the relayer's overall inventory is
-      // decreasing on the destination chain by the output amount but increasing by the input amount.
-      sampleDepositData.originChainId = ARBITRUM;
-      sampleDepositData.inputToken = toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM);
-
-      // First destination chain is evaluated, then origin chain.
-      sampleDepositData.inputAmount = toWei(1);
-      sampleDepositData.outputAmount = await computeOutputAmount(sampleDepositData);
-      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([MAINNET]);
-      // Starts with 20 tokens on Optimism and ends up with 20 post-repayment.
-      expect(spyLogIncludes(spy, -2, 'expectedPostRelayAllocation":"142857142857142857"')).to.be.true; // (20)/(140)=0.1428
-      // Starts with 10 tokens on Arbitrum and ends up with 11 post-repayment.
-      expect(spyLogIncludes(spy, -1, 'expectedPostRelayAllocation":"78571428571428571"')).to.be.true; // (10+1)/(140)=0.15
-
-      // Now, transfer away tokens from the origin chain to make it look under allocated:
-      tokenClient.setTokenData(ARBITRUM, toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM), toWei(5));
-      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([ARBITRUM, MAINNET]);
-      expect(spyLogIncludes(spy, -1, 'expectedPostRelayAllocation":"44444444444444444"')).to.be.true; // (5+1)/(135)=0.044444
-
-      // If we set the fill amount large enough, the origin chain choice won't be picked anymore.
-      sampleDepositData.inputAmount = toWei(5);
-      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([MAINNET]);
-      expect(spyLogIncludes(spy, -1, 'expectedPostRelayAllocation":"74074074074074074"')).to.be.true; // (5+5)/(135)=0.074074
-    });
-
     it("Normalizes repayment amount to correct precision", async function () {
-      // Identical setup to previous test but we'll pretend the L2 token uses a different precision than the L1 token.
       hubPoolClient.mapTokenInfo(l2TokensForWeth[ARBITRUM], "WETH", 6);
       const toL2Decimals = sdkUtils.ConvertDecimals(18, 6);
       tokenClient.setTokenData(
@@ -252,8 +224,6 @@ describe("InventoryClient: Refund chain selection", async function () {
       // equal to the destination chain, and otherwise it should have no affect. The repayment amount should not
       // affect the allocation percentage computation, which intuitively means that the relayer's overall inventory is
       // decreasing on the destination chain by the output amount but increasing by the input amount.
-      sampleDepositData.originChainId = ARBITRUM;
-      sampleDepositData.inputToken = toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM);
 
       // First destination chain is evaluated, then origin chain.
       sampleDepositData.inputAmount = toMegaWei(1);
@@ -275,83 +245,13 @@ describe("InventoryClient: Refund chain selection", async function () {
       expect(spyLogIncludes(spy, -1, 'expectedPostRelayAllocation":"74074074074074074"')).to.be.true; // (5+5)/(135)=0.074074
     });
 
-    it("Correctly factors in cross chain transfers when deciding where to refund", async function () {
-      // The relayer should correctly factor in pending cross-chain relays when thinking about shortfalls. Consider a large
-      // fictitious relay that exceeds all outstanding liquidity on the target chain(Arbitrum) of 15 Weth (target only)
-      // has 10 WETH in it.
-      const largeRelayAmount = toWei(15);
-      tokenClient.setTokenShortFallData(
-        ARBITRUM,
-        toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM),
-        [6969],
-        largeRelayAmount
-      ); // Mock the shortfall.
-      // The expected cross chain transfer amount is (0.05+0.02-(10-15)/140)*140=14.8 // Mock the cross-chain transfer
-      // leaving L1 to go to arbitrum by adding it to the mock cross chain transfers and removing from l1 balance.
-      const bridgedAmount = toWei(14.8);
-      adapterManager.setMockedOutstandingCrossChainTransfers(
-        ARBITRUM,
-        toAddressType(owner.address, MAINNET),
-        toAddressType(mainnetWeth, MAINNET),
-        bridgedAmount
-      );
-      await inventoryClient.update();
-      tokenClient.setTokenData(
-        MAINNET,
-        toAddressType(mainnetWeth, MAINNET),
-        initialAllocation[MAINNET][mainnetWeth].sub(bridgedAmount)
-      );
-
-      // Now, consider that the bot is run while these funds for the above deposit are in the canonical bridge and cant
-      // be filled yet. When it runs it picks up a relay that it can do, of size 1.69 WETH. Each part of the computation
-      // is broken down to explain how the bot chooses where to allocate funds:
-      // 1. chainVirtualBalance: Considering the funds on the target chain we have a balance of 10 WETH, with an amount of
-      //    14.8 that is currently coming over the bridge. This totals a "virtual" balance of (10+14.8)=24.8.
-      // 2. chainVirtualBalanceWithShortfall: this is the virtual balance minus the shortfall. 24.9-15=9.8.
-      // 3. chainVirtualBalanceWithShortfallPostRelay: virtual balance with shortfall minus the relay amount should be
-      //    same as above for destination chain.
-      // 4. cumulativeVirtualBalance: total balance across all chains considering fund movement. funds moving over the bridge
-      //    does not impact the balance; they are just "moving" so it should be 140-15+15=140
-      // 5. cumulativeVirtualBalancePostRefunds: should be same as above because there are no refunds.
-      // 6. expectedPostRelayAllocation: the expected post relay allocation is the chainVirtualBalanceWithShortfallPostRelay
-      //    divided by the cumulativeVirtualBalancePostRefunds. 9.8/140
-      // This number is then used to decide on where funds should be allocated! If this number is above the threshold plus
-      // the buffer then refund on L1. if it is below the threshold then refund on the target chain.
-
-      sampleDepositData.destinationChainId = ARBITRUM;
-      sampleDepositData.outputToken = toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM);
-      sampleDepositData.inputAmount = toWei(1.69);
-      sampleDepositData.outputAmount = toWei(1.69);
-      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([ARBITRUM, MAINNET]);
-
-      // We're evaluating destination chain since origin chain is mainnet which always gets evaluated last.
-      expect(lastSpyLogIncludes(spy, 'chainShortfall":"15000000000000000000"')).to.be.true;
-      expect(lastSpyLogIncludes(spy, 'chainVirtualBalance":"24800000000000000000"')).to.be.true; // (10+14.8)=24.8
-      expect(lastSpyLogIncludes(spy, 'chainVirtualBalanceWithShortfall":"9800000000000000000"')).to.be.true; // 24.8-15=9.8
-      expect(lastSpyLogIncludes(spy, 'chainVirtualBalanceWithShortfallPostRelay":"9800000000000000000"')).to.be.true;
-      // same as above for destination chain
-      expect(lastSpyLogIncludes(spy, 'cumulativeVirtualBalance":"140000000000000000000')).to.be.true; // 140-15+15=140
-      expect(lastSpyLogIncludes(spy, 'cumulativeVirtualBalancePostRefunds":"140000000000000000000"')).to.be.true;
-      expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"70000000000000000')).to.be.true; // 9.8 / 140
-
-      // Consider that we decrease the relayer's balance while it's large transfer is currently in the bridge.
-      tokenClient.setTokenData(
-        ARBITRUM,
-        toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM),
-        initialAllocation[ARBITRUM][mainnetWeth].sub(toWei(5))
-      );
-      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([ARBITRUM, MAINNET]);
-      expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"35555555555555555')).to.be.true; // 4.8/(140-5)
-    });
-
     it("Normalizes shortfalls to correct precision", async function () {
-      // Identical setup to previous test but we'll pretend the L2 token uses a different precision than the L1 token.
-      hubPoolClient.mapTokenInfo(l2TokensForWeth[ARBITRUM], "WETH", 6);
+      hubPoolClient.mapTokenInfo(l2TokensForWeth[POLYGON], "WETH", 6);
       const toL2Decimals = sdkUtils.ConvertDecimals(18, 6);
       tokenClient.setTokenData(
-        ARBITRUM,
-        toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM),
-        toL2Decimals(initialAllocation[ARBITRUM][mainnetWeth])
+        POLYGON,
+        toAddressType(l2TokensForWeth[POLYGON], POLYGON),
+        toL2Decimals(initialAllocation[POLYGON][mainnetWeth])
       );
 
       // The relayer should correctly factor in pending cross-chain relays when thinking about shortfalls. Consider a large
@@ -359,8 +259,8 @@ describe("InventoryClient: Refund chain selection", async function () {
       // has 10 WETH in it.
       const largeRelayAmount = toMegaWei(15);
       tokenClient.setTokenShortFallData(
-        ARBITRUM,
-        toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM),
+        POLYGON,
+        toAddressType(l2TokensForWeth[POLYGON], POLYGON),
         [6969],
         largeRelayAmount
       ); // Mock the shortfall.
@@ -368,7 +268,7 @@ describe("InventoryClient: Refund chain selection", async function () {
       // leaving L1 to go to arbitrum by adding it to the mock cross chain transfers and removing from l1 balance.
       const bridgedAmount = toWei(14.8);
       adapterManager.setMockedOutstandingCrossChainTransfers(
-        ARBITRUM,
+        POLYGON,
         toAddressType(owner.address, MAINNET),
         toAddressType(mainnetWeth, MAINNET),
         bridgedAmount
@@ -396,55 +296,33 @@ describe("InventoryClient: Refund chain selection", async function () {
       // This number is then used to decide on where funds should be allocated! If this number is above the threshold plus
       // the buffer then refund on L1. if it is below the threshold then refund on the target chain.
 
-      sampleDepositData.destinationChainId = ARBITRUM;
-      sampleDepositData.outputToken = toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM);
+      sampleDepositData.destinationChainId = POLYGON;
+      sampleDepositData.outputToken = toAddressType(l2TokensForWeth[POLYGON], POLYGON);
       sampleDepositData.inputAmount = toWei(1.69);
       sampleDepositData.outputAmount = toMegaWei(1.69);
-      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([ARBITRUM, MAINNET]);
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([POLYGON, MAINNET]);
 
       // We're evaluating destination chain since origin chain is mainnet which always gets evaluated last.
-      expect(lastSpyLogIncludes(spy, 'chainShortfall":"15000000000000000000"')).to.be.true;
-      expect(lastSpyLogIncludes(spy, 'chainVirtualBalance":"24800000000000000000"')).to.be.true; // (10+14.8)=24.8
-      expect(lastSpyLogIncludes(spy, 'chainVirtualBalanceWithShortfall":"9800000000000000000"')).to.be.true; // 24.8-15=9.8
-      expect(lastSpyLogIncludes(spy, 'chainVirtualBalanceWithShortfallPostRelay":"9800000000000000000"')).to.be.true;
+      expect(spyLogIncludes(spy, -2, 'chainShortfall":"15000000000000000000"')).to.be.true;
+      expect(spyLogIncludes(spy, -2, 'chainVirtualBalance":"24800000000000000000"')).to.be.true; // (10+14.8)=24.8
+      expect(spyLogIncludes(spy, -2, 'chainVirtualBalanceWithShortfall":"9800000000000000000"')).to.be.true; // 24.8-15=9.8
+      expect(spyLogIncludes(spy, -2, 'chainVirtualBalanceWithShortfallPostRelay":"9800000000000000000"')).to.be.true;
       // same as above for destination chain
-      expect(lastSpyLogIncludes(spy, 'cumulativeVirtualBalance":"140000000000000000000')).to.be.true; // 140-15+15=140
-      expect(lastSpyLogIncludes(spy, 'cumulativeVirtualBalancePostRefunds":"140000000000000000000"')).to.be.true;
-      expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"70000000000000000')).to.be.true; // 9.8 / 140
+      expect(spyLogIncludes(spy, -2, 'cumulativeVirtualBalance":"140000000000000000000')).to.be.true; // 140-15+15=140
+      expect(spyLogIncludes(spy, -2, 'cumulativeVirtualBalancePostRefunds":"140000000000000000000"')).to.be.true;
+      expect(spyLogIncludes(spy, -2, 'expectedPostRelayAllocation":"70000000000000000')).to.be.true; // 9.8 / 140
 
       // Consider that we decrease the relayer's balance while it's large transfer is currently in the bridge.
       tokenClient.setTokenData(
-        ARBITRUM,
-        toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM),
-        toL2Decimals(initialAllocation[ARBITRUM][mainnetWeth].sub(toWei(5)))
+        POLYGON,
+        toAddressType(l2TokensForWeth[POLYGON], POLYGON),
+        toL2Decimals(initialAllocation[POLYGON][mainnetWeth].sub(toWei(5)))
       );
-      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([ARBITRUM, MAINNET]);
-      expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"35555555555555555')).to.be.true; // 4.8/(140-5)
-    });
-
-    it("Correctly decides where to refund based on upcoming refunds", async function () {
-      // Consider a case where the relayer is filling a marginally larger relay of size 5 WETH. Without refunds, the post relay
-      // allocation on optimism would be (15)/(135)=11.1%. This would be below the target plus buffer of 12%. However, if we now
-      // factor in 10 WETH in refunds (5 from pending and 5 from next bundle) that are coming to L2 and 5 more WETH refunds coming to L1,
-      // the allocation should actually be (15+10)/(135+15)=16.7%, which is above L2 target.
-      // Therefore, the bot should choose refund on L1 instead of L2.
-      tokenClient.setTokenData(OPTIMISM, toAddressType(l2TokensForWeth[OPTIMISM], OPTIMISM), toWei(15));
-
-      sampleDepositData.inputAmount = toWei(5);
-      sampleDepositData.outputAmount = await computeOutputAmount(sampleDepositData);
-      bundleDataClient.setReturnedPendingBundleRefunds({
-        [MAINNET]: createRefunds(owner.address, toWei(5), mainnetWeth),
-        [OPTIMISM]: createRefunds(owner.address, toWei(5), l2TokensForWeth[OPTIMISM]),
-      });
-      bundleDataClient.setReturnedNextBundleRefunds({
-        [OPTIMISM]: createRefunds(owner.address, toWei(5), l2TokensForWeth[OPTIMISM]),
-      });
-      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([MAINNET]);
-      expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"166666666666666666"')).to.be.true;
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([POLYGON, MAINNET]);
+      expect(spyLogIncludes(spy, -2, 'expectedPostRelayAllocation":"35555555555555555')).to.be.true; // 4.8/(140-5)
     });
 
     it("Normalizes upcoming refunds to correct precision", async function () {
-      // Identical setup to previous test but we'll pretend the L2 token uses a different precision than the L1 token.
       hubPoolClient.mapTokenInfo(l2TokensForWeth[OPTIMISM], "WETH", 6);
       tokenClient.setTokenData(OPTIMISM, toAddressType(l2TokensForWeth[OPTIMISM], OPTIMISM), toMegaWei(15));
 
@@ -458,7 +336,7 @@ describe("InventoryClient: Refund chain selection", async function () {
         [OPTIMISM]: createRefunds(owner.address, toMegaWei(5), l2TokensForWeth[OPTIMISM]),
       });
       expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([MAINNET]);
-      expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"166666666666666666"')).to.be.true;
+      expect(spyLogIncludes(spy, -2, 'expectedPostRelayAllocation":"166666666666666666"')).to.be.true;
     });
 
     it("Correctly throws when Deposit tokens are not equivalent", async function () {
@@ -968,6 +846,65 @@ describe("InventoryClient: Refund chain selection", async function () {
         expect(possibleRepaymentChains).to.include(chainId);
       });
       expect(possibleRepaymentChains.length).to.equal(4);
+    });
+  });
+
+  describe("Prioritizes LP utilization and origin chain is a fast rebalance source", function () {
+    beforeEach(async function () {
+      inventoryClient = new MockInventoryClient(
+        toAddressType(owner.address, MAINNET),
+        spyLogger,
+        inventoryConfig,
+        tokenClient,
+        enabledChainIds,
+        hubPoolClient,
+        bundleDataClient,
+        adapterManager,
+        crossChainTransferClient,
+        false, // simMode
+        true // prioritizeUtilization <--- this is the only difference from the previous tests
+      );
+      (inventoryClient as MockInventoryClient).setTokenMapping({
+        [mainnetUsdc]: {
+          [MAINNET]: mainnetUsdc,
+          [POLYGON]: TOKEN_SYMBOLS_MAP.USDC.addresses[POLYGON],
+          [ARBITRUM]: TOKEN_SYMBOLS_MAP.USDC.addresses[ARBITRUM],
+        },
+      });
+      hubPoolClient.setTokenMapping(mainnetUsdc, POLYGON, TOKEN_SYMBOLS_MAP.USDC.addresses[POLYGON]);
+      hubPoolClient.setTokenMapping(mainnetUsdc, ARBITRUM, TOKEN_SYMBOLS_MAP.USDC.addresses[ARBITRUM]);
+      sampleDepositData = {
+        depositId: bnZero,
+        fromLiteChain: false,
+        toLiteChain: false,
+        originChainId: POLYGON,
+        destinationChainId: ARBITRUM,
+        depositor: toAddressType(owner.address, MAINNET),
+        recipient: toAddressType(owner.address, MAINNET),
+        inputToken: toAddressType(TOKEN_SYMBOLS_MAP.USDC.addresses[POLYGON], POLYGON),
+        inputAmount: toMegaWei(10),
+        outputToken: toAddressType(TOKEN_SYMBOLS_MAP.USDC.addresses[ARBITRUM], ARBITRUM),
+        outputAmount: toMegaWei(10),
+        message: "0x",
+        messageHash: "0x",
+        quoteTimestamp: hubPoolClient.currentTime!,
+        fillDeadline: 0,
+        exclusivityDeadline: 0,
+        exclusiveRelayer: toAddressType(ZERO_ADDRESS, MAINNET),
+      };
+    });
+    it("returns only origin chain as repayment chain, even if it is over allocated", async function () {
+      // Assert that this deposit does not force origin chain repayment, which allows this test to isolate that if
+      // prioritizeLpUtilization is true and the origin token and chain is a fast repayment source,
+      // then the origin chain will be prioritized over the hub chain.
+      expect(depositForcesOriginChainRepayment(sampleDepositData, hubPoolClient)).to.be.false;
+      tokenClient.setTokenData(
+        sampleDepositData.originChainId,
+        toAddressType(l2TokensForWeth[sampleDepositData.originChainId], sampleDepositData.originChainId),
+        toMegaWei(1000)
+      );
+      const refundChains = await inventoryClient.determineRefundChainId(sampleDepositData);
+      expect(refundChains).to.deep.equal([sampleDepositData.originChainId]);
     });
   });
 });

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -17,7 +17,7 @@ import {
   randomAddress,
 } from "./utils";
 
-import { ConfigStoreClient, HubPoolClient, InventoryClient } from "../src/clients"; // Tested
+import { ConfigStoreClient, InventoryClient } from "../src/clients"; // Tested
 import { CrossChainTransferClient } from "../src/clients/bridges";
 import { Deposit, InventoryConfig } from "../src/interfaces";
 import {
@@ -188,18 +188,18 @@ describe("InventoryClient: Refund chain selection", async function () {
     seedMocks(initialAllocation);
   });
 
-  describe("Decimal precision and miscellaneous tests", function () {
+  describe("origin chain is equal to hub chain", function () {
     beforeEach(async function () {
       const inputAmount = toBNWei(1);
       sampleDepositData = {
         depositId: bnZero,
         fromLiteChain: false,
         toLiteChain: false,
-        originChainId: ARBITRUM,
+        originChainId: MAINNET,
         destinationChainId: OPTIMISM,
-        depositor: toAddressType(owner.address, ARBITRUM),
-        recipient: toAddressType(owner.address, ARBITRUM),
-        inputToken: toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM),
+        depositor: toAddressType(owner.address, MAINNET),
+        recipient: toAddressType(owner.address, MAINNET),
+        inputToken: toAddressType(mainnetWeth, MAINNET),
         inputAmount,
         outputToken: toAddressType(l2TokensForWeth[OPTIMISM], OPTIMISM),
         outputAmount: inputAmount,
@@ -208,10 +208,39 @@ describe("InventoryClient: Refund chain selection", async function () {
         quoteTimestamp: hubPoolClient.currentTime!,
         fillDeadline: 0,
         exclusivityDeadline: 0,
-        exclusiveRelayer: toAddressType(ZERO_ADDRESS, ARBITRUM),
+        exclusiveRelayer: toAddressType(ZERO_ADDRESS, MAINNET),
       };
     });
+    it("Correctly decides when to refund based on relay size", async function () {
+      // The repayment amount should be added to the numerator in the case where the repayment chain choice is not
+      // equal to the destination chain, and otherwise it should have no affect. The repayment amount should not
+      // affect the allocation percentage computation, which intuitively means that the relayer's overall inventory is
+      // decreasing on the destination chain by the output amount but increasing by the input amount.
+      sampleDepositData.originChainId = ARBITRUM;
+      sampleDepositData.inputToken = toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM);
+
+      // First destination chain is evaluated, then origin chain.
+      sampleDepositData.inputAmount = toWei(1);
+      sampleDepositData.outputAmount = await computeOutputAmount(sampleDepositData);
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([MAINNET]);
+      // Starts with 20 tokens on Optimism and ends up with 20 post-repayment.
+      expect(spyLogIncludes(spy, -2, 'expectedPostRelayAllocation":"142857142857142857"')).to.be.true; // (20)/(140)=0.1428
+      // Starts with 10 tokens on Arbitrum and ends up with 11 post-repayment.
+      expect(spyLogIncludes(spy, -1, 'expectedPostRelayAllocation":"78571428571428571"')).to.be.true; // (10+1)/(140)=0.15
+
+      // Now, transfer away tokens from the origin chain to make it look under allocated:
+      tokenClient.setTokenData(ARBITRUM, toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM), toWei(5));
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([ARBITRUM, MAINNET]);
+      expect(spyLogIncludes(spy, -1, 'expectedPostRelayAllocation":"44444444444444444"')).to.be.true; // (5+1)/(135)=0.044444
+
+      // If we set the fill amount large enough, the origin chain choice won't be picked anymore.
+      sampleDepositData.inputAmount = toWei(5);
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([MAINNET]);
+      expect(spyLogIncludes(spy, -1, 'expectedPostRelayAllocation":"74074074074074074"')).to.be.true; // (5+5)/(135)=0.074074
+    });
+
     it("Normalizes repayment amount to correct precision", async function () {
+      // Identical setup to previous test but we'll pretend the L2 token uses a different precision than the L1 token.
       hubPoolClient.mapTokenInfo(l2TokensForWeth[ARBITRUM], "WETH", 6);
       const toL2Decimals = sdkUtils.ConvertDecimals(18, 6);
       tokenClient.setTokenData(
@@ -224,6 +253,8 @@ describe("InventoryClient: Refund chain selection", async function () {
       // equal to the destination chain, and otherwise it should have no affect. The repayment amount should not
       // affect the allocation percentage computation, which intuitively means that the relayer's overall inventory is
       // decreasing on the destination chain by the output amount but increasing by the input amount.
+      sampleDepositData.originChainId = ARBITRUM;
+      sampleDepositData.inputToken = toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM);
 
       // First destination chain is evaluated, then origin chain.
       sampleDepositData.inputAmount = toMegaWei(1);
@@ -245,22 +276,14 @@ describe("InventoryClient: Refund chain selection", async function () {
       expect(spyLogIncludes(spy, -1, 'expectedPostRelayAllocation":"74074074074074074"')).to.be.true; // (5+5)/(135)=0.074074
     });
 
-    it("Normalizes shortfalls to correct precision", async function () {
-      hubPoolClient.mapTokenInfo(l2TokensForWeth[POLYGON], "WETH", 6);
-      const toL2Decimals = sdkUtils.ConvertDecimals(18, 6);
-      tokenClient.setTokenData(
-        POLYGON,
-        toAddressType(l2TokensForWeth[POLYGON], POLYGON),
-        toL2Decimals(initialAllocation[POLYGON][mainnetWeth])
-      );
-
+    it("Correctly factors in cross chain transfers when deciding where to refund", async function () {
       // The relayer should correctly factor in pending cross-chain relays when thinking about shortfalls. Consider a large
       // fictitious relay that exceeds all outstanding liquidity on the target chain(Arbitrum) of 15 Weth (target only)
       // has 10 WETH in it.
-      const largeRelayAmount = toMegaWei(15);
+      const largeRelayAmount = toWei(15);
       tokenClient.setTokenShortFallData(
-        POLYGON,
-        toAddressType(l2TokensForWeth[POLYGON], POLYGON),
+        ARBITRUM,
+        toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM),
         [6969],
         largeRelayAmount
       ); // Mock the shortfall.
@@ -268,7 +291,7 @@ describe("InventoryClient: Refund chain selection", async function () {
       // leaving L1 to go to arbitrum by adding it to the mock cross chain transfers and removing from l1 balance.
       const bridgedAmount = toWei(14.8);
       adapterManager.setMockedOutstandingCrossChainTransfers(
-        POLYGON,
+        ARBITRUM,
         toAddressType(owner.address, MAINNET),
         toAddressType(mainnetWeth, MAINNET),
         bridgedAmount
@@ -296,33 +319,133 @@ describe("InventoryClient: Refund chain selection", async function () {
       // This number is then used to decide on where funds should be allocated! If this number is above the threshold plus
       // the buffer then refund on L1. if it is below the threshold then refund on the target chain.
 
-      sampleDepositData.destinationChainId = POLYGON;
-      sampleDepositData.outputToken = toAddressType(l2TokensForWeth[POLYGON], POLYGON);
+      sampleDepositData.destinationChainId = ARBITRUM;
+      sampleDepositData.outputToken = toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM);
       sampleDepositData.inputAmount = toWei(1.69);
-      sampleDepositData.outputAmount = toMegaWei(1.69);
-      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([POLYGON, MAINNET]);
+      sampleDepositData.outputAmount = toWei(1.69);
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([ARBITRUM, MAINNET]);
 
       // We're evaluating destination chain since origin chain is mainnet which always gets evaluated last.
-      expect(spyLogIncludes(spy, -2, 'chainShortfall":"15000000000000000000"')).to.be.true;
-      expect(spyLogIncludes(spy, -2, 'chainVirtualBalance":"24800000000000000000"')).to.be.true; // (10+14.8)=24.8
-      expect(spyLogIncludes(spy, -2, 'chainVirtualBalanceWithShortfall":"9800000000000000000"')).to.be.true; // 24.8-15=9.8
-      expect(spyLogIncludes(spy, -2, 'chainVirtualBalanceWithShortfallPostRelay":"9800000000000000000"')).to.be.true;
+      expect(lastSpyLogIncludes(spy, 'chainShortfall":"15000000000000000000"')).to.be.true;
+      expect(lastSpyLogIncludes(spy, 'chainVirtualBalance":"24800000000000000000"')).to.be.true; // (10+14.8)=24.8
+      expect(lastSpyLogIncludes(spy, 'chainVirtualBalanceWithShortfall":"9800000000000000000"')).to.be.true; // 24.8-15=9.8
+      expect(lastSpyLogIncludes(spy, 'chainVirtualBalanceWithShortfallPostRelay":"9800000000000000000"')).to.be.true;
       // same as above for destination chain
-      expect(spyLogIncludes(spy, -2, 'cumulativeVirtualBalance":"140000000000000000000')).to.be.true; // 140-15+15=140
-      expect(spyLogIncludes(spy, -2, 'cumulativeVirtualBalancePostRefunds":"140000000000000000000"')).to.be.true;
-      expect(spyLogIncludes(spy, -2, 'expectedPostRelayAllocation":"70000000000000000')).to.be.true; // 9.8 / 140
+      expect(lastSpyLogIncludes(spy, 'cumulativeVirtualBalance":"140000000000000000000')).to.be.true; // 140-15+15=140
+      expect(lastSpyLogIncludes(spy, 'cumulativeVirtualBalancePostRefunds":"140000000000000000000"')).to.be.true;
+      expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"70000000000000000')).to.be.true; // 9.8 / 140
 
       // Consider that we decrease the relayer's balance while it's large transfer is currently in the bridge.
       tokenClient.setTokenData(
-        POLYGON,
-        toAddressType(l2TokensForWeth[POLYGON], POLYGON),
-        toL2Decimals(initialAllocation[POLYGON][mainnetWeth].sub(toWei(5)))
+        ARBITRUM,
+        toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM),
+        initialAllocation[ARBITRUM][mainnetWeth].sub(toWei(5))
       );
-      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([POLYGON, MAINNET]);
-      expect(spyLogIncludes(spy, -2, 'expectedPostRelayAllocation":"35555555555555555')).to.be.true; // 4.8/(140-5)
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([ARBITRUM, MAINNET]);
+      expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"35555555555555555')).to.be.true; // 4.8/(140-5)
+    });
+
+    it("Normalizes shortfalls to correct precision", async function () {
+      // Identical setup to previous test but we'll pretend the L2 token uses a different precision than the L1 token.
+      hubPoolClient.mapTokenInfo(l2TokensForWeth[ARBITRUM], "WETH", 6);
+      const toL2Decimals = sdkUtils.ConvertDecimals(18, 6);
+      tokenClient.setTokenData(
+        ARBITRUM,
+        toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM),
+        toL2Decimals(initialAllocation[ARBITRUM][mainnetWeth])
+      );
+
+      // The relayer should correctly factor in pending cross-chain relays when thinking about shortfalls. Consider a large
+      // fictitious relay that exceeds all outstanding liquidity on the target chain(Arbitrum) of 15 Weth (target only)
+      // has 10 WETH in it.
+      const largeRelayAmount = toMegaWei(15);
+      tokenClient.setTokenShortFallData(
+        ARBITRUM,
+        toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM),
+        [6969],
+        largeRelayAmount
+      ); // Mock the shortfall.
+      // The expected cross chain transfer amount is (0.05+0.02-(10-15)/140)*140=14.8 // Mock the cross-chain transfer
+      // leaving L1 to go to arbitrum by adding it to the mock cross chain transfers and removing from l1 balance.
+      const bridgedAmount = toWei(14.8);
+      adapterManager.setMockedOutstandingCrossChainTransfers(
+        ARBITRUM,
+        toAddressType(owner.address, MAINNET),
+        toAddressType(mainnetWeth, MAINNET),
+        bridgedAmount
+      );
+      await inventoryClient.update();
+      tokenClient.setTokenData(
+        MAINNET,
+        toAddressType(mainnetWeth, MAINNET),
+        initialAllocation[MAINNET][mainnetWeth].sub(bridgedAmount)
+      );
+
+      // Now, consider that the bot is run while these funds for the above deposit are in the canonical bridge and cant
+      // be filled yet. When it runs it picks up a relay that it can do, of size 1.69 WETH. Each part of the computation
+      // is broken down to explain how the bot chooses where to allocate funds:
+      // 1. chainVirtualBalance: Considering the funds on the target chain we have a balance of 10 WETH, with an amount of
+      //    14.8 that is currently coming over the bridge. This totals a "virtual" balance of (10+14.8)=24.8.
+      // 2. chainVirtualBalanceWithShortfall: this is the virtual balance minus the shortfall. 24.9-15=9.8.
+      // 3. chainVirtualBalanceWithShortfallPostRelay: virtual balance with shortfall minus the relay amount should be
+      //    same as above for destination chain.
+      // 4. cumulativeVirtualBalance: total balance across all chains considering fund movement. funds moving over the bridge
+      //    does not impact the balance; they are just "moving" so it should be 140-15+15=140
+      // 5. cumulativeVirtualBalancePostRefunds: should be same as above because there are no refunds.
+      // 6. expectedPostRelayAllocation: the expected post relay allocation is the chainVirtualBalanceWithShortfallPostRelay
+      //    divided by the cumulativeVirtualBalancePostRefunds. 9.8/140
+      // This number is then used to decide on where funds should be allocated! If this number is above the threshold plus
+      // the buffer then refund on L1. if it is below the threshold then refund on the target chain.
+
+      sampleDepositData.destinationChainId = ARBITRUM;
+      sampleDepositData.outputToken = toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM);
+      sampleDepositData.inputAmount = toWei(1.69);
+      sampleDepositData.outputAmount = toMegaWei(1.69);
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([ARBITRUM, MAINNET]);
+
+      // We're evaluating destination chain since origin chain is mainnet which always gets evaluated last.
+      expect(lastSpyLogIncludes(spy, 'chainShortfall":"15000000000000000000"')).to.be.true;
+      expect(lastSpyLogIncludes(spy, 'chainVirtualBalance":"24800000000000000000"')).to.be.true; // (10+14.8)=24.8
+      expect(lastSpyLogIncludes(spy, 'chainVirtualBalanceWithShortfall":"9800000000000000000"')).to.be.true; // 24.8-15=9.8
+      expect(lastSpyLogIncludes(spy, 'chainVirtualBalanceWithShortfallPostRelay":"9800000000000000000"')).to.be.true;
+      // same as above for destination chain
+      expect(lastSpyLogIncludes(spy, 'cumulativeVirtualBalance":"140000000000000000000')).to.be.true; // 140-15+15=140
+      expect(lastSpyLogIncludes(spy, 'cumulativeVirtualBalancePostRefunds":"140000000000000000000"')).to.be.true;
+      expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"70000000000000000')).to.be.true; // 9.8 / 140
+
+      // Consider that we decrease the relayer's balance while it's large transfer is currently in the bridge.
+      tokenClient.setTokenData(
+        ARBITRUM,
+        toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM),
+        toL2Decimals(initialAllocation[ARBITRUM][mainnetWeth].sub(toWei(5)))
+      );
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([ARBITRUM, MAINNET]);
+      expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"35555555555555555')).to.be.true; // 4.8/(140-5)
+    });
+
+    it("Correctly decides where to refund based on upcoming refunds", async function () {
+      // Consider a case where the relayer is filling a marginally larger relay of size 5 WETH. Without refunds, the post relay
+      // allocation on optimism would be (15)/(135)=11.1%. This would be below the target plus buffer of 12%. However, if we now
+      // factor in 10 WETH in refunds (5 from pending and 5 from next bundle) that are coming to L2 and 5 more WETH refunds coming to L1,
+      // the allocation should actually be (15+10)/(135+15)=16.7%, which is above L2 target.
+      // Therefore, the bot should choose refund on L1 instead of L2.
+      tokenClient.setTokenData(OPTIMISM, toAddressType(l2TokensForWeth[OPTIMISM], OPTIMISM), toWei(15));
+
+      sampleDepositData.inputAmount = toWei(5);
+      sampleDepositData.outputAmount = await computeOutputAmount(sampleDepositData);
+      bundleDataClient.setReturnedPendingBundleRefunds({
+        [MAINNET]: createRefunds(owner.address, toWei(5), mainnetWeth),
+        [OPTIMISM]: createRefunds(owner.address, toWei(5), l2TokensForWeth[OPTIMISM]),
+      });
+      bundleDataClient.setReturnedNextBundleRefunds({
+        [OPTIMISM]: createRefunds(owner.address, toWei(5), l2TokensForWeth[OPTIMISM]),
+      });
+      expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([MAINNET]);
+      expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"166666666666666666"')).to.be.true;
     });
 
     it("Normalizes upcoming refunds to correct precision", async function () {
+      // Identical setup to previous test but we'll pretend the L2 token uses a different precision than the L1 token.
       hubPoolClient.mapTokenInfo(l2TokensForWeth[OPTIMISM], "WETH", 6);
       tokenClient.setTokenData(OPTIMISM, toAddressType(l2TokensForWeth[OPTIMISM], OPTIMISM), toMegaWei(15));
 
@@ -336,7 +459,7 @@ describe("InventoryClient: Refund chain selection", async function () {
         [OPTIMISM]: createRefunds(owner.address, toMegaWei(5), l2TokensForWeth[OPTIMISM]),
       });
       expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.deep.equal([MAINNET]);
-      expect(spyLogIncludes(spy, -2, 'expectedPostRelayAllocation":"166666666666666666"')).to.be.true;
+      expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"166666666666666666"')).to.be.true;
     });
 
     it("Correctly throws when Deposit tokens are not equivalent", async function () {


### PR DESCRIPTION
This is an opinionated PR so i'm looking for feedback. It changes the inventory client's behavior to take repayment on the origin chain if the origin chain is CCTP and the input token is USDC. It will only do so if `prioritizeLpUtilization` is set to true.