### PR TITLE
improve: `totalFeePct` log

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -566,19 +566,18 @@ export class ProfitClient {
     lpFeePct: BigNumber,
     l1Token: EvmAddress,
     repaymentChainId: number
-  ): Promise<Pick<FillProfit, "profitable" | "nativeGasCost" | "gasPrice" | "tokenGasCost" | "netRelayerFeePct">> {
+  ): Promise<
+    Pick<FillProfit, "profitable" | "nativeGasCost" | "gasPrice" | "tokenGasCost" | "netRelayerFeePct" | "totalFeePct">
+  > {
     let profitable = false;
     let netRelayerFeePct = bnZero;
     let nativeGasCost = uint256Max;
     let tokenGasCost = uint256Max;
     let gasPrice = uint256Max;
+    let totalFeePct = bnZero;
     try {
-      ({ profitable, netRelayerFeePct, nativeGasCost, tokenGasCost, gasPrice } = await this.getFillProfitability(
-        deposit,
-        lpFeePct,
-        l1Token,
-        repaymentChainId
-      ));
+      ({ profitable, netRelayerFeePct, nativeGasCost, tokenGasCost, gasPrice, totalFeePct } =
+        await this.getFillProfitability(deposit, lpFeePct, l1Token, repaymentChainId));
     } catch (err) {
       this.logger.debug({
         at: "ProfitClient#isFillProfitable",
@@ -594,6 +593,7 @@ export class ProfitClient {
       tokenGasCost,
       gasPrice,
       netRelayerFeePct,
+      totalFeePct,
     };
   }
 

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -47,6 +47,7 @@ type RepaymentChainProfitability = {
   gasCost: BigNumber;
   gasPrice: BigNumber;
   relayerFeePct: BigNumber;
+  totalUserFeePct: BigNumber;
   lpFeePct: BigNumber;
 };
 
@@ -741,6 +742,7 @@ export class Relayer {
       gasCost,
       gasLimit: _gasLimit,
       lpFeePct: realizedLpFeePct,
+      totalUserFeePct,
       gasPrice,
     } = repaymentChainProfitability;
 
@@ -798,7 +800,7 @@ export class Relayer {
     tokenClient.decrementLocalBalance(destinationChainId, outputToken, outputAmount);
 
     const gasLimit = isMessageEmpty(resolveDepositMessage(deposit)) ? undefined : _gasLimit;
-    this.fillRelay(deposit, repaymentChainId, realizedLpFeePct, gasPrice, gasLimit);
+    this.fillRelay(deposit, repaymentChainId, realizedLpFeePct, totalUserFeePct, gasPrice, gasLimit);
   }
 
   /**
@@ -1083,6 +1085,7 @@ export class Relayer {
     deposit: Deposit,
     repaymentChainId: number,
     realizedLpFeePct: BigNumber,
+    totalUserFeePct: BigNumber,
     gasPrice: BigNumber,
     gasLimit?: BigNumber
   ): void {
@@ -1137,7 +1140,13 @@ export class Relayer {
           ];
 
       const message = `Filled v3 deposit ${messageModifier}🚀`;
-      const mrkdwn = this.constructRelayFilledMrkdwn(deposit, repaymentChainId, realizedLpFeePct, gasPrice);
+      const mrkdwn = this.constructRelayFilledMrkdwn(
+        deposit,
+        repaymentChainId,
+        realizedLpFeePct,
+        totalUserFeePct,
+        gasPrice
+      );
 
       const contract = spokePoolClient.spokePool;
       const chainId = deposit.destinationChainId;
@@ -1152,7 +1161,13 @@ export class Relayer {
       assert(deposit.outputToken.isSVM());
 
       const message = "Filled v3 deposit on SVM 🚀";
-      const mrkdwn = this.constructRelayFilledMrkdwn(deposit, repaymentChainId, realizedLpFeePct, gasPrice);
+      const mrkdwn = this.constructRelayFilledMrkdwn(
+        deposit,
+        repaymentChainId,
+        realizedLpFeePct,
+        totalUserFeePct,
+        gasPrice
+      );
 
       this.clients.svmFillerClient.enqueueFill(
         spokePoolClient.spokePoolAddress,
@@ -1217,6 +1232,7 @@ export class Relayer {
           gasCost: bnUint256Max,
           gasPrice: bnUint256Max,
           relayerFeePct: bnZero,
+          totalUserFeePct: bnUint256Max,
           lpFeePct: bnUint256Max,
         },
       };
@@ -1251,13 +1267,15 @@ export class Relayer {
       gasCost: BigNumber;
       gasPrice: BigNumber;
       relayerFeePct: BigNumber;
+      totalUserFeePct: BigNumber;
     }> => {
       const {
         profitable,
         nativeGasCost: gasLimit,
         tokenGasCost: gasCost,
         gasPrice,
-        netRelayerFeePct: relayerFeePct, // net relayer fee is equal to total fee minus the lp fee.
+        netRelayerFeePct: relayerFeePct,
+        totalFeePct: totalUserFeePct,
       } = await profitClient.isFillProfitable(deposit, lpFeePct, hubPoolToken, preferredChainId);
       return {
         profitable,
@@ -1265,6 +1283,7 @@ export class Relayer {
         gasCost,
         gasPrice,
         relayerFeePct,
+        totalUserFeePct,
       };
     };
 
@@ -1283,12 +1302,14 @@ export class Relayer {
     // @dev The following internal function should be the only one used to set `preferredChain` above.
     const getProfitabilityDataForPreferredChainIndex = (preferredChainIndex: number): RepaymentChainProfitability => {
       const lpFeePct = lpFeePcts[preferredChainIndex];
-      const { gasLimit, gasCost, relayerFeePct, gasPrice } = repaymentChainProfitabilities[preferredChainIndex];
+      const { gasLimit, gasCost, relayerFeePct, gasPrice, totalUserFeePct } =
+        repaymentChainProfitabilities[preferredChainIndex];
       return {
         gasLimit,
         gasCost,
         gasPrice,
         relayerFeePct,
+        totalUserFeePct,
         lpFeePct,
       };
     };
@@ -1545,10 +1566,11 @@ export class Relayer {
     deposit: Deposit,
     repaymentChainId: number,
     realizedLpFeePct: BigNumber,
+    totalUserFeePct: BigNumber,
     gasPrice: BigNumber
   ): string {
     let mrkdwn =
-      this.constructBaseFillMarkdown(deposit, realizedLpFeePct, gasPrice) +
+      this.constructBaseFillMarkdown(deposit, realizedLpFeePct, gasPrice, totalUserFeePct) +
       ` Relayer repayment: ${getNetworkName(repaymentChainId)}.`;
 
     if (isDepositSpedUp(deposit)) {
@@ -1563,7 +1585,12 @@ export class Relayer {
     return mrkdwn;
   }
 
-  private constructBaseFillMarkdown(deposit: Deposit, _realizedLpFeePct: BigNumber, _gasPriceGwei: BigNumber): string {
+  private constructBaseFillMarkdown(
+    deposit: Deposit,
+    _realizedLpFeePct: BigNumber,
+    _totalUserFeePct: BigNumber,
+    _gasPriceGwei: BigNumber
+  ): string {
     const { symbol, decimals } = this.clients.hubPoolClient.getTokenInfoForAddress(
       deposit.inputToken,
       deposit.originChainId
@@ -1578,17 +1605,12 @@ export class Relayer {
 
     let msg = `Relayed depositId ${deposit.depositId.toString()} from ${srcChain} to ${dstChain} of ${inputAmount} ${symbol}`;
     const realizedLpFeePct = formatFeePct(_realizedLpFeePct);
-    const adjustedInputAmount = sdkUtils.ConvertDecimals(decimals, outputTokenDecimals)(deposit.inputAmount);
-    const _totalFeePct = adjustedInputAmount
-      .sub(deposit.outputAmount)
-      .mul(fixedPointAdjustment)
-      .div(adjustedInputAmount);
-    const totalFeePct = formatFeePct(_totalFeePct);
+    const totalUserFeePct = formatFeePct(_totalUserFeePct);
 
     const _outputAmount = createFormatFunction(2, 4, false, outputTokenDecimals)(deposit.outputAmount.toString());
     msg +=
       ` and output ${_outputAmount} ${outputTokenSymbol}, with depositor ${depositor}.` +
-      ` Realized LP fee: ${realizedLpFeePct}%, total fee: ${totalFeePct}%. Gas price used in profit calc: ${formatGwei(
+      ` Realized LP fee: ${realizedLpFeePct}%, total user fee: ${totalUserFeePct}%. Gas price used in profit calc: ${formatGwei(
         _gasPriceGwei.toString()
       )} Gwei.`;
 

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -16,7 +16,6 @@ import {
   getUnfilledDeposits,
   isDefined,
   winston,
-  fixedPointAdjustment,
   Profiler,
   formatGwei,
   depositForcesOriginChainRepayment,

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1231,7 +1231,7 @@ export class Relayer {
           gasCost: bnUint256Max,
           gasPrice: bnUint256Max,
           relayerFeePct: bnZero,
-          totalUserFeePct: bnUint256Max,
+          totalUserFeePct: bnZero,
           lpFeePct: bnUint256Max,
         },
       };


### PR DESCRIPTION
As we're changing some total fee logic calculations in https://github.com/across-protocol/relayer/pull/2642, our `totalFeePct` log in `Relayer.ts` has gone out of sync. I think it makes sense to just take the data from `ProfitClient` for this