### PR TITLE
feat: move to `@risk-labs/logger`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@maticnetwork/maticjs": "^3.6.0",
     "@maticnetwork/maticjs-ethers": "^1.0.3",
     "@openzeppelin/hardhat-upgrades": "^1.28.0",
-    "@risk-labs/logger": "^1.3.4",
+    "@risk-labs/logger": "1.3.5",
     "@solana-program/address-lookup-table": "^0.7.0",
     "@solana-program/compute-budget": "^0.8.0",
     "@solana-program/system": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.79",
     "@across-protocol/contracts": "^4.1.9",
-    "@across-protocol/sdk": "4.3.67",
+    "@across-protocol/sdk": "4.3.68-alpha.0",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",
@@ -27,12 +27,12 @@
     "@maticnetwork/maticjs": "^3.6.0",
     "@maticnetwork/maticjs-ethers": "^1.0.3",
     "@openzeppelin/hardhat-upgrades": "^1.28.0",
+    "@risk-labs/logger": "^1.3.4",
     "@solana-program/address-lookup-table": "^0.7.0",
     "@solana-program/compute-budget": "^0.8.0",
     "@solana-program/system": "^0.7.0",
     "@solana-program/token": "^0.5.0",
     "@solana/kit": "^2.1.0",
-    "@uma/logger": "^1.3.3",
     "@uma/serverless-orchestration": "^2.17.2",
     "axios": "^1.7.4",
     "binance-api-node": "0.12.7",
@@ -48,7 +48,7 @@
     "superstruct": "^1.0.3",
     "ts-node": "^10.9.1",
     "viem": "^2.33.1",
