### PR TITLE
feat: Support CCTP V2 rebalancing for EVM chains

### DIFF
--- a/src/adapter/bridges/UsdcCCTPBridge.ts
+++ b/src/adapter/bridges/UsdcCCTPBridge.ts
@@ -66,6 +66,8 @@ export class UsdcCCTPBridge extends BaseBridgeAdapter {
     amount: BigNumber
   ): Promise<BridgeTransactionDetails> {
     assert(l1Token.eq(this.l1UsdcTokenAddress));
+    // Check for fast-transfer allowance and also min fee, and if they are reasonable, then
+    // construct a fast transfer, otherwise default to a standard transfer.
     amount = amount.gt(this.CCTP_MAX_SEND_AMOUNT) ? this.CCTP_MAX_SEND_AMOUNT : amount;
     return Promise.resolve({
       contract: this.getL1Bridge(),

--- a/src/adapter/bridges/UsdcTokenSplitterBridge.ts
+++ b/src/adapter/bridges/UsdcTokenSplitterBridge.ts
@@ -24,7 +24,6 @@ export class UsdcTokenSplitterBridge extends BaseBridgeAdapter {
     l1Signer: Signer,
     l2SignerOrProvider: Signer | Provider,
     l1Token: EvmAddress,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     logger: winston.Logger
   ) {
     const canonicalBridge = new CANONICAL_BRIDGE[l2chainId](

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -623,6 +623,7 @@ export class ProfitClient {
     this.enabledChainIds.forEach((chainId) => {
       const symbol = getNativeTokenSymbol(chainId);
       let nativeTokenAddress = TOKEN_SYMBOLS_MAP[symbol]?.addresses[this._getNativeTokenNetwork(symbol)];
+      console.log(`native token address for chain ${chainId} is ${nativeTokenAddress}, native token symbol is ${symbol}`);
       // For testnet only, if the custom gas token has no mainnet address, use ETH.
       if (this.hubPoolClient.chainId === CHAIN_IDs.SEPOLIA && !isDefined(nativeTokenAddress)) {
         nativeTokenAddress = TOKEN_SYMBOLS_MAP["ETH"].addresses[CHAIN_IDs.MAINNET];
@@ -640,6 +641,7 @@ export class ProfitClient {
 
     try {
       const tokenAddrs = Array.from(new Set(Object.values(tokens)));
+      console.log("tokenAddrs", tokenAddrs);
       const tokenPrices = await this.priceClient.getPricesByAddress(tokenAddrs, "usd");
       tokenPrices.forEach(({ address, price }) => (this.tokenPrices[address] = toBNWei(price)));
       this.logger.debug({ at: "ProfitClient", message: "Updated token prices", tokenPrices: this.tokenPrices });

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -361,7 +361,7 @@ export const SUPPORTED_TOKENS: { [chainId: number]: string[] } = {
   [CHAIN_IDs.ARBITRUM]: ["USDC", "USDT", "WETH", "DAI", "WBTC", "UMA", "BAL", "ACX", "POOL", "ezETH"],
   [CHAIN_IDs.BASE]: ["BAL", "DAI", "ETH", "WETH", "USDC", "USDT", "POOL", "VLR", "ezETH"],
   [CHAIN_IDs.BLAST]: ["DAI", "WBTC", "WETH", "ezETH"],
-  [CHAIN_IDs.BSC]: ["CAKE", "WBNB", "USDC", "USDT", "WETH"],
+  // [CHAIN_IDs.BSC]: ["CAKE", "WBNB", "USDC", "USDT", "WETH"],
   [CHAIN_IDs.HYPEREVM]: ["USDC", "USDT"],
   [CHAIN_IDs.INK]: ["ETH", "WETH"],
   [CHAIN_IDs.LENS]: ["WETH", "WGHO", "USDC"],

--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -250,26 +250,26 @@ export const CONTRACT_ADDRESSES: {
     nativeToken: {
       address: "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
     },
-    cctpMessageTransmitter: {
-      address: "0x4d41f22c5a0e5c74090899e5a8fb597a8842b3e8",
-      abi: CCTP_MESSAGE_TRANSMITTER_ABI,
+    cctpV2MessageTransmitter: {
+      address: "0x81D40F21F12A8F0E3252Bccb954D722d4c464B64",
+      abi: CCTP_MESSAGE_TRANSMITTER_ABI, // Same ABI as V1 as far as functions we care about, so overload for now.
     },
-    cctpTokenMessenger: {
-      address: "0x2B4069517957735bE00ceE0fadAE88a26365528f",
-      abi: CCTP_TOKEN_MESSENGER_ABI,
+    cctpV2TokenMessenger: {
+      address: "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+      abi: CCTP_V2_TOKEN_MESSENGER_ABI,
     },
   },
   [CHAIN_IDs.POLYGON]: {
     withdrawableErc20: {
       abi: POLYGON_WITHDRAWABLE_ERC20_ABI,
     },
-    cctpMessageTransmitter: {
-      address: "0xF3be9355363857F3e001be68856A2f96b4C39Ba9",
-      abi: CCTP_MESSAGE_TRANSMITTER_ABI,
+    cctpV2MessageTransmitter: {
+      address: "0x81D40F21F12A8F0E3252Bccb954D722d4c464B64",
+      abi: CCTP_MESSAGE_TRANSMITTER_ABI, // Same ABI as V1 as far as functions we care about, so overload for now.
     },
-    cctpTokenMessenger: {
-      address: "0x9daF8c91AEFAE50b9c0E69629D3F6Ca40cA3B3FE",
-      abi: CCTP_TOKEN_MESSENGER_ABI,
+    cctpV2TokenMessenger: {
+      address: "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+      abi: CCTP_V2_TOKEN_MESSENGER_ABI,
     },
     nativeToken: {
       address: "0x0000000000000000000000000000000000001010",
@@ -300,13 +300,13 @@ export const CONTRACT_ADDRESSES: {
     },
   },
   [CHAIN_IDs.UNICHAIN]: {
-    cctpMessageTransmitter: {
-      address: "0x353bE9E2E38AB1D19104534e4edC21c643Df86f4",
-      abi: CCTP_MESSAGE_TRANSMITTER_ABI,
+    cctpV2MessageTransmitter: {
+      address: "0x81D40F21F12A8F0E3252Bccb954D722d4c464B64",
+      abi: CCTP_MESSAGE_TRANSMITTER_ABI, // Same ABI as V1 as far as functions we care about, so overload for now.
     },
-    cctpTokenMessenger: {
-      address: "0x4e744b28E787c3aD0e810eD65A24461D4ac5a762",
-      abi: CCTP_TOKEN_MESSENGER_ABI,
+    cctpV2TokenMessenger: {
+      address: "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+      abi: CCTP_V2_TOKEN_MESSENGER_ABI,
     },
     ovmStandardBridge: {
       address: "0x4200000000000000000000000000000000000010",
@@ -387,13 +387,13 @@ export const CONTRACT_ADDRESSES: {
     nativeToken: {
       address: "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
     },
-    cctpMessageTransmitter: {
-      address: "0xAD09780d193884d503182aD4588450C416D6F9D4",
-      abi: CCTP_MESSAGE_TRANSMITTER_ABI,
+    cctpV2MessageTransmitter: {
+      address: "0x81D40F21F12A8F0E3252Bccb954D722d4c464B64",
+      abi: CCTP_MESSAGE_TRANSMITTER_ABI, // Same ABI as V1 as far as functions we care about, so overload for now.
     },
-    cctpTokenMessenger: {
-      address: "0x1682Ae6375C4E4A97e4B583BC394c861A46D8962",
-      abi: CCTP_TOKEN_MESSENGER_ABI,
+    cctpV2TokenMessenger: {
+      address: "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+      abi: CCTP_V2_TOKEN_MESSENGER_ABI,
     },
   },
   [CHAIN_IDs.MODE]: {
@@ -438,13 +438,13 @@ export const CONTRACT_ADDRESSES: {
     },
   },
   [CHAIN_IDs.ARBITRUM]: {
-    cctpMessageTransmitter: {
-      address: "0xC30362313FBBA5cf9163F0bb16a0e01f01A896ca",
-      abi: CCTP_MESSAGE_TRANSMITTER_ABI,
+    cctpV2MessageTransmitter: {
+      address: "0x81D40F21F12A8F0E3252Bccb954D722d4c464B64",
+      abi: CCTP_MESSAGE_TRANSMITTER_ABI, // Same ABI as V1 as far as functions we care about, so overload for now.
     },
-    cctpTokenMessenger: {
-      address: "0x19330d10D9Cc8751218eaf51E8885D058642E08A",
-      abi: CCTP_TOKEN_MESSENGER_ABI,
+    cctpV2TokenMessenger: {
+      address: "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+      abi: CCTP_V2_TOKEN_MESSENGER_ABI,
     },
     arbSys: {
       address: "0x0000000000000000000000000000000000000064",
@@ -563,6 +563,14 @@ export const CONTRACT_ADDRESSES: {
       address: "0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5",
       abi: CCTP_TOKEN_MESSENGER_ABI,
     },
+    cctpV2MessageTransmitter: {
+      address: "0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275",
+      abi: CCTP_MESSAGE_TRANSMITTER_ABI, // Same ABI as V1 as far as functions we care about, so overload for now.
+    },
+    cctpV2TokenMessenger: {
+      address: "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA",
+      abi: CCTP_V2_TOKEN_MESSENGER_ABI,
+    },
     atomicDepositor: {
       address: "0xdf87d6eFd856D6145Fcd387252cefD12868AC593",
       abi: ATOMIC_DEPOSITOR_ABI,
@@ -606,28 +614,28 @@ export const CONTRACT_ADDRESSES: {
     },
   },
   [CHAIN_IDs.ARBITRUM_SEPOLIA]: {
-    cctpTokenMessenger: {
-      address: "0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5",
-      abi: CCTP_TOKEN_MESSENGER_ABI,
+    cctpV2MessageTransmitter: {
+      address: "0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275",
+      abi: CCTP_MESSAGE_TRANSMITTER_ABI, // Same ABI as V1 as far as functions we care about, so overload for now.
     },
-    cctpMessageTransmitter: {
-      address: "0xaCF1ceeF35caAc005e15888dDb8A3515C41B4872",
-      abi: CCTP_MESSAGE_TRANSMITTER_ABI,
-    },
+    cctpV2TokenMessenger: {
+      address: "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA",
+      abi: CCTP_V2_TOKEN_MESSENGER_ABI,
+    },  
   },
   [CHAIN_IDs.BASE_SEPOLIA]: {
     ovmStandardBridge: {
       address: "0x4200000000000000000000000000000000000010",
       abi: OVM_L2_STANDARD_BRIDGE_ABI,
     },
-    cctpMessageTransmitter: {
-      address: "0x7865fAfC2db2093669d92c0F33AeEF291086BEFD",
-      abi: CCTP_MESSAGE_TRANSMITTER_ABI,
+    cctpV2MessageTransmitter: {
+      address: "0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275",
+      abi: CCTP_MESSAGE_TRANSMITTER_ABI, // Same ABI as V1 as far as functions we care about, so overload for now.
     },
-    cctpTokenMessenger: {
-      address: "0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5",
-      abi: CCTP_TOKEN_MESSENGER_ABI,
-    },
+    cctpV2TokenMessenger: {
+      address: "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA",
+      abi: CCTP_V2_TOKEN_MESSENGER_ABI,
+    },  
   },
   [CHAIN_IDs.BLAST_SEPOLIA]: {
     ovmStandardBridge: {
@@ -670,27 +678,27 @@ export const CONTRACT_ADDRESSES: {
       address: "0x4200000000000000000000000000000000000010",
       abi: OVM_L2_STANDARD_BRIDGE_ABI,
     },
-    cctpTokenMessenger: {
-      address: "0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5",
-      abi: CCTP_TOKEN_MESSENGER_ABI,
+    cctpV2MessageTransmitter: {
+      address: "0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275",
+      abi: CCTP_MESSAGE_TRANSMITTER_ABI, // Same ABI as V1 as far as functions we care about, so overload for now.
     },
-    cctpMessageTransmitter: {
-      address: "0x7865fAfC2db2093669d92c0F33AeEF291086BEFD",
-      abi: CCTP_MESSAGE_TRANSMITTER_ABI,
-    },
+    cctpV2TokenMessenger: {
+      address: "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA",
+      abi: CCTP_V2_TOKEN_MESSENGER_ABI,
+    },  
   },
   [CHAIN_IDs.POLYGON_AMOY]: {
     withdrawableErc20: {
       abi: POLYGON_WITHDRAWABLE_ERC20_ABI,
     },
-    cctpTokenMessenger: {
-      address: "0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5",
-      abi: CCTP_TOKEN_MESSENGER_ABI,
+    cctpV2MessageTransmitter: {
+      address: "0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275",
+      abi: CCTP_MESSAGE_TRANSMITTER_ABI, // Same ABI as V1 as far as functions we care about, so overload for now.
     },
-    cctpMessageTransmitter: {
-      address: "0x7865fAfC2db2093669d92c0F33AeEF291086BEFD",
-      abi: CCTP_MESSAGE_TRANSMITTER_ABI,
-    },
+    cctpV2TokenMessenger: {
+      address: "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA",
+      abi: CCTP_V2_TOKEN_MESSENGER_ABI,
+    },  
   },
   [CHAIN_IDs.SCROLL_SEPOLIA]: {
     scrollGatewayRouter: {
@@ -704,13 +712,13 @@ export const CONTRACT_ADDRESSES: {
     },
   },
   [CHAIN_IDs.UNICHAIN_SEPOLIA]: {
-    cctpTokenMessenger: {
-      address: "0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5",
-      abi: CCTP_TOKEN_MESSENGER_ABI,
+    cctpV2MessageTransmitter: {
+      address: "0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275",
+      abi: CCTP_MESSAGE_TRANSMITTER_ABI, // Same ABI as V1 as far as functions we care about, so overload for now.
     },
-    cctpMessageTransmitter: {
-      address: "0x1F622c406DedB82119EAfADB09E64e7e36A6844b",
-      abi: CCTP_MESSAGE_TRANSMITTER_ABI,
+    cctpV2TokenMessenger: {
+      address: "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA",
+      abi: CCTP_V2_TOKEN_MESSENGER_ABI,
     },
     ovmStandardBridge: {
       address: "0x4200000000000000000000000000000000000010",

--- a/src/finalizer/types.ts
+++ b/src/finalizer/types.ts
@@ -35,6 +35,8 @@ export type FinalizerPromise = {
 
 export type AddressesToFinalize = Map<Address, string[]>;
 
+// A ChainFinalizer is a function that finalizes messages between two known chains, one is the source
+// chain and the other is the destination chain.
 export interface ChainFinalizer {
   (
     logger: winston.Logger,
@@ -43,6 +45,16 @@ export interface ChainFinalizer {
     l2SpokePoolClient: SpokePoolClient,
     l1SpokePoolClient: SpokePoolClient,
     l1ToL2AddressesToFinalize: AddressesToFinalize // Map from token address to associated token symbols to finalize for that address.
+  ): Promise<FinalizerPromise>;
+}
+
+// A Finalizer is a function that finalizes messages sent from a single chain to any other.
+export interface Finalizer {
+  (
+    logger: winston.Logger,
+    signer: Signer,
+    l2SpokePoolClient: SpokePoolClient,
+    l2AddressesToFinalize: AddressesToFinalize
   ): Promise<FinalizerPromise>;
 }
 

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -185,14 +185,14 @@ export async function runRebalancer(_logger: winston.Logger, baseSigner: Signer)
   try {
     await rebalancer.init();
     await rebalancer.update();
-    await rebalancer.checkForUnfilledDepositsAndFill(false, true);
+    // await rebalancer.checkForUnfilledDepositsAndFill(false, true);
 
     if (config.sendingTransactionsEnabled) {
-      await inventoryClient.setTokenApprovals();
+      // await inventoryClient.setTokenApprovals();
     }
 
     await inventoryClient.rebalanceInventoryIfNeeded();
-    await inventoryClient.withdrawExcessBalances();
+    // await inventoryClient.withdrawExcessBalances();
   } finally {
     await disconnectRedisClients(logger);
     logger.debug({ at, message: `${personality} instance completed.` });

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -191,8 +191,8 @@ export async function runRebalancer(_logger: winston.Logger, baseSigner: Signer)
       // await inventoryClient.setTokenApprovals();
     }
 
-    await inventoryClient.rebalanceInventoryIfNeeded();
-    // await inventoryClient.withdrawExcessBalances();
+    // await inventoryClient.rebalanceInventoryIfNeeded();
+    await inventoryClient.withdrawExcessBalances();
   } finally {
     await disconnectRedisClients(logger);
     logger.debug({ at, message: `${personality} instance completed.` });

--- a/src/utils/CCTPUtils.ts
+++ b/src/utils/CCTPUtils.ts
@@ -15,6 +15,8 @@ import {
   chainIsProd,
   Address,
   EvmAddress,
+  getTokenInfo,
+  toBNWei,
 } from "./SDKUtils";
 import { isDefined } from "./TypeGuards";
 import { getCachedProvider, getSvmProvider } from "./ProviderUtils";
@@ -48,6 +50,8 @@ type CCTPSvmAPIAttestation = {
 
 type CCTPSvmAPIGetAttestationResponse = { messages: CCTPSvmAPIAttestation[] };
 type CCTPAPIGetAttestationResponse = { status: string; attestation: string };
+type CCTPV2APIGetFeesResponse = { finalityThreshold: number; minimumFee: number }[];
+type CCTPV2APIGetFastBurnAllowanceResponse = { allowance: number };
 type CCTPV2APIAttestation = {
   status: string;
   attestation: string;
@@ -80,6 +84,8 @@ const CCTP_DEPOSIT_FOR_BURN_TOPIC_HASH_V1 = ethers.utils.id(
 const CCTP_DEPOSIT_FOR_BURN_TOPIC_HASH_V2 = ethers.utils.id(
   "DepositForBurn(address,uint256,address,bytes32,uint32,bytes32,bytes32,uint256,uint32,bytes)"
 );
+export const CCTPV2_FINALITY_THRESHOLD_STANDARD = 2000;
+export const CCTPV2_FINALITY_THRESHOLD_FAST = 1000;
 
 /**
  * @notice Returns whether the chainId is a CCTP V2 chain, based on a hardcoded list of CCTP V2 chain ID's
@@ -948,6 +954,115 @@ function _decodeDepositForBurnMessageDataV2(message: { data: string }, isSvm = f
 }
 
 /**
+ * @notice The maximum amount of USDC that can be sent using a fast transfer.
+ * @param isMainnet Toggles whether to call CCTP API on mainnet or sandbox environment.
+ * @returns USDC amount in units of USDC.
+ * @link https://developers.circle.com/api-reference/cctp/all/get-fast-burn-usdc-allowance
+ */
+async function _getV2FastBurnAllowance(isMainnet: boolean): Promise<string> {
+  const httpResponse = await axios.get<CCTPV2APIGetFastBurnAllowanceResponse>(
+    `https://iris-api${isMainnet ? "" : "-sandbox"}.circle.com/v2/fastBurn/USDC/allowance`
+  );
+  return httpResponse.data.allowance.toString();
+}
+
+/**
+ * Returns the minimum transfer fees required for a transfer to be relayed. When calling depositForBurn(), the maxFee
+ * parameter must be greater than or equal to the minimum fee.
+ * @param sourceChainId The source chain ID of the transfer.
+ * @param destinationChainId The destination chain ID of the transfer.
+ * @param isMainnet Toggles whether to call CCTP API on mainnet or sandbox environment.
+ * @returns The standard and fast transfer fees for the given source and destination chains.
+ * @link https://developers.circle.com/api-reference/cctp/all/get-burn-usdc-fees
+ */
+async function _getV2MinTransferFees(
+  sourceChainId: number,
+  destinationChainId: number
+): Promise<{ standard: BigNumber; fast: BigNumber }> {
+  const isMainnet = chainIsProd(destinationChainId);
+  const sourceDomain = getCctpDomainForChainId(sourceChainId);
+  const destinationDomain = getCctpDomainForChainId(destinationChainId);
+  const endpoint = `https://iris-api${
+    isMainnet ? "" : "-sandbox"
+  }.circle.com/v2/burn/USDC/fees/${sourceDomain}/${destinationDomain}`;
+  const httpResponse = await axios.get<CCTPV2APIGetFeesResponse>(endpoint);
+  const standardFee = httpResponse.data.find((fee) => fee.finalityThreshold === CCTPV2_FINALITY_THRESHOLD_STANDARD);
+  assert(
+    isDefined(standardFee?.minimumFee),
+    `CCTPUtils#getTransferFees: Standard fee not found in API response: ${endpoint}`
+  );
+  const fastFee = httpResponse.data.find((fee) => fee.finalityThreshold === CCTPV2_FINALITY_THRESHOLD_FAST);
+  assert(isDefined(fastFee?.minimumFee), `CCTPUtils#getTransferFees: Fast fee not found in API response: ${endpoint}`);
+  return {
+    standard: BigNumber.from(standardFee.minimumFee),
+    fast: BigNumber.from(fastFee.minimumFee),
+  };
+}
+
+/**
+ * @notice Returns the maxFee and finalityThreshold to set to transfer USDC via CCTP V2. If the finalityThreshold
+ * is < 2000, then the transfer is a "fast" transfer and the maxFee is > 0.
+ * @param originUsdcToken The address of the USDC token on the origin chain.
+ * @param originChainId The chain ID of the origin chain.
+ * @param destinationChainId The chain ID of the destination chain.
+ * @param amount The amount of USDC to transfer.
+ * @returns The maxFee (in units of USDC) and finalityThreshold to set to transfer USDC via CCTP V2.
+ */
+export async function getV2DepositForBurnMaxFee(
+  originUsdcToken: Address,
+  originChainId: number,
+  destinationChainId: number,
+  amount: BigNumber
+): Promise<{ maxFee: BigNumber; finalityThreshold: number }> {
+  const [_fastBurnAllowance, transferFees] = await Promise.all([
+    _getV2FastBurnAllowance(chainIsProd(destinationChainId)),
+    _getV2MinTransferFees(originChainId, destinationChainId),
+  ]);
+  console.log(
+    `Fetched transfer fees for USDC: standard ${transferFees.standard.toString()} and fast ${transferFees.fast.toString()}`
+  );
+  const expectedMaxFastTransferFee = getV2MaxExpectedTransferFee(originChainId);
+  console.log(`Expected max fast transfer fee for USDC: ${expectedMaxFastTransferFee.toString()}`);
+  
+  // If we are using CCTP V2 then try to use the fast transfer if the amount is under the
+  // fast burn allowance and the transfer fee is under the expected max fast transfer fee.
+  // Fees are taken out of the received amount on the destination chain.
+  let finalityThreshold = CCTPV2_FINALITY_THRESHOLD_STANDARD;
+  let maxFee = bnZero;
+  const { decimals } = getTokenInfo(originUsdcToken, originChainId);
+  const fastBurnAllowance = toBNWei(_fastBurnAllowance, decimals);
+  console.log(`Fetched fast burn allowance for USDC: ${fastBurnAllowance.toString()}`);
+  if (amount.lte(fastBurnAllowance) && transferFees.fast.lte(expectedMaxFastTransferFee)) {
+    finalityThreshold = CCTPV2_FINALITY_THRESHOLD_FAST;
+    // Set maxFee to the expected max fast transfer fee, which is larger and provides a buffer
+    // in case the transfer fee moves. maxFee must be set higher than the minFee.
+    maxFee = amount.mul(expectedMaxFastTransferFee).div(10000);
+    console.log(amount.toString(), maxFee.toString());
+  }
+  return {
+    maxFee,
+    finalityThreshold,
+  }
+}
+
+/**
+ * @notice Returns the maximum expected transfer fees that we can use to avoid overpaying for
+ * fast transfers. Based on empirical observations.
+ * @param sourceChainId The source chain ID of the transfer.
+ * @returns The fee in basis points.
+ */
+export function getV2MaxExpectedTransferFee(sourceChainId: number): BigNumber {
+  // Based on https://developers.circle.com/cctp/technical-guide#cctp-fees
+  // as of 09/26/2025.
+  switch (sourceChainId) {
+    case CHAIN_IDs.LINEA:
+      return BigNumber.from(20);
+    default:
+      return BigNumber.from(5);
+  }
+}
+
+/**
  * Generates an attestation proof for a given message hash. This is required to finalize a CCTP message.
  * @dev Only works for v1 messages because we don't have nonceHash filled in for message when the v2 event is emitted on-chain, so we can't generate a messageHash locally.
  * That's why for v2 messages we have to use _fetchAttestationsForTxn instead
@@ -983,7 +1098,7 @@ async function _fetchAttestationsForTxn(
 
 async function _fetchCCTPSvmAttestationProof(transactionHash: string): Promise<CCTPSvmAPIGetAttestationResponse> {
   const httpResponse = await axios.get<CCTPSvmAPIGetAttestationResponse>(
-    `https://iris-api.circle.com/messages/5/${transactionHash}`
+    `https://iris-api.circle.com/messages/${getCctpDomainForChainId(CHAIN_IDs.SOLANA)}/${transactionHash}`
   );
   const attestationResponse = httpResponse.data;
   return attestationResponse;


### PR DESCRIPTION
This should significantly improve capital efficiency by rebalancing via the CCTP V2 Fast Transfer protocol wherever possible. The fee is taken out from the destination chain mint transaction.

A follow up PR will add this to the Solana adapters but I'm not sure we support CCTP V2 on Solana yet. Once we confirm that we do, then we can easily switch over to using fast transfers, but if we're assuming in the code that we're interacting with V1 contracts and interfaces, then we can't easily switch. Regardless, I want to first demo this with EVM chains.