### PR TITLE
chore: Bump SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.79",
     "@across-protocol/contracts": "^4.1.9",
-    "@across-protocol/sdk": "4.3.68",
+    "@across-protocol/sdk": "4.3.69",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,10 +67,10 @@
     yargs "^17.7.2"
     zksync-web3 "^0.14.3"
 
-"@across-protocol/sdk@4.3.68":
-  version "4.3.68"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.68.tgz#c6df02c2418d913cb08651826b3c83f448bf0a65"
-  integrity sha512-RsZPIdmH5ZcnvElPHYC7bDP1FjrMqjve+R89lmzR5B4gVDQil7t6hEWyMM20oR9+uzyodpt6ezn+JMMe2eHkUw==
+"@across-protocol/sdk@4.3.69":
+  version "4.3.69"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.69.tgz#d3432d28aea35e450247d240a55a43fe80627bc4"
+  integrity sha512-3xttHXl+RL/59zTisUNpVUoVDUsSIZ16ioiIx2iL4R5A8hHFdfML3kiORxOClcyKMXuqVayVEsUfI2tYhGq5ow==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants" "^3.1.78"


### PR DESCRIPTION
Hopefully this produces a significant drop in the number of alerts from SVM block/slot issues.