### PR TITLE
improve: change user address config into map for finalizer

### DIFF
--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -1,7 +1,6 @@
 import { utils as sdkUtils } from "@across-protocol/sdk";
 import assert from "assert";
-import { Contract, ethers } from "ethers";
-import { getAddress } from "ethers/lib/utils";
+import { Contract } from "ethers";
 import { groupBy, uniq } from "lodash";
 import { AugmentedTransaction, HubPoolClient, MultiCallerClient, TransactionClient } from "../clients";
 import {
@@ -247,12 +246,10 @@ export async function finalize(
     // or the recipient so its important to track for both, even if that means more RPC requests.
     // Always track HubPool, SpokePool, AtomicDepositor. HubPool sends messages and
     // tokens to the SpokePool, while the relayer rebalances ETH via the AtomicDepositor.
-    const addressesToFinalize: Address[] = [
-      hubPoolClient.hubPool.address,
-      CONTRACT_ADDRESSES[hubChainId]?.atomicDepositor?.address,
-      ...config.userAddresses,
-    ].map((address) => EvmAddress.from(getAddress(address)));
-    addressesToFinalize.push(spokePoolClients[chainId].spokePoolAddress);
+    const addressesToFinalize = new Map(config.userAddresses);
+    addressesToFinalize.set(EvmAddress.from(hubPoolClient.hubPool.address), []);
+    addressesToFinalize.set(EvmAddress.from(CONTRACT_ADDRESSES[hubChainId]?.atomicDepositor?.address), []);
+    addressesToFinalize.set(spokePoolClients[chainId].spokePoolAddress, []);
 
     // We can subloop through the finalizers for each chain, and then execute the finalizer. For now, the
     // main reason for this is related to CCTP finalizations. We want to run the CCTP finalizer AND the
@@ -529,7 +526,7 @@ async function updateFinalizerClients(clients: Clients) {
 export class FinalizerConfig extends CommonConfig {
   public readonly finalizationStrategy: FinalizationType;
   public readonly maxFinalizerLookback: number;
-  public readonly userAddresses: string[];
+  public readonly userAddresses: Map<Address, string[]>;
   public chainsToFinalize: number[];
 
   constructor(env: ProcessEnv) {
@@ -541,9 +538,11 @@ export class FinalizerConfig extends CommonConfig {
     } = env;
     super(env);
 
-    const userAddresses = JSON.parse(FINALIZER_WITHDRAWAL_TO_ADDRESSES);
-    assert(Array.isArray(userAddresses), "FINALIZER_WITHDRAWAL_TO_ADDRESSES must be a JSON string array");
-    this.userAddresses = userAddresses.map(ethers.utils.getAddress);
+    const userAddresses: { [address: string]: string[] } = JSON.parse(FINALIZER_WITHDRAWAL_TO_ADDRESSES);
+    this.userAddresses = new Map();
+    Object.entries(userAddresses).forEach(([address, tokensToFinalize]) => {
+      this.userAddresses.set(EvmAddress.from(address), tokensToFinalize);
+    });
 
     this.chainsToFinalize = JSON.parse(FINALIZER_CHAINS);
 

--- a/src/finalizer/types.ts
+++ b/src/finalizer/types.ts
@@ -33,6 +33,8 @@ export type FinalizerPromise = {
   crossChainMessages: CrossChainMessage[];
 };
 
+export type AddressesToFinalize = Map<Address, string[]>;
+
 export interface ChainFinalizer {
   (
     logger: winston.Logger,
@@ -40,7 +42,7 @@ export interface ChainFinalizer {
     hubPoolClient: HubPoolClient,
     l2SpokePoolClient: SpokePoolClient,
     l1SpokePoolClient: SpokePoolClient,
-    l1ToL2AddressesToFinalize: Address[]
+    l1ToL2AddressesToFinalize: AddressesToFinalize // Map from token address to associated token symbols to finalize for that address.
   ): Promise<FinalizerPromise>;
 }
 

--- a/src/finalizer/utils/arbStack.ts
+++ b/src/finalizer/utils/arbStack.ts
@@ -28,12 +28,11 @@ import {
   assert,
   isEVMSpokePoolClient,
   EvmAddress,
-  Address,
 } from "../../utils";
 import { TokensBridged } from "../../interfaces";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
 import { CONTRACT_ADDRESSES } from "../../common";
-import { FinalizerPromise, CrossChainMessage } from "../types";
+import { FinalizerPromise, CrossChainMessage, AddressesToFinalize } from "../types";
 import { utils as sdkUtils, arch } from "@across-protocol/sdk";
 import ARBITRUM_ERC20_GATEWAY_L2_ABI from "../../common/abi/ArbitrumErc20GatewayL2.json";
 
@@ -83,11 +82,11 @@ export async function arbStackFinalizer(
   hubPoolClient: HubPoolClient,
   spokePoolClient: SpokePoolClient,
   _l1SpokePoolClient: SpokePoolClient,
-  _recipientAddresses: Address[]
+  _recipientAddresses: AddressesToFinalize
 ): Promise<FinalizerPromise> {
   assert(isEVMSpokePoolClient(spokePoolClient));
   // Recipient addresses are just used to query events.
-  const recipientAddresses = _recipientAddresses.map((address) => address.toEvmAddress());
+  const recipientAddresses = Array.from(_recipientAddresses.keys()).map((address) => address.toNative());
   LATEST_MAINNET_BLOCK = hubPoolClient.latestHeightSearched;
   const hubPoolProvider = await getProvider(hubPoolClient.chainId, logger);
   MAINNET_BLOCK_TIME = (await arch.evm.averageBlockTime(hubPoolProvider)).average;

--- a/src/finalizer/utils/binance.ts
+++ b/src/finalizer/utils/binance.ts
@@ -15,14 +15,13 @@ import {
   isEVMSpokePoolClient,
   assert,
   EvmAddress,
-  Address,
   getBinanceDeposits,
   getBinanceWithdrawals,
   getAccountCoins,
   DepositNetwork,
 } from "../../utils";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
-import { FinalizerPromise } from "../types";
+import { FinalizerPromise, AddressesToFinalize } from "../types";
 
 // Alias for a Binance deposit/withdrawal status.
 enum Status {
@@ -48,10 +47,10 @@ export async function binanceFinalizer(
   _hubPoolClient: HubPoolClient,
   l2SpokePoolClient: SpokePoolClient,
   l1SpokePoolClient: SpokePoolClient,
-  _senderAddresses: Address[]
+  _senderAddresses: AddressesToFinalize
 ): Promise<FinalizerPromise> {
   assert(isEVMSpokePoolClient(l1SpokePoolClient) && isEVMSpokePoolClient(l2SpokePoolClient));
-  const senderAddresses = _senderAddresses.map((address) => address.toEvmAddress());
+  const senderAddresses = Array.from(_senderAddresses.keys()).map((address) => address.toEvmAddress());
   const chainId = l2SpokePoolClient.chainId;
   const hubChainId = l1SpokePoolClient.chainId;
   const l1EventSearchConfig = l1SpokePoolClient.eventSearchConfig;

--- a/src/finalizer/utils/cctp/l1ToL2.ts
+++ b/src/finalizer/utils/cctp/l1ToL2.ts
@@ -14,7 +14,6 @@ import {
   isEVMSpokePoolClient,
   ethers,
   isSVMSpokePoolClient,
-  Address,
   getKitKeypairFromEvmSigner,
 } from "../../../utils";
 import {
@@ -24,7 +23,7 @@ import {
   getCctpMessageTransmitter,
   isDepositForBurnEvent,
 } from "../../../utils/CCTPUtils";
-import { FinalizerPromise, CrossChainMessage } from "../../types";
+import { FinalizerPromise, CrossChainMessage, AddressesToFinalize } from "../../types";
 import { KeyPairSigner } from "@solana/kit";
 import { finalizeCCTPV1MessagesSVM } from "./svm/l1Tol2";
 
@@ -34,7 +33,7 @@ export async function cctpL1toL2Finalizer(
   hubPoolClient: HubPoolClient,
   l2SpokePoolClient: SpokePoolClient,
   l1SpokePoolClient: SpokePoolClient,
-  senderAddresses: Address[]
+  senderAddresses: AddressesToFinalize
 ): Promise<FinalizerPromise> {
   assert(isEVMSpokePoolClient(l1SpokePoolClient));
   const searchConfig: EventSearchConfig = {
@@ -47,7 +46,7 @@ export async function cctpL1toL2Finalizer(
     signer = await getKitKeypairFromEvmSigner(_signer);
   }
   const outstandingMessages = await getAttestedCCTPMessages(
-    senderAddresses,
+    Array.from(senderAddresses.keys()),
     hubPoolClient.chainId,
     l2SpokePoolClient.chainId,
     l2SpokePoolClient.chainId,

--- a/src/finalizer/utils/cctp/l2ToL1.ts
+++ b/src/finalizer/utils/cctp/l2ToL1.ts
@@ -26,7 +26,7 @@ import {
   getAttestedCCTPDeposits,
   getCctpMessageTransmitter,
 } from "../../../utils/CCTPUtils";
-import { FinalizerPromise, CrossChainMessage } from "../../types";
+import { FinalizerPromise, CrossChainMessage, AddressesToFinalize } from "../../types";
 
 export async function cctpL2toL1Finalizer(
   logger: winston.Logger,
@@ -34,7 +34,7 @@ export async function cctpL2toL1Finalizer(
   hubPoolClient: HubPoolClient,
   spokePoolClient: SpokePoolClient,
   _l1SpokePoolClient: SpokePoolClient,
-  senderAddresses: Address[]
+  _senderAddresses: AddressesToFinalize
 ): Promise<FinalizerPromise> {
   const searchConfig: EventSearchConfig = {
     from: spokePoolClient.eventSearchConfig.from,
@@ -43,6 +43,7 @@ export async function cctpL2toL1Finalizer(
   };
 
   const finalizingFromSolana = chainIsSvm(spokePoolClient.chainId);
+  const senderAddresses = Array.from(_senderAddresses.keys());
   const augmentedSenderAddresses = finalizingFromSolana
     ? await augmentSendersListForSolana(senderAddresses, spokePoolClient)
     : senderAddresses;

--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -10,7 +10,6 @@ import {
   groupObjectCountsByProp,
   isEVMSpokePoolClient,
   assert,
-  Address,
 } from "../../utils";
 import { spreadEventWithBlockNumber } from "../../utils/EventUtils";
 import { FinalizerPromise, CrossChainMessage } from "../types";
@@ -61,9 +60,7 @@ export async function heliosL1toL2Finalizer(
   _signer: Signer,
   hubPoolClient: HubPoolClient,
   l2SpokePoolClient: SpokePoolClient,
-  l1SpokePoolClient: SpokePoolClient,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _senderAddresses: Address[]
+  l1SpokePoolClient: SpokePoolClient
 ): Promise<FinalizerPromise> {
   assert(
     isEVMSpokePoolClient(l2SpokePoolClient) && isEVMSpokePoolClient(l1SpokePoolClient),

--- a/src/finalizer/utils/linea/l1ToL2.ts
+++ b/src/finalizer/utils/linea/l1ToL2.ts
@@ -15,9 +15,8 @@ import {
   assert,
   isEVMSpokePoolClient,
   EvmAddress,
-  Address,
 } from "../../../utils";
-import { CrossChainMessage, FinalizerPromise } from "../../types";
+import { CrossChainMessage, FinalizerPromise, AddressesToFinalize } from "../../types";
 import {
   determineMessageType,
   findMessageFromTokenBridge,
@@ -53,10 +52,10 @@ export async function lineaL1ToL2Finalizer(
   hubPoolClient: HubPoolClient,
   l2SpokePoolClient: SpokePoolClient,
   l1SpokePoolClient: SpokePoolClient,
-  _senderAddresses: Address[]
+  _senderAddresses: AddressesToFinalize
 ): Promise<FinalizerPromise> {
   assert(isEVMSpokePoolClient(l1SpokePoolClient) && isEVMSpokePoolClient(l2SpokePoolClient));
-  const senderAddresses = _senderAddresses.map((address) => address.toEvmAddress());
+  const senderAddresses = Array.from(_senderAddresses.keys()).map((address) => address.toEvmAddress());
   const [l1ChainId] = [hubPoolClient.chainId, hubPoolClient.hubPool.address];
   if (l1ChainId !== CHAIN_IDs.MAINNET) {
     throw new Error("Finalizations for Linea testnet is not supported.");

--- a/src/finalizer/utils/linea/l2ToL1.ts
+++ b/src/finalizer/utils/linea/l2ToL1.ts
@@ -18,10 +18,9 @@ import {
   assert,
   isEVMSpokePoolClient,
   toAddressType,
-  Address,
   createFormatFunction,
 } from "../../../utils";
-import { FinalizerPromise, CrossChainMessage } from "../../types";
+import { FinalizerPromise, CrossChainMessage, AddressesToFinalize } from "../../types";
 import { TokensBridged } from "../../../interfaces";
 import {
   initLineaSdk,
@@ -168,7 +167,7 @@ export async function lineaL2ToL1Finalizer(
   hubPoolClient: HubPoolClient,
   spokePoolClient: SpokePoolClient,
   _l1SpokePoolClient: SpokePoolClient,
-  _senderAddresses: Address[]
+  _senderAddresses: AddressesToFinalize
 ): Promise<FinalizerPromise> {
   assert(isEVMSpokePoolClient(spokePoolClient));
   const [l1ChainId, l2ChainId] = [hubPoolClient.chainId, spokePoolClient.chainId];
@@ -230,7 +229,7 @@ export async function lineaL2ToL1Finalizer(
     );
 
   // Append raw MessageSent events for custom sender addresses to TokensBridged events
-  const senderAddresses = _senderAddresses
+  const senderAddresses = Array.from(_senderAddresses.keys())
     .map((address) => address.toEvmAddress())
     .filter((sender) => sender !== spokePoolClient.spokePool.address && sender !== hubPoolClient.hubPool.address);
   const l2TokenBridge = new Contract(

--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -43,11 +43,10 @@ import {
   isEVMSpokePoolClient,
   EvmAddress,
   ZERO_ADDRESS,
-  Address,
 } from "../../utils";
 import { CONTRACT_ADDRESSES, OPSTACK_CONTRACT_OVERRIDES } from "../../common";
 import OPStackPortalL1 from "../../common/abi/OpStackPortalL1.json";
-import { FinalizerPromise, CrossChainMessage } from "../types";
+import { FinalizerPromise, CrossChainMessage, AddressesToFinalize } from "../types";
 const { utils } = ethers;
 
 interface CrossChainMessageWithEvent {
@@ -106,7 +105,7 @@ export async function opStackFinalizer(
   hubPoolClient: HubPoolClient,
   spokePoolClient: SpokePoolClient,
   _l1SpokePoolClient: SpokePoolClient,
-  senderAddresses: Address[]
+  senderAddresses: AddressesToFinalize
 ): Promise<FinalizerPromise> {
   assert(isEVMSpokePoolClient(spokePoolClient));
   const { chainId, latestHeightSearched: to, spokePool } = spokePoolClient;
@@ -145,7 +144,7 @@ export async function opStackFinalizer(
   // and because they are lite chains, our only way to withdraw them is to initiate a manual bridge from the
   // the lite chain to Ethereum via the canonical OVM standard bridge.
   // Filter out SpokePool as sender since we query for it previously using the TokensBridged event query.
-  const ovmFromAddresses = senderAddresses
+  const ovmFromAddresses = Array.from(senderAddresses.keys())
     .map((sender) => sender.toEvmAddress())
     .filter((sender) => sender !== spokePool.address);
   const searchConfig = { ...spokePoolClient.eventSearchConfig, to };


### PR DESCRIPTION
The reason behind changing `addressesToFinalize` from an array to a map is to also specify to the finalizer which tokens the address should be receiving. This is mainly for binance.