### PR TITLE
improve(ProfitClient): Better inference of native gas tokens

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -766,16 +766,6 @@ export class ProfitClient {
     return dedupArray([...hubPoolTokens, ...additionalL1Tokens]);
   }
 
-  private _getNativeTokenNetwork(symbol: string): number {
-    const symbols = {
-      HYPE: CHAIN_IDs.HYPEREVM,
-      XPL: CHAIN_IDs.PLASMA,
-      SOL: CHAIN_IDs.SOLANA,
-    };
-
-    return symbols[symbol] ?? CHAIN_IDs.MAINNET;
-  }
-
   private constructRelayerFeeQuery(
     chainId: number,
     provider: Provider | SVMProvider


### PR DESCRIPTION
This area has been an issue for custom gas tokens on Solana, HyperEVM and Plasma. Always try to grab the mainnet address for the native gas token, and revert to the token address on the destination chain if that fails. This relies on the wrapped and native token addresses having the same configurations in the constants repo; for now that holds true.