### PR TITLE
fix(ProfitClient): revert "Override Linea gas costs (#2567)"

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -253,15 +253,6 @@ export class ProfitClient {
               inspect(_cause, { depth: 3, breakLength: 120 });
         }
       }
-
-      if (deposit.destinationChainId === CHAIN_IDs.LINEA) {
-        return {
-          nativeGasCost: BigNumber.from("130000"),
-          tokenGasCost: BigNumber.from("1154931972235"),
-          gasPrice: BigNumber.from("9077611"),
-        };
-      }
-
       this.logger.warn({
         at: "ProfitClient#getTotalGasCost",
         message: "Failed to simulate fill for deposit.",


### PR DESCRIPTION
This reverts commit e49c51b6e8033d419072ebf1f0362c8c35e87dc0.

The change was successful at mitigating failures on linea_estimateGas due to excessive load. RPC providers are behaving normally again, so this change can be reverted.