### PR TITLE
feat: ignore large SVM messages

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -349,6 +349,7 @@ export class Relayer {
         recipient: recipient.toString(),
         outputToken: deposit.outputToken.toString(),
         exclusiveRelayer: deposit.exclusiveRelayer.toString(),
+        txnRef: deposit.txnRef,
       });
 
       return ignoreDeposit();

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -28,10 +28,12 @@ import {
   CHAIN_IDs,
   convertRelayDataParamsToBytes32,
   chainIsSvm,
+  stringifyThrownValue,
+  addrsMatchDstChain,
 } from "../utils";
 import { RelayerClients } from "./RelayerClientHelper";
 import { RelayerConfig } from "./RelayerConfig";
-import { MultiCallerClient } from "../clients";
+import { MultiCallerClient, SOLANA_TX_SIZE_LIMIT } from "../clients";
 
 const { getAddress } = ethersUtils;
 const { isDepositSpedUp, isMessageEmpty, resolveDepositMessage } = sdkUtils;
@@ -333,6 +335,22 @@ export class Relayer {
         depositUpdated: isDepositSpedUp(deposit),
         deposit,
       });
+      return ignoreDeposit();
+    }
+
+    // Skip deposits which have ill-formatted addresses for the destination chain
+    if (!addrsMatchDstChain(deposit)) {
+      this.logger.debug({
+        at: "Relayer::filterDeposit",
+        message: "Dropping deposit as some of its address fields are incorrectly formatted for destination chain.",
+        originChainId: deposit.originChainId,
+        depositId: deposit.depositId.toString(),
+        destinationChainId: deposit.destinationChainId,
+        recipient: recipient.toString(),
+        outputToken: deposit.outputToken.toString(),
+        exclusiveRelayer: deposit.exclusiveRelayer.toString(),
+      });
+
       return ignoreDeposit();
     }
 
@@ -730,6 +748,32 @@ export class Relayer {
       }
     }
 
