### PR TITLE
chore: bump sdk for optimistic proposer

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.68",
     "@across-protocol/contracts": "^4.1.3",
-    "@across-protocol/sdk": "4.3.50",
+    "@across-protocol/sdk": "4.3.51",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -250,6 +250,7 @@ export class Dataworker {
     )[1];
 
     return this._getPoolRebalanceRoot(
+      spokePoolClients,
       blockRangesForChains,
       latestMainnetBlock ?? mainnetBundleEndBlock,
       mainnetBundleEndBlock,
@@ -521,7 +522,8 @@ export class Dataworker {
     };
     const [, mainnetBundleEndBlock] = blockRangesForProposal[0];
 
-    const poolRebalanceRoot = this._getPoolRebalanceRoot(
+    const poolRebalanceRoot = await this._getPoolRebalanceRoot(
+      spokePoolClients,
       blockRangesForProposal,
       latestMainnetBundleEndBlock,
       mainnetBundleEndBlock,
@@ -2598,7 +2600,8 @@ export class Dataworker {
     );
   }
 
-  _getPoolRebalanceRoot(
+  async _getPoolRebalanceRoot(
+    spokePoolClients: SpokePoolClientsByChain,
     blockRangesForChains: number[][],
     latestMainnetBlock: number,
     mainnetBundleEndBlock: number,
@@ -2607,14 +2610,14 @@ export class Dataworker {
     bundleSlowFills: BundleSlowFills,
     unexecutableSlowFills: BundleExcessSlowFills,
     expiredDepositsToRefundV3: ExpiredDepositsToRefundV3
-  ): PoolRebalanceRoot {
+  ): Promise<PoolRebalanceRoot> {
     const key = JSON.stringify(blockRangesForChains);
     // FIXME: Temporary fix to disable root cache rebalancing and to keep the
     //        executor running for tonight (2023-08-28) until we can fix the
     //        root cache rebalancing bug.
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     if (!this.rootCache[key] || process.env.DATAWORKER_DISABLE_REBALANCE_ROOT_CACHE === "true") {
-      this.rootCache[key] = _buildPoolRebalanceRoot(
+      this.rootCache[key] = await _buildPoolRebalanceRoot(
         latestMainnetBlock,
         mainnetBundleEndBlock,
         bundleV3Deposits,
@@ -2622,7 +2625,7 @@ export class Dataworker {
         bundleSlowFills,
         unexecutableSlowFills,
         expiredDepositsToRefundV3,
-        this.clients,
+        { ...this.clients, spokePoolClients },
         this.maxL1TokenCountOverride
       );
     }

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -936,15 +936,17 @@ export class Monitor {
       ),
     ]);
 
-    const poolRebalanceLeaves = _buildPoolRebalanceRoot(
-      lastProposedBundleBlockRanges[0][1],
-      lastProposedBundleBlockRanges[0][1],
-      poolRebalanceRoot.bundleDepositsV3,
-      poolRebalanceRoot.bundleFillsV3,
-      poolRebalanceRoot.bundleSlowFillsV3,
-      poolRebalanceRoot.unexecutableSlowFills,
-      poolRebalanceRoot.expiredDepositsToRefundV3,
-      this.clients
+    const poolRebalanceLeaves = (
+      await _buildPoolRebalanceRoot(
+        lastProposedBundleBlockRanges[0][1],
+        lastProposedBundleBlockRanges[0][1],
+        poolRebalanceRoot.bundleDepositsV3,
+        poolRebalanceRoot.bundleFillsV3,
+        poolRebalanceRoot.bundleSlowFillsV3,
+        poolRebalanceRoot.unexecutableSlowFills,
+        poolRebalanceRoot.expiredDepositsToRefundV3,
+        this.clients
+      )
     ).leaves;
 
     // Get the pool rebalance leaf amounts.

--- a/test/DataworkerUtils.ts
+++ b/test/DataworkerUtils.ts
@@ -193,7 +193,7 @@ describe("PoolRebalanceLeaf utils", function () {
       mockHubPoolClient.setTokenMapping(l1Token, originChainId, originToken);
     });
     it("Produces empty pool rebalance leaf for chains with only refunds and no running balances", async function () {
-      const { leaves } = _buildPoolRebalanceRoot(
+      const { leaves } = await _buildPoolRebalanceRoot(
         mockHubPoolClient.latestHeightSearched,
         mockHubPoolClient.latestHeightSearched,
         // To make this test simpler, create the minimum object that won't break the tested function:
@@ -229,7 +229,7 @@ describe("PoolRebalanceLeaf utils", function () {
       });
     });
     it("Inserts empty pool rebalance leaf in correct order", async function () {
-      const { leaves } = _buildPoolRebalanceRoot(
+      const { leaves } = await _buildPoolRebalanceRoot(
         mockHubPoolClient.latestHeightSearched,
         mockHubPoolClient.latestHeightSearched,
         // To make this test simpler, create the minimum object that won't break the tested function:

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,10 +92,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@4.3.50":
-  version "4.3.50"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.50.tgz#4e62977a700c5d5ea3882dba87941fa39a6a121b"
-  integrity sha512-IwMP8vMonjSW/MKP4O4kMeUQjpF3RHZdf6bHlxayg17o2UZiy/wzu9kQueAtFEyBHhoCtM2RR2w2drFj8vcrAw==
+"@across-protocol/sdk@4.3.51":
+  version "4.3.51"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.51.tgz#b4c56cf848e9e29adc250f1dab2ca3559a6c8a62"
+  integrity sha512-gW5f90QNKdEur21SS87d8UP+Pqhk+REYY+EgZp5h6x0hy1uau+Lh1Zfmie7BS08qPjlSdXhhr/3T5uYibd3KOw==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.71"


### PR DESCRIPTION
The SDK changes made `_buildPoolRebalanceRoot` an async function and also required `SpokePoolClientsByChain` as an input parameter.