### PR TITLE
improve(relayer): Proceed to active state despite degraded chains

### DIFF
--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -83,7 +83,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
         const degraded = Object.values(spokePoolClients)
           .filter(({ isUpdated }) => !isUpdated)
           .map(({ chainId }) => getNetworkName(chainId));
-        logger.debug({ at: "Relayer#run", message: "Assuming active relayer role in degraded state", degraded, });
+        logger.debug({ at: "Relayer#run", message: "Assuming active relayer role in degraded state", degraded });
       }
 
       // One time initialization of functions that handle lots of events only after all spokePoolClients are updated.

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -83,7 +83,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
         const degraded = Object.values(spokePoolClients)
           .filter(({ isUpdated }) => !isUpdated)
           .map(({ chainId }) => getNetworkName(chainId));
-        logger.debug({ at: "Relayer#run", message: "Assuming active relayer role in degraded state", degraded });
+        logger.warn({ at: "Relayer#run", message: "Assuming active relayer role in degraded state", degraded });
       }
 
       // One time initialization of functions that handle lots of events only after all spokePoolClients are updated.


### PR DESCRIPTION
Observed this morning on Polygon - the relayer refused to start due to Polygon node issues. Try to proceed to active state even though one or more chains did not come up successfully.