### PR TITLE
fix(zkstack-finalizer): Add special case for USDC withdrawals

### DIFF
--- a/src/common/abi/ZkStackUSDCBridge.json
+++ b/src/common/abi/ZkStackUSDCBridge.json
@@ -72,5 +72,66 @@
     ],
     "name": "BridgehubDepositInitiated",
     "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2BatchNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2MessageIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_l2TxNumberInBatch",
+        "type": "uint16"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_message",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "_merkleProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "finalizeWithdrawal",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { 
+        "internalType": "uint256", 
+        "name": "chainId", 
+        "type": "uint256"
+       },
+      { 
+        "internalType": "uint256", "name": "l2BatchNumber", "type": "uint256"
+      },
+      { 
+        "internalType": "uint256", "name": "l2ToL1MessageNumber", "type": "uint256"
+      }
+    ],
+    "name": "isWithdrawalFinalized",
+    "outputs": [
+      { 
+        "internalType": "bool", "name": "isFinalized", "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/src/common/abi/ZkStackUSDCBridge.json
+++ b/src/common/abi/ZkStackUSDCBridge.json
@@ -113,22 +113,28 @@
   },
   {
     "inputs": [
-      { 
-        "internalType": "uint256", 
-        "name": "chainId", 
+      {
+        "internalType": "uint256",
+        "name": "chainId",
         "type": "uint256"
-       },
-      { 
-        "internalType": "uint256", "name": "l2BatchNumber", "type": "uint256"
       },
-      { 
-        "internalType": "uint256", "name": "l2ToL1MessageNumber", "type": "uint256"
+      {
+        "internalType": "uint256",
+        "name": "l2BatchNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "l2ToL1MessageNumber",
+        "type": "uint256"
       }
     ],
     "name": "isWithdrawalFinalized",
     "outputs": [
-      { 
-        "internalType": "bool", "name": "isFinalized", "type": "bool"
+      {
+        "internalType": "bool",
+        "name": "isFinalized",
+        "type": "bool"
       }
     ],
     "stateMutability": "view",


### PR DESCRIPTION
USDC withdrawals require special handling because the L2 USDC bridge doesn't have an `l1SharedBridge` method but instead has a `l1USDCBridge` method. The rest of the process is the same.

This PR keeps the `zksync` finalizer adapter very light weight but we should replace it eventually with a bump to `zksync-ethers>=6.20.0`
