### PR TITLE
fix(rebalancer): Don't flush TokenClient state prematurely

### DIFF
--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -172,7 +172,7 @@ export async function runRebalancer(_logger: winston.Logger, baseSigner: Signer)
   logger.debug({ at, message: `${personality} started 🏃‍♂️`, loggedConfig });
   const clients = await constructRelayerClients(logger, config, baseSigner);
 
-  const { inventoryClient, tokenClient } = clients;
+  const { inventoryClient } = clients;
   const inventoryManagement = clients.inventoryClient.isInventoryManagementEnabled();
   if (!inventoryManagement) {
     logger.debug({ at, message: "Inventory management disabled, nothing to do." });
@@ -188,9 +188,6 @@ export async function runRebalancer(_logger: winston.Logger, baseSigner: Signer)
     await rebalancer.checkForUnfilledDepositsAndFill(false, true);
     await rebalancer.runMaintenance();
 
-    // It's necessary to update token balances in case WETH was wrapped.
-    tokenClient.clearTokenData();
-    await tokenClient.update();
     if (config.sendingTransactionsEnabled) {
       await inventoryClient.setTokenApprovals();
     }

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -186,7 +186,6 @@ export async function runRebalancer(_logger: winston.Logger, baseSigner: Signer)
     await rebalancer.init();
     await rebalancer.update();
     await rebalancer.checkForUnfilledDepositsAndFill(false, true);
-    await rebalancer.runMaintenance();
 
     if (config.sendingTransactionsEnabled) {
       await inventoryClient.setTokenApprovals();


### PR DESCRIPTION
Flushing TokenClient state before considering withdrawals means that the rebalancer assumes that there are no deposits awaiting to be filled. This can cause the rebalancer to pull back tokens that were intended to be used by the relayer to fill shortfalls. The rebalancer should instead factor in any simulated fills that were made as part of identifying shortfalls. 