### PR TITLE
improve(Monitor): Refactor getPendingWithdrawalAmounts and skip BSC

### DIFF
--- a/src/clients/bridges/AdapterManager.ts
+++ b/src/clients/bridges/AdapterManager.ts
@@ -14,17 +14,16 @@ import {
   isDefined,
   winston,
   Signer,
-  getL2TokenAddresses,
   TransactionResponse,
   assert,
   EvmAddress,
-  toAddressType,
   TOKEN_EQUIVALENCE_REMAPPING,
   getRemoteTokenForL1Token,
   getTokenInfo,
   isEVMSpokePoolClient,
   Address,
   isSVMSpokePoolClient,
+  bnZero,
 } from "../../utils";
 import { SpokePoolClient, HubPoolClient } from "../";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
@@ -210,6 +209,36 @@ export class AdapterManager {
     return await this.adapters[chainId].getL2PendingWithdrawalAmount(lookbackPeriodSeconds, fromAddress, l2Token);
   }
 
+  async getTotalPendingWithdrawalAmount(
+    lookbackPeriodSeconds: number,
+    l2ChainIds: number[],
+    fromAddress: Address,
+    l1Token: EvmAddress
+  ): Promise<{ [l2ChainId: number]: BigNumber }> {
+    const l1TokenInfo = getTokenInfo(l1Token, this.hubPoolClient.chainId);
+    const totalBalance: { [l2ChainId: number]: BigNumber } = {};
+    await Promise.all(
+      l2ChainIds
+        .filter((chainId) => chainId !== this.hubPoolClient.chainId)
+        .map(async (chainId) => {
+          totalBalance[chainId] = bnZero;
+          if (!this.l2TokenExistForL1Token(l1Token, chainId)) {
+            return;
+          }
+          const l2Token = this.l2TokenForL1Token(l1Token, chainId);
+          const l2TokenInfo = getTokenInfo(l2Token, chainId);
+          const l2ToL1DecimalConverter = utils.ConvertDecimals(l2TokenInfo.decimals, l1TokenInfo.decimals);
+          const pendingAmount = await this.adapters[chainId].getL2PendingWithdrawalAmount(
+            lookbackPeriodSeconds,
+            fromAddress,
+            l2Token
+          );
+          totalBalance[chainId] = l2ToL1DecimalConverter(pendingAmount);
+        })
+    );
+    return totalBalance;
+  }
+
   // Check how many native tokens are on the target chain and if the number of tokens is above the wrap threshold, execute a wrap. Note that this only
   // needs to be done on chains where rebalancing the native token from L1 to L2 results in the relayer receiving the unwrapped native token
   // (not the ERC20), or if the relayer expects to be sent the native token perhaps as a gas refund from an original L1 to L2
@@ -247,11 +276,6 @@ export class AdapterManager {
       const l2TokenForL1Token = getRemoteTokenForL1Token(l1Token, chainId, this.hubPoolClient.chainId);
       if (!l2TokenForL1Token) {
         throw new Error(`No L2 token found for L1 token ${l1Token} on chain ${chainId}`);
-      }
-      if (!l2TokenForL1Token.eq(toAddressType(getL2TokenAddresses(l1Token.toEvmAddress())[chainId], chainId))) {
-        throw new Error(
-          `Token address mismatch (${l2TokenForL1Token} != ${getL2TokenAddresses(l1Token.toEvmAddress())[chainId]})`
-        );
       }
       return l2TokenForL1Token;
     } catch (error) {


### PR DESCRIPTION
Adds a function `getTotalPendingWithdrawalAmount` to the `AdapterManager` that will be easier to use in the InventoryClient in the future, also skips BSC since `getL2PendingWithdrawalAmount` makes async API calls which tend to get rate limited by Binance API