-    "winston": "^3.10.0",
+    "winston": "^3.17.0",
     "zksync-ethers": "^5.7.2"
   },
   "files": [

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -60,7 +60,7 @@ import { createDataworker } from "../dataworker";
 import { _buildSlowRelayRoot, getBlockForChain } from "../dataworker/DataworkerUtils";
 import { Log, ProposedRootBundle, SpokePoolClientsByChain, BundleData } from "../interfaces";
 import { CONTRACT_ADDRESSES, constructSpokePoolClientsWithStartBlocks, updateSpokePoolClients } from "../common";
-import { createConsoleTransport } from "@uma/logger";
+import { createConsoleTransport } from "@risk-labs/logger";
 import { interfaces as sdkInterfaces } from "@across-protocol/sdk";
 import _ from "lodash";
 import { SpokePoolClient } from "../clients/SpokePoolClient";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -25,7 +25,7 @@ export type { Block, TransactionResponse, TransactionReceipt, Provider } from "@
 
 export { config } from "dotenv";
 
-export { Logger, waitForLogger } from "@uma/logger";
+export { Logger, waitForLogger } from "@risk-labs/logger";
 
 export {
   CHAIN_IDs,

--- a/tasks/integration-tests.ts
+++ b/tasks/integration-tests.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { task } from "hardhat/config";
 import { getSigner, winston } from "../src/utils";
-import { SpyTransport, bigNumberFormatter } from "@uma/logger";
+import { SpyTransport, bigNumberFormatter } from "@risk-labs/logger";
 import { runDataworker } from "../src/dataworker";
 import { runRelayer } from "../src/relayer";
 import { runFinalizer } from "../src/finalizer";

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,5 +1,5 @@
 export * as contracts from "@across-protocol/contracts/dist/test-utils";
-export * as uma from "@uma/logger";
+export * as uma from "@risk-labs/logger";
 
 export * from "./utils";
 export * from "./BlockchainUtils";

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -1,5 +1,5 @@
 import * as utils from "@across-protocol/contracts/dist/test-utils";
-import { SpyTransport, bigNumberFormatter } from "@uma/logger";
+import { SpyTransport, bigNumberFormatter } from "@risk-labs/logger";
 import { AcrossConfigStore, FakeContract } from "@across-protocol/contracts";
 import { constants, utils as sdkUtils } from "@across-protocol/sdk";
 import { Contract, providers } from "ethers";
@@ -50,7 +50,7 @@ export {
   lastSpyLogLevel,
   spyLogIncludes,
   spyLogLevel,
-} from "@uma/logger";
+} from "@risk-labs/logger";
 export { MAX_SAFE_ALLOWANCE, MAX_UINT_VAL } from "../../src/utils";
 export const {
   ethers,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2526,10 +2526,10 @@
     path-browserify "^1.0.0"
     url "^0.11.0"
 
-"@risk-labs/logger@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@risk-labs/logger/-/logger-1.3.4.tgz#4ff2815f1f718e5f1843945922c0d239361fe7dc"
-  integrity sha512-eeGoUyUEejf3l/VpBTLrEKZivFjHWggi/e4ysHIlIxSkDSP1LHpT2gNWLSvqSsuUCGKdCRzscv0uy6qaMv9S2g==
+"@risk-labs/logger@1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@risk-labs/logger/-/logger-1.3.5.tgz#084924c9bc596a98874d7bf32eae839ee8a0bb20"
+  integrity sha512-HN5WNytgU0d8784GWsbyg5DCL2z/efsHEQEKATmX6KoUsh2hyxmxiejTDSi4EqYztSdVJwjqUvansKzMMIgfwA==
   dependencies:
     "@google-cloud/logging-winston" "^4.1.1"
     "@google-cloud/trace-agent" "^5.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,10 +67,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@4.3.67":
-  version "4.3.67"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.67.tgz#a3b39ecd3334d16ea27bb5340baf391883a46bd6"
-  integrity sha512-XTDbi7Qm7mbxVAhTns8fZujsEJ2gzT0HQwXbKofbsJKwGXSW9z8MqsjghjagvvB4HqanY7EHrW0cWfSvu73hjA==
+"@across-protocol/sdk@4.3.68-alpha.0":
+  version "4.3.68-alpha.0"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.68-alpha.0.tgz#2bc7224505535aadb1980a77e34920ce7d736b4f"
+  integrity sha512-We37pePSDIGO4udncJoVMXhGxzbmBaaBfCCHI8RQFDc8Ae6ETW3ppuQurC0njos9suXHUYfqPpQdkxJ/NNZosg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.78"
@@ -2526,6 +2526,24 @@
     path-browserify "^1.0.0"
     url "^0.11.0"
 
+"@risk-labs/logger@^1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@risk-labs/logger/-/logger-1.3.4.tgz#4ff2815f1f718e5f1843945922c0d239361fe7dc"
+  integrity sha512-eeGoUyUEejf3l/VpBTLrEKZivFjHWggi/e4ysHIlIxSkDSP1LHpT2gNWLSvqSsuUCGKdCRzscv0uy6qaMv9S2g==
+  dependencies:
+    "@google-cloud/logging-winston" "^4.1.1"
+    "@google-cloud/trace-agent" "^5.1.6"
+    "@pagerduty/pdjs" "^2.2.4"
+    axios "^1.12.2"
+    discord.js "^14.11.0"
+    dotenv "^9.0.0"
+    minimist "^1.2.0"
+    node-pagerduty "^1.2.0"
+    redis "^4.6.13"
+    superstruct "^2.0.2"
+    winston "^3.17.0"
+    winston-transport "^4.9.0"
+
 "@sapphire/async-queue@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@sapphire/async-queue/-/async-queue-1.5.0.tgz#2f255a3f186635c4fb5a2381e375d3dfbc5312d8"
@@ -4948,6 +4966,15 @@ axios@^0.27.2:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
 
+axios@^1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.12.2.tgz#6c307390136cf7a2278d09cec63b136dfc6e6da7"
+  integrity sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.4"
+    proxy-from-env "^1.1.0"
+
 axios@^1.6.1:
   version "1.7.9"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
@@ -7224,6 +7251,16 @@ es-set-tostringtag@^2.0.1:
     has "^1.0.3"
     has-tostringtag "^1.0.0"
 
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
+
 es-shim-unscopables@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz#702e632193201e3edf8713635d083d378e510241"
@@ -8447,6 +8484,17 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+form-data@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
+  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -8760,7 +8808,7 @@ get-intrinsic@^1.2.4:
     has-symbols "^1.0.3"
     hasown "^2.0.0"
 
-get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -9466,6 +9514,13 @@ has-tostringtag@^1.0.0:
   integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
   dependencies:
     has-symbols "^1.0.2"
+
+has-tostringtag@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
+  dependencies:
+    has-symbols "^1.0.3"
 
 has-unicode@^2.0.0, has-unicode@^2.0.1:
   version "2.0.1"
@@ -17117,24 +17172,7 @@ winston-transport@^4.9.0:
     readable-stream "^3.6.2"
     triple-beam "^1.3.0"
 
-winston@^3.10.0, winston@^3.2.1:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-3.10.0.tgz#d033cb7bd3ced026fed13bf9d92c55b903116803"
-  integrity sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==
-  dependencies:
-    "@colors/colors" "1.5.0"
-    "@dabh/diagnostics" "^2.0.2"
-    async "^3.2.3"
-    is-stream "^2.0.0"
-    logform "^2.4.0"
-    one-time "^1.0.0"
-    readable-stream "^3.4.0"
-    safe-stable-stringify "^2.3.1"
-    stack-trace "0.0.x"
-    triple-beam "^1.3.0"
-    winston-transport "^4.5.0"
-
-winston@^3.12.0:
+winston@^3.12.0, winston@^3.17.0:
   version "3.17.0"
   resolved "https://registry.yarnpkg.com/winston/-/winston-3.17.0.tgz#74b8665ce9b4ea7b29d0922cfccf852a08a11423"
   integrity sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==
@@ -17150,6 +17188,23 @@ winston@^3.12.0:
     stack-trace "0.0.x"
     triple-beam "^1.3.0"
     winston-transport "^4.9.0"
+
+winston@^3.2.1:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.10.0.tgz#d033cb7bd3ced026fed13bf9d92c55b903116803"
+  integrity sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==
+  dependencies:
+    "@colors/colors" "1.5.0"
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.2.3"
+    is-stream "^2.0.0"
+    logform "^2.4.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    safe-stable-stringify "^2.3.1"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.5.0"
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.4"


### PR DESCRIPTION
`v1.3.5` of `@risk-labs/logger` is in sync with `@uma/logger@1.3.3` + some package bumps + dependency removals