### PR TITLE
feat(InventoryClient): Factor in L2->L1 pending withdrawals in balance allocation

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -35,6 +35,7 @@ import {
   Address,
   toAddressType,
   repaymentChainCanBeQuicklyRebalanced,
+  forEachAsync,
 } from "../utils";
 import { BundleDataApproxClient, HubPoolClient, TokenClient } from ".";
 import { Deposit, ProposedRootBundle } from "../interfaces";
@@ -67,6 +68,7 @@ export class InventoryClient {
   private excessRunningBalancePromises: { [l1Token: string]: Promise<{ [chainId: number]: BigNumber }> } = {};
   private profiler: InstanceType<typeof Profiler>;
   private bundleDataApproxClient: BundleDataApproxClient;
+  private pendingL2Withdrawals: { [l1Token: string]: { [chainId: number]: BigNumber } } = {};
 
   constructor(
     readonly relayer: EvmAddress,
@@ -152,10 +154,26 @@ export class InventoryClient {
 
     const { decimals: l1TokenDecimals } = getTokenInfo(l1Token, this.hubPoolClient.chainId);
 
+    // If chain is L1, add all pending L2->L1 withdrawals.
+    if (chainId === this.hubPoolClient.chainId) {
+      const pendingL2WithdrawalsForL1Token = this.pendingL2Withdrawals[l1Token.toNative()];
+      if (isDefined(pendingL2WithdrawalsForL1Token)) {
+        const pendingWithdrawalVolume = Object.values(pendingL2WithdrawalsForL1Token).reduce(
+          (acc, curr) => acc.add(curr),
+          bnZero
+        );
+        balance = pendingWithdrawalVolume;
+      }
+    } else {
+      balance = bnZero;
+    }
+
     // Return the balance for a specific l2 token on the remote chain.
     if (isDefined(l2Token)) {
       const { decimals: l2TokenDecimals } = this.hubPoolClient.getTokenInfoForAddress(l2Token, chainId);
-      balance = sdkUtils.ConvertDecimals(l2TokenDecimals, l1TokenDecimals)(tokenClient.getBalance(chainId, l2Token));
+      balance = balance.add(
+        sdkUtils.ConvertDecimals(l2TokenDecimals, l1TokenDecimals)(tokenClient.getBalance(chainId, l2Token))
+      );
       return balance.add(
         ignoreL1ToL2PendingAmount
           ? bnZero
@@ -164,12 +182,14 @@ export class InventoryClient {
     }
 
     const l2Tokens = this.getRemoteTokensForL1Token(l1Token, chainId);
-    balance = l2Tokens
-      .map((l2Token) => {
-        const { decimals: l2TokenDecimals } = this.hubPoolClient.getTokenInfoForAddress(l2Token, chainId);
-        return sdkUtils.ConvertDecimals(l2TokenDecimals, l1TokenDecimals)(tokenClient.getBalance(chainId, l2Token));
-      })
-      .reduce((acc, curr) => acc.add(curr), bnZero);
+    balance = balance.add(
+      l2Tokens
+        .map((l2Token) => {
+          const { decimals: l2TokenDecimals } = this.hubPoolClient.getTokenInfoForAddress(l2Token, chainId);
+          return sdkUtils.ConvertDecimals(l2TokenDecimals, l1TokenDecimals)(tokenClient.getBalance(chainId, l2Token));
+        })
+        .reduce((acc, curr) => acc.add(curr), bnZero)
+    );
 
     return balance.add(
       ignoreL1ToL2PendingAmount
@@ -1532,12 +1552,31 @@ export class InventoryClient {
     await this.adapterManager.wrapNativeTokenIfAboveThreshold(this.inventoryConfig, this.simMode);
   }
 
-  update(chainIds?: number[]): Promise<void> {
+  async update(chainIds?: number[]): Promise<void> {
     if (!this.isInventoryManagementEnabled()) {
       return;
     }
 
-    return this.crossChainTransferClient.update(this.getL1Tokens(), chainIds);
+    await this.crossChainTransferClient.update(this.getL1Tokens(), chainIds);
+
+    await forEachAsync(this.getL1Tokens(), async (l1Token) => {
+      this.pendingL2Withdrawals[l1Token.toNative()] = {};
+      const pendingWithdrawalBalances =
+        await this.crossChainTransferClient.adapterManager.getTotalPendingWithdrawalAmount(
+          7200,
+          this.getEnabledChains().filter((chainId) => chainId !== this.hubPoolClient.chainId),
+          this.relayer,
+          l1Token
+        );
+      Object.keys(pendingWithdrawalBalances).forEach((chainId) => {
+        this.pendingL2Withdrawals[l1Token.toNative()][Number(chainId)] = pendingWithdrawalBalances[Number(chainId)];
+      });
+    });
+    this.logger.debug({
+      at: "InventoryClient#update",
+      message: "Updated pending L2->L1 withdrawals",
+      pendingL2Withdrawals: this.pendingL2Withdrawals,
+    });
   }
 
   isInventoryManagementEnabled(): boolean {

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -229,6 +229,16 @@ describe("InventoryClient: Refund chain selection", async function () {
       expect(spyLogIncludes(spy, -1, 'expectedPostRelayAllocation":"74074074074074074"')).to.be.true; // (5+5)/(135)=0.074074
     });
 
+    it("Correctly factors in pending L2->L1 withdrawals when deciding where to refund", async function () {
+      // This fakes a 10 WETH pending withdrawal on each L2 chain, of which there are 4, so the cumulative balance
+      // should go from 140 to 180.
+      adapterManager.setL2PendingWithdrawalAmount(7200, toWei(10));
+      await inventoryClient.update();
+
+      await inventoryClient.determineRefundChainId(sampleDepositData);
+      expect(spyLogIncludes(spy, -1, 'cumulativeVirtualBalance":"180000000000000000000"')).to.be.true;
+    });
+
     it("Normalizes repayment amount to correct precision", async function () {
       // Identical setup to previous test but we'll pretend the L2 token uses a different precision than the L1 token.
       hubPoolClient.mapTokenInfo(l2TokensForWeth[ARBITRUM], "WETH", 6);

--- a/test/mocks/MockAdapterManager.ts
+++ b/test/mocks/MockAdapterManager.ts
@@ -94,14 +94,15 @@ export class MockAdapterManager extends AdapterManager {
     }
   }
 
-  getTotalPendingWithdrawalAmount(
+  async getTotalPendingWithdrawalAmount(
     lookbackPeriodSeconds: number,
     chainsToEvaluate: number[]
   ): Promise<{ [chainId: number]: BigNumber }> {
+    const pendingL2WithdrawalAmount = await this.getL2PendingWithdrawalAmount(lookbackPeriodSeconds);
     return Promise.resolve(
       Object.fromEntries(
         chainsToEvaluate.map((chainId) => {
-          return [chainId, bnZero];
+          return [chainId, pendingL2WithdrawalAmount];
         })
       )
     );


### PR DESCRIPTION
As we increasingly use "fast" l2->l1 withdrawal systems like CCTP and OFT we should factor in the pending balances to get more accurate per chain allocations. This PR adds a 2 hour query of these pending withdrawals and adds those balances to hub chain balances.
