### PR TITLE
fix: cap max CCTP transfer amount at 1M

### DIFF
--- a/src/adapter/bridges/UsdcCCTPBridge.ts
+++ b/src/adapter/bridges/UsdcCCTPBridge.ts
@@ -84,11 +84,12 @@ export class UsdcCCTPBridge extends BaseBridgeAdapter {
       if (optionalParams?.fastMode) {
         ({ maxFee, finalityThreshold } = await this._getCctpV2DepositForBurnMaxFee(amount));
       }
+      const adjustedAmount = amount.add(maxFee);
       return Promise.resolve({
         contract: this.getL1Bridge(),
         method: "depositForBurn",
         args: [
-          amount.add(maxFee), // Add maxFee so that we end up with desired amount of tokens on destinationchain.
+          adjustedAmount.gt(CCTP_MAX_SEND_AMOUNT) ? CCTP_MAX_SEND_AMOUNT : adjustedAmount, // Add maxFee so that we end up with desired amount of tokens on destination chain.
           this.l2DestinationDomain,
           toAddress.toBytes32(),
           this.l1UsdcTokenAddress.toNative(),

--- a/src/adapter/l2Bridges/UsdcCCTPBridge.ts
+++ b/src/adapter/l2Bridges/UsdcCCTPBridge.ts
@@ -74,7 +74,7 @@ export class UsdcCCTPBridge extends BaseL2BridgeAdapter {
       if (optionalParams?.fastMode) {
         ({ maxFee, finalityThreshold } = await this._getCctpV2DepositForBurnMaxFee(amount));
       }
-      let adjustedAmount = amount.add(maxFee);
+      const adjustedAmount = amount.add(maxFee);
       return Promise.resolve([
         {
           contract: this.l2Bridge,

--- a/src/adapter/l2Bridges/UsdcCCTPBridge.ts
+++ b/src/adapter/l2Bridges/UsdcCCTPBridge.ts
@@ -74,6 +74,7 @@ export class UsdcCCTPBridge extends BaseL2BridgeAdapter {
       if (optionalParams?.fastMode) {
         ({ maxFee, finalityThreshold } = await this._getCctpV2DepositForBurnMaxFee(amount));
       }
+      let adjustedAmount = amount.add(maxFee);
       return Promise.resolve([
         {
           contract: this.l2Bridge,
@@ -85,7 +86,7 @@ export class UsdcCCTPBridge extends BaseL2BridgeAdapter {
             optionalParams?.fastMode ? ` using fast mode with a max fee of ${formatter(maxFee.toString())}` : ""
           }`,
           args: [
-            amount.add(maxFee), // Add maxFee so that we end up with desired amount of tokens on destinationchain.
+            adjustedAmount.gt(CCTP_MAX_SEND_AMOUNT) ? CCTP_MAX_SEND_AMOUNT : adjustedAmount, // Add maxFee so that we end up with desired amount of tokens on destinationchain.
             this.l1DestinationDomain,
             toAddress.toBytes32(),
             this.l2UsdcTokenAddress.toNative(),

--- a/test/InventoryClient.InventoryRebalance.ts
+++ b/test/InventoryClient.InventoryRebalance.ts
@@ -299,7 +299,7 @@ describe("InventoryClient: Rebalancing inventory", async function () {
       POLYGON,
       EvmAddress.from(owner.address),
       EvmAddress.from(mainnetWeth),
-      shortfallAmount1
+      shortfallAmount1 // 10 WETH
     );
 
     // Send tokens out of the relayer's balance so we can send a follow up rebalance without getting tripped up
@@ -332,7 +332,8 @@ describe("InventoryClient: Rebalancing inventory", async function () {
     await inventoryClient.rebalanceInventoryIfNeeded();
     expect(lastSpyLogIncludes(spy, "No rebalances required")).to.be.true;
 
-    // Ok, now try mocking some pending transfers such that only the larger transfer will go through:
+    // Ok, now try mocking some pending transfers such that part of the larger transfer is already covered by
+    // pending transfers.
     adapterManager.setMockedOutstandingCrossChainTransfers(
       POLYGON,
       EvmAddress.from(owner.address),
@@ -343,8 +344,8 @@ describe("InventoryClient: Rebalancing inventory", async function () {
     await inventoryClient.rebalanceInventoryIfNeeded();
     expect(lastSpyLogIncludes(spy, "Executed Inventory rebalances")).to.be.true;
     expect(lastSpyLogIncludes(spy, "Rebalances sent to Polygon")).to.be.true;
-    expect(lastSpyLogIncludes(spy, "10.00 WETH rebalanced to cover total chain shortfall of 18.00 WETH")).to.be.true;
-    expect(lastSpyLogIncludes(spy, "8.00 WETH rebalanced to cover total chain shortfall of 18.00 WETH")).to.be.false;
+    expect(lastSpyLogIncludes(spy, "1.00 WETH rebalanced to cover total chain shortfall of 18.00 WETH")).to.be.true;
+    expect(lastSpyLogIncludes(spy, "8.00 WETH rebalanced to cover total chain shortfall of 18.00 WETH")).to.be.true;
   });
 
   it("Refuses to send rebalance when ERC20 balance changes", async function () {


### PR DESCRIPTION
I think we can go over the max transfer size when we want to rebalance > 1M using fast mode.