### PR TITLE
improve(reporter): Log total balance to datadog

### DIFF
--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -527,7 +527,7 @@ export class Monitor {
           throw new Error(`No decimals found for ${tokenSymbol}`);
         }
         Object.entries(columns).forEach(([chainName, cell]) => {
-          if (this._tokenEnabledForNetwork(tokenSymbol, chainName)) {
+          if (this._tokenEnabledForNetwork(tokenSymbol, chainName) || chainName === ALL_CHAINS_NAME) {
             Object.entries(cell).forEach(([balanceType, balance]) => {
               // Don't log zero balances.
               if (balance.isZero()) {


### PR DESCRIPTION
We currently only log single chain balances for Datadog consumption which makes tracking total balance at snapshots in time difficult
