### PR TITLE
improve: report balances of svm relayers

### DIFF
--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -110,9 +110,7 @@ export class Monitor {
     readonly clients: MonitorClients
   ) {
     this.crossChainAdapterSupportedChains = clients.crossChainTransferClient.adapterManager.supportedChains();
-    this.monitorChains = Object.values(clients.spokePoolClients)
-      .map(({ chainId }) => chainId)
-      .filter(chainIsEvm);
+    this.monitorChains = Object.values(clients.spokePoolClients).map(({ chainId }) => chainId);
     for (const chainId of this.monitorChains) {
       this.spokePoolsBlocks[chainId] = { startingBlock: undefined, endingBlock: undefined };
     }
@@ -147,7 +145,7 @@ export class Monitor {
     const { hubPoolClient } = this.clients;
     const l1Tokens = hubPoolClient.getL1Tokens().map(({ address }) => address);
     const tokensPerChain = Object.fromEntries(
-      this.monitorChains.map((chainId) => {
+      this.monitorChains.filter(chainIsEvm).map((chainId) => {
         const l2Tokens = l1Tokens.map((l1Token) => this.getRemoteTokenForL1Token(l1Token, chainId)).filter(isDefined);
         return [chainId, l2Tokens];
       })
@@ -1490,7 +1488,7 @@ export class Monitor {
         this.spokePoolsBlocks[chainId].startingBlock = startingBlock;
         this.spokePoolsBlocks[chainId].endingBlock = endingBlock;
       } else if (isSVMSpokePoolClient(spokePoolClient)) {
-        const svmProvider = await spokePoolClient.svmEventsClient.getRpc();
+        const svmProvider = spokePoolClient.svmEventsClient.getRpc();
         const { slot: latestSlot } = await arch.svm.getNearestSlotTime(
           svmProvider,
           { commitment: "confirmed" },


### PR DESCRIPTION
Open question: There's no way to correlate an EVM address with an SVM address, so we can either choose to report the two addresses as completely separate addresses (what this PR does) or we can update the config to have `monitoredRelayers` contain both an svm and evm aspect, and then combine their inventories. 

This PR can be updated to the second part if there is a demand for that.