### PR TITLE
opStack: use L1 chain for viem getTimeToFinalize

### DIFF
--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -427,7 +427,7 @@ async function viem_multicallOptimismFinalizations(
       }
     } else if (withdrawalStatus === "waiting-to-finalize") {
       const { seconds } = await getTimeToFinalize(publicClientL1 as viem.Client, {
-        chain: VIEM_OP_STACK_CHAINS[hubChainId],
+        chain: publicClientL1.chain as viem.Chain,
         withdrawalHash: withdrawal.withdrawalHash,
         targetChain: viemOpStackTargetChainParam,
       });


### PR DESCRIPTION
- getTimeToFinalize executes on L1 and expects the L1 chain object; previously it used VIEM_OP_STACK_CHAINS[hubChainId], which maps L2 chains and is incorrect for an L1 id.
- Using an L2 mapping keyed by an L1 id can resolve to undefined and/or query the wrong chain, producing incorrect challenge-period timings.
- This aligns with surrounding viem calls that already pass L1 (getWithdrawalStatus, getL2Output) and keeps the L2 chain only for buildProveWithdrawal.