### PR TITLE
chore(TransactionUtils): Drop LEGACY_TRANSACTION_CHAINS

### DIFF
--- a/scripts/sendTokens.ts
+++ b/scripts/sendTokens.ts
@@ -1,4 +1,5 @@
 import {
+  bnZero,
   ethers,
   retrieveSignerFromCLIArgs,
   getProvider,
@@ -8,7 +9,6 @@ import {
   getGasPrice,
   toGWei,
   getNativeTokenSymbol,
-  LEGACY_TRANSACTION_CHAINS,
 } from "../src/utils";
 import { askYesNoQuestion } from "./utils";
 import minimist from "minimist";
@@ -68,7 +68,7 @@ export async function run(): Promise<void> {
   console.log(
     `Submitting txn with maxFeePerGas ${gas.maxFeePerGas.toString()} and priority fee ${gas.maxPriorityFeePerGas.toString()} with overridden nonce ${nonce}`
   );
-  const gasParams = LEGACY_TRANSACTION_CHAINS.includes(Number(args.chainId))
+  const gasParams = gas.maxPriorityFeePerGas.eq(bnZero)
     ? { gasPrice: gas.maxFeePerGas.add(gas.maxPriorityFeePerGas) }
     : { ...gas };
 

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -31,9 +31,6 @@ import {
 
 dotenv.config();
 
-// Define chains that require legacy (type 0) transactions
-export const LEGACY_TRANSACTION_CHAINS = [CHAIN_IDs.BSC];
-
 export type TransactionSimulationResult = {
   transaction: AugmentedTransaction;
   succeed: boolean;
@@ -339,8 +336,8 @@ function scaleGasPrice(
   const scaler = toBNWei(retryScaler);
   const flooredPriorityFeePerGas = parseUnits(process.env[`MIN_PRIORITY_FEE_PER_GAS_${chainId}`] || "0", 9);
 
-  // Check if the chain requires legacy transactions
-  if (LEGACY_TRANSACTION_CHAINS.includes(chainId)) {
+  // Legacy/type0 transactions are supplied as a type2 transaction with priority fee 0. Convert to type0 here.
+  if (gas.maxPriorityFeePerGas.eq(bnZero)) {
     const gasPrice = sdkUtils.bnMax(gas.maxFeePerGas, flooredPriorityFeePerGas).mul(scaler).div(fixedPointAdjustment);
     return { gasPrice };
   }


### PR DESCRIPTION
sdk/gasPriceOracle already has a mapping for legacy chains. It always returns gas prices in type2 formatting, but it sets the priority fee on type0 chains to 0. Currently this is BSC, Scroll and zkSync, but the mapping here only considered BSC.