### PR TITLE
improve: retry on Binance deposit/withdraw event queries

### DIFF
--- a/src/finalizer/utils/binance.ts
+++ b/src/finalizer/utils/binance.ts
@@ -1,4 +1,3 @@
-import { type Binance } from "binance-api-node";
 import { SUPPORTED_TOKENS } from "../../common";
 import {
   winston,
@@ -12,12 +11,15 @@ import {
   floatToBN,
   bnZero,
   getTokenInfo,
-  ethers,
   groupObjectCountsByProp,
   isEVMSpokePoolClient,
   assert,
   EvmAddress,
   Address,
+  getBinanceDeposits,
+  getBinanceWithdrawals,
+  getAccountCoins,
+  DepositNetwork,
 } from "../../utils";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
 import { FinalizerPromise } from "../types";
@@ -32,48 +34,8 @@ enum Status {
   WaitingUserConfirm = 8,
 }
 
-// Alias for Binance network symbols.
-enum DepositNetwork {
-  Ethereum = "ETH",
-  BSC = "BSC",
-}
-
-// A Coin contains balance data and network information (such as withdrawal limits, extra information about the network, etc.) for a specific
-// token.
-type Coin = {
-  symbol: string;
-  balance: string;
-  networkList: Network[];
-};
-
-// Network represents basic information corresponding to a Binance supported deposit/withdrawal network. It is always associated with a coin.
-type Network = {
-  name: string;
-  coin: string;
-  withdrawMin: string;
-  withdrawMax: string;
-  contractAddress: string;
-};
-
-// A BinanceInteraction is either a deposit or withdrawal into/from a Binance hot wallet.
-type BinanceInteraction = {
-  // The amount of `coin` transferred in this interaction.
-  amount: number;
-  // The external (non binance-wallet) EOA involved with this interaction.
-  externalAddress: string;
-  // The coin used in this interaction (i.e. the token symbol).
-  coin: string;
-  // The network on which this interaction took place.
-  network: string;
-  // The status of the deposit/withdrawal.
-  status?: number;
-};
-
 // The precision of a `DECIMAL` type in the Binance API.
 const DECIMAL_PRECISION = 1_000_000;
-
-// ParsedAccountCoins represents a simplified return type of the Binance `accountCoins` endpoint.
-type ParsedAccountCoins = Coin[];
 
 /**
  * Unlike other finalizers, the Binance finalizer is only used to withdraw EOA deposits on Binance.
@@ -135,7 +97,13 @@ export async function binanceFinalizer(
     let coinBalance = coin.balance;
     const l1Token = TOKEN_SYMBOLS_MAP[symbol].addresses[hubChainId];
     const { decimals: l1Decimals } = getTokenInfo(EvmAddress.from(l1Token), hubChainId);
-    const withdrawals = await getBinanceWithdrawals(binanceApi, symbol, fromTimestamp);
+    const withdrawals = await getBinanceWithdrawals(
+      binanceApi,
+      symbol,
+      l1SpokePoolClient.spokePool.provider,
+      l2SpokePoolClient.spokePool.provider,
+      fromTimestamp
+    );
 
     for (const address of senderAddresses) {
       // Filter our list of deposits by the withdrawal address. We will only finalize deposits when the depositor EOA is in `senderAddresses`.
@@ -233,68 +201,4 @@ export async function binanceFinalizer(
     callData: [],
     crossChainMessages: [],
   };
-}
-
-// Gets all binance deposits for the Binance account starting from `startTime`-present.
-async function getBinanceDeposits(
-  binanceApi: Binance,
-  l1Provider: ethers.providers.Provider,
-  l2Provider: ethers.providers.Provider,
-  startTime: number
-): Promise<BinanceInteraction[]> {
-  const _depositHistory = await binanceApi.depositHistory({ startTime });
-  const depositHistory = Object.values(_depositHistory);
-
-  return mapAsync(depositHistory, async (deposit) => {
-    const provider = deposit.network === DepositNetwork.Ethereum ? l1Provider : l2Provider;
-    const depositTxnReceipt = await provider.getTransactionReceipt(deposit.txId);
-    return {
-      amount: Number(deposit.amount),
-      externalAddress: depositTxnReceipt.from,
-      coin: deposit.coin,
-      network: deposit.network,
-      status: deposit.status,
-    };
-  });
-}
-
-// Gets all Binance withdrawals of a specific coin starting from `startTime`-present.
-async function getBinanceWithdrawals(
-  binanceApi: Binance,
-  coin: string,
-  startTime: number
-): Promise<BinanceInteraction[]> {
-  const withdrawals = await binanceApi.withdrawHistory({ coin, startTime });
-
-  return Object.values(withdrawals).map((withdrawal) => {
-    return {
-      amount: Number(withdrawal.amount),
-      externalAddress: withdrawal.address,
-      coin,
-      network: withdrawal.network,
-      status: withdrawal.status,
-    };
-  });
-}
-
-// The call to accountCoins returns an opaque `unknown` object with extraneous information. This function
-// parses the unknown into a readable object to be used by the finalizers.
-async function getAccountCoins(binanceApi: Binance): Promise<ParsedAccountCoins> {
-  const coins = Object.values(await binanceApi["accountCoins"]());
-  return coins.map((coin) => {
-    const networkList = coin["networkList"]?.map((network) => {
-      return {
-        name: network["network"],
-        coin: network["coin"],
-        withdrawMin: network["withdrawMin"],
-        withdrawMax: network["withdrawMax"],
-        contractAddress: network["contractAddress"],
-      } as Network;
-    });
-    return {
-      symbol: coin["coin"],
-      balance: coin["free"],
-      networkList,
-    } as Coin;
-  });
 }

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -1,6 +1,7 @@
 import Binance, { HttpMethod, type Binance as BinanceApi } from "binance-api-node";
 import minimist from "minimist";
-import { getGckmsConfig, retrieveGckmsKeys, isDefined, assert } from "./";
+import { SortableEvent } from "../interfaces";
+import { getGckmsConfig, retrieveGckmsKeys, isDefined, assert, ethers, mapAsync, delay } from "./";
 
 // Store global promises on Gckms key retrieval actions so that we don't retrieve the same key multiple times.
 let binanceSecretKeyPromise = undefined;
@@ -9,6 +10,46 @@ type WithdrawalQuota = {
   wdQuota: number;
   usedWdQuota: number;
 };
+
+// Alias for Binance network symbols.
+export enum DepositNetwork {
+  Ethereum = "ETH",
+  BSC = "BSC",
+}
+
+// A Coin contains balance data and network information (such as withdrawal limits, extra information about the network, etc.) for a specific
+// token.
+export type Coin = {
+  symbol: string;
+  balance: string;
+  networkList: Network[];
+};
+
+// Network represents basic information corresponding to a Binance supported deposit/withdrawal network. It is always associated with a coin.
+type Network = {
+  name: string;
+  coin: string;
+  withdrawMin: string;
+  withdrawMax: string;
+  contractAddress: string;
+};
+
+// A BinanceInteraction is either a deposit or withdrawal into/from a Binance hot wallet.
+export type BinanceInteraction = SortableEvent & {
+  // The amount of `coin` transferred in this interaction.
+  amount: number;
+  // The external (non binance-wallet) EOA involved with this interaction.
+  externalAddress: string;
+  // The coin used in this interaction (i.e. the token symbol).
+  coin: string;
+  // The network on which this interaction took place.
+  network: string;
+  // The status of the deposit/withdrawal.
+  status?: number;
+};
+
+// ParsedAccountCoins represents a simplified return type of the Binance `accountCoins` endpoint.
+export type ParsedAccountCoins = Coin[];
 
 /**
  * Returns an API client to interface with Binance
@@ -66,4 +107,122 @@ export async function getBinanceWithdrawalLimits(binanceApi: BinanceApi): Promis
     wdQuota: unparsedQuota["wdQuota"],
     usedWdQuota: unparsedQuota["usedWdQuota"],
   };
+}
+
+/**
+ * Gets all binance deposits for the Binance account starting from `startTime`-present.
+ * @returns An array of parsed binance deposits.
+ */
+export async function getBinanceDeposits(
+  binanceApi: BinanceApi,
+  l1Provider: ethers.providers.Provider,
+  l2Provider: ethers.providers.Provider,
+  startTime: number,
+  nRetries = 0,
+  maxRetries = 10
+): Promise<BinanceInteraction[]> {
+  try {
+    const _depositHistory = await binanceApi.depositHistory({ startTime });
+    const depositHistory = Object.values(_depositHistory);
+    return mapAsync(depositHistory, async (deposit) => {
+      const provider = deposit.network === DepositNetwork.Ethereum ? l1Provider : l2Provider;
+      const depositTxnReceipt = await provider.getTransactionReceipt(deposit.txId);
+      return {
+        amount: Number(deposit.amount),
+        externalAddress: depositTxnReceipt.from,
+        coin: deposit.coin,
+        network: deposit.network,
+        status: deposit.status,
+        blockNumber: depositTxnReceipt.blockNumber,
+        txnRef: depositTxnReceipt.transactionHash,
+        // Only query the first log in the deposit event since a deposit corresponds to a single ERC20 `Transfer` event.
+        // Alternatively, if this was a native token transfer, then there were no logs, so just assign 0. This should not
+        // affect `sortEvents*` since the transaction index should be able to discriminate any two rebalances.
+        logIndex: depositTxnReceipt.logs[0]?.logIndex ?? 0,
+        txnIndex: depositTxnReceipt.transactionIndex,
+      };
+    });
+  } catch (_err) {
+    const err = _err.toString();
+    if (
+      err.includes("Timestamp for this request is outside of the recvWindow") ||
+      err.includes("Too many requests; current request has limited")
+    ) {
+      const delaySeconds = 2 ** nRetries + Math.random();
+      await delay(delaySeconds);
+      return getBinanceDeposits(binanceApi, l1Provider, l2Provider, startTime, ++nRetries, maxRetries);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Gets all Binance withdrawals of a specific coin starting from `startTime`-present.
+ * @returns An array of parsed binance withdrawals.
+ */
+export async function getBinanceWithdrawals(
+  binanceApi: BinanceApi,
+  coin: string,
+  l1Provider: ethers.providers.Provider,
+  l2Provider: ethers.providers.Provider,
+  startTime: number,
+  nRetries = 0,
+  maxRetries = 10
+): Promise<BinanceInteraction[]> {
+  try {
+    const _withdrawHistory = await binanceApi.withdrawHistory({ coin, startTime });
+    const withdrawHistory = Object.values(_withdrawHistory);
+    return mapAsync(withdrawHistory, async (withdrawal) => {
+      const provider = withdrawal.network === DepositNetwork.Ethereum ? l1Provider : l2Provider;
+      const withdrawalTxnReceipt = await provider.getTransactionReceipt(withdrawal.txId);
+      return {
+        amount: Number(withdrawal.amount),
+        externalAddress: withdrawal.address,
+        coin,
+        network: withdrawal.network,
+        status: withdrawal.status,
+        blockNumber: withdrawalTxnReceipt.blockNumber,
+        txnRef: withdrawalTxnReceipt.transactionHash,
+        // Same logic as `getBinanceDeposits`.
+        logIndex: withdrawalTxnReceipt.logs[0]?.logIndex ?? 0,
+        txnIndex: withdrawalTxnReceipt.transactionIndex,
+      };
+    });
+  } catch (_err) {
+    const err = _err.toString();
+    if (
+      err.includes("Timestamp for this request is outside of the recvWindow") ||
+      err.includes("Too many requests; current request has limited")
+    ) {
+      const delaySeconds = 2 ** nRetries + Math.random();
+      await delay(delaySeconds);
+      return getBinanceDeposits(binanceApi, l1Provider, l2Provider, startTime, ++nRetries, maxRetries);
+    }
+    throw err;
+  }
+}
+
+/**
+ * The call to accountCoins returns an opaque `unknown` object with extraneous information. This function
+ * parses the unknown into a readable object to be used by the finalizers.
+ * @returns A typed `AccountCoins` response.
+ */
+export async function getAccountCoins(binanceApi: BinanceApi): Promise<ParsedAccountCoins> {
+  const coins = Object.values(await binanceApi["accountCoins"]());
+  return coins.map((coin) => {
+    const networkList = coin["networkList"]?.map((network) => {
+      return {
+        name: network["network"],
+        coin: network["coin"],
+        withdrawMin: network["withdrawMin"],
+        withdrawMax: network["withdrawMax"],
+        contractAddress: network["contractAddress"],
+      } as Network;
+    });
+    return {
+      symbol: coin["coin"],
+      balance: coin["free"],
+      networkList,
+    } as Coin;
+  });
 }


### PR DESCRIPTION
Should help with throwing when we are get rate-limited. Also addresses the "... outside of recvWindow" error, which seems to happen sporadically (not sure why it happens, but it could be because API time drifts from the host time?).