### PR TITLE
fix: drop `gasLimit`

### DIFF
--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -709,8 +709,8 @@ function addUpdateAndExecuteTxns(
     unpermissioned: true,
     // @dev Simulation of `executeMessage` depends on prior state update via SP1Helios.update
     canFailInSimulation: true,
-    // todo? this hardcoded gas limit of 1 mil could be improved if we were able to simulate this tx on top of blockchain state created by the tx above
-    gasLimit: BigNumber.from(1000000),
+    // todo? this hardcoded gas limit of 500K could be improved if we were able to simulate this tx on top of blockchain state created by the tx above
+    gasLimit: BigNumber.from(500000),
     message: `Finalize Helios msg (HubPoolStore nonce ${l1Event.nonce.toString()}) - Step 2: Execute on SpokePool`,
   };
   transactions.push(executeTx);

--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -709,8 +709,8 @@ function addUpdateAndExecuteTxns(
     unpermissioned: true,
     // @dev Simulation of `executeMessage` depends on prior state update via SP1Helios.update
     canFailInSimulation: true,
-    // todo? this hardcoded gas limit of 2 mil could be improved if we were able to simulate this tx on top of blockchain state created by the tx above
-    gasLimit: BigNumber.from(2000000),
+    // todo? this hardcoded gas limit of 1 mil could be improved if we were able to simulate this tx on top of blockchain state created by the tx above
+    gasLimit: BigNumber.from(1000000),
     message: `Finalize Helios msg (HubPoolStore nonce ${l1Event.nonce.toString()}) - Step 2: Execute on SpokePool`,
   };
   transactions.push(executeTx);


### PR DESCRIPTION
HyperEVM's small blocks are 2M gas total. 

Examples of message executions (we use ~100K gas):
https://hyperevmscan.io/tx/0x1de6ddac291c500d84aa05073138b096f7bdc1b2097b6e0192235d4c0df452fe
https://bscscan.com/tx/0x0d67a07bf24de175dea4211fbf65c812c893f6914c4756295e41a37f4c9cdfaf