### PR TITLE
fix: do not update inventory client in parallel with spoke pool clients

### DIFF
--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -185,7 +185,8 @@ export async function runRebalancer(_logger: winston.Logger, baseSigner: Signer)
 
   try {
     await rebalancer.init();
-    await Promise.all([inventoryClient.update(rebalancer.inventoryChainIds), rebalancer.update()]);
+    await rebalancer.update();
+    await inventoryClient.update(rebalancer.inventoryChainIds);
     await rebalancer.checkForUnfilledDepositsAndFill(false, true);
 
     if (config.sendingTransactionsEnabled) {


### PR DESCRIPTION
The inventory client needs to have all spoke pool clients updated before it can update.