### PR TITLE
Fix: typos in comments/docs

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -447,7 +447,7 @@ export const CANONICAL_BRIDGE: Record<number, L1BridgeConstructor<BaseBridgeAdap
   [CHAIN_IDs.OPTIMISM_SEPOLIA]: OpStackDefaultERC20Bridge,
   [CHAIN_IDs.POLYGON_AMOY]: PolygonERC20Bridge,
   [CHAIN_IDs.SCROLL_SEPOLIA]: ScrollERC20Bridge,
-  [CHAIN_IDs.TATARA]: PolygonERC20Bridge, // No rebalacing is supported.
+  [CHAIN_IDs.TATARA]: PolygonERC20Bridge, // No rebalancing is supported.
   [CHAIN_IDs.UNICHAIN_SEPOLIA]: OpStackDefaultERC20Bridge,
 };
 

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -25,7 +25,7 @@ export async function constructDataworkerClients(
   baseSigner: Signer
 ): Promise<DataworkerClients> {
   // Set hubPoolLookback conservatively to be equal to one month of blocks. If the config.dataworkerFastLookbackCount
-  // exceeds ~720 then we'll just use the gensis block since in that case, this dataworker is being used for
+  // exceeds ~720 then we'll just use the genesis block since in that case, this dataworker is being used for
   // non-production circumstances (i.e. to execute a very old leaf). 720 is chosen because it's roughly equal to
   // one month worth of bundles assuming 1 bundle an hour.
   const BUNDLES_PER_MONTH = 720;

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -520,7 +520,7 @@ export async function constructFinalizerClients(
 }
 
 // @dev The HubPoolClient is dependent on the state of the ConfigStoreClient,
-//      so update the ConfigStoreClient first. @todo: Use common/ClientHelpter.ts.
+//      so update the ConfigStoreClient first. @todo: Use common/ClientHelper.ts.
 async function updateFinalizerClients(clients: Clients) {
   await clients.configStoreClient.update();
   await clients.hubPoolClient.update();

--- a/src/finalizer/utils/arbStack.ts
+++ b/src/finalizer/utils/arbStack.ts
@@ -45,7 +45,7 @@ type PartialArbitrumNetwork = Omit<ArbitrumNetwork, "confirmPeriodBlocks"> & {
   registered: boolean;
 };
 // These network configs are defined in the Arbitrum SDK, and we need to register them in the SDK's memory.
-// We should export this out of a common file but we don't use this SDK elsewhere currentlyl.
+// We should export this out of a common file but we don't use this SDK elsewhere currently.
 const ARB_ORBIT_NETWORK_CONFIGS: PartialArbitrumNetwork[] = [
   {
     // Addresses are available here:

--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -416,7 +416,7 @@ async function getRelevantL1Events(
   const hubPoolStoreContract = getHubPoolStoreContract(l1ChainId, l1Provider);
 
   /**
-   * @dev We artificially shorten the lookback time peiod for L1 events by a factor of 2. We want to avoid race conditions where
+   * @dev We artificially shorten the lookback time period for L1 events by a factor of 2. We want to avoid race conditions where
    * we see an old event on L1, but not look back far enough on L2 to see that the event has been executed successfully.
    */
   const toBlock = l1SpokePoolClient.latestHeightSearched;

--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -36,7 +36,7 @@ const IGNORED_WITHDRAWALS = [
 ];
 
 /**
- * @returns Withdrawal finalizaton calldata and metadata.
+ * @returns Withdrawal finalization calldata and metadata.
  */
 export async function zkSyncFinalizer(
   logger: winston.Logger,

--- a/src/libexec/RelayerSpokePoolListener.ts
+++ b/src/libexec/RelayerSpokePoolListener.ts
@@ -245,7 +245,7 @@ async function run(argv: string[]): Promise<void> {
     stop = true;
   });
 
-  // Note: An event emitted between scrapeEvents() and listen(). @todo: Ensure that there is overlap and dedpulication.
+  // Note: An event emitted between scrapeEvents() and listen(). @todo: Ensure that there is overlap and deduplication.
   logger.debug({ at: "RelayerSpokePoolListener::run", message: `Scraping previous ${chain} events.`, opts });
 
   if (latestBlock.number > startBlock) {

--- a/src/libexec/RelayerSpokePoolListenerHTTPS.ts
+++ b/src/libexec/RelayerSpokePoolListenerHTTPS.ts
@@ -213,7 +213,7 @@ async function run(argv: string[]): Promise<void> {
     stop = true;
   });
 
-  // Note: An event emitted between scrapeEvents() and listen(). @todo: Ensure that there is overlap and dedpulication.
+  // Note: An event emitted between scrapeEvents() and listen(). @todo: Ensure that there is overlap and deduplication.
   logger.debug({ at: "RelayerSpokePoolListener::run", message: `Scraping previous ${chain} events.`, opts });
 
   if (latestBlock.number > startBlock) {

--- a/src/libexec/RelayerSpokePoolListenerSVM.ts
+++ b/src/libexec/RelayerSpokePoolListenerSVM.ts
@@ -97,7 +97,7 @@ async function scrapeEvents(
 /**
  * Given a SpokePool eventsClient instance and an array of event names, subscribe to all future event emissions.
  * Periodically transmit received events to the parent process (if defined).
- * @param eventMgr Event manager instancea.
+ * @param eventMgr Event manager instance.
  * @param eventsClient eventsClient instance.
  * @param eventNames Event names to listen for.
  * @param quorum Minimum quorum requirement for events.

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -2,7 +2,7 @@ import Binance, { HttpMethod, type Binance as BinanceApi } from "binance-api-nod
 import minimist from "minimist";
 import { getGckmsConfig, retrieveGckmsKeys, isDefined, assert } from "./";
 
-// Store global promises on Gckms key retrievel actions so that we don't retrieve the same key multiple times.
+// Store global promises on Gckms key retrieval actions so that we don't retrieve the same key multiple times.
 let binanceSecretKeyPromise = undefined;
 
 type WithdrawalQuota = {

--- a/src/utils/CCTPUtils.ts
+++ b/src/utils/CCTPUtils.ts
@@ -448,9 +448,9 @@ function getRelevantCCTPEventsFromReceipt(
     the logs array, not necessarily consecutively)
   */
 
-  // Indicies of individual `MessageSent` events in `receipt.logs`
+  // Indices of individual `MessageSent` events in `receipt.logs`
   const messageSentIndices = [];
-  // Pairs of indicies representing a single CCTP token transfer
+  // Pairs of indices representing a single CCTP token transfer
   const depositIndexPairs = [];
   receipt.logs.forEach((log, i) => {
     // Attempt to parse as `MessageSent`

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -221,7 +221,7 @@ export async function waitForPubSub(
 }
 
 export async function disconnectRedisClients(logger?: winston.Logger): Promise<void> {
-  // todo understand why redisClients arent't GCed automagically.
+  // todo understand why redisClients aren't GCed automagically.
   const clients = Object.entries(redisClients);
   for (const [url, client] of clients) {
     const logParams = {
@@ -251,7 +251,7 @@ export function shouldCache(eventTimestamp: number, latestTime: number): boolean
   return latestTime - eventTimestamp >= REDIS_CACHEABLE_AGE;
 }
 
-// JSON.stringify(object) ends up stringfying BigNumber objects as "{type:BigNumber,hex...}" so we can pass
+// JSON.stringify(object) ends up stringifying BigNumber objects as "{type:BigNumber,hex...}" so we can pass
 // this reviver function as the second arg to JSON.parse to instruct it to correctly revive a stringified
 // object with BigNumber values.
 export function objectWithBigNumberReviver(_: string, value: { type: string; hex: BigNumberish }): unknown {

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -168,7 +168,7 @@ export async function runTransaction(
     }
   } catch (error) {
     if (retriesRemaining > 0 && txnRetryable(error)) {
-      // If error is due to a nonce collision or gas underpricement then re-submit to fetch latest params.
+      // If error is due to a nonce collision or gas underpricing then re-submit to fetch latest params.
       retriesRemaining -= 1;
       logger.debug({
         at: "TxUtil#runTransaction",


### PR DESCRIPTION
- Fixes minor typos in comments and docstrings only; no functional changes.
- Files and corrections:
  - src/utils/CCTPUtils.ts: Indicies → Indices
  - src/utils/RedisUtils.ts: arent't → aren't; stringfying → stringifying
  - src/utils/BinanceUtils.ts: retrievel → retrieval
  - src/finalizer/utils/helios.ts: peiod → period
  - src/finalizer/index.ts: ClientHelpter → ClientHelper
  - src/finalizer/utils/arbStack.ts: currentlyl → currently
  - src/finalizer/utils/zkSync.ts: finalizaton → finalization
  - src/libexec/RelayerSpokePoolListener.ts & HTTPS.ts: dedpulication → deduplication
  - src/libexec/RelayerSpokePoolListenerSVM.ts: instancea → instance
  - src/dataworker/DataworkerClientHelper.ts: gensis → genesis
  - src/common/Constants.ts: rebalacing → rebalancing
  - src/utils/TransactionUtils.ts: underpricement → underpricing
