### PR TITLE
fix: validateRootBundle script incorrectly assumes proposal is not optimistic

### DIFF
--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -22,8 +22,6 @@ import {
   getDisputeForTimestamp,
   disconnectRedisClients,
   Signer,
-  getEndBlockBuffers,
-  getWidestPossibleExpectedBlockRange,
 } from "../utils";
 import {
   constructSpokePoolClientsForFastDataworker,
@@ -31,7 +29,7 @@ import {
 } from "../dataworker/DataworkerClientHelper";
 import { PendingRootBundle, ProposedRootBundle } from "../interfaces";
 import { createDataworker } from "../dataworker";
-import { getBlockForChain, getImpliedBundleBlockRanges } from "../dataworker/DataworkerUtils";
+import { getImpliedBundleBlockRanges } from "../dataworker/DataworkerUtils";
 
 config();
 let logger: winston.Logger;
@@ -169,12 +167,6 @@ export async function validate(_logger: winston.Logger, baseSigner: Signer): Pro
     baseSigner,
     fromBlocks,
     toBlocks
-  );
-
-  const mainnetBundleEndBlock = getBlockForChain(
-    rootBundle.bundleEvaluationBlockNumbers,
-    clients.hubPoolClient.chainId,
-    dataworker.chainIdListForBundleEvaluationBlockNumbers
   );
 
   const bundleImpliedBlockRanges = getImpliedBundleBlockRanges(

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -46,7 +46,7 @@ export async function validate(_logger: winston.Logger, baseSigner: Signer): Pro
   // enough data to limit # of excess historical deposit queries.
   // - SPOKE_ROOTS_LOOKBACK_COUNT unused in this script so set to something < DATAWORKER_FAST_LOOKBACK_COUNT
   // to avoid configuration error.
-  process.env.DATAWORKER_FAST_LOOKBACK_COUNT = "40";
+  process.env.DATAWORKER_FAST_LOOKBACK_COUNT = "10";
   process.env.SPOKE_ROOTS_LOOKBACK_COUNT = "1";
   const { clients, config, dataworker } = await createDataworker(logger, baseSigner);
   logger[startupLogLevel(config)]({


### PR DESCRIPTION
There is an implicit assumption in `validateRootBundle` that the root bundle being validated has a mainnet bundle end block which is strictly after the last root bundle was executed. This is obviously not the case when we create a root bundle optimistically (that is, under the assumption that the pending root bundle is valid and will pass liveness). 

The main thing to keep in mind is that when checking a bundle, **latestMainnetBlock is set to the bundle to validate's bundleEndBlock** in the validate root bundle script. The block ranges we pass in to `dataworker.validateRootBundle` requires that the start block corresponds to a bundle's start block (see [this derivation](https://github.com/across-protocol/relayer/blob/0e9a7083d12b812d20d9162255093cd4be98cc5b/src/dataworker/Dataworker.ts#L874) of the bundle to validate's start block). This means that we need to pass in a proper range into `validateRootBundle` in the `validateRootBundle` script. Before, we used `getWidestPossibleExpectedBlockRage`, [which gets the start block number](https://github.com/across-protocol/sdk/blob/a92892703d41dcbcc9c200c9d5840fe9b0314938/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts#L95) of a historical root bundle by calling the hub pool client. The hub pool client, however, gets that block by looking at the [latest fully executed root bundle](https://github.com/across-protocol/sdk/blob/a92892703d41dcbcc9c200c9d5840fe9b0314938/src/clients/HubPoolClient.ts#L770). However, since the `latestMainnetBlock` is the bundle's end block (and since this is an optimistic proposal, meaning that the previous bundle was still pending at the time of this bundle's creation), the last executed block we return here corresponds to the bundle two proposals ago. The fix is to pass in the implied block range of the bundle to validate rather than the widest possible block range at the bundle's end block number. 

An example of this is [this proposal](https://etherscan.io/tx/0x4af1524ef2880473915d0ce9fc67641b963c3f9bd31dc1eed03eea112569c4b5). The mainnet bundle end block is 23241562, but the preceding root bundle [was executed](https://etherscan.io/tx/0x95288bbd78411d2ff5b6e8f14200a4d4d11fb3052e65d181123eaa75a6874a77) at block 23241600, so `getLatestBundleEndBlockForChain` would return the end block of the bundle two proposals ago. 