### PR TITLE
Relayer: Rename handleUnprofitableFill to handleUnfillableDeposit and remove outdated TODO

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1548,7 +1548,7 @@ export class Relayer {
 
     if (mrkdwn) {
       this.logger[this.config.sendingRelaysEnabled ? "warn" : "debug"]({
-         at: "Relayer::handleUnfillableDeposit",
+        at: "Relayer::handleUnfillableDeposit",
         message: "Not relaying unprofitable deposits 🙅‍♂️!",
         mrkdwn,
         notificationPath: "across-unprofitable-fills",


### PR DESCRIPTION
Rename a private method to accurately reflect its behavior and remove an outdated TODO comment.

## Rationale
  - The method handles more than unprofitable fills (e.g., failed simulations, lite-chain over-allocation). Clear naming reduces cognitive load and prevents misuse.

## Changes
  - Renamed `handleUnprofitableFill` → `handleUnfillableDeposit`.
  - Updated the single call site and the `at` field in logging.

