### PR TITLE
feat: Create Refiller bot

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -15,6 +15,7 @@ import { runDataworker } from "./src/dataworker";
 import { runMonitor } from "./src/monitor";
 import { runFinalizer } from "./src/finalizer";
 import { version } from "./package.json";
+import { runRefiller } from "./src/refiller";
 
 let logger: typeof Logger;
 let cmd: string;
@@ -24,6 +25,7 @@ const CMDS = {
   finalizer: runFinalizer,
   help: help,
   monitor: runMonitor,
+  refiller: runRefiller,
   relayer: runRelayer,
   rebalancer: runRebalancer,
 };

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "run-proposer": "PROPOSER_ENABLED=true node ./dist/index.js --dataworker",
     "run-rebalancer": "node ./dist/index.js --rebalancer",
     "run-monitor": "node ./dist/index.js --monitor",
+    "run-refiller": "node ./dist/index.js --refiller",
     "run-finalizer": "node ./dist/index.js --finalizer",
     "relay": "node ./dist/index.js --relayer",
     "deposit": "yarn ts-node ./scripts/spokepool.ts deposit",

--- a/src/caching/RedisCache.ts
+++ b/src/caching/RedisCache.ts
@@ -28,6 +28,10 @@ export class RedisCache implements interfaces.CachingMechanismInterface {
     return this.redisClient.get(key) as T;
   }
 