+    // Skip a fill if the message would be too big to fit into a single SVM-side TX
+    try {
+      const fillTooLarge = await this.isSVMFillTooLarge(deposit);
+      if (fillTooLarge.tooLarge) {
+        this.logger.debug({
+          at: "Relayer::evaluateFill",
+          message: "Skipping SVM-destined deposit: fill tx too large",
+          originChain,
+          destChain,
+          txnRef,
+          fillSizeBytes: fillTooLarge.sizeBytes,
+        });
+        return;
+      }
+    } catch (error) {
+      this.logger.debug({
+        at: "Relayer::evaluateFill",
+        message: "Skipping SVM-destined deposit: Failed to estimate fill size",
+        originChain,
+        destChain,
+        txnRef,
+        error: stringifyThrownValue(error),
+      });
+      return;
+    }
+
     const l1Token = this.clients.inventoryClient.getL1TokenAddress(inputToken, originChainId);
 
     const { repaymentChainId, repaymentChainProfitability } = await this.resolveRepaymentChain(
@@ -1066,25 +1110,13 @@ export class Relayer {
     } else {
       assert(isSVMSpokePoolClient(spokePoolClient));
       assert(spokePoolClient.spokePoolAddress.isSVM());
-
-      const [recipient, outputToken] = [deposit.recipient, deposit.outputToken];
-      if (!(recipient.isSVM() && outputToken.isSVM())) {
-        // @dev recipient or outputToken are incorrectly formatted for the destination chain, drop deposit processing and log
-        this.logger.debug({
-          at: "Relayer",
-          message: "Dropping slow fill request because recipient or outputToken are not valid SVM addresses.",
-          originChainId: deposit.originChainId,
-          depositId: deposit.depositId.toString(),
-          destinationChainId: deposit.destinationChainId,
-          recipient: recipient.toString(),
-          outputToken: outputToken.toString(),
-        });
-        return;
-      }
+      // We're good to assert here. Deposits that didn't adhere to this were dropped at the filter stage
+      assert(deposit.recipient.isSVM());
+      assert(deposit.outputToken.isSVM());
 
       this.clients.svmFillerClient.enqueueSlowFill(
         spokePoolClient.spokePoolAddress,
-        { ...deposit, recipient, outputToken },
+        { ...deposit, recipient: deposit.recipient, outputToken: deposit.outputToken },
         "Requested slow fill for deposit.",
         formatSlowFillRequestMarkdown()
       );
@@ -1160,20 +1192,9 @@ export class Relayer {
     } else {
       assert(isSVMSpokePoolClient(spokePoolClient));
       assert(spokePoolClient.spokePoolAddress.isSVM());
-      const [recipient, outputToken] = [deposit.recipient, deposit.outputToken];
-      if (!(recipient.isSVM() && outputToken.isSVM())) {
-        // @dev recipient or outputToken are incorrectly formatted for the destination chain, drop deposit processing and log
-        this.logger.debug({
-          at: "Relayer",
-          message: "Dropping fill request because recipient or outputToken are not valid SVM addresses.",
-          originChainId: deposit.originChainId,
-          depositId: deposit.depositId.toString(),
-          destinationChainId: deposit.destinationChainId,
-          recipient: recipient.toString(),
-          outputToken: outputToken.toString(),
-        });
-        return;
-      }
+      // We're good to assert here. Deposits that didn't adhere to this were dropped at the filter stage
+      assert(deposit.recipient.isSVM());
+      assert(deposit.outputToken.isSVM());
 
       const message = "Filled v3 deposit on SVM 🚀";
       const mrkdwn = this.constructRelayFilledMrkdwn(deposit, repaymentChainId, realizedLpFeePct, gasPrice);
@@ -1182,8 +1203,8 @@ export class Relayer {
         spokePoolClient.spokePoolAddress,
         {
           ...deposit,
-          recipient: recipient,
-          outputToken: outputToken,
+          recipient: deposit.recipient,
+          outputToken: deposit.outputToken,
         },
         repaymentChainId,
         this.getRelayerAddrOn(repaymentChainId),
@@ -1623,5 +1644,41 @@ export class Relayer {
     return this.config.tryMulticallChains.includes(chainId)
       ? this.clients.tryMulticallClient
       : this.clients.multiCallerClient;
+  }
+
+  /**
+   * Estimates size in bytes of a potential Fill attempt for the given deposit. Checks against Solana TX size limit
+   * @throws If deposit is ill-formatted for SVM chain OR if destinationChainId is not SVM or not enabled
+   */
+  private async isSVMFillTooLarge(deposit: Deposit): Promise<{
+    tooLarge: boolean;
+    sizeBytes: number;
+  }> {
+    const destinationChainId = deposit.destinationChainId;
+    const spokePoolClient = this.clients.spokePoolClients[destinationChainId];
+
+    assert(chainIsSvm(destinationChainId));
+    assert(deposit.recipient.isSVM());
+    assert(deposit.outputToken.isSVM());
+    assert(isSVMSpokePoolClient(spokePoolClient));
+    assert(spokePoolClient.spokePoolAddress.isSVM());
+
+    // We don't know repayment chain id for this fill attempt. That shouldn't affect our TX size estimation though (at
+    // least not significantly). We use `deposit.destinationChainId`
+    const repaymentChainId = deposit.destinationChainId;
+    const sizeBytes = await this.clients.svmFillerClient.calculateFillSizeBytes(
+      spokePoolClient.spokePoolAddress,
+      {
+        ...deposit,
+        recipient: deposit.recipient,
+        outputToken: deposit.outputToken,
+      },
+      repaymentChainId,
+      this.getRelayerAddrOn(repaymentChainId)
+    );
+    return {
+      tooLarge: sizeBytes > SOLANA_TX_SIZE_LIMIT,
+      sizeBytes,
+    };
   }
 }

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -1,0 +1,20 @@
+import { Deposit } from "../interfaces";
+import { chainIsEvm } from "./SDKUtils";
+
+// Checks if deposit's .recipient, .outputToken and .exclusiveRelayer are correct for its destinationChainId
+export function addrsMatchDstChain(deposit: Deposit): boolean {
+  const destinationChainId = deposit.destinationChainId;
+  const isEvmChain = chainIsEvm(destinationChainId);
+
+  const addrValidityChecks = [
+    isEvmChain ? deposit.recipient.isEVM() : deposit.recipient.isSVM(),
+    isEvmChain ? deposit.outputToken.isEVM() : deposit.outputToken.isSVM(),
+    deposit.exclusiveRelayer.isZeroAddress()
+      ? isEvmChain
+        ? deposit.exclusiveRelayer.isEVM()
+        : deposit.exclusiveRelayer.isSVM()
+      : true,
+  ];
+
+  return addrValidityChecks.some((check) => !check);
+}

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -16,5 +16,5 @@ export function addrsMatchDstChain(deposit: Deposit): boolean {
       : true,
   ];
 
-  return addrValidityChecks.some((check) => !check);
+  return addrValidityChecks.every((check) => check);
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -57,6 +57,7 @@ export * from "./SignerUtils";
 export * from "./SvmSignerUtils";
 export * from "./BlockUtils";
 export * from "./EventUtils";
+export * from "./DepositUtils";
 export * from "./FillUtils";
 export * from "./ObjectUtils";
 export * from "./ContractUtils";


### PR DESCRIPTION
Estimated how many bytes would a fill for a deposit take. Drop deposit processing if > 1232 bytes as we don't support multi-part SVM-side filling