### PR TITLE
improve(TransactionUtils): Force reset nonce

### DIFF
--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -177,6 +177,7 @@ export async function runTransaction(
         retriesRemaining,
       });
 
+      nonceReset[chainId] = false;
       return await runTransaction(logger, contract, method, args, value, gasLimit, null, retriesRemaining);
     } else {
       // Empirically we have observed that Ethers can produce nested errors, so we try to recurse down them


### PR DESCRIPTION
On Linea it's observed that the relayer is occasionally resuming from the pending nonce, rather than the latest confirmed nonce. Try to force the relayer to always resume from the latest confirmed nonce, rather than outsourcing nonce resolution to ethers.