### PR TITLE
improve(relayer): Don't auto-bail on block error

### DIFF
--- a/src/libexec/RelayerSpokePoolListener.ts
+++ b/src/libexec/RelayerSpokePoolListener.ts
@@ -87,7 +87,7 @@ export async function scrapeEvents(spokePool: Contract, eventNames: string[], op
  */
 async function listen(eventMgr: EventManager, spokePool: Contract, eventNames: string[], quorum = 1): Promise<void> {
   const urls = Object.values(getNodeUrlList(chainId, quorum, "wss"));
-  let nProviders = urls.length;
+  const nProviders = urls.length;
   assert(nProviders >= quorum, `Insufficient providers for ${chain} (required ${quorum} by quorum)`);
 
   const providers = urls.map((url) =>

--- a/src/libexec/RelayerSpokePoolListener.ts
+++ b/src/libexec/RelayerSpokePoolListener.ts
@@ -120,16 +120,6 @@ async function listen(eventMgr: EventManager, spokePool: Contract, eventNames: s
     const message = `Caught ${chain} provider error.`;
     const { message: errorMessage, details, shortMessage, metaMessages } = error as BaseError;
     logger.debug({ at, message, errorMessage, shortMessage, provider, details, metaMessages });
-
-    if (!stop && --nProviders < quorum) {
-      stop = true;
-      logger.warn({
-        at: "RelayerSpokePoolListener::run",
-        message: `Insufficient ${chain} providers to continue.`,
-        quorum,
-        nProviders,
-      });
-    }
   };
 
   providers.forEach((provider, idx) => {


### PR DESCRIPTION
The existing hard-stop implementation might be too strict and causing fragility in the relayer. viem is OK to reconnect in the background and continue listening for new blocks. This doesn't affect re-org detection since that's based on the individual events; in fact it allows more time for a re-org to be detected.

This change is prompted by an odd pairing of zkSync & QuickNode, which tends to cause a lot of JSON parsing errors to be thrown. Unfortunately it's unclear exactly which response is causing the error, investigation ongoing.