### PR TITLE
Guard stringifyThrownValue against null/undefined

### DIFF
--- a/src/utils/LogUtils.ts
+++ b/src/utils/LogUtils.ts
@@ -1,6 +1,9 @@
 export type DefaultLogLevels = "debug" | "info" | "warn" | "error";
 
 export function stringifyThrownValue(value: unknown): string {
+  if (value == null) {
+    return `ThrownValue: ${String(value)}`;
+  }
   if (value instanceof Error) {
     const errToString = value.toString();
     return value.stack


### PR DESCRIPTION
## Description

Add a null/undefined guard to stringifyThrownValue in `src/utils/LogUtils.ts` to prevent `null.toString()`/`undefined.toString()` TypeErrors during error logging. This path is hit when non-Error values (e.g., rejected promises, library throws) bubble up to logging.