### PR TITLE
improve(InventoryClient): Initialize BundleDataApproxClient with all possible L1 tokens

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -92,7 +92,7 @@ export class InventoryClient {
       this.tokenClient?.spokePoolClients ?? {},
       this.hubPoolClient,
       this.chainIdList,
-      this.getL1TokensFromInventoryConfig().concat(this.hubPoolClient.getL1Tokens().map((l1Token) => l1Token.address)),
+      this.getL1TokensFromInventoryConfig().concat(this.getL1TokensEnabledInHubPool()),
       this.logger
     );
   }
@@ -312,12 +312,16 @@ export class InventoryClient {
 
   getL1Tokens(): EvmAddress[] {
     return this.inventoryConfig?.tokenConfig
-      ? Object.keys(this.inventoryConfig?.tokenConfig).map((token) => EvmAddress.from(token))
-      : this.hubPoolClient.getL1Tokens().map((l1Token) => l1Token.address);
+      ? this.getL1TokensFromInventoryConfig()
+      : this.getL1TokensEnabledInHubPool();
   }
 
   getL1TokensFromInventoryConfig(): EvmAddress[] {
     return Object.keys(this.inventoryConfig?.tokenConfig ?? {}).map((token) => EvmAddress.from(token));
+  }
+
+  getL1TokensEnabledInHubPool(): EvmAddress[] {
+    return this.hubPoolClient.getL1Tokens().map((l1Token) => l1Token.address);
   }
 
   // Decrement Tokens Balance And Increment Cross Chain Transfer

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -232,7 +232,7 @@ export class InventoryClient {
    */
   getTokenDistributionPerL1Token(): TokenDistributionPerL1Token {
     const distributionPerL1Token: TokenDistributionPerL1Token = {};
-    this.getL1TokensFromInventoryConfig().forEach(
+    this.getL1Tokens().forEach(
       (l1Token) => (distributionPerL1Token[l1Token.toNative()] = this.getChainDistribution(l1Token))
     );
     return distributionPerL1Token;

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -1538,6 +1538,7 @@ export class InventoryClient {
     if (!this.isInventoryManagementEnabled()) {
       return;
     }
+    const l1Tokens = this.getL1Tokens();
     this.log("Checking token approvals", { l1Tokens: l1Tokens.map((token) => token.toEvmAddress()) });
 
     await this.adapterManager.setL1TokenApprovals(l1Tokens);

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -88,11 +88,17 @@ export class InventoryClient {
       logger: this.logger,
       at: "InventoryClient",
     });
+    // Load all L1 tokens from inventory config and hub pool into a Set to deduplicate.
+    const allL1Tokens = new Set<string>(
+      this.getL1TokensFromInventoryConfig()
+        .concat(this.getL1TokensEnabledInHubPool())
+        .map((l1Token) => l1Token.toNative())
+    );
     this.bundleDataApproxClient = new BundleDataApproxClient(
       this.tokenClient?.spokePoolClients ?? {},
       this.hubPoolClient,
       this.chainIdList,
-      this.getL1TokensFromInventoryConfig().concat(this.getL1TokensEnabledInHubPool()),
+      Array.from(allL1Tokens.values()).map((l1Token) => EvmAddress.from(l1Token)),
       this.logger
     );
   }

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -28,6 +28,7 @@ import {
   TOKEN_SYMBOLS_MAP,
   toAddressType,
   depositForcesOriginChainRepayment,
+  EvmAddress,
 } from "../src/utils";
 import { MockAdapterManager, MockHubPoolClient, MockInventoryClient, MockTokenClient } from "./mocks";
 import { utils as sdkUtils } from "@across-protocol/sdk";
@@ -91,8 +92,8 @@ describe("InventoryClient: Refund chain selection", async function () {
   };
 
   const seedMocks = (seedBalances: { [chainId: string]: { [token: string]: BigNumber } }) => {
-    hubPoolClient.addL1Token({ address: mainnetWeth, decimals: 18, symbol: "WETH" });
-    hubPoolClient.addL1Token({ address: mainnetUsdc, decimals: 6, symbol: "USDC" });
+    hubPoolClient.addL1Token({ address: EvmAddress.from(mainnetWeth), decimals: 18, symbol: "WETH" });
+    hubPoolClient.addL1Token({ address: EvmAddress.from(mainnetUsdc), decimals: 6, symbol: "USDC" });
     Object.keys(seedBalances).forEach((_chainId) => {
       const chainId = Number(_chainId);
       adapterManager.setMockedOutstandingCrossChainTransfers(

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -409,7 +409,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
           profitClient,
           multiCallerClient,
           tryMulticallClient,
-          inventoryClient: new MockInventoryClient(),
+          inventoryClient: new MockInventoryClient(null, null, null, null, null, hubPoolClient),
           acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, chainIds),
         },
         {


### PR DESCRIPTION
Downside:
- initialize()-ing the BundleDataApproxClient will be slower because it is now fetching refunds over all L1 tokens, regardless if the user sets a smaller subset in the inventory config

Upside:
- Relayer will not complain if a token is enabled in RELAYED_SUPPORTED_TOKENS but not in the INVENTORY_CONFIG because the refund data will now be available in the BundleDataApproxClient
