### PR TITLE
improve: use toBlockOverride in dataworker

### DIFF
--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -252,8 +252,8 @@ export async function constructSpokePoolClientsWithStartBlocks(
     await Promise.all(
       enabledChains.map(async (chainId) => {
         // Allow caller to hardcode the spoke pool client end blocks.
-        if (isDefined(toBlockOverride[chainId])) {
-          return [chainId, toBlockOverride[chainId]];
+        if (isDefined(config.toBlockOverride[chainId])) {
+          return [chainId, config.toBlockOverride[chainId]];
         }
         if (chainId === hubPoolClient.chainId) {
           return [chainId, hubPoolBlock.number];


### PR DESCRIPTION
We have the ability to set the toBlock but we don't use this in the dataworker due to [this](https://github.com/across-protocol/relayer/blob/951bdf33e18eea8c2cbe21e72f1526d19e7efc9d/src/dataworker/DataworkerClientHelper.ts#L118). This lets the override supersede `dataworker.fastStartBundle`.