+  public async ttl(key: string): Promise<number | undefined> {
+    return this.redisClient.ttl(key);
+  }
+
   public async set<T>(key: string, value: T, ttl: number = constants.DEFAULT_CACHING_TTL): Promise<string | undefined> {
     // Call the setRedisKey function to set the value in redis.
     await setRedisKey(key, String(value), this.redisClient, ttl);

--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -81,7 +81,7 @@ export class AcrossSwapApiClient {
         params,
       });
       if (!response?.data) {
-        this.logger.error({
+        this.logger.warn({
           at: "AcrossAPIClient",
           message: `Invalid response from ${this.urlBase}`,
           url: this.urlBase,
@@ -91,7 +91,7 @@ export class AcrossSwapApiClient {
         return;
       }
       if (!response.data.swapTx.simulationSuccess) {
-        this.logger.error({
+        this.logger.warn({
           at: "AcrossSwapApiClient",
           message: "Swap simulation failed in API",
           url: this.urlBase,
@@ -106,7 +106,7 @@ export class AcrossSwapApiClient {
         value: BigNumber.from(response.data.swapTx.value),
       };
     } catch (err) {
-      this.logger.error({
+      this.logger.warn({
         at: "AcrossSwapApiClient",
         message: `Failed to post to ${this.urlBase}`,
         url: this.urlBase,

--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -1,0 +1,139 @@
+import axios, { AxiosError } from "axios";
+import { BigNumber, CHAIN_IDs, EvmAddress, winston, ZERO_ADDRESS } from "../utils";
+
+interface Route {
+  inputToken: EvmAddress;
+  outputToken: EvmAddress;
+  originChainId: number;
+  destinationChainId: number;
+}
+interface SwapApiResponse {
+  swapTx: {
+    simulationSuccess: boolean;
+    to: string;
+    data: string;
+    value: string;
+  };
+}
+interface SwapData {
+  target: EvmAddress;
+  calldata: string;
+  value: BigNumber;
+}
+
+/**
+ * @notice This class interfaces with the Across Swap API to execute swaps between chains.
+ */
+export class AcrossSwapApiClient {
+  private routesSupported: Set<Route> = new Set([
+    {
+      // Allow refilling bot balances from ETH on Arbitrum, where we receive excess ETH as a gas refund
+      // periodically, to MATIC on Polygon.
+      inputToken: EvmAddress.from(ZERO_ADDRESS),
+      outputToken: EvmAddress.from(ZERO_ADDRESS),
+      originChainId: CHAIN_IDs.ARBITRUM,
+      destinationChainId: CHAIN_IDs.POLYGON,
+    },
+  ]);
+  private initialized = false;
+  private readonly urlBase = "https://app.across.to/api/swap/approval";
+  private readonly apiResponseTimeout = 3000;
+  private readonly swapExactOutputCacheTtl = 10 * 60; // Allow exactly one swap per route per 10 minutes.
+
+  constructor(readonly logger: winston.Logger) {}
+
+  /**
+   * @notice Returns calldata necessary to swap exact output using the Across Swap API.
+   * @param route The route to swap on.
+   * @param amountOut The amount of output tokens to swap for.
+   * @param swapper The address of the swapper.
+   * @param recipient The address of the recipient.
+   * @returns The swap data if the swap is successful, undefined otherwise.
+   */
+  async swapExactOutput(
+    route: Route,
+    amountOut: BigNumber,
+    swapper: EvmAddress,
+    recipient: EvmAddress
+  ): Promise<SwapData | undefined> {
+    if (!this._isRouteSupported(route)) {
+      throw new Error(
+        `Route ${route.inputToken.toNative()} -> ${route.outputToken.toNative()} on ${route.originChainId} -> ${
+          route.destinationChainId
+        } is not supported`
+      );
+    }
+
+    const params = {
+      originChainId: route.originChainId,
+      destinationChainId: route.destinationChainId,
+      inputToken: route.inputToken.toNative(),
+      outputToken: route.outputToken.toNative(),
+      tradeType: "exactOutput",
+      amount: amountOut.toString(),
+      depositor: swapper.toNative(),
+      recipient: recipient.toNative(),
+    };
+    let swapData: SwapData;
+    try {
+      const response = await axios.get<SwapApiResponse>(`${this.urlBase}`, {
+        timeout: this.apiResponseTimeout,
+        params,
+      });
+      if (!response?.data) {
+        this.logger.error({
+          at: "AcrossAPIClient",
+          message: `Invalid response from ${this.urlBase}`,
+          url: this.urlBase,
+          params,
+          response,
+        });
+        return;
+      }
+      if (!response.data.swapTx.simulationSuccess) {
+        this.logger.error({
+          at: "AcrossSwapApiClient",
+          message: "Swap simulation failed in API",
+          url: this.urlBase,
+          params,
+          response,
+        });
+        return;
+      }
+      swapData = {
+        target: EvmAddress.from(response.data.swapTx.to),
+        calldata: response.data.swapTx.data,
+        value: BigNumber.from(response.data.swapTx.value),
+      };
+    } catch (err) {
+      this.logger.error({
+        at: "AcrossSwapApiClient",
+        message: `Failed to post to ${this.urlBase}`,
+        url: this.urlBase,
+        params,
+        error: (err as AxiosError).message,
+      });
+      return;
+    }
+
+    this.logger.debug({
+      at: "AcrossSwapApiClient",
+      message: `Successfully fetched swap calldata for ${route.originChainId}-${route.inputToken.toNative()} -> ${
+        route.destinationChainId
+      }-${route.outputToken.toNative()}`,
+      swapData,
+    });
+
+    return swapData;
+  }
+
+  private _isRouteSupported(route: Route): boolean {
+    return Array.from(this.routesSupported).some(
+      (r) =>
+        r.inputToken.eq(route.inputToken) &&
+        r.outputToken.eq(route.outputToken) &&
+        r.originChainId === route.originChainId &&
+        r.destinationChainId === route.destinationChainId
+    );
+  }
+}

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -21,3 +21,4 @@ export * from "./InventoryClient";
 export * from "./AcrossAPIClient";
 export * from "./SvmFillerClient";
 export * from "./BundleDataApproxClient";
+export * from "./AcrossSwapApiClient";

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -41,7 +41,7 @@ export interface Clients {
   arweaveClient: caching.ArweaveClient;
 }
 
-async function getSpokePoolSigners(
+export async function getSpokePoolSigners(
   baseSigner: Signer,
   spokePoolChains: number[]
 ): Promise<{ [chainId: number]: Signer }> {
@@ -176,7 +176,7 @@ export async function constructSpokePoolClientsWithLookback(
  * process.env.SPOKE_POOL_CHAINS_OVERRIDE to force certain spoke pool clients to be constructed.
  * @returns number[] List of enabled spoke pool chains.
  */
-function getEnabledChainsInBlockRange(
+export function getEnabledChainsInBlockRange(
   configStoreClient: clients.AcrossConfigStoreClient,
   spokePoolChainsOverride: number[],
   mainnetStartBlock: number,

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -751,7 +751,6 @@ export class Monitor {
             toAddressType(signerAddress, chainId),
             deficit
           );
-          canRefill = false;
           const spokePoolClient = this.clients.spokePoolClients[chainId];
           // If token is gas token, try unwrapping deficit amount of WETH into ETH to have available for refill.
           if (!canRefill && token.eq(getNativeTokenAddressForChain(chainId)) && isEVMSpokePoolClient(spokePoolClient)) {

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -720,6 +720,7 @@ export class Monitor {
    * listed in `monitorBalances`. These accounts might also be listed in `refillBalances` with a higher target than
    * the `monitorBalances` target. This function will ensure that `checkBalances` will rarely alert for those
    * balances.
+   * @dev @todo This entirefunction should be moved to a new bot that runs independently of the monitor.
    */
   async refillBalances(): Promise<void> {
     const { refillEnabledBalances } = this.monitorConfig;

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -766,8 +766,9 @@ export class Monitor {
                 deficit
               );
           const spokePoolClient = this.clients.spokePoolClients[chainId];
-          // If token is gas token, try unwrapping deficit amount of WETH into ETH to have available for refill.
           if (!canRefill && token.eq(getNativeTokenAddressForChain(chainId)) && isEVMSpokePoolClient(spokePoolClient)) {
+            // If token is the native token and the native token is ETH, try unwrapping some WETH into ETH first before
+            // transferring ETH to the account.
             if (getNativeTokenSymbol(chainId) === "ETH") {
               const weth = new Contract(
                 TOKEN_SYMBOLS_MAP.WETH.addresses[chainId],

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -826,12 +826,12 @@ export class Monitor {
                 });
                 return;
               }
-              const arbitrumSpokePoolClient = this.clients.spokePoolClients[CHAIN_IDs.ARBITRUM];
+              const originSpokePoolClient = this.clients.spokePoolClients[swapRoute.originChainId];
               assert(
-                isEVMSpokePoolClient(arbitrumSpokePoolClient),
-                "Missing Arbitrum spoke pool client, cannot swap ETH on Arbitrum to MATIC on Polygon"
+                isEVMSpokePoolClient(originSpokePoolClient),
+                `Missing origin spoke pool client for chain ${swapRoute.originChainId}`
               );
-              const arbitrumSigner = arbitrumSpokePoolClient.spokePool.signer;
+              const arbitrumSigner = originSpokePoolClient.spokePool.signer;
               const swapData = await this.acrossSwapApiClient.swapExactOutput(
                 swapRoute,
                 deficit,
@@ -860,7 +860,9 @@ export class Monitor {
                 });
                 this.logger.info({
                   at: "Monitor#refillBalances",
-                  message: `Swapped ETH on Arbitrum to MATIC on Polygon for ${account} 🎁!`,
+                  message: `Swapped ETH on ${getNetworkName(
+                    swapRoute.originChainId
+                  )} to MATIC on Polygon for ${account} 🎁!`,
                   transactionHash: blockExplorerLink(txn.transactionHash, chainId),
                 });
               } else {
@@ -869,7 +871,9 @@ export class Monitor {
                 // miscellaneous reasons.
                 this.logger.warn({
                   at: "Monitor#refillBalances",
-                  message: `Failed to swap ETH on Arbitrum to MATIC on Polygon for ${account}`,
+                  message: `Failed to swap ETH on ${getNetworkName(
+                    swapRoute.originChainId
+                  )} to MATIC on Polygon for ${account}`,
                   swapRoute,
                   deficit,
                   swapper: EvmAddress.from(signerAddress).toNative(),

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -863,7 +863,7 @@ export class Monitor {
                   message: `Swapped ETH on ${getNetworkName(
                     swapRoute.originChainId
                   )} to MATIC on Polygon for ${account} 🎁!`,
-                  transactionHash: blockExplorerLink(txn.transactionHash, chainId),
+                  transactionHash: blockExplorerLink(txn.transactionHash, swapRoute.originChainId),
                 });
               } else {
                 // swapData will be undefined if the transaction simulation fails on the Across Swap API side, which

--- a/src/refiller/Refiller.ts
+++ b/src/refiller/Refiller.ts
@@ -1,0 +1,419 @@
+import winston from "winston";
+import { RefillerConfig } from "./RefillerConfig";
+import {
+  Address,
+  assert,
+  BigNumber,
+  blockExplorerLink,
+  CHAIN_IDs,
+  chainIsEvm,
+  chainIsSvm,
+  Contract,
+  ERC20,
+  EvmAddress,
+  formatUnits,
+  getNativeTokenAddressForChain,
+  getNativeTokenSymbol,
+  getNetworkName,
+  getProvider,
+  getRedisCache,
+  getSolanaTokenBalance,
+  getSvmProvider,
+  getTokenInfo,
+  mapAsync,
+  parseUnits,
+  runTransaction,
+  sendRawTransaction,
+  Signer,
+  toAddressType,
+  toBN,
+  TOKEN_SYMBOLS_MAP,
+  TransactionReceipt,
+  WETH9,
+  ZERO_ADDRESS,
+} from "../utils";
+import { arch } from "@across-protocol/sdk";
+import { AcrossSwapApiClient, BalanceAllocator, HubPoolClient, MultiCallerClient } from "../clients";
+import { RedisCache } from "../caching/RedisCache";
+
+export interface RefillerClients {
+  balanceAllocator: BalanceAllocator;
+  hubPoolClient: HubPoolClient;
+  multiCallerClient: MultiCallerClient;
+}
+
+type SwapRoute = {
+  inputToken: EvmAddress;
+  outputToken: EvmAddress;
+  originChainId: number;
+  destinationChainId: number;
+};
+/**
+ * @notice This class is in charge of refilling native token balances for accounts running other bots, like the relayer and
+ * dataworker. It is run with an account whose funds are used to refill balances for other accounts by either swapping
+ * and transferring on the same chain or sending a cross chain swap.
+ */
+export class Refiller {
+  private balanceCache: { [chainId: number]: { [token: string]: { [account: string]: BigNumber } } } = {};
+  private decimals: { [chainId: number]: { [token: string]: number } } = {};
+  private acrossSwapApiClient: AcrossSwapApiClient;
+  private redisCache: RedisCache;
+  private baseSigner: Signer;
+  private baseSignerAddress: EvmAddress;
+  private enabledChainIds: number[];
+
+  public constructor(
+    readonly logger: winston.Logger,
+    readonly config: RefillerConfig,
+    readonly clients: RefillerClients
+  ) {
+    this.enabledChainIds = Object.keys(clients.balanceAllocator.providers).map(Number);
+    this.acrossSwapApiClient = new AcrossSwapApiClient(this.logger);
+    this.baseSigner = this.clients.hubPoolClient.hubPool.signer;
+  }
+
+  /**
+   * @notice One time initialization of the Refiller for any async operations.
+   */
+  async initialize(): Promise<void> {
+    this.baseSignerAddress = EvmAddress.from(await this.baseSigner.getAddress());
+    this.redisCache = (await getRedisCache(this.logger)) as RedisCache;
+  }
+
+  async refillNativeTokenBalances(): Promise<void> {
+    const { refillEnabledBalances } = this.config;
+    if (refillEnabledBalances.some(({ chainId }) => !this.enabledChainIds.includes(chainId))) {
+      throw new Error(
+        `Refiller#refillNativeTokenBalances: Some chain IDs are not enabled but requested in refillEnabledBalances: (enabledChains: ${
+          this.enabledChainIds
+        }, refillEnabledBalancesChains: ${refillEnabledBalances.map(({ chainId }) => chainId)})`
+      );
+    }
+
+    // Check for current balances.
+    const currentBalances = await this._getBalances(refillEnabledBalances);
+    const decimalValues = await this._getDecimals(refillEnabledBalances);
+    this.logger.debug({
+      at: "Refiller#refillNativeTokenBalances",
+      message: "Checking native token balances",
+      currentBalances: refillEnabledBalances.map(({ chainId, token, account, target }, i) => {
+        return {
+          chainId,
+          token: token.toEvmAddress(),
+          account: account.toEvmAddress(),
+          currentBalance: currentBalances[i].toString(),
+          target: parseUnits(target.toString(), decimalValues[i]),
+        };
+      }),
+    });
+
+    // Compare current balances with triggers and send tokens if signer has enough balance.
+    await mapAsync(refillEnabledBalances, async ({ chainId, isHubPool, token, account, target, trigger }, i) => {
+      assert(token.eq(getNativeTokenAddressForChain(chainId)), "Token must be the native token");
+      const currentBalance = currentBalances[i];
+      const decimals = decimalValues[i];
+      const balanceTrigger = parseUnits(trigger.toString(), decimals);
+      const isBelowTrigger = currentBalance.lte(balanceTrigger);
+      if (isBelowTrigger) {
+        // Fill balance back to target, not trigger.
+        const balanceTarget = parseUnits(target.toString(), decimals);
+        const deficit = balanceTarget.sub(currentBalance);
+        const selfRefill = account.eq(this.baseSignerAddress);
+        // If the account and the signer are the same, we can't transfer to ourselves so we need to try to go through
+        // one of the `canRefill` paths below, which tries to source the `token` from other means, like unwrapping
+        // WETH or sending a cross chain swap.
+        let canRefill = selfRefill
+          ? false
+          : await this.clients.balanceAllocator.requestBalanceAllocation(
+              chainId,
+              [token],
+              this.baseSignerAddress,
+              deficit
+            );
+        if (!canRefill && chainIsEvm(chainId)) {
+          // If token is the native token and the native token is ETH, try unwrapping some WETH into ETH first before
+          // transferring ETH to the account.
+          if (getNativeTokenSymbol(chainId) === "ETH") {
+            this.logger.debug({
+              at: "Refiller#refillNativeTokenBalances",
+              message: `Balance of ETH below trigger on chain ${chainId} and account has insufficient ETH to transfer on chain, now trying to unwrap WETH to refill ETH`,
+              chainId,
+              deficit,
+              account: this.baseSignerAddress,
+            });
+            const txn = await this._unwrapWethToRefill(chainId, deficit);
+            if (txn) {
+              this.logger.info({
+                at: "Refiller#refillNativeTokenBalances",
+                message: `Unwrapped WETH from ${this.baseSignerAddress} to refill ETH in ${account} 🎁!`,
+                chainId,
+                requiredUnwrapAmount: deficit.toString(),
+                ethBalance: currentBalance.toString(),
+                transactionHash: blockExplorerLink(txn.transactionHash, chainId),
+              });
+              // Don't return early and flip canRefill to true because we now have enough ETH to transfer to the account
+              canRefill = true;
+            } else {
+              return;
+            }
+          } else if (getNativeTokenSymbol(chainId) === "MATIC") {
+            // To refill MATIC, we will first submit an async cross chain swap to receive MATIC, and then on the next
+            // run, the refill should be successful. By default we will swap ETH on Arbitrum to MATIC on Polygon because
+            // bridging from Arbitrum is fast, and we tend to accumulate ETH on Arbitrum because its refunded for
+            // each L1->Arbitrum message we initiate.
+            const swapRoute: SwapRoute = {
+              // @dev When calling the Swap API, the ZERO_ADDRESS is associated with the native gas token, even if
+              // the native token address is not actually ZERO_ADDRESS.
+              inputToken: EvmAddress.from(ZERO_ADDRESS),
+              outputToken: EvmAddress.from(ZERO_ADDRESS),
+              originChainId: CHAIN_IDs.ARBITRUM,
+              destinationChainId: chainId,
+            };
+            this.logger.debug({
+              at: "Refiller#refillNativeTokenBalances",
+              message: `Balance of MATIC below trigger on chain ${chainId} and account has insufficient MATIC to transfer on chain, now trying to swap ETH from ${getNetworkName(
+                swapRoute.originChainId
+              )} to MATIC`,
+              swapRoute,
+              deficit,
+              account: this.baseSignerAddress,
+            });
+            const txn = await this._swapEthToMaticToRefill(swapRoute, deficit, EvmAddress.from(account.toEvmAddress()));
+            if (txn) {
+              this.logger.info({
+                at: "Monitor#refillBalances",
+                message: `Swapped ETH on ${getNetworkName(
+                  swapRoute.originChainId
+                )} to MATIC on Polygon for ${account} 🎁!`,
+                transactionHash: blockExplorerLink(txn.transactionHash, swapRoute.originChainId),
+              });
+            }
+            // Return early now because the cross chain swap, successful or not, is async and we won't be able to
+            // refill balances via a transfer() until the next bot iteration.
+            return;
+          }
+        }
+
+        // Now try to transfer native tokens from the base account to the target account on the same chain.
+        if (canRefill && chainIsEvm(chainId)) {
+          this.logger.debug({
+            at: "Monitor#refillBalances",
+            message: "Balance below trigger and can refill to target",
+            from: this.baseSignerAddress,
+            to: account.toEvmAddress(),
+            balanceTrigger,
+            balanceTarget,
+            deficit,
+            token: token.toEvmAddress(),
+            chainId,
+            isHubPool,
+          });
+          // There are three cases:
+          // 1. The account is the HubPool. In which case we need to call a special function to load ETH into it.
+          // 2. The account is not a HubPool and we want to load ETH.
+          if (isHubPool) {
+            // Note: We ignore the `token` if the account is HubPool because we can't call the method with other tokens.
+            this.clients.multiCallerClient.enqueueTransaction({
+              contract: this.clients.hubPoolClient.hubPool,
+              chainId: this.clients.hubPoolClient.chainId,
+              method: "loadEthForL2Calls",
+              args: [],
+              message: "Reloaded ETH in HubPool 🫡!",
+              mrkdwn: `Loaded ${formatUnits(deficit, decimals)} ETH from ${this.baseSignerAddress}.`,
+              value: deficit,
+            });
+          } else {
+            const nativeSymbolForChain = getNativeTokenSymbol(chainId);
+            // To send a raw transaction, we need to create a fake Contract instance at the recipient address and
+            // set the method param to be an empty string.
+            const sendRawTransactionContract = new Contract(
+              account.toEvmAddress(),
+              [],
+              this.baseSigner.connect(await getProvider(chainId))
+            );
+            const txn = await (await sendRawTransaction(this.logger, sendRawTransactionContract, deficit)).wait();
+            this.logger.info({
+              at: "Refiller#refillBalances",
+              message: `Reloaded ${formatUnits(deficit, decimals)} ${nativeSymbolForChain} for ${account} from ${
+                this.baseSignerAddress
+              } 🫡!`,
+              transactionHash: blockExplorerLink(txn.transactionHash, chainId),
+            });
+          }
+        } else {
+          this.logger.warn({
+            at: "Refiller#refillBalances",
+            message: "Cannot refill balance to target",
+            from: this.baseSignerAddress,
+            to: account,
+            currentBalance: currentBalance.toString(),
+            balanceTrigger,
+            balanceTarget,
+            deficit,
+            token,
+            chainId,
+          });
+        }
+      } else {
+        this.logger.debug({
+          at: "Refiller#refillBalances",
+          message: "Balance is above trigger",
+          account,
+          balanceTrigger,
+          currentBalance: currentBalance.toString(),
+          token,
+          chainId,
+        });
+      }
+    });
+  }
+
+  private async _unwrapWethToRefill(chainId: number, amount: BigNumber): Promise<TransactionReceipt | undefined> {
+    const weth = new Contract(
+      TOKEN_SYMBOLS_MAP.WETH.addresses[chainId],
+      WETH9.abi,
+      this.baseSigner.connect(await getProvider(chainId))
+    );
+    const hasSufficientWethBalance = await this.clients.balanceAllocator.requestBalanceAllocation(
+      chainId,
+      [toAddressType(weth.address, chainId)],
+      this.baseSignerAddress,
+      amount
+    );
+    if (hasSufficientWethBalance) {
+      return await (await runTransaction(this.logger, weth, "withdraw", [amount])).wait();
+    } else {
+      this.logger.warn({
+        at: "Refiller#refillNativeTokenBalances",
+        message: `Trying to unwrap WETH balance from ${this.baseSignerAddress} to use for refilling ETH but not enough WETH to unwrap`,
+        chainId,
+        requiredUnwrapAmount: amount.toString(),
+        wethAddress: weth.address,
+        account: this.baseSignerAddress,
+      });
+      return;
+    }
+  }
+
+  private async _swapEthToMaticToRefill(
+    swapRoute: SwapRoute,
+    amount: BigNumber,
+    recipient: EvmAddress
+  ): Promise<TransactionReceipt | undefined> {
+    const redisKey = `acrossSwap:${swapRoute.originChainId}-${swapRoute.inputToken.toNative()}->${
+      swapRoute.destinationChainId
+    }-${swapRoute.outputToken.toNative()}`;
+    const pendingSwap = await this.redisCache.get(redisKey);
+    if (pendingSwap) {
+      const ttl = await this.redisCache.ttl(redisKey);
+      this.logger.debug({
+        at: "Refiller#refillNativeTokenBalances",
+        message: `Found pending swap in cache with key ${redisKey}, avoiding new swap`,
+        ttl,
+      });
+      return;
+    }
+    const originSigner = this.baseSigner.connect(await getProvider(swapRoute.originChainId));
+    const swapData = await this.acrossSwapApiClient.swapExactOutput(
+      swapRoute,
+      amount,
+      this.baseSignerAddress,
+      recipient
+    );
+    if (swapData) {
+      const txn = await (
+        await sendRawTransaction(
+          this.logger,
+          new Contract(swapData.target.toNative(), [], originSigner),
+          swapData.value,
+          swapData.calldata
+        )
+      ).wait();
+      // Cache the swap for 10 minutes
+      // @todo Consider caching for some time relative to the estimated fill time returned by API, but
+      // 10 minutes is a reasonable conservative value to avoid duplicate swaps.
+      const ttl = 10 * 60;
+      await this.redisCache.set(redisKey, "true", ttl);
+      this.logger.debug({
+        at: "Monitor#refillBalances",
+        message: `Cached swap for ${redisKey}`,
+        ttl,
+      });
+      return txn;
+    } else {
+      // swapData will be undefined if the transaction simulation fails on the Across Swap API side, which
+      // can happen if the swapper doesn't have enough swap input token balance in addition to other
+      // miscellaneous reasons.
+      this.logger.warn({
+        at: "Monitor#refillBalances",
+        message: `Failed to swap ETH on ${getNetworkName(swapRoute.originChainId)} to MATIC on Polygon`,
+        swapRoute,
+        amount,
+        swapper: this.baseSignerAddress,
+        recipient: recipient.toEvmAddress(),
+      });
+    }
+  }
+
+  private async _getBalances(balanceRequests: BalanceRequest[]): Promise<BigNumber[]> {
+    return await Promise.all(
+      balanceRequests.map(async ({ chainId, token, account }) => {
+        if (this.balanceCache[chainId]?.[token.toBytes32()]?.[account.toBytes32()]) {
+          return this.balanceCache[chainId][token.toBytes32()][account.toBytes32()];
+        }
+        if (chainIsEvm(chainId)) {
+          const gasTokenAddressForChain = getNativeTokenAddressForChain(chainId);
+          const provider = await getProvider(chainId);
+          const balance = token.eq(gasTokenAddressForChain)
+            ? await provider.getBalance(account.toEvmAddress())
+            : await new Contract(token.toEvmAddress(), ERC20.abi, provider).balanceOf(account.toEvmAddress());
+          this.balanceCache[chainId] ??= {};
+          this.balanceCache[chainId][token.toBytes32()] ??= {};
+          this.balanceCache[chainId][token.toBytes32()][account.toBytes32()] = balance;
+          return balance;
+        }
+        // Assert balance request has solana types.
+        assert(chainIsSvm(chainId));
+        assert(token.isSVM());
+        assert(account.isSVM());
+        const provider = getSvmProvider(await getRedisCache());
+        if (!token.eq(getNativeTokenAddressForChain(chainId))) {
+          return getSolanaTokenBalance(provider, token, account);
+        } else {
+          const balanceInLamports = await provider.getBalance(arch.svm.toAddress(account)).send();
+          return toBN(Number(balanceInLamports.value));
+        }
+      })
+    );
+  }
+
+  private async _getDecimals(decimalrequests: { chainId: number; token: Address }[]): Promise<number[]> {
+    return await Promise.all(
+      decimalrequests.map(async ({ chainId, token }) => {
+        const gasTokenAddressForChain = getNativeTokenAddressForChain(chainId);
+        if (token.eq(gasTokenAddressForChain)) {
+          return chainIsEvm(chainId) ? 18 : 9;
+        } // Assume all EVM chains have 18 decimal native tokens.
+        if (this.decimals[chainId]?.[token.toBytes32()]) {
+          return this.decimals[chainId][token.toBytes32()];
+        }
+        let decimals: number;
+        if (chainIsEvm(chainId)) {
+          const provider = this.baseSigner.connect(await getProvider(chainId));
+          decimals = await new Contract(token.toEvmAddress(), ERC20.abi, provider).decimals();
+        } else {
+          decimals = getTokenInfo(token, chainId).decimals;
+        }
+        if (!this.decimals[chainId]) {
+          this.decimals[chainId] = {};
+        }
+        if (!this.decimals[chainId][token.toBytes32()]) {
+          this.decimals[chainId][token.toBytes32()] = decimals;
+        }
+        return decimals;
+      })
+    );
+  }
+}
+
+type BalanceRequest = { chainId: number; token: Address; account: Address };

--- a/src/refiller/RefillerClientHelper.ts
+++ b/src/refiller/RefillerClientHelper.ts
@@ -1,0 +1,34 @@
+import winston from "winston";
+import { RefillerClients } from "./Refiller";
+import { constructClients, getEnabledChainsInBlockRange, updateClients } from "../common";
+import { getProvider, mapAsync, Signer } from "../utils";
+import { BalanceAllocator } from "../clients";
+import { RefillerConfig } from "./RefillerConfig";
+
+export async function constructRefillerClients(
+  config: RefillerConfig,
+  logger: winston.Logger,
+  baseSigner: Signer
+): Promise<RefillerClients> {
+  // Set hubPoolLookback conservatively to be equal to one month of blocks. If the config.maxRelayerLookBack
+  // exceeds half a month, then we'll just use the gensis block since in that case, this monitor is being used
+  // for non-production circumstances.
+  const hubPoolLookback = config.maxRelayerLookBack > 3600 * 24 * 15 ? undefined : 3600 * 24 * 30;
+  const commonClients = await constructClients(logger, config, baseSigner, hubPoolLookback);
+  const { hubPoolClient, configStoreClient } = commonClients;
+
+  await updateClients(commonClients, config, logger);
+  await hubPoolClient.update();
+
+  const enabledChains = getEnabledChainsInBlockRange(
+    configStoreClient,
+    config.spokePoolChainsOverride,
+    hubPoolLookback
+  );
+  const l2Providers = Object.fromEntries(
+    await mapAsync(enabledChains, async (chainId) => [chainId, await getProvider(chainId)])
+  );
+  const balanceAllocator = new BalanceAllocator(l2Providers);
+
+  return { ...commonClients, balanceAllocator };
+}

--- a/src/refiller/RefillerConfig.ts
+++ b/src/refiller/RefillerConfig.ts
@@ -1,0 +1,52 @@
+import { CommonConfig, ProcessEnv } from "../common";
+import { getNativeTokenAddressForChain, Address, toAddressType } from "../utils";
+
+export class RefillerConfig extends CommonConfig {
+  readonly refillEnabledBalances: {
+    chainId: number;
+    isHubPool: boolean;
+    account: Address;
+    token: Address;
+    target: number;
+    trigger: number;
+  }[] = [];
+
+  constructor(env: ProcessEnv) {
+    super(env);
+
+    const { REFILL_BALANCES } = env;
+
+    // Used to send tokens if available in wallet to balances under target balances.
+    if (REFILL_BALANCES) {
+      this.refillEnabledBalances = JSON.parse(REFILL_BALANCES).map(
+        ({ chainId, account, isHubPool, target, trigger }) => {
+          if (Number.isNaN(target) || target <= 0) {
+            throw new Error(`target for ${chainId} and ${account} must be > 0, got ${target}`);
+          }
+          if (Number.isNaN(trigger) || trigger <= 0) {
+            throw new Error(`trigger for ${chainId} and ${account} must be > 0, got ${trigger}`);
+          }
+          if (trigger >= target) {
+            throw new Error("trigger must be < target");
+          }
+          return {
+            // Required fields:
+            chainId,
+            account: toAddressType(account, chainId),
+            target,
+            trigger,
+            // Optional fields that will set to defaults:
+            isHubPool: Boolean(isHubPool),
+            // Fields that are always set to defaults:
+            token: getNativeTokenAddressForChain(chainId),
+          };
+        }
+      );
+    }
+
+    // Should only have 1 HubPool.
+    if (Object.values(this.refillEnabledBalances).filter((x) => x.isHubPool).length > 1) {
+      throw new Error("REFILL_BALANCES should only have 1 account marked isHubPool as true");
+    }
+  }
+}

--- a/src/refiller/index.ts
+++ b/src/refiller/index.ts
@@ -1,0 +1,32 @@
+import { winston, processEndPollingLoop, config, startupLogLevel, Signer, disconnectRedisClients } from "../utils";
+import { Refiller } from "./Refiller";
+import { constructRefillerClients } from "./RefillerClientHelper";
+import { RefillerConfig } from "./RefillerConfig";
+config();
+let logger: winston.Logger;
+
+export async function runRefiller(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
+  logger = _logger;
+  const config = new RefillerConfig(process.env);
+  const clients = await constructRefillerClients(config, logger, baseSigner);
+  const refiller = new Refiller(logger, config, clients);
+  await refiller.initialize();
+
+  try {
+    logger[startupLogLevel(config)]({ at: "Refiller#index", message: "Refiller started ⛽️", config });
+    for (;;) {
+      const loopStart = Date.now();
+      await refiller.refillNativeTokenBalances();
+
+      await clients.multiCallerClient.executeTxnQueues();
+
+      logger.debug({ at: "Monitor#index", message: `Time to loop: ${(Date.now() - loopStart) / 1000}s` });
+
+      if (await processEndPollingLoop(logger, "Monitor#index", config.pollingDelay)) {
+        break;
+      }
+    }
+  } finally {
+    await disconnectRedisClients(logger);
+  }
+}

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -39,6 +39,10 @@ export class RedisClient {
     return this.client.get(this.getNamespacedKey(key));
   }
 
+  async ttl(key: string): Promise<number | undefined> {
+    return this.client.ttl(this.getNamespacedKey(key));
+  }
+
   async set(key: string, val: string, expirySeconds = constants.DEFAULT_CACHING_TTL): Promise<void> {
     // Apply namespace to key.
     key = this.getNamespacedKey(key);

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -162,7 +162,7 @@ export async function runTransaction(
 
   try {
     return sendRawTxn
-      ? await signer.sendTransaction({ to, value, ...gas })
+      ? await signer.sendTransaction({ to, value, data: args as ethers.utils.BytesLike, ...gas })
       : await contract[method](...(args as Array<unknown>), txConfig);
   } catch (error) {
     if (retries > 0 && txnRetryable(error)) {

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -215,6 +215,20 @@ export async function runTransaction(
   }
 }
 
+export async function sendRawTransaction(
+  logger: winston.Logger,
+  contract: Contract,
+  value = bnZero,
+  calldata: unknown | null = null,
+  gasLimit: BigNumber | null = null,
+  nonce: number | null = null,
+  retries = 1
+): Promise<TransactionResponse> {
+  // method is always an empty string when sending a raw transaction
+  // calldata should be undefined if not sending any calldata to a contract.
+  return await runTransaction(logger, contract, "", calldata, value, gasLimit, nonce, retries);
+}
+
 export async function sendAndConfirmSolanaTransaction(
   unsignedTransaction: CompilableTransactionMessage,
   signer: KeyPairSigner,


### PR DESCRIPTION
This removes all the `refillBalances` logic from the Monitor and moves it into its own bot. This should be much easier to maintain

