### PR TITLE
feat(Monitor): Incorporate SwapHelper into Monitor.refiller

### DIFF
--- a/src/caching/RedisCache.ts
+++ b/src/caching/RedisCache.ts
@@ -28,6 +28,10 @@ export class RedisCache implements interfaces.CachingMechanismInterface {
     return this.redisClient.get(key) as T;
   }
 
+  public async ttl(key: string): Promise<number | undefined> {
+    return this.redisClient.ttl(key);
+  }
+
   public async set<T>(key: string, value: T, ttl: number = constants.DEFAULT_CACHING_TTL): Promise<string | undefined> {
     // Call the setRedisKey function to set the value in redis.
     await setRedisKey(key, String(value), this.redisClient, ttl);

--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -81,7 +81,7 @@ export class AcrossSwapApiClient {
         params,
       });
       if (!response?.data) {
-        this.logger.error({
+        this.logger.warn({
           at: "AcrossAPIClient",
           message: `Invalid response from ${this.urlBase}`,
           url: this.urlBase,
@@ -91,7 +91,7 @@ export class AcrossSwapApiClient {
         return;
       }
       if (!response.data.swapTx.simulationSuccess) {
-        this.logger.error({
+        this.logger.warn({
           at: "AcrossSwapApiClient",
           message: "Swap simulation failed in API",
           url: this.urlBase,
@@ -106,7 +106,7 @@ export class AcrossSwapApiClient {
         value: BigNumber.from(response.data.swapTx.value),
       };
     } catch (err) {
-      this.logger.error({
+      this.logger.warn({
         at: "AcrossSwapApiClient",
         message: `Failed to post to ${this.urlBase}`,
         url: this.urlBase,

--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -1,0 +1,139 @@
+import axios, { AxiosError } from "axios";
+import { BigNumber, CHAIN_IDs, EvmAddress, winston, ZERO_ADDRESS } from "../utils";
+
+interface Route {
+  inputToken: EvmAddress;
+  outputToken: EvmAddress;
+  originChainId: number;
+  destinationChainId: number;
+}
+interface SwapApiResponse {
+  swapTx: {
+    simulationSuccess: boolean;
+    to: string;
+    data: string;
+    value: string;
+  };
+}
+interface SwapData {
+  target: EvmAddress;
+  calldata: string;
+  value: BigNumber;
+}
+
+/**
+ * @notice This class interfaces with the Across Swap API to execute swaps between chains.
+ */
+export class AcrossSwapApiClient {
+  private routesSupported: Set<Route> = new Set([
+    {
+      // Allow refilling bot balances from ETH on Arbitrum, where we receive excess ETH as a gas refund
+      // periodically, to MATIC on Polygon.
+      inputToken: EvmAddress.from(ZERO_ADDRESS),
+      outputToken: EvmAddress.from(ZERO_ADDRESS),
+      originChainId: CHAIN_IDs.ARBITRUM,
+      destinationChainId: CHAIN_IDs.POLYGON,
+    },
+  ]);
+  private initialized = false;
+  private readonly urlBase = "https://app.across.to/api/swap/approval";
+  private readonly apiResponseTimeout = 3000;
+  private readonly swapExactOutputCacheTtl = 10 * 60; // Allow exactly one swap per route per 10 minutes.
+
+  constructor(readonly logger: winston.Logger) {}
+
+  /**
+   * @notice Returns calldata necessary to swap exact output using the Across Swap API.
+   * @param route The route to swap on.
+   * @param amountOut The amount of output tokens to swap for.
+   * @param swapper The address of the swapper.
+   * @param recipient The address of the recipient.
+   * @returns The swap data if the swap is successful, undefined otherwise.
+   */
+  async swapExactOutput(
+    route: Route,
+    amountOut: BigNumber,
+    swapper: EvmAddress,
+    recipient: EvmAddress
+  ): Promise<SwapData | undefined> {
+    if (!this._isRouteSupported(route)) {
+      throw new Error(
+        `Route ${route.inputToken.toNative()} -> ${route.outputToken.toNative()} on ${route.originChainId} -> ${
+          route.destinationChainId
+        } is not supported`
+      );
+    }
+
+    const params = {
+      originChainId: route.originChainId,
+      destinationChainId: route.destinationChainId,
+      inputToken: route.inputToken.toNative(),
+      outputToken: route.outputToken.toNative(),
+      tradeType: "exactOutput",
+      amount: amountOut.toString(),
+      depositor: swapper.toNative(),
+      recipient: recipient.toNative(),
+    };
+    let swapData: SwapData;
+    try {
+      const response = await axios.get<SwapApiResponse>(`${this.urlBase}`, {
+        timeout: this.apiResponseTimeout,
+        params,
+      });
+      if (!response?.data) {
+        this.logger.error({
+          at: "AcrossAPIClient",
+          message: `Invalid response from ${this.urlBase}`,
+          url: this.urlBase,
+          params,
+          response,
+        });
+        return;
+      }
+      if (!response.data.swapTx.simulationSuccess) {
+        this.logger.error({
+          at: "AcrossSwapApiClient",
+          message: "Swap simulation failed in API",
+          url: this.urlBase,
+          params,
+          response,
+        });
+        return;
+      }
+      swapData = {
+        target: EvmAddress.from(response.data.swapTx.to),
+        calldata: response.data.swapTx.data,
+        value: BigNumber.from(response.data.swapTx.value),
+      };
+    } catch (err) {
+      this.logger.error({
+        at: "AcrossSwapApiClient",
+        message: `Failed to post to ${this.urlBase}`,
+        url: this.urlBase,
+        params,
+        error: (err as AxiosError).message,
+      });
+      return;
+    }
+
+    this.logger.debug({
+      at: "AcrossSwapApiClient",
+      message: `Successfully fetched swap calldata for ${route.originChainId}-${route.inputToken.toNative()} -> ${
+        route.destinationChainId
+      }-${route.outputToken.toNative()}`,
+      swapData,
+    });
+
+    return swapData;
+  }
+
+  private _isRouteSupported(route: Route): boolean {
+    return Array.from(this.routesSupported).some(
+      (r) =>
+        r.inputToken.eq(route.inputToken) &&
+        r.outputToken.eq(route.outputToken) &&
+        r.originChainId === route.originChainId &&
+        r.destinationChainId === route.destinationChainId
+    );
+  }
+}

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -21,3 +21,4 @@ export * from "./InventoryClient";
 export * from "./AcrossAPIClient";
 export * from "./SvmFillerClient";
 export * from "./BundleDataApproxClient";
+export * from "./AcrossSwapApiClient";

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -751,7 +751,6 @@ export class Monitor {
             toAddressType(signerAddress, chainId),
             deficit
           );
-          canRefill = false;
           const spokePoolClient = this.clients.spokePoolClients[chainId];
           // If token is gas token, try unwrapping deficit amount of WETH into ETH to have available for refill.
           if (!canRefill && token.eq(getNativeTokenAddressForChain(chainId)) && isEVMSpokePoolClient(spokePoolClient)) {

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -720,6 +720,7 @@ export class Monitor {
    * listed in `monitorBalances`. These accounts might also be listed in `refillBalances` with a higher target than
    * the `monitorBalances` target. This function will ensure that `checkBalances` will rarely alert for those
    * balances.
+   * @dev @todo This entirefunction should be moved to a new bot that runs independently of the monitor.
    */
   async refillBalances(): Promise<void> {
     const { refillEnabledBalances } = this.monitorConfig;

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -766,8 +766,9 @@ export class Monitor {
                 deficit
               );
           const spokePoolClient = this.clients.spokePoolClients[chainId];
-          // If token is gas token, try unwrapping deficit amount of WETH into ETH to have available for refill.
           if (!canRefill && token.eq(getNativeTokenAddressForChain(chainId)) && isEVMSpokePoolClient(spokePoolClient)) {
+            // If token is the native token and the native token is ETH, try unwrapping some WETH into ETH first before
+            // transferring ETH to the account.
             if (getNativeTokenSymbol(chainId) === "ETH") {
               const weth = new Contract(
                 TOKEN_SYMBOLS_MAP.WETH.addresses[chainId],

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -826,12 +826,12 @@ export class Monitor {
                 });
                 return;
               }
-              const arbitrumSpokePoolClient = this.clients.spokePoolClients[CHAIN_IDs.ARBITRUM];
+              const originSpokePoolClient = this.clients.spokePoolClients[swapRoute.originChainId];
               assert(
-                isEVMSpokePoolClient(arbitrumSpokePoolClient),
-                "Missing Arbitrum spoke pool client, cannot swap ETH on Arbitrum to MATIC on Polygon"
+                isEVMSpokePoolClient(originSpokePoolClient),
+                `Missing origin spoke pool client for chain ${swapRoute.originChainId}`
               );
-              const arbitrumSigner = arbitrumSpokePoolClient.spokePool.signer;
+              const arbitrumSigner = originSpokePoolClient.spokePool.signer;
               const swapData = await this.acrossSwapApiClient.swapExactOutput(
                 swapRoute,
                 deficit,
@@ -860,7 +860,9 @@ export class Monitor {
                 });
                 this.logger.info({
                   at: "Monitor#refillBalances",
-                  message: `Swapped ETH on Arbitrum to MATIC on Polygon for ${account} 🎁!`,
+                  message: `Swapped ETH on ${getNetworkName(
+                    swapRoute.originChainId
+                  )} to MATIC on Polygon for ${account} 🎁!`,
                   transactionHash: blockExplorerLink(txn.transactionHash, chainId),
                 });
               } else {
@@ -869,7 +871,9 @@ export class Monitor {
                 // miscellaneous reasons.
                 this.logger.warn({
                   at: "Monitor#refillBalances",
-                  message: `Failed to swap ETH on Arbitrum to MATIC on Polygon for ${account}`,
+                  message: `Failed to swap ETH on ${getNetworkName(
+                    swapRoute.originChainId
+                  )} to MATIC on Polygon for ${account}`,
                   swapRoute,
                   deficit,
                   swapper: EvmAddress.from(signerAddress).toNative(),

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -863,7 +863,7 @@ export class Monitor {
                   message: `Swapped ETH on ${getNetworkName(
                     swapRoute.originChainId
                   )} to MATIC on Polygon for ${account} 🎁!`,
-                  transactionHash: blockExplorerLink(txn.transactionHash, chainId),
+                  transactionHash: blockExplorerLink(txn.transactionHash, swapRoute.originChainId),
                 });
               } else {
                 // swapData will be undefined if the transaction simulation fails on the Across Swap API side, which

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -39,6 +39,10 @@ export class RedisClient {
     return this.client.get(this.getNamespacedKey(key));
   }
 
+  async ttl(key: string): Promise<number | undefined> {
+    return this.client.ttl(this.getNamespacedKey(key));
+  }
+
   async set(key: string, val: string, expirySeconds = constants.DEFAULT_CACHING_TTL): Promise<void> {
     // Apply namespace to key.
     key = this.getNamespacedKey(key);

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -162,7 +162,7 @@ export async function runTransaction(
 
   try {
     return sendRawTxn
-      ? await signer.sendTransaction({ to, value, ...gas })
+      ? await signer.sendTransaction({ to, value, data: args as ethers.utils.BytesLike, ...gas })
       : await contract[method](...(args as Array<unknown>), txConfig);
   } catch (error) {
     if (retries > 0 && txnRetryable(error)) {


### PR DESCRIPTION
Eventually we can move the refiller logic out of the Monitor but I wanted to test this PoC out in the Monitor without adding too much code. Assuming the SwapClient works well we can productionize it into a separate bot in a follow up PR