### PR TITLE
chore: mark Polygon USDT withdrawals

### DIFF
--- a/src/finalizer/utils/polygon.ts
+++ b/src/finalizer/utils/polygon.ts
@@ -147,8 +147,11 @@ async function getFinalizableTransactions(
       // one followed by a non-USDC one, the USDC 'logIndex' as far as building the payload is concerned
       // will be 0 and the non-USDC 'logIndex' will be 1. This is why we can't filter out USDC CCTP withdrawals
       // until after we've computed payloads.
-      if (l2TokenAddress.eq(toAddressType(TOKEN_SYMBOLS_MAP.USDC.addresses[chainId], chainId))) {
-        return { status: "USDC_CCTP_L2_WITHDRAWAL" };
+      if (
+        l2TokenAddress.eq(toAddressType(TOKEN_SYMBOLS_MAP.USDC.addresses[chainId], chainId)) ||
+        l2TokenAddress.eq(toAddressType(TOKEN_SYMBOLS_MAP.USDT.addresses[chainId], chainId))
+      ) {
+        return { status: "USDC_ALT_L2_WITHDRAWAL" };
       }
 
       try {


### PR DESCRIPTION
Right now we take the USDT0 withdrawal `TokensBridged` event and try to call `exit()` on it in the finalizer. We obviously don't need to do this since these withdrawals will always fail, like CCTP withdrawals, so it should be skipped.