### PR TITLE
chore: define more CEX bridge routes

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -649,6 +649,7 @@ export const CUSTOM_L2_BRIDGE: {
     [TOKEN_SYMBOLS_MAP.ezETH.addresses[CHAIN_IDs.MAINNET]]: HyperlaneXERC20BridgeL2,
     [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: L2UsdcCCTPBridge,
     [TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.MAINNET]]: OFTL2Bridge,
+    [TOKEN_SYMBOLS_MAP.DAI.addresses[CHAIN_IDs.MAINNET]]: L2BinanceCEXBridge,
   },
   [CHAIN_IDs.HYPEREVM]: {
     [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: L2UsdcCCTPBridge,
@@ -685,6 +686,9 @@ export const CUSTOM_L2_BRIDGE: {
   [CHAIN_IDs.WORLD_CHAIN]: {
     [TOKEN_SYMBOLS_MAP.ezETH.addresses[CHAIN_IDs.MAINNET]]: HyperlaneXERC20BridgeL2,
     [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: L2UsdcCCTPBridge,
+  },
+  [CHAIN_IDs.ZK_SYNC]: {
+    [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: L2BinanceCEXBridge,
   },
 };
 

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -24,11 +24,12 @@ type WithdrawalQuota = {
 
 // Alias for Binance network symbols.
 export const BINANCE_NETWORKS: { [chainId: number]: string } = {
-  [CHAIN_IDs.MAINNET]: "ETH",
-  [CHAIN_IDs.BSC]: "BSC",
   [CHAIN_IDs.ARBITRUM]: "ARBITRUM",
-  [CHAIN_IDs.OPTIMISM]: "OPTIMISM",
   [CHAIN_IDs.BASE]: "BASE",
+  [CHAIN_IDs.BSC]: "BSC",
+  [CHAIN_IDs.MAINNET]: "ETH",
+  [CHAIN_IDs.OPTIMISM]: "OPTIMISM",
+  [CHAIN_IDs.ZK_SYNC]: "ZKSYNCERA",
 };
 
 // A Coin contains balance data and network information (such as withdrawal limits, extra information about the network, etc.) for a specific


### PR DESCRIPTION
This can be merged with no immediate effect since in order for withdrawals to happen, withdrawal parameters need to be set in the inventory config.