### PR TITLE
docs(env): fix typo in .env.example comment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -269,7 +269,7 @@ RELAYER_TOKENS='["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", "0xA0b86991c6218b
 # and ARWEAVE_GATEWAY must be set to valid values.
 PERSIST_DATA_TO_ARWEAVE=false
 
-# This wallet JWK is used to sign transactions intended for permenant storage of bundle
+# This wallet JWK is used to sign transactions intended for permanent storage of bundle
 # data on Arweave. Ensure that the wallet has enough AR to cover the cost of storage.
 ARWEAVE_WALLET_JWK=$({"kty":"", "e":"", "n":"", "d":"", "p":"", "q":"", "dp":"", "dq":"", "qi":""})
 


### PR DESCRIPTION


### Description
- Corrected typo: “permenant” → “permanent” in Arweave bundle storage comment.
- Docs-only change in `.env.example`; no functional impact.

