### PR TITLE
fix: use getNativeTokenAddressForChain when querying balance allocator

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2440,7 +2440,7 @@ export class Dataworker {
             const signer = await client.spokePool.signer.getAddress();
             balanceRequestsToQuery.push({
               chainId: leaf.chainId,
-              tokens: [getNativeTokenAddressForChain(leaf.chainId) ?? toAddressType(ZERO_ADDRESS, leaf.chainId)], // ZERO_ADDRESS is used to represent ETH.
+              tokens: [getNativeTokenAddressForChain(leaf.chainId)], // ZERO_ADDRESS is used to represent ETH.
               holder: toAddressType(signer, leaf.chainId), // The signer's address is what will be sending the ETH.
               amount: valueToPassViaPayable,
             });


### PR DESCRIPTION
The native token address for polygon is 0x0....1010. If we don't specify this, then we try to query `address(0).balanceOf(holder)` in the balance allocator because of this: https://github.com/across-protocol/relayer/blob/d6b43bfecbf81b6d8824739ecd622c6d0f825738/src/clients/BalanceAllocator.ts#L176.

We could also probably have the balance allocator not use `getNativeTokenAddressForChain`, but I think this is less invasive. 