### PR TITLE
improve: do not withdraw credited balances from binance

### DIFF
--- a/src/finalizer/utils/binance.ts
+++ b/src/finalizer/utils/binance.ts
@@ -182,7 +182,7 @@ export async function binanceFinalizer(
         // deposits, then we can continue.
         if (
           amountToFinalize >= Number(networkLimits.withdrawMin) &&
-          amountToFinalize < coinBalance - creditedDepositAmount
+          amountToFinalize <= coinBalance - creditedDepositAmount
         ) {
           // Lastly, we need to truncate the amount to withdraw to 6 decimal places.
           amountToFinalize = Math.floor(amountToFinalize * DECIMAL_PRECISION) / DECIMAL_PRECISION;


### PR DESCRIPTION
We sometimes run into issues when timing of withdrawals cause pending deposits to be credited to the binance hot wallet but not finalized/ready to withdraw. This causes the finalizer to crash since we then attempt to withdraw this credited amount (as currently we are only aware of our balance). 

This PR makes the finalizer aware of the credited, but not finalized deposits, and will check whether the amount it wants to finalize falls within the finalized balance amounts (and does not overlap with the credited balance). 