### PR TITLE
improve: Extend Binance rebalancer routes for WETH

### DIFF
--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -180,13 +180,13 @@ Inputs:
 High-level flow:
 
 1. Compute cumulative deficits (`current < threshold`, target refill amount `target - current`) and cumulative excesses (`current > target`, excess amount `current - target`).
-2. Sort cumulative deficits by token `priorityTier` (higher first), then larger deficits first.
-3. Sort cumulative excesses by token `priorityTier` (lower first), then larger excesses first.
+2. Sort cumulative deficits by token `priorityTier` (higher first), then larger USD-normalized deficits first.
+3. Sort cumulative excesses by token `priorityTier` (lower first), then larger USD-normalized excesses first.
 4. For each excess token used to fill a deficit token, sort source chains from `cumulativeTargetBalances[excessToken].chains` by:
    - chain `priorityTier` ascending,
    - then current chain balance descending.
 5. For each candidate source chain, evaluate all destination chains configured for the deficit token that have valid routes, then choose the route with the lowest `getEstimatedCost`.
-6. Cap transfer amount by remaining deficit, remaining excess, chain balance, and configured `maxAmountsToTransfer`.
+6. Cap transfer amount by remaining deficit, remaining excess, chain balance, and configured `maxAmountsToTransfer`. For mixed-asset routes such as `WETH <-> stablecoin`, the client converts between source and destination token amounts through hub-chain USD prices before capping and decrementing the remaining deficit.
 7. Enforce max fee pct and adapter pending-order caps before calling `initializeRebalance`.
 
 Design tradeoff:

--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -21,6 +21,17 @@ A `RebalanceRoute` defines:
 
 Routes are assembled by the rebalancer construction layer and passed at client initialization time (`initialize(rebalanceRoutes)`). The mode clients then filter to routes that are valid for current balances/config.
 
+The built-in production route set is generated in `src/rebalancer/buildRebalanceRoutes.ts`. It covers:
+
+- stablecoin swap routes between `USDC` and `USDT` on Binance and Hyperliquid,
+- same-asset bridge routes for `USDC` via CCTP and `USDT` via OFT,
+- Binance-only `WETH <-> USDC`, `WETH <-> USDT`, and `WETH <-> WETH` routes on chains where Binance exposes direct ETH deposit and withdrawal networks.
+
+Operational note:
+
+- Binance same-coin `WETH <-> WETH` routes skip the spot swap leg and treat on-chain `WETH` as Binance `ETH`.
+- Intermediate on-chain bridge legs into or out of Binance remain restricted to `USDC` and `USDT`; `WETH` routes must start and end on direct Binance ETH networks.
+
 ### Rebalancer Adapter
 
 Adapters in `src/rebalancer/adapters/` initiate and progress multi-stage swap workflows. The interface currently is:

--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -25,7 +25,7 @@ The built-in production route set is generated in `src/rebalancer/buildRebalance
 
 - stablecoin swap routes between `USDC` and `USDT` on Binance and Hyperliquid,
 - same-asset routes for `USDC` via CCTP and on direct Binance-supported USDC networks via Binance, and for `USDT` via OFT and on direct Binance-supported USDT networks via Binance,
-- Binance-only `WETH <-> USDC`, `WETH <-> USDT`, and `WETH <-> WETH` routes on chains where Binance exposes direct ETH deposit and withdrawal networks.
+- Binance-only `WETH <-> USDC` and `WETH <-> USDT` routes sourced or settled through mainnet. `WETH <-> WETH` route handling exists in the adapter, but no cross-chain `WETH <-> WETH` routes are generated while WETH Binance support is limited to mainnet.
 
 Route construction keeps two token-keyed chain maps:
 
@@ -36,8 +36,9 @@ Operational note:
 
 - Same-asset `USDC <-> USDC` and `USDT <-> USDT` Binance routes are included deliberately so they can compete on estimated cost against CCTP/OFT paths, but they are only generated when both chains are direct Binance networks for that asset.
 - Updating Binance venue support for a token does not automatically widen rebalancer support. New chains should usually be added to both maps intentionally after inventory/config/runtime review.
-- Binance same-coin `WETH <-> WETH` routes skip the spot swap leg and treat on-chain `WETH` as Binance `ETH`.
-- Intermediate on-chain bridge legs into or out of Binance remain restricted to `USDC` and `USDT`; `WETH` routes must start and end on direct Binance ETH networks.
+- Current route construction limits Binance `WETH` support to mainnet because the rebalancer's native-ETH deposit path relies on the mainnet Atomic Depositor and transfer proxy wiring.
+- If additional direct Binance ETH networks are enabled later, same-coin `WETH <-> WETH` routes skip the spot swap leg and treat on-chain `WETH` as Binance `ETH`.
+- Intermediate on-chain bridge legs into or out of Binance remain restricted to `USDC` and `USDT`; current `WETH` routes therefore source or settle through mainnet rather than bridging WETH into another Binance ETH network.
 
 ### Rebalancer Adapter
 

--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -27,9 +27,15 @@ The built-in production route set is generated in `src/rebalancer/buildRebalance
 - same-asset routes for `USDC` via CCTP and on direct Binance-supported USDC networks via Binance, and for `USDT` via OFT and on direct Binance-supported USDT networks via Binance,
 - Binance-only `WETH <-> USDC`, `WETH <-> USDT`, and `WETH <-> WETH` routes on chains where Binance exposes direct ETH deposit and withdrawal networks.
 
+Route construction keeps two token-keyed chain maps:
+
+- `BINANCE_NETWORKS_BY_SYMBOL`: direct Binance deposit/withdraw networks known for each token.
+- `REBALANCE_CHAINS_BY_SYMBOL`: the narrower set of chains this repo currently enables for rebalancing that token.
+
 Operational note:
 
 - Same-asset `USDC <-> USDC` and `USDT <-> USDT` Binance routes are included deliberately so they can compete on estimated cost against CCTP/OFT paths, but they are only generated when both chains are direct Binance networks for that asset.
+- Updating Binance venue support for a token does not automatically widen rebalancer support. New chains should usually be added to both maps intentionally after inventory/config/runtime review.
 - Binance same-coin `WETH <-> WETH` routes skip the spot swap leg and treat on-chain `WETH` as Binance `ETH`.
 - Intermediate on-chain bridge legs into or out of Binance remain restricted to `USDC` and `USDT`; `WETH` routes must start and end on direct Binance ETH networks.
 

--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -24,12 +24,12 @@ Routes are assembled by the rebalancer construction layer and passed at client i
 The built-in production route set is generated in `src/rebalancer/buildRebalanceRoutes.ts`. It covers:
 
 - stablecoin swap routes between `USDC` and `USDT` on Binance and Hyperliquid,
-- same-asset routes for `USDC` via CCTP and Binance, and for `USDT` via OFT and Binance,
+- same-asset routes for `USDC` via CCTP and on direct Binance-supported USDC networks via Binance, and for `USDT` via OFT and on direct Binance-supported USDT networks via Binance,
 - Binance-only `WETH <-> USDC`, `WETH <-> USDT`, and `WETH <-> WETH` routes on chains where Binance exposes direct ETH deposit and withdrawal networks.
 
 Operational note:
 
-- Same-asset `USDC <-> USDC` and `USDT <-> USDT` Binance routes are included deliberately so they can compete on estimated cost against CCTP/OFT paths.
+- Same-asset `USDC <-> USDC` and `USDT <-> USDT` Binance routes are included deliberately so they can compete on estimated cost against CCTP/OFT paths, but they are only generated when both chains are direct Binance networks for that asset.
 - Binance same-coin `WETH <-> WETH` routes skip the spot swap leg and treat on-chain `WETH` as Binance `ETH`.
 - Intermediate on-chain bridge legs into or out of Binance remain restricted to `USDC` and `USDT`; `WETH` routes must start and end on direct Binance ETH networks.
 

--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -24,11 +24,12 @@ Routes are assembled by the rebalancer construction layer and passed at client i
 The built-in production route set is generated in `src/rebalancer/buildRebalanceRoutes.ts`. It covers:
 
 - stablecoin swap routes between `USDC` and `USDT` on Binance and Hyperliquid,
-- same-asset bridge routes for `USDC` via CCTP and `USDT` via OFT,
+- same-asset routes for `USDC` via CCTP and Binance, and for `USDT` via OFT and Binance,
 - Binance-only `WETH <-> USDC`, `WETH <-> USDT`, and `WETH <-> WETH` routes on chains where Binance exposes direct ETH deposit and withdrawal networks.
 
 Operational note:
 
+- Same-asset `USDC <-> USDC` and `USDT <-> USDT` Binance routes are included deliberately so they can compete on estimated cost against CCTP/OFT paths.
 - Binance same-coin `WETH <-> WETH` routes skip the spot swap leg and treat on-chain `WETH` as Binance `ETH`.
 - Intermediate on-chain bridge legs into or out of Binance remain restricted to `USDC` and `USDT`; `WETH` routes must start and end on direct Binance ETH networks.
 

--- a/src/rebalancer/RebalancerClientHelper.ts
+++ b/src/rebalancer/RebalancerClientHelper.ts
@@ -8,10 +8,12 @@ import { ReadOnlyRebalancerClient } from "./clients/ReadOnlyRebalancerClient";
 
 import { RebalancerConfig } from "./RebalancerConfig";
 import { RebalancerAdapter, RebalanceRoute } from "./utils/interfaces";
+import { buildRebalanceRoutes } from "./buildRebalanceRoutes";
 
 function constructRebalancerDependencies(
   logger: winston.Logger,
-  baseSigner: Signer
+  baseSigner: Signer,
+  rebalanceRoutesOverride?: RebalanceRoute[]
 ): {
   rebalancerConfig: RebalancerConfig;
   adapters: { [name: string]: RebalancerAdapter };
@@ -37,91 +39,7 @@ function constructRebalancerDependencies(
     oftAdapter
   );
   const adapterMap = { hyperliquid: hyperliquidAdapter, binance: binanceAdapter, cctp: cctpAdapter, oft: oftAdapter };
-
-  // Following two variables are hardcoded to aid testing:
-  const usdtChains = [
-    CHAIN_IDs.HYPEREVM,
-    CHAIN_IDs.ARBITRUM,
-    CHAIN_IDs.OPTIMISM,
-    CHAIN_IDs.MAINNET,
-    CHAIN_IDs.UNICHAIN,
-    CHAIN_IDs.MONAD,
-    CHAIN_IDs.BSC,
-  ];
-  const usdcChains = [
-    CHAIN_IDs.HYPEREVM,
-    CHAIN_IDs.ARBITRUM,
-    CHAIN_IDs.OPTIMISM,
-    CHAIN_IDs.MAINNET,
-    CHAIN_IDs.BASE,
-    CHAIN_IDs.UNICHAIN,
-    CHAIN_IDs.MONAD,
-    CHAIN_IDs.BSC,
-  ];
-  const rebalanceRoutes: RebalanceRoute[] = [];
-  for (const usdtChain of usdtChains) {
-    for (const usdcChain of usdcChains) {
-      if (!rebalancerConfig.chainIds.includes(usdtChain) || !rebalancerConfig.chainIds.includes(usdcChain)) {
-        continue;
-      }
-      for (const adapter of ["binance", "hyperliquid"]) {
-        // Handle exceptions:
-        if (adapter !== "binance" && (usdtChain === CHAIN_IDs.BSC || usdcChain === CHAIN_IDs.BSC)) {
-          continue;
-        }
-
-        rebalanceRoutes.push({
-          sourceChain: usdtChain,
-          sourceToken: "USDT",
-          destinationChain: usdcChain,
-          destinationToken: "USDC",
-          adapter,
-        });
-        rebalanceRoutes.push({
-          sourceChain: usdcChain,
-          sourceToken: "USDC",
-          destinationChain: usdtChain,
-          destinationToken: "USDT",
-          adapter,
-        });
-      }
-    }
-  }
-
-  for (const usdtChain of usdtChains.filter((chain) => chain !== CHAIN_IDs.BSC)) {
-    for (const otherUsdtChain of usdtChains.filter((chain) => chain !== CHAIN_IDs.BSC)) {
-      if (!rebalancerConfig.chainIds.includes(usdtChain) || !rebalancerConfig.chainIds.includes(otherUsdtChain)) {
-        continue;
-      }
-      if (usdtChain === otherUsdtChain) {
-        continue;
-      }
-      rebalanceRoutes.push({
-        sourceChain: usdtChain,
-        sourceToken: "USDT",
-        destinationChain: otherUsdtChain,
-        destinationToken: "USDT",
-        adapter: "oft",
-      });
-    }
-  }
-  for (const usdcChain of usdcChains.filter((chain) => chain !== CHAIN_IDs.BSC)) {
-    for (const otherUsdcChain of usdcChains.filter((chain) => chain !== CHAIN_IDs.BSC)) {
-      if (!rebalancerConfig.chainIds.includes(usdcChain) || !rebalancerConfig.chainIds.includes(otherUsdcChain)) {
-        continue;
-      }
-      if (usdcChain === otherUsdcChain) {
-        continue;
-      }
-      rebalanceRoutes.push({
-        sourceChain: usdcChain,
-        sourceToken: "USDC",
-        destinationChain: otherUsdcChain,
-        destinationToken: "USDC",
-        adapter: "cctp",
-      });
-    }
-  }
+  const rebalanceRoutes = rebalanceRoutesOverride ?? buildRebalanceRoutes(rebalancerConfig);
 
   // @todo: Add test-net support for this client. For now, we only support production and we do not construct
   // any adapters or routes when running on test net.
@@ -133,9 +51,14 @@ function constructRebalancerDependencies(
 
 export async function constructCumulativeBalanceRebalancerClient(
   logger: winston.Logger,
-  baseSigner: Signer
+  baseSigner: Signer,
+  rebalanceRoutesOverride?: RebalanceRoute[]
 ): Promise<CumulativeBalanceRebalancerClient> {
-  const { rebalancerConfig, adapters, rebalanceRoutes } = constructRebalancerDependencies(logger, baseSigner);
+  const { rebalancerConfig, adapters, rebalanceRoutes } = constructRebalancerDependencies(
+    logger,
+    baseSigner,
+    rebalanceRoutesOverride
+  );
   const isReadonly = false;
   const rebalancerClient = new CumulativeBalanceRebalancerClient(
     logger,

--- a/src/rebalancer/RebalancerClientHelper.ts
+++ b/src/rebalancer/RebalancerClientHelper.ts
@@ -7,8 +7,8 @@ import { CumulativeBalanceRebalancerClient } from "./clients/CumulativeBalanceRe
 import { ReadOnlyRebalancerClient } from "./clients/ReadOnlyRebalancerClient";
 
 import { RebalancerConfig } from "./RebalancerConfig";
-import { RebalancerAdapter, RebalanceRoute } from "./utils/interfaces";
 import { buildRebalanceRoutes } from "./buildRebalanceRoutes";
+import { RebalancerAdapter, RebalanceRoute } from "./utils/interfaces";
 
 function constructRebalancerDependencies(
   logger: winston.Logger,

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -779,6 +779,17 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         truncate(withdrawalDetails.amount, binanceWithdrawalNetworkTokenInfo.decimals),
         binanceWithdrawalNetworkTokenInfo.decimals
       );
+      if (destinationToken === "WETH") {
+        this.logger.debug({
+          at: "BinanceStablecoinSwapAdapter.getPendingRebalances",
+          message:
+            `Withdrawal for order ${cloid} has finalized to ETH on ${binanceWithdrawalNetwork}, but the order remains pending until the ETH is wrapped into WETH. Keeping the destination-chain WETH credit until then`,
+          cloid: cloid,
+          orderDetails: orderDetails,
+          withdrawalDetails,
+        });
+        continue;
+      }
       this.logger.debug({
         at: "BinanceStablecoinSwapAdapter.getPendingRebalances",
         message: `Withdrawal for order ${cloid} has finalized, subtracting the order's virtual balance of ${withdrawAmountWei.toString()} from binance withdrawal network ${binanceWithdrawalNetwork}`,
@@ -1200,11 +1211,12 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       atomicDepositorContracts.transferProxyAbi
     );
     const bridgeCalldata = transferProxy.interface.encodeFunctionData("transfer", [depositAddress]);
-    const binanceDepositNetwork = await this._getEntrypointNetwork(sourceChain, "WETH");
+    // @dev The AtomicWethDepositor today is only deployed to Ethereum and the only way to use it to deposit ETH
+    // into Binance is to use the bridgeCalldata as the whitelisted function selector mapped to chain ID 56.
     return this._submitTransaction({
       contract: atomicDepositor,
       method: "bridgeWeth",
-      args: [binanceDepositNetwork, amountToDeposit, amountToDeposit, bnZero, bridgeCalldata],
+      args: [CHAIN_IDs.BSC, amountToDeposit, amountToDeposit, bnZero, bridgeCalldata],
       chainId: sourceChain,
       nonMulticall: true,
       unpermissioned: false,

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1420,8 +1420,9 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     }
     const priceData = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, sourceAmount);
     const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
+    const destinationAmount = toBNWei(truncate(value, destinationTokenInfo.decimals), destinationTokenInfo.decimals);
     return convertBinanceRouteAmount({
-      amount: sourceAmount,
+      amount: destinationAmount,
       sourceTokenDecimals: sourceTokenInfo.decimals,
       destinationTokenDecimals: destinationTokenInfo.decimals,
       isBuy: spotMarketMeta.isBuy,

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -746,7 +746,6 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       const { unfinalizedWithdrawals, finalizedWithdrawals } = await this._getBinanceWithdrawals(
         destinationToken,
         binanceWithdrawalNetwork,
-
         isDefined(matchingFill) ? Math.floor(matchingFill.time / 1000) - 5 * 60 : getCurrentTime() - 6 * 60 * 60,
         // If there is a matching fill, then look up withdrawals after the fill time. If there is no fill because
         // its not a swap route, then use a conservative lookback period. If the withdrawal is older than this lookback

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -967,7 +967,6 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         .withdrawFee,
       destinationTokenInfo.decimals
     );
-
     const latestPrice = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, amountToTransfer);
     const withdrawFeeConvertedToSourceToken = await this._convertDestinationToSource(
       destinationToken,

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1215,16 +1215,20 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     return Number(coin.balance);
   }
 
-  private async _getSymbol(sourceToken: string, destinationToken: string) {
-    const sourceAsset = resolveBinanceCoinSymbol(sourceToken);
-    const destinationAsset = resolveBinanceCoinSymbol(destinationToken);
-    let exchangeInfo;
+  private async _getExchangeInfo(): ReturnType<Binance["exchangeInfo"]> {
+    this.exchangeInfoPromise ??= this.binanceApiClient.exchangeInfo();
     try {
-      exchangeInfo = await this.exchangeInfoPromise;
+      return await this.exchangeInfoPromise;
     } catch (error) {
       this.exchangeInfoPromise = undefined;
       throw error;
     }
+  }
+
+  private async _getSymbol(sourceToken: string, destinationToken: string) {
+    const sourceAsset = resolveBinanceCoinSymbol(sourceToken);
+    const destinationAsset = resolveBinanceCoinSymbol(destinationToken);
+    const exchangeInfo = await this._getExchangeInfo();
     const symbol = exchangeInfo.symbols.find((symbols) => {
       return (
         symbols.symbol === `${sourceAsset}${destinationAsset}` || symbols.symbol === `${destinationAsset}${sourceAsset}`

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -510,7 +510,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       if (!initiatedWithdrawalId) {
         this.logger.debug({
           at: "BinanceStablecoinSwapAdapter.updateRebalanceStatuses",
-          message: `Cannot find initiated withdrawal for cloid ${cloid}, waiting`,
+          message: `Cannot find initiated withdrawal for cloid ${cloid} which filled at ${matchingFill.time}, waiting`,
           cloid: cloid,
           matchingFill: matchingFill,
         });
@@ -747,7 +747,6 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       const { unfinalizedWithdrawals, finalizedWithdrawals } = await this._getBinanceWithdrawals(
         destinationToken,
         binanceWithdrawalNetwork,
-
         isDefined(matchingFill) ? Math.floor(matchingFill.time / 1000) - 5 * 60 : getCurrentTime() - 6 * 60 * 60,
         // If there is a matching fill, then look up withdrawals after the fill time. If there is no fill because
         // its not a swap route, then use a conservative lookback period. If the withdrawal is older than this lookback

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -497,11 +497,11 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       // a bridge to the final non-Binance network destination chain if necessary.
 
       const orderDetails = await this._redisGetOrderDetails(cloid, this.baseSignerAddress);
-      const { destinationToken, destinationChain } = orderDetails;
-      const matchingFill = this._routeRequiresSwap(orderDetails.sourceToken, orderDetails.destinationToken)
+      const { sourceToken, destinationToken, destinationChain } = orderDetails;
+      const matchingFill = this._routeRequiresSwap(sourceToken, destinationToken)
         ? (await this._getMatchingFillForCloid(cloid, this.baseSignerAddress))?.matchingFill
         : undefined;
-      if (this._routeRequiresSwap(orderDetails.sourceToken, orderDetails.destinationToken) && !matchingFill) {
+      if (this._routeRequiresSwap(sourceToken, destinationToken) && !matchingFill) {
         throw new Error(`No matching fill found for cloid ${cloid} that has status PENDING_WITHDRAWAL`);
       }
       const binanceWithdrawalNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
@@ -521,8 +521,8 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         binanceWithdrawalNetwork,
         isDefined(matchingFill) ? Math.floor(matchingFill.time / 1000) - 5 * 60 : getCurrentTime() - 6 * 60 * 60,
         // If there is a matching fill, then look up withdrawals after the fill time. If there is no fill because
-        // its not a swap route, then use a conservative lookback period. If the withdrawal is older than this lookback
-        // period then it should have already been deleted from the Redis DB.
+        // it's not a swap route, then use a conservative lookback period. If the withdrawal is older than this
+        // lookback period then it should have already been deleted from Redis.
         this.baseSignerAddress.toNative()
       );
       const failedWithdrawal = failedWithdrawals.find((withdrawal) => withdrawal.id === initiatedWithdrawalId);
@@ -538,9 +538,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         await this._redisUpdateOrderStatus(
           cloid,
           STATUS.PENDING_WITHDRAWAL,
-          this._routeRequiresSwap(orderDetails.sourceToken, orderDetails.destinationToken)
-            ? STATUS.PENDING_SWAP
-            : STATUS.PENDING_DEPOSIT,
+          this._routeRequiresSwap(sourceToken, destinationToken) ? STATUS.PENDING_SWAP : STATUS.PENDING_DEPOSIT,
           this.baseSignerAddress
         );
         continue;
@@ -748,8 +746,8 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         binanceWithdrawalNetwork,
         isDefined(matchingFill) ? Math.floor(matchingFill.time / 1000) - 5 * 60 : getCurrentTime() - 6 * 60 * 60,
         // If there is a matching fill, then look up withdrawals after the fill time. If there is no fill because
-        // its not a swap route, then use a conservative lookback period. If the withdrawal is older than this lookback
-        // period then it should have already been deleted from the Redis DB.
+        // it's not a swap route, then use a conservative lookback period. If the withdrawal is older than this
+        // lookback period then it should have already been deleted from Redis.
         account.toNative()
       );
       const initiatedWithdrawalIsUnfinalized = unfinalizedWithdrawals.find(

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -812,25 +812,26 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     );
     const { withdrawMin, withdrawMax } = destinationBinanceNetwork;
     const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
+    const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationEntrypointNetwork);
 
     // Make sure that the amount to transfer will be larger than the minimum withdrawal size after expected fees.
     const expectedCost = await this.getEstimatedCost(rebalanceRoute, amountToTransfer, false);
     const expectedAmountToWithdraw = amountToTransfer.sub(expectedCost);
-    const minimumWithdrawalSize = await this._convertNumberToSource(
+    const minimumWithdrawalSize = await this._convertDestinationToSource(
       destinationToken,
       destinationEntrypointNetwork,
       sourceToken,
       sourceChain,
       // add 1% buffer to minimum withdrawal size to account for any precision loss due to the conversion from
       // destination to source token precision.
-      Number(withdrawMin) * 1.01
+      toBNWei(truncate(Number(withdrawMin) * 1.01, destinationTokenInfo.decimals), destinationTokenInfo.decimals)
     );
-    const maximumWithdrawalSize = await this._convertNumberToSource(
+    const maximumWithdrawalSize = await this._convertDestinationToSource(
       destinationToken,
       destinationEntrypointNetwork,
       sourceToken,
       sourceChain,
-      Number(withdrawMax)
+      toBNWei(truncate(Number(withdrawMax), destinationTokenInfo.decimals), destinationTokenInfo.decimals)
     );
     if (expectedAmountToWithdraw.lt(minimumWithdrawalSize)) {
       this.logger.debug({
@@ -853,15 +854,19 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     // error.
     if (routeRequiresSwap) {
       const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
+      const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationChain);
       const minimumOrderSize = spotMarketMeta.isBuy
-        ? await this._convertNumberToSource(
+        ? await this._convertDestinationToSource(
             destinationToken,
             destinationChain,
             sourceToken,
             sourceChain,
-            spotMarketMeta.minimumOrderSize
+            toBNWei(
+              truncate(spotMarketMeta.minimumOrderSize, destinationTokenInfo.decimals),
+              destinationTokenInfo.decimals
+            )
           )
-        : toBNWei(spotMarketMeta.minimumOrderSize, sourceTokenInfo.decimals);
+        : toBNWei(truncate(spotMarketMeta.minimumOrderSize, sourceTokenInfo.decimals), sourceTokenInfo.decimals);
       if (amountToTransfer.lt(minimumOrderSize)) {
         this.logger.debug({
           at: "BinanceStablecoinSwapAdapter.initializeRebalance",
@@ -965,12 +970,13 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     ).withdrawFee;
 
     const latestPrice = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, amountToTransfer);
-    const withdrawFeeConvertedToSourceToken = await this._convertNumberToSource(
+    const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationEntrypointNetwork);
+    const withdrawFeeConvertedToSourceToken = await this._convertDestinationToSource(
       destinationToken,
       destinationEntrypointNetwork,
       sourceToken,
       sourceChain,
-      Number(withdrawFee)
+      toBNWei(truncate(Number(withdrawFee), destinationTokenInfo.decimals), destinationTokenInfo.decimals)
     );
 
     const spreadPct = latestPrice.slippagePct; // slippage is a percentage so we need to divide it by an additional
@@ -1405,22 +1411,31 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     });
   }
 
-  private async _convertNumberToSource(
+  private async _convertDestinationToSource(
     destinationToken: string,
     destinationChain: number,
     sourceToken: string,
     sourceChain: number,
-    value: number
+    destinationAmount: BigNumber
   ): Promise<BigNumber> {
     const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
     const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationChain);
-    const sourceAmount = toBNWei(truncate(value, sourceTokenInfo.decimals), sourceTokenInfo.decimals);
+    const destinationAmountInSourcePrecision = this._getAmountConverter(
+      destinationChain,
+      destinationTokenInfo.address,
+      sourceChain,
+      sourceTokenInfo.address
+    )(destinationAmount);
     if (!this._routeRequiresSwap(sourceToken, destinationToken)) {
-      return sourceAmount;
+      return destinationAmountInSourcePrecision;
     }
-    const priceData = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, sourceAmount);
+    const priceData = await this._getLatestPrice(
+      sourceToken,
+      destinationToken,
+      sourceChain,
+      destinationAmountInSourcePrecision
+    );
     const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
-    const destinationAmount = toBNWei(truncate(value, destinationTokenInfo.decimals), destinationTokenInfo.decimals);
     return convertBinanceRouteAmount({
       amount: destinationAmount,
       sourceTokenDecimals: sourceTokenInfo.decimals,

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -780,8 +780,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       if (destinationToken === "WETH") {
         this.logger.debug({
           at: "BinanceStablecoinSwapAdapter.getPendingRebalances",
-          message:
-            `Withdrawal for order ${cloid} has finalized to ETH on ${binanceWithdrawalNetwork}, but the order remains pending until the ETH is wrapped into WETH. Keeping the destination-chain WETH credit until then`,
+          message: `Withdrawal for order ${cloid} has finalized to ETH on ${binanceWithdrawalNetwork}, but the order remains pending until the ETH is wrapped into WETH. Keeping the destination-chain WETH credit until then`,
           cloid: cloid,
           orderDetails: orderDetails,
           withdrawalDetails,
@@ -1233,7 +1232,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     return Number(coin.balance);
   }
 
-  private async _getExchangeInfo(): ReturnType<Binance["exchangeInfo"]> {
+  private async _getExchangeInfo(): Promise<ReturnType<Binance["exchangeInfo"]>> {
     this.exchangeInfoPromise ??= this.binanceApiClient.exchangeInfo();
     try {
       return await this.exchangeInfoPromise;
@@ -1458,7 +1457,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     });
   }
 
-  private async _getTradeFees(): ReturnType<Binance["tradeFee"]> {
+  private async _getTradeFees(): Promise<ReturnType<Binance["tradeFee"]>> {
     this.tradeFeesPromise ??= this.binanceApiClient.tradeFee();
     try {
       return await this.tradeFeesPromise;

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1431,7 +1431,10 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   }
 
   private async _getTradeFees(): ReturnType<Binance["tradeFee"]> {
-    this.tradeFeesPromise ??= this.binanceApiClient.tradeFee({ useServerTime: true });
+    this.tradeFeesPromise ??= this.binanceApiClient.tradeFee({ useServerTime: true }).catch((error) => {
+      this.tradeFeesPromise = undefined;
+      throw error;
+    });
     return this.tradeFeesPromise;
   }
 

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -76,10 +76,6 @@ export function isTerminalBinanceWithdrawal(status?: number): boolean {
   }
 }
 
-function supportsBinanceIntermediateBridgeToken(token: string): boolean {
-  return token === "USDC" || token === "USDT";
-}
-
 export function resolveBinanceCoinSymbol(token: string): string {
   return token === "WETH" ? "ETH" : token;
 }

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -42,6 +42,7 @@ import { CctpAdapter } from "./cctpAdapter";
 import { OftAdapter } from "./oftAdapter";
 import { CONTRACT_ADDRESSES } from "../../common";
 import WETH_ABI from "../../common/abi/Weth.json";
+
 interface SPOT_MARKET_META {
   symbol: string;
   baseAssetName: string;
@@ -746,6 +747,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       const { unfinalizedWithdrawals, finalizedWithdrawals } = await this._getBinanceWithdrawals(
         destinationToken,
         binanceWithdrawalNetwork,
+
         isDefined(matchingFill) ? Math.floor(matchingFill.time / 1000) - 5 * 60 : getCurrentTime() - 6 * 60 * 60,
         // If there is a matching fill, then look up withdrawals after the fill time. If there is no fill because
         // its not a swap route, then use a conservative lookback period. If the withdrawal is older than this lookback
@@ -967,6 +969,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         .withdrawFee,
       destinationTokenInfo.decimals
     );
+
     const latestPrice = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, amountToTransfer);
     const withdrawFeeConvertedToSourceToken = await this._convertDestinationToSource(
       destinationToken,

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -811,11 +811,11 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       (network) => network.name === BINANCE_NETWORKS[destinationEntrypointNetwork]
     );
     const { withdrawMin, withdrawMax } = destinationBinanceNetwork;
-    const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
-    const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationEntrypointNetwork);
 
     // Make sure that the amount to transfer will be larger than the minimum withdrawal size after expected fees.
     const expectedCost = await this.getEstimatedCost(rebalanceRoute, amountToTransfer, false);
+    const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
+    const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationEntrypointNetwork);
     const expectedAmountToWithdraw = amountToTransfer.sub(expectedCost);
     const minimumWithdrawalSize = await this._convertDestinationToSource(
       destinationToken,

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1,4 +1,4 @@
-import { Binance, NewOrderSpot, OrderType, QueryOrderResult } from "binance-api-node";
+import { Binance, NewOrderSpot, OrderType, OrderType_LT, QueryOrderResult, Symbol } from "binance-api-node";
 import {
   assert,
   BigNumber,
@@ -19,13 +19,16 @@ import {
   getBinanceApiClient,
   getBinanceTransactionTypeKey,
   getBinanceWithdrawals,
+  getCurrentTime,
   getNetworkName,
   getProvider,
+  getTokenInfoFromSymbol,
   isDefined,
-  paginatedEventQuery,
+  MAX_SAFE_ALLOWANCE,
   setBinanceDepositType,
   setBinanceWithdrawalType,
   Signer,
+  toBN,
   toBNWei,
   truncate,
   winston,
@@ -33,10 +36,12 @@ import {
 import { OrderDetails, RebalanceRoute } from "../utils/interfaces";
 import { STATUS } from "../utils/utils";
 import { BaseAdapter } from "./baseAdapter";
-import { AugmentedTransaction } from "../../clients";
+import { AugmentedTransaction, MultiCallerClient } from "../../clients";
 import { RebalancerConfig } from "../RebalancerConfig";
 import { CctpAdapter } from "./cctpAdapter";
 import { OftAdapter } from "./oftAdapter";
+import { CONTRACT_ADDRESSES } from "../../common";
+import WETH_ABI from "../../common/abi/Weth.json";
 
 interface SPOT_MARKET_META {
   symbol: string;
@@ -71,38 +76,117 @@ export function isTerminalBinanceWithdrawal(status?: number): boolean {
   }
 }
 
+export function resolveBinanceCoinSymbol(token: string): string {
+  return token === "WETH" ? "ETH" : token;
+}
+
+export function isSameBinanceCoin(sourceToken: string, destinationToken: string): boolean {
+  return resolveBinanceCoinSymbol(sourceToken) === resolveBinanceCoinSymbol(destinationToken);
+}
+
+export function supportsBinanceIntermediateBridgeToken(token: string): boolean {
+  return token === "USDC" || token === "USDT";
+}
+
+function getAtomicDepositorContracts(chainId: number):
+  | {
+      atomicDepositorAddress: string;
+      atomicDepositorAbi: unknown[];
+      transferProxyAddress: string;
+      transferProxyAbi: unknown[];
+    }
+  | undefined {
+  const chainContracts = CONTRACT_ADDRESSES[chainId];
+  const atomicDepositorAddress = chainContracts?.atomicDepositor?.address;
+  const atomicDepositorAbi = chainContracts?.atomicDepositor?.abi;
+  const transferProxyAddress = chainContracts?.atomicDepositorTransferProxy?.address;
+  const transferProxyAbi = chainContracts?.atomicDepositorTransferProxy?.abi;
+  if (
+    !isDefined(atomicDepositorAddress) ||
+    !isDefined(atomicDepositorAbi) ||
+    !isDefined(transferProxyAddress) ||
+    !isDefined(transferProxyAbi)
+  ) {
+    return undefined;
+  }
+  return { atomicDepositorAddress, atomicDepositorAbi, transferProxyAddress, transferProxyAbi };
+}
+
+function usesBinanceAtomicDepositorTransfer(token: string, chainId: number): boolean {
+  return token === "WETH" && isDefined(getAtomicDepositorContracts(chainId));
+}
+
+export function deriveBinanceSpotMarketMeta(
+  sourceToken: string,
+  destinationToken: string,
+  symbol: Symbol<OrderType_LT>
+): SPOT_MARKET_META {
+  const sourceAsset = resolveBinanceCoinSymbol(sourceToken);
+  const destinationAsset = resolveBinanceCoinSymbol(destinationToken);
+  const isBuy = symbol.baseAsset === destinationAsset && symbol.quoteAsset === sourceAsset;
+  const isSell = symbol.baseAsset === sourceAsset && symbol.quoteAsset === destinationAsset;
+  assert(isBuy || isSell, `No spot market meta found for route: ${sourceToken}-${destinationToken}`);
+
+  const priceFilter = symbol.filters.find((filter) => filter.filterType === "PRICE_FILTER");
+  const sizeFilter = symbol.filters.find((filter) => filter.filterType === "LOT_SIZE");
+  assert(isDefined(priceFilter?.tickSize), `PRICE_FILTER missing tickSize for ${symbol.symbol}`);
+  assert(isDefined(sizeFilter?.stepSize) && isDefined(sizeFilter?.minQty), `LOT_SIZE missing for ${symbol.symbol}`);
+
+  return {
+    symbol: symbol.symbol,
+    baseAssetName: symbol.baseAsset,
+    quoteAssetName: symbol.quoteAsset,
+    pxDecimals: resolveStepPrecision(priceFilter.tickSize),
+    szDecimals: resolveStepPrecision(sizeFilter.stepSize),
+    minimumOrderSize: Number(sizeFilter.minQty),
+    isBuy,
+  };
+}
+
+export function convertBinanceRouteAmount(params: {
+  amount: BigNumber;
+  sourceTokenDecimals: number;
+  destinationTokenDecimals: number;
+  isBuy: boolean;
+  price: number;
+  direction: "source-to-destination" | "destination-to-source";
+}): BigNumber {
+  const isSourceToDestination = params.direction === "source-to-destination";
+  const inputDecimals = isSourceToDestination ? params.sourceTokenDecimals : params.destinationTokenDecimals;
+  const outputDecimals = isSourceToDestination ? params.destinationTokenDecimals : params.sourceTokenDecimals;
+  const readableAmount = Number(fromWei(params.amount, inputDecimals));
+  const convertedAmount = isSourceToDestination
+    ? params.isBuy
+      ? readableAmount / params.price
+      : readableAmount * params.price
+    : params.isBuy
+      ? readableAmount * params.price
+      : readableAmount / params.price;
+
+  return toBNWei(truncate(convertedAmount, outputDecimals), outputDecimals);
+}
+
+function resolveStepPrecision(stepSize: string): number {
+  const normalized = stepSize.replace(/0+$/, "").replace(/\.$/, "");
+  const decimalPart = normalized.split(".")[1];
+  return decimalPart?.length ?? 0;
+}
+
 export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   private binanceApiClient: Binance;
+  private tradeFeesPromise?: ReturnType<Binance["tradeFee"]>;
+  private exchangeInfoPromise?: ReturnType<Binance["exchangeInfo"]>;
   private orderBookPromiseBySymbol = new Map<string, Promise<Awaited<ReturnType<Binance["book"]>>>>();
   private orderBookSnapshotBySymbol = new Map<
     string,
     { fetchedAtMs: number; book: Awaited<ReturnType<Binance["book"]>> }
   >();
+  private spotMarketMetaPromiseByRoute = new Map<string, Promise<SPOT_MARKET_META>>();
 
   REDIS_PREFIX = "binance-stablecoin-swap:";
   private static readonly ORDER_BOOK_CACHE_TTL_MS = 30_000;
 
   REDIS_KEY_INITIATED_WITHDRAWALS = this.REDIS_PREFIX + "initiated-withdrawals";
-  private spotMarketMeta: { [name: string]: SPOT_MARKET_META } = {
-    "USDT-USDC": {
-      symbol: "USDCUSDT",
-      baseAssetName: "USDC",
-      quoteAssetName: "USDT",
-      pxDecimals: 4, // PRICE_FILTER.tickSize: '0.00010000'
-      szDecimals: 0, // SIZE_FILTER.stepSize: '1.00000000'
-      isBuy: true,
-      minimumOrderSize: 1,
-    },
-    "USDC-USDT": {
-      symbol: "USDCUSDT",
-      baseAssetName: "USDC",
-      quoteAssetName: "USDT",
-      pxDecimals: 4, // PRICE_FILTER.tickSize: '0.00010000'
-      szDecimals: 0, // SIZE_FILTER.stepSize: '1.00000000'
-      isBuy: false,
-      minimumOrderSize: 1,
-    },
-  };
   constructor(
     readonly logger: winston.Logger,
     readonly config: RebalancerConfig,
@@ -141,6 +225,12 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       const getIntermediateAdapterName = (token: string) => (token === "USDT" ? "oft" : "cctp");
       // Validate that route can be supported using intermediate bridges to get to/from Arbitrum to access Binance.
       if (destinationEntrypointNetwork !== destinationChain) {
+        assert(
+          supportsBinanceIntermediateBridgeToken(destinationToken),
+          `Destination chain ${getNetworkName(
+            destinationChain
+          )} is not a direct Binance withdrawal network for ${destinationToken}; this token cannot use intermediate bridge legs`
+        );
         const intermediateRoute = {
           ...route,
           sourceChain: destinationEntrypointNetwork,
@@ -157,6 +247,12 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         );
       }
       if (sourceEntrypointNetwork !== sourceChain) {
+        assert(
+          supportsBinanceIntermediateBridgeToken(sourceToken),
+          `Source chain ${getNetworkName(
+            sourceChain
+          )} is not a direct Binance deposit network for ${sourceToken}; this token cannot use intermediate bridge legs`
+        );
         const intermediateRoute = {
           ...route,
           destinationChain: sourceEntrypointNetwork,
@@ -172,6 +268,13 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
           )} bridge route to the Binance entrypoint network ${sourceEntrypointNetwork}`
         );
       }
+      // Enforce that if source token is WETH that the source chain has an atomic depositor contract.
+      if (sourceToken === "WETH") {
+        assert(
+          isDefined(getAtomicDepositorContracts(sourceEntrypointNetwork)),
+          `Atomic depositor contracts missing for ${getNetworkName(sourceEntrypointNetwork)}`
+        );
+      }
       assert(
         sourceCoin.networkList.find((network) => network.name === BINANCE_NETWORKS[sourceEntrypointNetwork]),
         `Source token ${sourceToken} network list does not contain Binance source entrypoint network "${
@@ -185,6 +288,51 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         }", available networks: ${destinationCoin.networkList.map((network) => network.name).join(", ")}`
       );
     });
+  }
+
+  async setApprovals(): Promise<void> {
+    this._assertInitialized();
+    const approvalChains = Array.from(
+      new Set(
+        this.availableRoutes
+          .filter(({ sourceToken, sourceChain }) => usesBinanceAtomicDepositorTransfer(sourceToken, sourceChain))
+          .map(({ sourceChain }) => sourceChain)
+      )
+    );
+    if (approvalChains.length === 0) {
+      return;
+    }
+
+    this.multicallerClient = new MultiCallerClient(this.logger, this.config.multiCallChunkSize, this.baseSigner);
+
+    await forEachAsync(approvalChains, async (sourceChain) => {
+      const connectedSigner = this.baseSigner.connect(await getProvider(sourceChain));
+      const weth = new Contract(this._getTokenInfo("WETH", sourceChain).address.toNative(), ERC20.abi, connectedSigner);
+      const atomicDepositorContracts = getAtomicDepositorContracts(sourceChain);
+      assert(
+        isDefined(atomicDepositorContracts),
+        `Atomic depositor contracts missing for ${getNetworkName(sourceChain)}`
+      );
+      const allowance = await weth.allowance(
+        this.baseSignerAddress.toNative(),
+        atomicDepositorContracts.atomicDepositorAddress
+      );
+      if (allowance.lt(toBN(MAX_SAFE_ALLOWANCE).div(2))) {
+        this.multicallerClient.enqueueTransaction({
+          contract: weth,
+          chainId: sourceChain,
+          method: "approve",
+          nonMulticall: true,
+          unpermissioned: false,
+          args: [atomicDepositorContracts.atomicDepositorAddress, MAX_SAFE_ALLOWANCE],
+          message: "Approved WETH for AtomicDepositor",
+          mrkdwn: "Approved WETH for AtomicDepositor",
+        });
+      }
+    });
+
+    const simMode = !this.config.sendingTransactionsEnabled;
+    await this.multicallerClient.executeTxnQueues(simMode);
   }
 
   async updateRebalanceStatuses(): Promise<void> {
@@ -250,7 +398,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     }
     for (const cloid of pendingDeposits) {
       const orderDetails = await this._redisGetOrderDetails(cloid, this.baseSignerAddress);
-      const { sourceToken, sourceChain, amountToTransfer } = orderDetails;
+      const { sourceToken, sourceChain, destinationToken, destinationChain, amountToTransfer } = orderDetails;
 
       const binanceBalance = await this._getBinanceBalance(sourceToken);
       const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
@@ -268,11 +416,26 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         availableBalance: binanceBalanceWei.toString(),
         requiredBalance: amountToTransfer.toString(),
       });
-      await this._placeMarketOrder(cloid, orderDetails);
-      await this._redisUpdateOrderStatus(cloid, STATUS.PENDING_DEPOSIT, STATUS.PENDING_SWAP, this.baseSignerAddress);
+      if (this._routeRequiresSwap(sourceToken, destinationToken)) {
+        await this._placeMarketOrder(cloid, orderDetails);
+        await this._redisUpdateOrderStatus(cloid, STATUS.PENDING_DEPOSIT, STATUS.PENDING_SWAP, this.baseSignerAddress);
+      } else {
+        await this._withdraw(
+          cloid,
+          Number(fromWei(amountToTransfer, sourceTokenInfo.decimals)),
+          destinationToken,
+          destinationChain
+        );
+        await this._redisUpdateOrderStatus(
+          cloid,
+          STATUS.PENDING_DEPOSIT,
+          STATUS.PENDING_WITHDRAWAL,
+          this.baseSignerAddress
+        );
+      }
       // Delay a bit before checking balances to withdraw so we can give this function a chance to successively place
-      // a market order successfully and subsequently withdraw the filled order. It takes a short time for the just filled
-      // order to be reflected in the balance.
+      // a market order successfully and subsequently withdraw the filled order. It also gives direct same-coin
+      // withdrawals a short time to be reflected in Binance/accounting state.
       await this._wait(10);
     }
 
@@ -336,8 +499,10 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
 
       const orderDetails = await this._redisGetOrderDetails(cloid, this.baseSignerAddress);
       const { destinationToken, destinationChain } = orderDetails;
-      const { matchingFill } = await this._getMatchingFillForCloid(cloid, this.baseSignerAddress);
-      if (!matchingFill) {
+      const matchingFill = this._routeRequiresSwap(orderDetails.sourceToken, orderDetails.destinationToken)
+        ? (await this._getMatchingFillForCloid(cloid, this.baseSignerAddress))?.matchingFill
+        : undefined;
+      if (this._routeRequiresSwap(orderDetails.sourceToken, orderDetails.destinationToken) && !matchingFill) {
         throw new Error(`No matching fill found for cloid ${cloid} that has status PENDING_WITHDRAWAL`);
       }
       const binanceWithdrawalNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
@@ -345,7 +510,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       if (!initiatedWithdrawalId) {
         this.logger.debug({
           at: "BinanceStablecoinSwapAdapter.updateRebalanceStatuses",
-          message: `Cannot find initiated withdrawal for cloid ${cloid} which filled at ${matchingFill.time}, waiting`,
+          message: `Cannot find initiated withdrawal for cloid ${cloid}, waiting`,
           cloid: cloid,
           matchingFill: matchingFill,
         });
@@ -355,8 +520,10 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       const { unfinalizedWithdrawals, finalizedWithdrawals, failedWithdrawals } = await this._getBinanceWithdrawals(
         orderDetails.destinationToken,
         binanceWithdrawalNetwork,
-        Math.floor(matchingFill.time / 1000) - 5 * 60, // Floor this so we can grab the initiated withdrawal data whose
-        // ID we've already saved into Redis
+        isDefined(matchingFill) ? Math.floor(matchingFill.time / 1000) - 5 * 60 : getCurrentTime() - 6 * 60 * 60,
+        // If there is a matching fill, then look up withdrawals after the fill time. If there is no fill because
+        // its not a swap route, then use a conservative lookback period. If the withdrawal is older than this lookback
+        // period then it should have already been deleted from the Redis DB.
         this.baseSignerAddress.toNative()
       );
       const failedWithdrawal = failedWithdrawals.find((withdrawal) => withdrawal.id === initiatedWithdrawalId);
@@ -372,7 +539,9 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         await this._redisUpdateOrderStatus(
           cloid,
           STATUS.PENDING_WITHDRAWAL,
-          STATUS.PENDING_SWAP,
+          this._routeRequiresSwap(orderDetails.sourceToken, orderDetails.destinationToken)
+            ? STATUS.PENDING_SWAP
+            : STATUS.PENDING_DEPOSIT,
           this.baseSignerAddress
         );
         continue;
@@ -395,23 +564,43 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       if (!withdrawalDetails) {
         this.logger.debug({
           at: "BinanceStablecoinSwapAdapter.updateRebalanceStatuses",
-          message: `Cannot find withdrawal details in Binance API response for withdrawal history for cloid ${cloid} which filled at ${matchingFill.time}, waiting....`,
+          message: `Cannot find withdrawal details in Binance API response for withdrawal history for cloid ${cloid}, waiting....`,
         });
         continue;
+      }
+
+      const binanceWithdrawalNetworkTokenInfo = this._getTokenInfo(destinationToken, binanceWithdrawalNetwork);
+      const withdrawAmountWei = toBNWei(
+        truncate(withdrawalDetails.amount, binanceWithdrawalNetworkTokenInfo.decimals),
+        binanceWithdrawalNetworkTokenInfo.decimals
+      );
+
+      // Check if we need to wrap the withdrawal to WETH:
+      if (destinationToken === "WETH") {
+        const balance = await this.baseSigner.connect(await getProvider(binanceWithdrawalNetwork)).getBalance();
+        if (balance.lt(withdrawAmountWei)) {
+          this.logger.debug({
+            at: "BinanceStablecoinSwapAdapter.updateRebalanceStatuses",
+            message: `Order ${cloid} has finalized withdrawing to ${binanceWithdrawalNetwork} and needs to be wrapped to WETH, but there is not enough balance on ${binanceWithdrawalNetwork} to wrap ${destinationToken} to ${destinationChain} for ${withdrawAmountWei.toString()}, waiting...`,
+            balance: balance.toString(),
+            requiredWithdrawAmount: withdrawAmountWei.toString(),
+          });
+          continue;
+        }
+        await this._wrapEth(binanceWithdrawalNetwork, withdrawAmountWei);
       }
 
       // Check if we need to bridge the withdrawal to the final destination chain:
       const requiresBridgeAfterWithdrawal = binanceWithdrawalNetwork !== destinationChain;
       if (requiresBridgeAfterWithdrawal) {
+        assert(
+          supportsBinanceIntermediateBridgeToken(destinationToken),
+          `Destination token ${destinationToken} cannot use an intermediate bridge leg out of Binance`
+        );
         const balance = await this._getERC20Balance(
           binanceWithdrawalNetwork,
           this._getTokenInfo(destinationToken, binanceWithdrawalNetwork).address.toNative(),
           this.baseSignerAddress
-        );
-        const binanceWithdrawalNetworkTokenInfo = this._getTokenInfo(destinationToken, binanceWithdrawalNetwork);
-        const withdrawAmountWei = toBNWei(
-          truncate(withdrawalDetails.amount, binanceWithdrawalNetworkTokenInfo.decimals),
-          binanceWithdrawalNetworkTokenInfo.decimals
         );
         if (balance.lt(withdrawAmountWei)) {
           this.logger.debug({
@@ -450,7 +639,6 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     // Finalizer because we set the TTL to 30 minutes when we deposited the funds and called
     // setBinanceDepositType().
   }
-
   async getPendingRebalances(account: EvmAddress): Promise<{ [chainId: number]: { [token: string]: BigNumber } }> {
     this._assertInitialized();
     const pendingRebalances: { [chainId: number]: { [token: string]: BigNumber } } = {};
@@ -468,13 +656,13 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       const orderDetails = await this._redisGetOrderDetails(cloid, account);
       const { sourceChain, sourceToken, amountToTransfer } = orderDetails;
       const binanceDepositNetwork = await this._getEntrypointNetwork(sourceChain, sourceToken);
-      const amountConverter = this._getAmountConverter(
+      const convertedAmount = await this._convertSourceToDestination(
+        sourceToken,
         sourceChain,
-        this._getTokenInfo(sourceToken, sourceChain).address,
+        sourceToken,
         binanceDepositNetwork,
-        this._getTokenInfo(sourceToken, binanceDepositNetwork).address
+        amountToTransfer
       );
-      const convertedAmount = amountConverter(amountToTransfer);
       pendingRebalances[binanceDepositNetwork] ??= {};
       pendingRebalances[binanceDepositNetwork][sourceToken] = (
         pendingRebalances[binanceDepositNetwork][sourceToken] ?? bnZero
@@ -498,23 +686,36 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     for (const cloid of pendingOrders) {
       const orderDetails = await this._redisGetOrderDetails(cloid, account);
       const { destinationChain, destinationToken, sourceChain, sourceToken, amountToTransfer } = orderDetails;
-      // Convert amountToTransfer to destination chain precision:
-      const amountConverter = this._getAmountConverter(
-        sourceChain,
-        this._getTokenInfo(sourceToken, sourceChain).address,
-        destinationChain,
-        this._getTokenInfo(destinationToken, destinationChain).address
-      );
-      const convertedAmount = amountConverter(amountToTransfer);
+
+      let expectedAmountToReceive: BigNumber;
+
+      const matchingFill = this._routeRequiresSwap(sourceToken, destinationToken)
+        ? await this._getMatchingFillForCloid(cloid, account)
+        : undefined;
+      if (matchingFill) {
+        const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationChain);
+        expectedAmountToReceive = toBNWei(
+          truncate(Number(matchingFill.expectedAmountToReceive), destinationTokenInfo.decimals),
+          destinationTokenInfo.decimals
+        );
+      } else {
+        expectedAmountToReceive = await this._convertSourceToDestination(
+          sourceToken,
+          sourceChain,
+          destinationToken,
+          destinationChain,
+          amountToTransfer
+        );
+      }
       this.logger.debug({
         at: "BinanceStablecoinSwapAdapter.getPendingRebalances",
-        message: `Adding ${convertedAmount.toString()} for pending order cloid ${cloid} to destination chain ${destinationChain}`,
+        message: `Adding ${expectedAmountToReceive.toString()} for pending order cloid ${cloid} to destination chain ${destinationChain}`,
         cloid: cloid,
       });
       pendingRebalances[destinationChain] ??= {};
       pendingRebalances[destinationChain][destinationToken] = (
         pendingRebalances[destinationChain][destinationToken] ?? bnZero
-      ).add(convertedAmount);
+      ).add(expectedAmountToReceive);
     }
 
     // Similar to how we treat orders that are in the state of being bridged to a Binance deposit network, we need to
@@ -524,16 +725,20 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const pendingWithdrawals = await this._redisGetPendingWithdrawals(account);
     for (const cloid of pendingWithdrawals) {
       const orderDetails = await this._redisGetOrderDetails(cloid, account);
-      const { destinationChain, destinationToken, sourceChain, sourceToken, amountToTransfer } = orderDetails;
-      const { matchingFill } = await this._getMatchingFillForCloid(cloid, account);
-      assert(isDefined(matchingFill), "Matching fill should be defined for order with status PENDING_WITHDRAWAL");
+      const { destinationChain, destinationToken, sourceToken } = orderDetails;
+      const matchingFill = this._routeRequiresSwap(sourceToken, destinationToken)
+        ? (await this._getMatchingFillForCloid(cloid, account))?.matchingFill
+        : undefined;
+      if (this._routeRequiresSwap(sourceToken, destinationToken)) {
+        assert(isDefined(matchingFill), "Matching fill should be defined for order with status PENDING_WITHDRAWAL");
+      }
 
       const binanceWithdrawalNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
       const initiatedWithdrawalId = await this._redisGetInitiatedWithdrawalId(cloid);
       if (!initiatedWithdrawalId) {
         this.logger.debug({
           at: "BinanceStablecoinSwapAdapter.getPendingRebalances",
-          message: `Cannot find initiated withdrawal for cloid ${cloid} which filled at ${matchingFill.time}, waiting`,
+          message: `Cannot find initiated withdrawal for cloid ${cloid}, waiting`,
           cloid: cloid,
           matchingFill: matchingFill,
         });
@@ -542,8 +747,11 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       const { unfinalizedWithdrawals, finalizedWithdrawals } = await this._getBinanceWithdrawals(
         destinationToken,
         binanceWithdrawalNetwork,
-        Math.floor(matchingFill.time / 1000) - 5 * 60, // Floor this so we can grab the initiated withdrawal data whose
-        // ID we've already saved into Redis
+
+        isDefined(matchingFill) ? Math.floor(matchingFill.time / 1000) - 5 * 60 : getCurrentTime() - 6 * 60 * 60,
+        // If there is a matching fill, then look up withdrawals after the fill time. If there is no fill because
+        // its not a swap route, then use a conservative lookback period. If the withdrawal is older than this lookback
+        // period then it should have already been deleted from the Redis DB.
         account.toNative()
       );
       const initiatedWithdrawalIsUnfinalized = unfinalizedWithdrawals.find(
@@ -564,20 +772,18 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       if (!withdrawalDetails) {
         this.logger.debug({
           at: "BinanceStablecoinSwapAdapter.getPendingRebalances",
-          message: `Cannot find withdrawal details for cloid ${cloid} which filled at ${matchingFill.time}, waiting...`,
+          message: `Cannot find withdrawal details for cloid ${cloid}, waiting...`,
         });
         continue;
       }
-      const amountConverter = this._getAmountConverter(
-        sourceChain,
-        this._getTokenInfo(sourceToken, sourceChain).address,
-        destinationChain,
-        this._getTokenInfo(destinationToken, destinationChain).address
+      const binanceWithdrawalNetworkTokenInfo = this._getTokenInfo(destinationToken, binanceWithdrawalNetwork);
+      const withdrawAmountWei = toBNWei(
+        truncate(withdrawalDetails.amount, binanceWithdrawalNetworkTokenInfo.decimals),
+        binanceWithdrawalNetworkTokenInfo.decimals
       );
-      const convertedAmount = amountConverter(amountToTransfer);
       this.logger.debug({
         at: "BinanceStablecoinSwapAdapter.getPendingRebalances",
-        message: `Withdrawal for order ${cloid} has finalized, subtracting the order's virtual balance of ${convertedAmount.toString()} from binance withdrawal network ${binanceWithdrawalNetwork}`,
+        message: `Withdrawal for order ${cloid} has finalized, subtracting the order's virtual balance of ${withdrawAmountWei.toString()} from binance withdrawal network ${binanceWithdrawalNetwork}`,
         cloid: cloid,
         orderDetails: orderDetails,
         withdrawalDetails,
@@ -585,7 +791,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       pendingRebalances[binanceWithdrawalNetwork] ??= {};
       pendingRebalances[binanceWithdrawalNetwork][destinationToken] = (
         pendingRebalances[binanceWithdrawalNetwork][destinationToken] ?? bnZero
-      ).sub(convertedAmount);
+      ).sub(withdrawAmountWei);
     }
 
     return pendingRebalances;
@@ -599,6 +805,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     this._assertInitialized();
     this._assertRouteIsSupported(rebalanceRoute);
     const { sourceChain, sourceToken, destinationToken, destinationChain } = rebalanceRoute;
+    const routeRequiresSwap = this._routeRequiresSwap(sourceToken, destinationToken);
 
     const destinationCoin = await this._getAccountCoins(destinationToken);
     const destinationEntrypointNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
@@ -606,14 +813,28 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       (network) => network.name === BINANCE_NETWORKS[destinationEntrypointNetwork]
     );
     const { withdrawMin, withdrawMax } = destinationBinanceNetwork;
+    const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
+    const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationEntrypointNetwork);
 
     // Make sure that the amount to transfer will be larger than the minimum withdrawal size after expected fees.
     const expectedCost = await this.getEstimatedCost(rebalanceRoute, amountToTransfer, false);
     const expectedAmountToWithdraw = amountToTransfer.sub(expectedCost);
-    const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
-    const minimumWithdrawalSize = toBNWei(Number(withdrawMin) + 1, sourceTokenInfo.decimals); // Add buffer to minimum to account
-    // for price volatility. For stablecoin swaps, this should be totally fine since price isn't volatile.
-    const maximumWithdrawalSize = toBNWei(withdrawMax, sourceTokenInfo.decimals);
+    const minimumWithdrawalSize = await this._convertDestinationToSource(
+      destinationToken,
+      destinationEntrypointNetwork,
+      sourceToken,
+      sourceChain,
+      // add 1% buffer to minimum withdrawal size to account for any precision loss due to the conversion from
+      // destination to source token precision.
+      toBNWei(Number(withdrawMin), destinationTokenInfo.decimals).mul(toBNWei(101, 18)).div(toBNWei(100, 18))
+    );
+    const maximumWithdrawalSize = await this._convertDestinationToSource(
+      destinationToken,
+      destinationEntrypointNetwork,
+      sourceToken,
+      sourceChain,
+      toBNWei(withdrawMax, destinationTokenInfo.decimals)
+    );
     if (expectedAmountToWithdraw.lt(minimumWithdrawalSize)) {
       this.logger.debug({
         at: "BinanceStablecoinSwapAdapter.initializeRebalance",
@@ -633,14 +854,24 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     // tick size. We try not to precompute the size required to place an order here because the price might change
     // and the amount transferred in might be insufficient to place the order later on, producing more dust or an
     // error.
-    const spotMarketMeta = this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
-    const minimumOrderSize = toBNWei(spotMarketMeta.minimumOrderSize, sourceTokenInfo.decimals);
-    if (amountToTransfer.lt(minimumOrderSize)) {
-      this.logger.debug({
-        at: "BinanceStablecoinSwapAdapter.initializeRebalance",
-        message: `Amount to transfer ${amountToTransfer.toString()} is less than minimum order size ${minimumOrderSize.toString()}`,
-      });
-      return bnZero;
+    if (routeRequiresSwap) {
+      const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
+      const minimumOrderSize = spotMarketMeta.isBuy
+        ? await this._convertDestinationToSource(
+            destinationToken,
+            destinationChain,
+            sourceToken,
+            sourceChain,
+            toBNWei(spotMarketMeta.minimumOrderSize, destinationTokenInfo.decimals)
+          )
+        : toBNWei(spotMarketMeta.minimumOrderSize, sourceTokenInfo.decimals);
+      if (amountToTransfer.lt(minimumOrderSize)) {
+        this.logger.debug({
+          at: "BinanceStablecoinSwapAdapter.initializeRebalance",
+          message: `Amount to transfer ${amountToTransfer.toString()} is less than minimum order size ${minimumOrderSize.toString()}`,
+        });
+        return bnZero;
+      }
     }
 
     const cloid = await this._redisGetNextCloid();
@@ -652,6 +883,10 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const binanceDepositNetwork = await this._getEntrypointNetwork(sourceChain, sourceToken);
     const requiresBridgeBeforeDeposit = binanceDepositNetwork !== sourceChain;
     if (requiresBridgeBeforeDeposit) {
+      assert(
+        supportsBinanceIntermediateBridgeToken(sourceToken),
+        `Source token ${sourceToken} cannot use an intermediate bridge leg into Binance`
+      );
       const balance = await this._getERC20Balance(
         sourceChain,
         this._getTokenInfo(sourceToken, sourceChain).address.toNative(),
@@ -717,11 +952,14 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   ): Promise<BigNumber> {
     this._assertRouteIsSupported(rebalanceRoute);
     const { sourceToken, destinationToken, sourceChain, destinationChain } = rebalanceRoute;
-    const spotMarketMeta = this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
+    const routeRequiresSwap = this._routeRequiresSwap(sourceToken, destinationToken);
+    const spotMarketMeta = routeRequiresSwap
+      ? await this._getSpotMarketMetaForRoute(sourceToken, destinationToken)
+      : undefined;
     // Commission is denominated in percentage points.
-    const tradeFeePct = (await this.binanceApiClient.tradeFee()).find(
-      (fee) => fee.symbol === spotMarketMeta.symbol
-    ).takerCommission;
+    const tradeFeePct = routeRequiresSwap
+      ? (await this._getTradeFees()).find((fee) => fee.symbol === spotMarketMeta.symbol).takerCommission
+      : "0";
     const tradeFee = toBNWei(tradeFeePct, 18).mul(amountToTransfer).div(toBNWei(100, 18));
     const destinationCoin = await this._getAccountCoins(destinationToken);
     const destinationEntrypointNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
@@ -731,32 +969,28 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         .withdrawFee,
       destinationTokenInfo.decimals
     );
-    const amountConverter = this._getAmountConverter(
+
+    const latestPrice = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, amountToTransfer);
+    const withdrawFeeConvertedToSourceToken = await this._convertDestinationToSource(
+      destinationToken,
       destinationEntrypointNetwork,
-      this._getTokenInfo(destinationToken, destinationEntrypointNetwork).address,
+      sourceToken,
       sourceChain,
-      this._getTokenInfo(sourceToken, sourceChain).address
+      withdrawFee
     );
-    const withdrawFeeConvertedToSourceToken = amountConverter(withdrawFee);
 
-    const { latestPrice } = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, amountToTransfer);
-
-    // Bridge fee
-
-    const isBuy = spotMarketMeta.isBuy;
-    let spreadPct = 0;
-    if (isBuy) {
-      // if is buy, the fee is positive if the price is over 1
-      spreadPct = latestPrice - 1;
-    } else {
-      spreadPct = 1 - latestPrice;
-    }
-    const spreadFee = toBNWei(spreadPct.toFixed(18), 18).mul(amountToTransfer).div(toBNWei(1, 18));
+    const spreadPct = latestPrice.slippagePct; // slippage is a percentage so we need to divide it by an additional
+    // 100 to get it to a decimal.
+    const spreadFee = toBNWei(spreadPct, 18).mul(amountToTransfer).div(toBNWei(1, 20));
 
     // Bridge to Binance deposit network Fee:
     let bridgeToBinanceFee = bnZero;
     const binanceDepositNetwork = await this._getEntrypointNetwork(sourceChain, sourceToken);
     if (binanceDepositNetwork !== sourceChain) {
+      assert(
+        supportsBinanceIntermediateBridgeToken(sourceToken),
+        `Source token ${sourceToken} cannot use an intermediate bridge leg into Binance`
+      );
       const _rebalanceRoute = { ...rebalanceRoute, destinationChain: binanceDepositNetwork };
       if (
         sourceToken === "USDT" &&
@@ -781,14 +1015,25 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     let bridgeFromBinanceFee = bnZero;
     const binanceWithdrawNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
     if (binanceWithdrawNetwork !== destinationChain) {
+      assert(
+        supportsBinanceIntermediateBridgeToken(destinationToken),
+        `Destination token ${destinationToken} cannot use an intermediate bridge leg out of Binance`
+      );
       const _rebalanceRoute = { ...rebalanceRoute, sourceChain: binanceWithdrawNetwork };
+      const bridgeAmountConverted = await this._convertSourceToDestination(
+        sourceToken,
+        sourceChain,
+        destinationToken,
+        binanceWithdrawNetwork,
+        amountToTransfer
+      );
       if (
         destinationToken === "USDT" &&
         this.oftAdapter.supportsRoute({ ..._rebalanceRoute, sourceToken: "USDT", adapter: "oft" })
       ) {
         bridgeFromBinanceFee = await this.oftAdapter.getEstimatedCost(
           { ..._rebalanceRoute, sourceToken: "USDT", adapter: "oft" },
-          amountToTransfer
+          bridgeAmountConverted
         );
       } else if (
         destinationToken === "USDC" &&
@@ -796,7 +1041,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       ) {
         bridgeFromBinanceFee = await this.cctpAdapter.getEstimatedCost(
           { ..._rebalanceRoute, sourceToken: "USDC", adapter: "cctp" },
-          amountToTransfer
+          bridgeAmountConverted
         );
       }
     }
@@ -827,11 +1072,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     if (debugLog) {
       this.logger.debug({
         at: "BinanceStablecoinSwapAdapter.getEstimatedCost",
-        message: `Calculating total fees for rebalance route ${sourceToken} on ${getNetworkName(
-          sourceChain
-        )} to ${destinationToken} on ${getNetworkName(
-          destinationChain
-        )} with amount to transfer ${amountToTransfer.toString()}`,
+        message: `Calculating total fees for rebalance route ${sourceToken} on ${getNetworkName(sourceChain)} to ${destinationToken} on ${getNetworkName(destinationChain)} with amount to transfer ${amountToTransfer.toString()}`,
         tradeFeePct,
         tradeFee: tradeFee.toString(),
         withdrawFeeConvertedToSourceToken: withdrawFeeConvertedToSourceToken.toString(),
@@ -853,6 +1094,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   // ////////////////////////////////////////////////////////////
 
   private async _getAccountCoins(symbol: string, skipCache = false): Promise<Coin> {
+    const binanceSymbol = resolveBinanceCoinSymbol(symbol);
     const cacheKey = "binance-account-coins";
 
     type ParsedAccountCoins = Awaited<ReturnType<typeof getAccountCoins>>;
@@ -870,8 +1112,8 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       // the entry for this coin is not expected to change frequently.
     }
 
-    const coin = accountCoins.find((coin) => coin.symbol === symbol);
-    assert(coin, `Coin ${symbol} not found in account coins`);
+    const coin = accountCoins.find((coin) => coin.symbol === binanceSymbol);
+    assert(coin, `Coin ${binanceSymbol} not found in account coins`);
     return coin;
   }
 
@@ -889,26 +1131,41 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
 
   private async _depositToBinance(sourceToken: string, sourceChain: number, amountToDeposit: BigNumber): Promise<void> {
     assert(isDefined(BINANCE_NETWORKS[sourceChain]), "Source chain should be a Binance network");
+    assert(
+      sourceToken !== "WETH" || isDefined(getAtomicDepositorContracts(sourceChain)),
+      `Atomic depositor contracts missing for WETH source chain ${getNetworkName(sourceChain)}`
+    );
     const depositAddress = await this.binanceApiClient.depositAddress({
-      coin: sourceToken,
+      coin: resolveBinanceCoinSymbol(sourceToken),
       network: BINANCE_NETWORKS[sourceChain],
     });
     const sourceProvider = await getProvider(sourceChain);
     const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
-    const erc20 = new Contract(sourceTokenInfo.address.toNative(), ERC20.abi, this.baseSigner.connect(sourceProvider));
     const amountReadable = fromWei(amountToDeposit, sourceTokenInfo.decimals);
-    const txn: AugmentedTransaction = {
-      contract: erc20,
-      method: "transfer",
-      args: [depositAddress.address, amountToDeposit],
-      chainId: sourceChain,
-      nonMulticall: true,
-      unpermissioned: false,
-      ensureConfirmation: true,
-      message: `Deposited ${amountReadable} ${sourceToken} to Binance on chain ${getNetworkName(sourceChain)}`,
-      mrkdwn: `Deposited ${amountReadable} ${sourceToken} to Binance on chain ${getNetworkName(sourceChain)}`,
-    };
-    const txnHash = await this._submitTransaction(txn);
+    const connectedSigner = this.baseSigner.connect(sourceProvider);
+
+    let txnHash: string;
+    if (usesBinanceAtomicDepositorTransfer(sourceToken, sourceChain)) {
+      txnHash = await this._depositNativeEthToBinanceViaAtomicDepositor(
+        sourceChain,
+        depositAddress.address,
+        amountToDeposit
+      );
+    } else {
+      const erc20 = new Contract(sourceTokenInfo.address.toNative(), ERC20.abi, connectedSigner);
+      const txn: AugmentedTransaction = {
+        contract: erc20,
+        method: "transfer",
+        args: [depositAddress.address, amountToDeposit],
+        chainId: sourceChain,
+        nonMulticall: true,
+        unpermissioned: false,
+        ensureConfirmation: true,
+        message: `Deposited ${amountReadable} ${sourceToken} to Binance on chain ${getNetworkName(sourceChain)}`,
+        mrkdwn: `Deposited ${amountReadable} ${sourceToken} to Binance on chain ${getNetworkName(sourceChain)}`,
+      };
+      txnHash = await this._submitTransaction(txn);
+    }
     // Set the TTL to 30 minutes so that the Binance sweeper finalizer only attempts to pull back these deposited
     // funds after 30 minutes. If the swap hasn't occurred in 30 mins then something has gone wrong.
     await setBinanceDepositType(sourceChain, txnHash, BinanceTransactionType.SWAP, 30 * 60);
@@ -919,18 +1176,61 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     });
   }
 
+  private async _depositNativeEthToBinanceViaAtomicDepositor(
+    sourceChain: number,
+    depositAddress: string,
+    amountToDeposit: BigNumber
+  ): Promise<string> {
+    const sourceProvider = await getProvider(sourceChain);
+    const connectedSigner = this.baseSigner.connect(sourceProvider);
+    const atomicDepositorContracts = getAtomicDepositorContracts(sourceChain);
+    assert(
+      isDefined(atomicDepositorContracts),
+      `Atomic depositor contracts missing for ${getNetworkName(sourceChain)}`
+    );
+    const atomicDepositor = new Contract(
+      atomicDepositorContracts.atomicDepositorAddress,
+      atomicDepositorContracts.atomicDepositorAbi,
+      connectedSigner
+    );
+    const transferProxy = new Contract(
+      atomicDepositorContracts.transferProxyAddress,
+      atomicDepositorContracts.transferProxyAbi
+    );
+    const bridgeCalldata = transferProxy.interface.encodeFunctionData("transfer", [depositAddress]);
+    const binanceDepositNetwork = await this._getEntrypointNetwork(sourceChain, "WETH");
+    return this._submitTransaction({
+      contract: atomicDepositor,
+      method: "bridgeWeth",
+      args: [binanceDepositNetwork, amountToDeposit, amountToDeposit, bnZero, bridgeCalldata],
+      chainId: sourceChain,
+      nonMulticall: true,
+      unpermissioned: false,
+      ensureConfirmation: true,
+      message: `Deposited ${fromWei(amountToDeposit, 18)} WETH to Binance via native ETH on chain ${getNetworkName(
+        sourceChain
+      )}`,
+      mrkdwn: `Deposited ${fromWei(amountToDeposit, 18)} WETH to Binance via native ETH on chain ${getNetworkName(
+        sourceChain
+      )}`,
+    });
+  }
+
   private async _getBinanceBalance(token: string): Promise<number> {
     const coin = await this._getAccountCoins(token, true); // Skip cache so we load the balance fresh each time.
     return Number(coin.balance);
   }
 
   private async _getSymbol(sourceToken: string, destinationToken: string) {
-    const symbol = (await this.binanceApiClient.exchangeInfo()).symbols.find((symbols) => {
+    const sourceAsset = resolveBinanceCoinSymbol(sourceToken);
+    const destinationAsset = resolveBinanceCoinSymbol(destinationToken);
+    this.exchangeInfoPromise ??= this.binanceApiClient.exchangeInfo();
+    const symbol = (await this.exchangeInfoPromise).symbols.find((symbols) => {
       return (
-        symbols.symbol === `${sourceToken}${destinationToken}` || symbols.symbol === `${destinationToken}${sourceToken}`
+        symbols.symbol === `${sourceAsset}${destinationAsset}` || symbols.symbol === `${destinationAsset}${sourceAsset}`
       );
     });
-    assert(symbol, `No market found for ${sourceToken} and ${destinationToken}`);
+    assert(symbol, `No market found for ${sourceAsset} and ${destinationAsset}`);
     return symbol;
   }
 
@@ -940,10 +1240,13 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     sourceChain: number,
     amountToTransfer: BigNumber
   ): Promise<{ latestPrice: number; slippagePct: number }> {
+    if (!this._routeRequiresSwap(sourceToken, destinationToken)) {
+      return { latestPrice: 1, slippagePct: 0 };
+    }
     const symbol = await this._getSymbol(sourceToken, destinationToken);
     const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
     const book = await this._getOrderBook(symbol.symbol);
-    const spotMarketMeta = this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
+    const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
     const sideOfBookToTraverse = spotMarketMeta.isBuy ? book.asks : book.bids;
     assert(sideOfBookToTraverse.length > 0, `Order book is empty for ${symbol.symbol}`);
     const bestPx = Number(sideOfBookToTraverse[0].price);
@@ -1019,27 +1322,117 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     sourceToken: string,
     sourceChain: number,
     destinationToken: string,
-    amountToTransfer: BigNumber,
-    price: number
-  ): number {
-    const spotMarketMeta = this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
-    const sz = spotMarketMeta.isBuy
-      ? amountToTransfer.mul(10 ** spotMarketMeta.pxDecimals).div(toBNWei(price, spotMarketMeta.pxDecimals))
-      : amountToTransfer;
-    const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
-    // Floor this number so we can guarantee that we have enough balance to place the order:
-    const szNumber = Number(fromWei(sz, sourceTokenInfo.decimals));
-    const szFormatted = truncate(szNumber, spotMarketMeta.szDecimals);
-    assert(
-      szFormatted >= spotMarketMeta.minimumOrderSize,
-      `size of order ${szFormatted} is less than minimum order size ${spotMarketMeta.minimumOrderSize}`
-    );
-    return szFormatted;
+    destinationChain: number,
+    amountToTransfer: BigNumber
+  ): Promise<number> {
+    return this._getSpotMarketMetaForRoute(sourceToken, destinationToken).then(async (spotMarketMeta) => {
+      const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
+      const amountToOrder = spotMarketMeta.isBuy
+        ? await this._convertSourceToDestination(
+            sourceToken,
+            sourceChain,
+            destinationToken,
+            destinationChain,
+            amountToTransfer
+          )
+        : amountToTransfer;
+      const decimals = spotMarketMeta.isBuy
+        ? this._getTokenInfo(destinationToken, destinationChain).decimals
+        : sourceTokenInfo.decimals;
+      const szNumber = Number(fromWei(amountToOrder, decimals));
+      const szFormatted = truncate(szNumber, spotMarketMeta.szDecimals);
+      assert(
+        szFormatted >= spotMarketMeta.minimumOrderSize,
+        `size of order ${szFormatted} is less than minimum order size ${spotMarketMeta.minimumOrderSize}`
+      );
+      return szFormatted;
+    });
   }
 
-  private _getSpotMarketMetaForRoute(sourceToken: string, destinationToken: string): SPOT_MARKET_META {
-    const name = `${sourceToken}-${destinationToken}`;
-    return this.spotMarketMeta[name];
+  private async _getSpotMarketMetaForRoute(sourceToken: string, destinationToken: string): Promise<SPOT_MARKET_META> {
+    assert(
+      this._routeRequiresSwap(sourceToken, destinationToken),
+      `Route ${sourceToken}-${destinationToken} does not require a Binance spot market`
+    );
+    const routeName = `${sourceToken}-${destinationToken}`;
+    const existingPromise = this.spotMarketMetaPromiseByRoute.get(routeName);
+    if (existingPromise !== undefined) {
+      return existingPromise;
+    }
+
+    const promise = this._getSymbol(sourceToken, destinationToken).then((symbol) =>
+      deriveBinanceSpotMarketMeta(sourceToken, destinationToken, symbol)
+    );
+    this.spotMarketMetaPromiseByRoute.set(routeName, promise);
+    void promise.finally(() => {
+      if (this.spotMarketMetaPromiseByRoute.get(routeName) === promise) {
+        this.spotMarketMetaPromiseByRoute.delete(routeName);
+      }
+    });
+    return promise;
+  }
+
+  private async _convertSourceToDestination(
+    sourceToken: string,
+    sourceChain: number,
+    destinationToken: string,
+    destinationChain: number,
+    sourceAmount: BigNumber
+  ): Promise<BigNumber> {
+    const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
+    const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationChain);
+    if (!this._routeRequiresSwap(sourceToken, destinationToken)) {
+      return this._getAmountConverter(
+        sourceChain,
+        sourceTokenInfo.address,
+        destinationChain,
+        destinationTokenInfo.address
+      )(sourceAmount);
+    }
+    const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
+    const priceData = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, sourceAmount);
+    return convertBinanceRouteAmount({
+      amount: sourceAmount,
+      sourceTokenDecimals: sourceTokenInfo.decimals,
+      destinationTokenDecimals: destinationTokenInfo.decimals,
+      isBuy: spotMarketMeta.isBuy,
+      price: priceData.latestPrice,
+      direction: "source-to-destination",
+    });
+  }
+
+  private async _convertDestinationToSource(
+    destinationToken: string,
+    destinationChain: number,
+    sourceToken: string,
+    sourceChain: number,
+    destinationAmount: BigNumber
+  ): Promise<BigNumber> {
+    const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
+    const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationChain);
+    if (!this._routeRequiresSwap(sourceToken, destinationToken)) {
+      return this._getAmountConverter(
+        destinationChain,
+        destinationTokenInfo.address,
+        sourceChain,
+        sourceTokenInfo.address
+      )(destinationAmount);
+    }
+    const priceData = await this._getLatestPrice(destinationToken, sourceToken, destinationChain, destinationAmount);
+    const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
+    return convertBinanceRouteAmount({
+      amount: destinationAmount,
+      sourceTokenDecimals: sourceTokenInfo.decimals,
+      destinationTokenDecimals: destinationTokenInfo.decimals,
+      isBuy: spotMarketMeta.isBuy,
+      price: priceData.latestPrice,
+      direction: "destination-to-source",
+    });
+  }
+
+  private async _getTradeFees(): ReturnType<Binance["tradeFee"]> {
+    this.tradeFeesPromise ??= this.binanceApiClient.tradeFee({ useServerTime: true });
+    return this.tradeFeesPromise;
   }
 
   private async _getMatchingFillForCloid(
@@ -1047,27 +1440,35 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     account: EvmAddress
   ): Promise<{ matchingFill: QueryOrderResult; expectedAmountToReceive: string } | undefined> {
     const orderDetails = await this._redisGetOrderDetails(cloid, account);
-    const spotMarketMeta = this._getSpotMarketMetaForRoute(orderDetails.sourceToken, orderDetails.destinationToken);
+    const spotMarketMeta = await this._getSpotMarketMetaForRoute(
+      orderDetails.sourceToken,
+      orderDetails.destinationToken
+    );
     const allOrders = await this.binanceApiClient.allOrders({
       symbol: spotMarketMeta.symbol,
     });
     const matchingFill = allOrders.find((order) => order.clientOrderId === cloid && order.status === "FILLED");
+    if (!matchingFill) {
+      return undefined;
+    }
     const expectedAmountToReceive = spotMarketMeta.isBuy ? matchingFill.executedQty : matchingFill.cummulativeQuoteQty;
     return { matchingFill, expectedAmountToReceive };
   }
 
+  private _routeRequiresSwap(sourceToken: string, destinationToken: string): boolean {
+    return !isSameBinanceCoin(sourceToken, destinationToken);
+  }
+
   private async _placeMarketOrder(cloid: string, orderDetails: OrderDetails): Promise<void> {
-    const { sourceToken, sourceChain, destinationToken, amountToTransfer } = orderDetails;
-    const latestPx = (await this._getLatestPrice(sourceToken, destinationToken, sourceChain, amountToTransfer))
-      .latestPrice;
-    const szForOrder = this._getQuantityForOrder(
+    const { sourceToken, sourceChain, destinationToken, destinationChain, amountToTransfer } = orderDetails;
+    const szForOrder = await this._getQuantityForOrder(
       sourceToken,
       sourceChain,
       destinationToken,
-      amountToTransfer,
-      latestPx
+      destinationChain,
+      amountToTransfer
     );
-    const spotMarketMeta = this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
+    const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
     const orderStruct = {
       symbol: spotMarketMeta.symbol,
       newClientOrderId: cloid,
@@ -1099,10 +1500,11 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     startTime: number,
     account: string
   ): Promise<BinanceWithdrawal[]> {
+    const binanceToken = resolveBinanceCoinSymbol(token);
     assert(isDefined(BINANCE_NETWORKS[chain]), "Chain should be a Binance network");
-    return (await getBinanceWithdrawals(this.binanceApiClient, token, startTime)).filter(
+    return (await getBinanceWithdrawals(this.binanceApiClient, binanceToken, startTime)).filter(
       (withdrawal) =>
-        withdrawal.coin === token &&
+        withdrawal.coin === binanceToken &&
         withdrawal.network === BINANCE_NETWORKS[chain] &&
         withdrawal.recipient.toLowerCase() === account.toLowerCase() &&
         isTerminalBinanceWithdrawal(withdrawal.status)
@@ -1120,24 +1522,6 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     failedWithdrawals: BinanceWithdrawal[];
   }> {
     assert(isDefined(BINANCE_NETWORKS[destinationChain]), "Destination chain should be a Binance network");
-    const provider = await getProvider(destinationChain);
-    // @dev Binance withdrawals are fast, so setting a lookback of 6 hours should capture any unfinalized withdrawals.
-    const withdrawalInitiatedLookbackPeriodSeconds = 6 * 60 * 60;
-    const withdrawalInitiatedFromTimestampSeconds = startTimeSeconds - withdrawalInitiatedLookbackPeriodSeconds;
-    const eventSearchConfig = await this._getEventSearchConfig(
-      destinationChain,
-      withdrawalInitiatedFromTimestampSeconds
-    );
-    const destinationTokenContract = new Contract(
-      this._getTokenInfo(destinationToken, destinationChain).address.toNative(),
-      ERC20.abi,
-      this.baseSigner.connect(provider)
-    );
-    const destinationChainTransferEvents = await paginatedEventQuery(
-      destinationTokenContract,
-      destinationTokenContract.filters.Transfer(null, account),
-      eventSearchConfig
-    );
     const initiatedWithdrawals = await this._getInitiatedBinanceWithdrawals(
       destinationToken,
       destinationChain,
@@ -1153,17 +1537,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         failedWithdrawals.push(initiated);
         continue;
       }
-      const withdrawalAmount = toBNWei(
-        initiated.amount, // @dev This should be the post-withdrawal fee amount so it should match perfectly
-        // with the finalized amount.
-        this._getTokenInfo(destinationToken, destinationChain).decimals
-      );
-      const matchingFinalizedAmount = destinationChainTransferEvents.find(
-        (finalized) =>
-          !finalizedWithdrawals.some((finalizedWithdrawal) => finalizedWithdrawal.txId === finalized.transactionHash) &&
-          finalized.args.value.toString() === withdrawalAmount.toString()
-      );
-      if (matchingFinalizedAmount) {
+      if (initiated.status === BINANCE_WITHDRAWAL_STATUS.COMPLETED) {
         finalizedWithdrawals.push(initiated);
       } else {
         unfinalizedWithdrawals.push(initiated);
@@ -1233,7 +1607,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationEntrypointNetwork);
     const amountToWithdraw = truncate(quantity, destinationTokenInfo.decimals);
     const withdrawalId = await this.binanceApiClient.withdraw({
-      coin: destinationToken,
+      coin: resolveBinanceCoinSymbol(destinationToken),
       address: this.baseSignerAddress.toNative(),
       amount: Number(amountToWithdraw),
       network: BINANCE_NETWORKS[destinationEntrypointNetwork],
@@ -1250,6 +1624,34 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       redisWithdrawalIdKey: initiatedWithdrawalKey,
       redisWithdrawalTypeKey: getBinanceTransactionTypeKey(destinationEntrypointNetwork, withdrawalId.id),
       finalDestinationChain: destinationChain,
+    });
+  }
+
+  private async _wrapEth(chainId: number, amount: BigNumber): Promise<void> {
+    const tokenInfo = getTokenInfoFromSymbol("WETH", chainId);
+    const contract = new Contract(
+      tokenInfo.address.toEvmAddress(),
+      WETH_ABI,
+      this.baseSigner.connect(await getProvider(chainId))
+    );
+    const amountReadable = fromWei(amount, tokenInfo.decimals);
+    const txn: AugmentedTransaction = {
+      contract,
+      method: "deposit",
+      args: [],
+      value: amount,
+      chainId: chainId,
+      nonMulticall: true,
+      unpermissioned: false,
+      ensureConfirmation: true,
+      message: `Wrapped ${amountReadable} WETH on chain ${getNetworkName(chainId)} to finalize withdrawal`,
+      mrkdwn: `Wrapped ${amountReadable} WETH on chain ${getNetworkName(chainId)} to finalize withdrawal`,
+    };
+    const txnHash = await this._submitTransaction(txn);
+    this.logger.debug({
+      at: "BinanceStablecoinSwapAdapter._wrapEth",
+      message: `Wrapped ${amountReadable} WETH on chain ${getNetworkName(chainId)} to finalize withdrawal`,
+      txnHash,
     });
   }
 }

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1410,7 +1410,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   ): Promise<BigNumber> {
     const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
     const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationChain);
-    const sourceAmount = toBNWei(value, sourceTokenInfo.decimals);
+    const sourceAmount = toBNWei(truncate(value, sourceTokenInfo.decimals), sourceTokenInfo.decimals);
     if (!this._routeRequiresSwap(sourceToken, destinationToken)) {
       return sourceAmount;
     }

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -962,7 +962,9 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const tradeFeePct = routeRequiresSwap
       ? (await this._getTradeFees()).find((fee) => fee.symbol === spotMarketMeta.symbol).takerCommission
       : "0";
-    const tradeFee = toBNWei(tradeFeePct, 18).mul(amountToTransfer).div(toBNWei(100, 18));
+    const tradeFee = toBNWei(truncate(Number(tradeFeePct), 18), 18)
+      .mul(amountToTransfer)
+      .div(toBNWei(100, 18));
     const destinationCoin = await this._getAccountCoins(destinationToken);
     const destinationEntrypointNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
     const withdrawFee = destinationCoin.networkList.find(
@@ -981,7 +983,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
 
     const spreadPct = latestPrice.slippagePct; // slippage is a percentage so we need to divide it by an additional
     // 100 to get it to a decimal.
-    const spreadFee = toBNWei(spreadPct, 18).mul(amountToTransfer).div(toBNWei(1, 20));
+    const spreadFee = toBNWei(truncate(spreadPct, 18), 18).mul(amountToTransfer).div(toBNWei(1, 20));
 
     // Bridge to Binance deposit network Fee:
     let bridgeToBinanceFee = bnZero;
@@ -1058,7 +1060,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const opportunityCostOfCapitalPct = requiresOftBridgeFromHyperevm
       ? this._getOpportunityCostOfCapitalPctForRebalanceTime(11 * 60 * 60 * 1000)
       : bnZero;
-    const opportunityCostOfCapitalFixed = toBNWei(opportunityCostOfCapitalPct, 18)
+    const opportunityCostOfCapitalFixed = toBNWei(truncate(Number(opportunityCostOfCapitalPct), 18), 18)
       .mul(amountToTransfer)
       .div(toBNWei(100, 18));
 

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -42,7 +42,6 @@ import { CctpAdapter } from "./cctpAdapter";
 import { OftAdapter } from "./oftAdapter";
 import { CONTRACT_ADDRESSES } from "../../common";
 import WETH_ABI from "../../common/abi/Weth.json";
-
 interface SPOT_MARKET_META {
   symbol: string;
   baseAssetName: string;

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -509,7 +509,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       if (!initiatedWithdrawalId) {
         this.logger.debug({
           at: "BinanceStablecoinSwapAdapter.updateRebalanceStatuses",
-          message: `Cannot find initiated withdrawal for cloid ${cloid} which filled at ${matchingFill.time}, waiting`,
+          message: `Cannot find initiated withdrawal for cloid ${cloid}, waiting`,
           cloid: cloid,
           matchingFill: matchingFill,
         });

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -173,13 +173,13 @@ function resolveStepPrecision(stepSize: string): number {
 
 export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   private binanceApiClient: Binance;
-  private tradeFeesPromise?: ReturnType<Binance["tradeFee"]>;
   private exchangeInfoPromise?: ReturnType<Binance["exchangeInfo"]>;
   private orderBookPromiseBySymbol = new Map<string, Promise<Awaited<ReturnType<Binance["book"]>>>>();
   private orderBookSnapshotBySymbol = new Map<
     string,
     { fetchedAtMs: number; book: Awaited<ReturnType<Binance["book"]>> }
   >();
+  private tradeFeesPromise?: ReturnType<Binance["tradeFee"]>;
   private spotMarketMetaPromiseByRoute = new Map<string, Promise<SPOT_MARKET_META>>();
 
   REDIS_PREFIX = "binance-stablecoin-swap:";

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -813,26 +813,25 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     );
     const { withdrawMin, withdrawMax } = destinationBinanceNetwork;
     const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
-    const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationEntrypointNetwork);
 
     // Make sure that the amount to transfer will be larger than the minimum withdrawal size after expected fees.
     const expectedCost = await this.getEstimatedCost(rebalanceRoute, amountToTransfer, false);
     const expectedAmountToWithdraw = amountToTransfer.sub(expectedCost);
-    const minimumWithdrawalSize = await this._convertDestinationToSource(
+    const minimumWithdrawalSize = await this._convertNumberToSource(
       destinationToken,
       destinationEntrypointNetwork,
       sourceToken,
       sourceChain,
       // add 1% buffer to minimum withdrawal size to account for any precision loss due to the conversion from
       // destination to source token precision.
-      toBNWei(Number(withdrawMin), destinationTokenInfo.decimals).mul(toBNWei(101, 18)).div(toBNWei(100, 18))
+      Number(withdrawMin) * 1.01
     );
-    const maximumWithdrawalSize = await this._convertDestinationToSource(
+    const maximumWithdrawalSize = await this._convertNumberToSource(
       destinationToken,
       destinationEntrypointNetwork,
       sourceToken,
       sourceChain,
-      toBNWei(withdrawMax, destinationTokenInfo.decimals)
+      Number(withdrawMax)
     );
     if (expectedAmountToWithdraw.lt(minimumWithdrawalSize)) {
       this.logger.debug({
@@ -856,12 +855,12 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     if (routeRequiresSwap) {
       const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
       const minimumOrderSize = spotMarketMeta.isBuy
-        ? await this._convertDestinationToSource(
+        ? await this._convertNumberToSource(
             destinationToken,
             destinationChain,
             sourceToken,
             sourceChain,
-            toBNWei(spotMarketMeta.minimumOrderSize, destinationTokenInfo.decimals)
+            spotMarketMeta.minimumOrderSize
           )
         : toBNWei(spotMarketMeta.minimumOrderSize, sourceTokenInfo.decimals);
       if (amountToTransfer.lt(minimumOrderSize)) {
@@ -962,20 +961,17 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const tradeFee = toBNWei(tradeFeePct, 18).mul(amountToTransfer).div(toBNWei(100, 18));
     const destinationCoin = await this._getAccountCoins(destinationToken);
     const destinationEntrypointNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
-    const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationEntrypointNetwork);
-    const withdrawFee = toBNWei(
-      destinationCoin.networkList.find((network) => network.name === BINANCE_NETWORKS[destinationEntrypointNetwork])
-        .withdrawFee,
-      destinationTokenInfo.decimals
-    );
+    const withdrawFee = destinationCoin.networkList.find(
+      (network) => network.name === BINANCE_NETWORKS[destinationEntrypointNetwork]
+    ).withdrawFee;
 
     const latestPrice = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, amountToTransfer);
-    const withdrawFeeConvertedToSourceToken = await this._convertDestinationToSource(
+    const withdrawFeeConvertedToSourceToken = await this._convertNumberToSource(
       destinationToken,
       destinationEntrypointNetwork,
       sourceToken,
       sourceChain,
-      withdrawFee
+      Number(withdrawFee)
     );
 
     const spreadPct = latestPrice.slippagePct; // slippage is a percentage so we need to divide it by an additional
@@ -1406,33 +1402,23 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     });
   }
 
-  private async _convertDestinationToSource(
+  private async _convertNumberToSource(
     destinationToken: string,
     destinationChain: number,
     sourceToken: string,
     sourceChain: number,
-    destinationAmount: BigNumber
+    value: number
   ): Promise<BigNumber> {
     const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
     const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationChain);
-    const destinationAmountInSourcePrecision = this._getAmountConverter(
-      destinationChain,
-      destinationTokenInfo.address,
-      sourceChain,
-      sourceTokenInfo.address
-    )(destinationAmount);
+    const sourceAmount = toBNWei(value, sourceTokenInfo.decimals);
     if (!this._routeRequiresSwap(sourceToken, destinationToken)) {
-      return destinationAmountInSourcePrecision;
+      return sourceAmount;
     }
-    const priceData = await this._getLatestPrice(
-      sourceToken,
-      destinationToken,
-      sourceChain,
-      destinationAmountInSourcePrecision
-    );
+    const priceData = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, sourceAmount);
     const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
     return convertBinanceRouteAmount({
-      amount: destinationAmount,
+      amount: sourceAmount,
       sourceTokenDecimals: sourceTokenInfo.decimals,
       destinationTokenDecimals: destinationTokenInfo.decimals,
       isBuy: spotMarketMeta.isBuy,

--- a/src/rebalancer/buildRebalanceRoutes.ts
+++ b/src/rebalancer/buildRebalanceRoutes.ts
@@ -79,6 +79,9 @@ function canUseHyperliquidStablecoinRoute({
 }
 
 function buildSameAssetRoutes(rebalancerConfig: RebalancerConfig, token: SupportedToken): RebalanceRoute[] {
+  if (!rebalancerConfig.cumulativeTargetBalances[token]?.targetBalance) {
+    return [];
+  }
   const routes: RebalanceRoute[] = [];
   const configuredChains = configuredChainsForToken(rebalancerConfig, token);
   const directBinanceNetworks = new Set(BINANCE_NETWORKS_BY_SYMBOL[token]);
@@ -186,6 +189,12 @@ function buildDifferentAssetRoutes(rebalancerConfig: RebalancerConfig): Rebalanc
     const chainsA = rule.chainsA(rebalancerConfig);
     const chainsB = rule.chainsB(rebalancerConfig);
 
+    if (
+      !rebalancerConfig.cumulativeTargetBalances[rule.tokenA]?.targetBalance ||
+      !rebalancerConfig.cumulativeTargetBalances[rule.tokenB]?.targetBalance
+    ) {
+      return [];
+    }
     pushDirectedDifferentAssetRoutes(routes, rule, rule.tokenA, chainsA, rule.tokenB, chainsB);
     pushDirectedDifferentAssetRoutes(routes, rule, rule.tokenB, chainsB, rule.tokenA, chainsA);
   }

--- a/src/rebalancer/buildRebalanceRoutes.ts
+++ b/src/rebalancer/buildRebalanceRoutes.ts
@@ -80,6 +80,24 @@ export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): Rebala
     }
   }
 
+  for (const usdtChain of USDT_REBALANCE_CHAINS) {
+    for (const otherUsdtChain of USDT_REBALANCE_CHAINS) {
+      if (!rebalancerConfig.chainIds.includes(usdtChain) || !rebalancerConfig.chainIds.includes(otherUsdtChain)) {
+        continue;
+      }
+      if (usdtChain === otherUsdtChain) {
+        continue;
+      }
+      rebalanceRoutes.push({
+        sourceChain: usdtChain,
+        sourceToken: "USDT",
+        destinationChain: otherUsdtChain,
+        destinationToken: "USDT",
+        adapter: "binance",
+      });
+    }
+  }
+
   for (const usdcChain of USDC_REBALANCE_CHAINS.filter((chain) => chain !== CHAIN_IDs.BSC)) {
     for (const otherUsdcChain of USDC_REBALANCE_CHAINS.filter((chain) => chain !== CHAIN_IDs.BSC)) {
       if (!rebalancerConfig.chainIds.includes(usdcChain) || !rebalancerConfig.chainIds.includes(otherUsdcChain)) {
@@ -94,6 +112,24 @@ export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): Rebala
         destinationChain: otherUsdcChain,
         destinationToken: "USDC",
         adapter: "cctp",
+      });
+    }
+  }
+
+  for (const usdcChain of USDC_REBALANCE_CHAINS) {
+    for (const otherUsdcChain of USDC_REBALANCE_CHAINS) {
+      if (!rebalancerConfig.chainIds.includes(usdcChain) || !rebalancerConfig.chainIds.includes(otherUsdcChain)) {
+        continue;
+      }
+      if (usdcChain === otherUsdcChain) {
+        continue;
+      }
+      rebalanceRoutes.push({
+        sourceChain: usdcChain,
+        sourceToken: "USDC",
+        destinationChain: otherUsdcChain,
+        destinationToken: "USDC",
+        adapter: "binance",
       });
     }
   }

--- a/src/rebalancer/buildRebalanceRoutes.ts
+++ b/src/rebalancer/buildRebalanceRoutes.ts
@@ -193,7 +193,7 @@ function buildDifferentAssetRoutes(rebalancerConfig: RebalancerConfig): Rebalanc
       !rebalancerConfig.cumulativeTargetBalances[rule.tokenA]?.targetBalance ||
       !rebalancerConfig.cumulativeTargetBalances[rule.tokenB]?.targetBalance
     ) {
-      return [];
+      continue;
     }
     pushDirectedDifferentAssetRoutes(routes, rule, rule.tokenA, chainsA, rule.tokenB, chainsB);
     pushDirectedDifferentAssetRoutes(routes, rule, rule.tokenB, chainsB, rule.tokenA, chainsA);

--- a/src/rebalancer/buildRebalanceRoutes.ts
+++ b/src/rebalancer/buildRebalanceRoutes.ts
@@ -45,7 +45,7 @@ const REBALANCE_CHAINS_BY_SYMBOL: Record<SupportedToken, readonly number[]> = {
     CHAIN_IDs.MONAD,
     CHAIN_IDs.BSC,
   ],
-  WETH: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.BASE, CHAIN_IDs.BSC, CHAIN_IDs.MAINNET, CHAIN_IDs.OPTIMISM],
+  WETH: [CHAIN_IDs.MAINNET],
 };
 
 const SAME_ASSET_BRIDGE_ADAPTER_BY_SYMBOL: Record<StableToken, "cctp" | "oft"> = {

--- a/src/rebalancer/buildRebalanceRoutes.ts
+++ b/src/rebalancer/buildRebalanceRoutes.ts
@@ -1,0 +1,179 @@
+import { CHAIN_IDs } from "../utils";
+import { RebalancerConfig } from "./RebalancerConfig";
+import { RebalanceRoute } from "./utils/interfaces";
+
+const USDT_REBALANCE_CHAINS = [
+  CHAIN_IDs.HYPEREVM,
+  CHAIN_IDs.ARBITRUM,
+  CHAIN_IDs.OPTIMISM,
+  CHAIN_IDs.MAINNET,
+  CHAIN_IDs.UNICHAIN,
+  CHAIN_IDs.MONAD,
+  CHAIN_IDs.BSC,
+];
+
+const USDC_REBALANCE_CHAINS = [
+  CHAIN_IDs.HYPEREVM,
+  CHAIN_IDs.ARBITRUM,
+  CHAIN_IDs.OPTIMISM,
+  CHAIN_IDs.MAINNET,
+  CHAIN_IDs.BASE,
+  CHAIN_IDs.UNICHAIN,
+  CHAIN_IDs.MONAD,
+  CHAIN_IDs.BSC,
+];
+
+const WETH_REBALANCE_CHAINS = [
+  CHAIN_IDs.ARBITRUM,
+  CHAIN_IDs.BASE,
+  CHAIN_IDs.BSC,
+  CHAIN_IDs.MAINNET,
+  CHAIN_IDs.OPTIMISM,
+];
+
+export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): RebalanceRoute[] {
+  const rebalanceRoutes: RebalanceRoute[] = [];
+
+  for (const usdtChain of USDT_REBALANCE_CHAINS) {
+    for (const usdcChain of USDC_REBALANCE_CHAINS) {
+      if (!rebalancerConfig.chainIds.includes(usdtChain) || !rebalancerConfig.chainIds.includes(usdcChain)) {
+        continue;
+      }
+      for (const adapter of ["binance", "hyperliquid"]) {
+        if (adapter !== "binance" && (usdtChain === CHAIN_IDs.BSC || usdcChain === CHAIN_IDs.BSC)) {
+          continue;
+        }
+
+        rebalanceRoutes.push({
+          sourceChain: usdtChain,
+          sourceToken: "USDT",
+          destinationChain: usdcChain,
+          destinationToken: "USDC",
+          adapter,
+        });
+        rebalanceRoutes.push({
+          sourceChain: usdcChain,
+          sourceToken: "USDC",
+          destinationChain: usdtChain,
+          destinationToken: "USDT",
+          adapter,
+        });
+      }
+    }
+  }
+
+  for (const usdtChain of USDT_REBALANCE_CHAINS.filter((chain) => chain !== CHAIN_IDs.BSC)) {
+    for (const otherUsdtChain of USDT_REBALANCE_CHAINS.filter((chain) => chain !== CHAIN_IDs.BSC)) {
+      if (!rebalancerConfig.chainIds.includes(usdtChain) || !rebalancerConfig.chainIds.includes(otherUsdtChain)) {
+        continue;
+      }
+      if (usdtChain === otherUsdtChain) {
+        continue;
+      }
+      rebalanceRoutes.push({
+        sourceChain: usdtChain,
+        sourceToken: "USDT",
+        destinationChain: otherUsdtChain,
+        destinationToken: "USDT",
+        adapter: "oft",
+      });
+    }
+  }
+
+  for (const usdcChain of USDC_REBALANCE_CHAINS.filter((chain) => chain !== CHAIN_IDs.BSC)) {
+    for (const otherUsdcChain of USDC_REBALANCE_CHAINS.filter((chain) => chain !== CHAIN_IDs.BSC)) {
+      if (!rebalancerConfig.chainIds.includes(usdcChain) || !rebalancerConfig.chainIds.includes(otherUsdcChain)) {
+        continue;
+      }
+      if (usdcChain === otherUsdcChain) {
+        continue;
+      }
+      rebalanceRoutes.push({
+        sourceChain: usdcChain,
+        sourceToken: "USDC",
+        destinationChain: otherUsdcChain,
+        destinationToken: "USDC",
+        adapter: "cctp",
+      });
+    }
+  }
+
+  // WETH<->stablecoin swap routes via Binance only. WETH chains are restricted to direct Binance deposit/withdrawal
+  // networks for ETH.
+  for (const wethChain of WETH_REBALANCE_CHAINS) {
+    if (!rebalancerConfig.chainIds.includes(wethChain)) {
+      continue;
+    }
+    for (const usdtChain of USDT_REBALANCE_CHAINS) {
+      if (!rebalancerConfig.chainIds.includes(usdtChain)) {
+        continue;
+      }
+      rebalanceRoutes.push({
+        sourceChain: wethChain,
+        sourceToken: "WETH",
+        destinationChain: usdtChain,
+        destinationToken: "USDT",
+        adapter: "binance",
+      });
+      rebalanceRoutes.push({
+        sourceChain: usdtChain,
+        sourceToken: "USDT",
+        destinationChain: wethChain,
+        destinationToken: "WETH",
+        adapter: "binance",
+      });
+    }
+    for (const usdcChain of USDC_REBALANCE_CHAINS) {
+      if (!rebalancerConfig.chainIds.includes(usdcChain)) {
+        continue;
+      }
+      rebalanceRoutes.push({
+        sourceChain: wethChain,
+        sourceToken: "WETH",
+        destinationChain: usdcChain,
+        destinationToken: "USDC",
+        adapter: "binance",
+      });
+      rebalanceRoutes.push({
+        sourceChain: usdcChain,
+        sourceToken: "USDC",
+        destinationChain: wethChain,
+        destinationToken: "WETH",
+        adapter: "binance",
+      });
+    }
+  }
+
+  for (const sourceWethChain of WETH_REBALANCE_CHAINS) {
+    if (!rebalancerConfig.chainIds.includes(sourceWethChain)) {
+      continue;
+    }
+    for (const destinationWethChain of WETH_REBALANCE_CHAINS) {
+      if (!rebalancerConfig.chainIds.includes(destinationWethChain) || sourceWethChain === destinationWethChain) {
+        continue;
+      }
+      rebalanceRoutes.push({
+        sourceChain: sourceWethChain,
+        sourceToken: "WETH",
+        destinationChain: destinationWethChain,
+        destinationToken: "WETH",
+        adapter: "binance",
+      });
+    }
+  }
+
+  return rebalanceRoutes;
+}
+
+export function dedupeRebalanceRoutes(routes: RebalanceRoute[]): RebalanceRoute[] {
+  const uniqueRoutes = new Map<string, RebalanceRoute>();
+  for (const route of routes) {
+    uniqueRoutes.set(
+      [route.sourceChain, route.sourceToken, route.destinationChain, route.destinationToken, route.adapter].join("|"),
+      route
+    );
+  }
+  return Array.from(uniqueRoutes.values());
+}
+
+export { USDC_REBALANCE_CHAINS, USDT_REBALANCE_CHAINS };

--- a/src/rebalancer/buildRebalanceRoutes.ts
+++ b/src/rebalancer/buildRebalanceRoutes.ts
@@ -31,6 +31,15 @@ const WETH_REBALANCE_CHAINS = [
   CHAIN_IDs.OPTIMISM,
 ];
 
+const DIRECT_BINANCE_USDT_CHAINS = [CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.BSC];
+const DIRECT_BINANCE_USDC_CHAINS = [
+  CHAIN_IDs.ARBITRUM,
+  CHAIN_IDs.OPTIMISM,
+  CHAIN_IDs.MAINNET,
+  CHAIN_IDs.BASE,
+  CHAIN_IDs.BSC,
+];
+
 export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): RebalanceRoute[] {
   const rebalanceRoutes: RebalanceRoute[] = [];
 
@@ -62,24 +71,6 @@ export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): Rebala
     }
   }
 
-  for (const usdtChain of USDT_REBALANCE_CHAINS.filter((chain) => chain !== CHAIN_IDs.BSC)) {
-    for (const otherUsdtChain of USDT_REBALANCE_CHAINS.filter((chain) => chain !== CHAIN_IDs.BSC)) {
-      if (!rebalancerConfig.chainIds.includes(usdtChain) || !rebalancerConfig.chainIds.includes(otherUsdtChain)) {
-        continue;
-      }
-      if (usdtChain === otherUsdtChain) {
-        continue;
-      }
-      rebalanceRoutes.push({
-        sourceChain: usdtChain,
-        sourceToken: "USDT",
-        destinationChain: otherUsdtChain,
-        destinationToken: "USDT",
-        adapter: "oft",
-      });
-    }
-  }
-
   for (const usdtChain of USDT_REBALANCE_CHAINS) {
     for (const otherUsdtChain of USDT_REBALANCE_CHAINS) {
       if (!rebalancerConfig.chainIds.includes(usdtChain) || !rebalancerConfig.chainIds.includes(otherUsdtChain)) {
@@ -88,31 +79,27 @@ export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): Rebala
       if (usdtChain === otherUsdtChain) {
         continue;
       }
-      rebalanceRoutes.push({
-        sourceChain: usdtChain,
-        sourceToken: "USDT",
-        destinationChain: otherUsdtChain,
-        destinationToken: "USDT",
-        adapter: "binance",
-      });
-    }
-  }
-
-  for (const usdcChain of USDC_REBALANCE_CHAINS.filter((chain) => chain !== CHAIN_IDs.BSC)) {
-    for (const otherUsdcChain of USDC_REBALANCE_CHAINS.filter((chain) => chain !== CHAIN_IDs.BSC)) {
-      if (!rebalancerConfig.chainIds.includes(usdcChain) || !rebalancerConfig.chainIds.includes(otherUsdcChain)) {
-        continue;
+      if (otherUsdtChain !== CHAIN_IDs.BSC) {
+        rebalanceRoutes.push({
+          sourceChain: usdtChain,
+          sourceToken: "USDT",
+          destinationChain: otherUsdtChain,
+          destinationToken: "USDT",
+          adapter: "oft",
+        });
       }
-      if (usdcChain === otherUsdcChain) {
-        continue;
+      if (
+        DIRECT_BINANCE_USDT_CHAINS.includes(usdtChain) &&
+        DIRECT_BINANCE_USDT_CHAINS.includes(otherUsdtChain)
+      ) {
+        rebalanceRoutes.push({
+          sourceChain: usdtChain,
+          sourceToken: "USDT",
+          destinationChain: otherUsdtChain,
+          destinationToken: "USDT",
+          adapter: "binance",
+        });
       }
-      rebalanceRoutes.push({
-        sourceChain: usdcChain,
-        sourceToken: "USDC",
-        destinationChain: otherUsdcChain,
-        destinationToken: "USDC",
-        adapter: "cctp",
-      });
     }
   }
 
@@ -124,13 +111,27 @@ export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): Rebala
       if (usdcChain === otherUsdcChain) {
         continue;
       }
-      rebalanceRoutes.push({
-        sourceChain: usdcChain,
-        sourceToken: "USDC",
-        destinationChain: otherUsdcChain,
-        destinationToken: "USDC",
-        adapter: "binance",
-      });
+      if (otherUsdcChain !== CHAIN_IDs.BSC) {
+        rebalanceRoutes.push({
+          sourceChain: usdcChain,
+          sourceToken: "USDC",
+          destinationChain: otherUsdcChain,
+          destinationToken: "USDC",
+          adapter: "cctp",
+        });
+      }
+      if (
+        DIRECT_BINANCE_USDC_CHAINS.includes(usdcChain) &&
+        DIRECT_BINANCE_USDC_CHAINS.includes(otherUsdcChain)
+      ) {
+        rebalanceRoutes.push({
+          sourceChain: usdcChain,
+          sourceToken: "USDC",
+          destinationChain: otherUsdcChain,
+          destinationToken: "USDC",
+          adapter: "binance",
+        });
+      }
     }
   }
 
@@ -212,4 +213,4 @@ export function dedupeRebalanceRoutes(routes: RebalanceRoute[]): RebalanceRoute[
   return Array.from(uniqueRoutes.values());
 }
 
-export { USDC_REBALANCE_CHAINS, USDT_REBALANCE_CHAINS };
+export { DIRECT_BINANCE_USDC_CHAINS, DIRECT_BINANCE_USDT_CHAINS, USDC_REBALANCE_CHAINS, USDT_REBALANCE_CHAINS };

--- a/src/rebalancer/buildRebalanceRoutes.ts
+++ b/src/rebalancer/buildRebalanceRoutes.ts
@@ -4,6 +4,8 @@ import { RebalanceRoute } from "./utils/interfaces";
 
 type SupportedToken = "USDC" | "USDT" | "WETH";
 type StableToken = Exclude<SupportedToken, "WETH">;
+type DifferentAssetAdapter = "binance" | "hyperliquid";
+type ChainSelector = (rebalancerConfig: RebalancerConfig) => number[];
 
 // Direct Binance deposit/withdraw networks for each token. This is intentionally separate from the rebalancer route
 // set so we can track venue support without automatically enabling every listed network operationally.
@@ -12,12 +14,37 @@ const BINANCE_NETWORKS_BY_SYMBOL: Record<SupportedToken, readonly number[]> = {
   USDT: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.BSC],
   // Live Binance ETH networkList currently includes ARBITRUM, BASE, BSC, ETH, OPTIMISM, SCROLL, and ZKSYNCERA.
   // The rebalancer support list below stays narrower until we intentionally enable more of those networks.
-  WETH: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.BASE, CHAIN_IDs.BSC, CHAIN_IDs.MAINNET, CHAIN_IDs.OPTIMISM, CHAIN_IDs.SCROLL, CHAIN_IDs.ZK_SYNC],
+  WETH: [
+    CHAIN_IDs.ARBITRUM,
+    CHAIN_IDs.BASE,
+    CHAIN_IDs.BSC,
+    CHAIN_IDs.MAINNET,
+    CHAIN_IDs.OPTIMISM,
+    CHAIN_IDs.SCROLL,
+    CHAIN_IDs.ZK_SYNC,
+  ],
 };
 
 const REBALANCE_CHAINS_BY_SYMBOL: Record<SupportedToken, readonly number[]> = {
-  USDT: [CHAIN_IDs.HYPEREVM, CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.UNICHAIN, CHAIN_IDs.MONAD, CHAIN_IDs.BSC],
-  USDC: [CHAIN_IDs.HYPEREVM, CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.BASE, CHAIN_IDs.UNICHAIN, CHAIN_IDs.MONAD, CHAIN_IDs.BSC],
+  USDT: [
+    CHAIN_IDs.HYPEREVM,
+    CHAIN_IDs.ARBITRUM,
+    CHAIN_IDs.OPTIMISM,
+    CHAIN_IDs.MAINNET,
+    CHAIN_IDs.UNICHAIN,
+    CHAIN_IDs.MONAD,
+    CHAIN_IDs.BSC,
+  ],
+  USDC: [
+    CHAIN_IDs.HYPEREVM,
+    CHAIN_IDs.ARBITRUM,
+    CHAIN_IDs.OPTIMISM,
+    CHAIN_IDs.MAINNET,
+    CHAIN_IDs.BASE,
+    CHAIN_IDs.UNICHAIN,
+    CHAIN_IDs.MONAD,
+    CHAIN_IDs.BSC,
+  ],
   WETH: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.BASE, CHAIN_IDs.BSC, CHAIN_IDs.MAINNET, CHAIN_IDs.OPTIMISM],
 };
 
@@ -32,6 +59,30 @@ function hasSameAssetBridgeAdapter(token: SupportedToken): token is StableToken 
 
 function configuredChainsForToken(rebalancerConfig: RebalancerConfig, token: SupportedToken): number[] {
   return REBALANCE_CHAINS_BY_SYMBOL[token].filter((chainId) => rebalancerConfig.chainIds.includes(chainId));
+}
+
+function configuredDirectBinanceChainsForToken(rebalancerConfig: RebalancerConfig, token: SupportedToken): number[] {
+  return configuredChainsForToken(rebalancerConfig, token).filter((chainId) =>
+    BINANCE_NETWORKS_BY_SYMBOL[token].includes(chainId)
+  );
+}
+
+function configuredChains(token: SupportedToken): ChainSelector {
+  return (rebalancerConfig) => configuredChainsForToken(rebalancerConfig, token);
+}
+
+function configuredDirectBinanceChains(token: SupportedToken): ChainSelector {
+  return (rebalancerConfig) => configuredDirectBinanceChainsForToken(rebalancerConfig, token);
+}
+
+function canUseHyperliquidStablecoinRoute({
+  sourceChain,
+  destinationChain,
+}: {
+  sourceChain: number;
+  destinationChain: number;
+}): boolean {
+  return sourceChain !== CHAIN_IDs.BSC && destinationChain !== CHAIN_IDs.BSC;
 }
 
 function buildSameAssetRoutes(rebalancerConfig: RebalancerConfig, token: SupportedToken): RebalanceRoute[] {
@@ -70,73 +121,80 @@ function buildSameAssetRoutes(rebalancerConfig: RebalancerConfig, token: Support
   return routes;
 }
 
-function buildDifferentAssetRoutes(rebalancerConfig: RebalancerConfig): RebalanceRoute[] {
-  const routes: RebalanceRoute[] = [];
-  const usdtChains = configuredChainsForToken(rebalancerConfig, "USDT");
-  const usdcChains = configuredChainsForToken(rebalancerConfig, "USDC");
-  const wethChains = configuredChainsForToken(rebalancerConfig, "WETH");
-  const directBinanceWethChains = wethChains.filter((chainId) => BINANCE_NETWORKS_BY_SYMBOL.WETH.includes(chainId));
+type DifferentAssetPairRule = {
+  tokenA: SupportedToken;
+  tokenB: SupportedToken;
+  adapter: DifferentAssetAdapter;
+  chainsA: ChainSelector;
+  chainsB: ChainSelector;
+  allow?: (params: { sourceChain: number; destinationChain: number }) => boolean;
+};
 
-  for (const usdtChain of usdtChains) {
-    for (const usdcChain of usdcChains) {
-      for (const adapter of ["binance", "hyperliquid"]) {
-        if (adapter !== "binance" && (usdtChain === CHAIN_IDs.BSC || usdcChain === CHAIN_IDs.BSC)) {
-          continue;
-        }
+const DIFFERENT_ASSET_ROUTE_RULES: readonly DifferentAssetPairRule[] = [
+  {
+    tokenA: "USDT",
+    tokenB: "USDC",
+    adapter: "binance",
+    chainsA: configuredChains("USDT"),
+    chainsB: configuredChains("USDC"),
+  },
+  {
+    tokenA: "USDT",
+    tokenB: "USDC",
+    adapter: "hyperliquid",
+    chainsA: configuredChains("USDT"),
+    chainsB: configuredChains("USDC"),
+    allow: canUseHyperliquidStablecoinRoute,
+  },
+  {
+    tokenA: "WETH",
+    tokenB: "USDT",
+    adapter: "binance",
+    chainsA: configuredDirectBinanceChains("WETH"),
+    chainsB: configuredChains("USDT"),
+  },
+  {
+    tokenA: "WETH",
+    tokenB: "USDC",
+    adapter: "binance",
+    chainsA: configuredDirectBinanceChains("WETH"),
+    chainsB: configuredChains("USDC"),
+  },
+];
 
-        routes.push({
-          sourceChain: usdtChain,
-          sourceToken: "USDT",
-          destinationChain: usdcChain,
-          destinationToken: "USDC",
-          adapter,
-        });
-        routes.push({
-          sourceChain: usdcChain,
-          sourceToken: "USDC",
-          destinationChain: usdtChain,
-          destinationToken: "USDT",
-          adapter,
-        });
+function pushDirectedDifferentAssetRoutes(
+  routes: RebalanceRoute[],
+  rule: DifferentAssetPairRule,
+  sourceToken: SupportedToken,
+  sourceChains: readonly number[],
+  destinationToken: SupportedToken,
+  destinationChains: readonly number[]
+): void {
+  for (const sourceChain of sourceChains) {
+    for (const destinationChain of destinationChains) {
+      if (rule.allow && !rule.allow({ sourceChain, destinationChain })) {
+        continue;
       }
+
+      routes.push({
+        sourceChain,
+        sourceToken,
+        destinationChain,
+        destinationToken,
+        adapter: rule.adapter,
+      });
     }
   }
+}
 
-  // WETH<->stablecoin swap routes via Binance only. WETH chains are restricted to direct Binance deposit/withdrawal
-  // networks for ETH.
-  for (const wethChain of directBinanceWethChains) {
-    for (const usdtChain of usdtChains) {
-      routes.push({
-        sourceChain: wethChain,
-        sourceToken: "WETH",
-        destinationChain: usdtChain,
-        destinationToken: "USDT",
-        adapter: "binance",
-      });
-      routes.push({
-        sourceChain: usdtChain,
-        sourceToken: "USDT",
-        destinationChain: wethChain,
-        destinationToken: "WETH",
-        adapter: "binance",
-      });
-    }
-    for (const usdcChain of usdcChains) {
-      routes.push({
-        sourceChain: wethChain,
-        sourceToken: "WETH",
-        destinationChain: usdcChain,
-        destinationToken: "USDC",
-        adapter: "binance",
-      });
-      routes.push({
-        sourceChain: usdcChain,
-        sourceToken: "USDC",
-        destinationChain: wethChain,
-        destinationToken: "WETH",
-        adapter: "binance",
-      });
-    }
+function buildDifferentAssetRoutes(rebalancerConfig: RebalancerConfig): RebalanceRoute[] {
+  const routes: RebalanceRoute[] = [];
+  for (const rule of DIFFERENT_ASSET_ROUTE_RULES) {
+    const chainsA = rule.chainsA(rebalancerConfig);
+    const chainsB = rule.chainsB(rebalancerConfig);
+
+    pushDirectedDifferentAssetRoutes(routes, rule, rule.tokenA, chainsA, rule.tokenB, chainsB);
+    pushDirectedDifferentAssetRoutes(routes, rule, rule.tokenB, chainsB, rule.tokenA, chainsA);
   }
 
   return routes;

--- a/src/rebalancer/buildRebalanceRoutes.ts
+++ b/src/rebalancer/buildRebalanceRoutes.ts
@@ -13,15 +13,10 @@ const BINANCE_NETWORKS_BY_SYMBOL: Record<SupportedToken, readonly number[]> = {
   USDC: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.BASE, CHAIN_IDs.BSC],
   USDT: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.BSC],
   // Live Binance ETH networkList currently includes ARBITRUM, BASE, BSC, ETH, OPTIMISM, SCROLL, and ZKSYNCERA.
-  // The rebalancer support list below stays narrower until we intentionally enable more of those networks.
+  // The rebalancer support list below stays narrower until we intentionally enable more of those networks. We filter
+  // this further by limiting to chains where we have an Atomic Depositor contract.
   WETH: [
-    CHAIN_IDs.ARBITRUM,
-    CHAIN_IDs.BASE,
-    CHAIN_IDs.BSC,
-    CHAIN_IDs.MAINNET,
-    CHAIN_IDs.OPTIMISM,
-    CHAIN_IDs.SCROLL,
-    CHAIN_IDs.ZK_SYNC,
+    CHAIN_IDs.MAINNET
   ],
 };
 

--- a/src/rebalancer/buildRebalanceRoutes.ts
+++ b/src/rebalancer/buildRebalanceRoutes.ts
@@ -15,9 +15,7 @@ const BINANCE_NETWORKS_BY_SYMBOL: Record<SupportedToken, readonly number[]> = {
   // Live Binance ETH networkList currently includes ARBITRUM, BASE, BSC, ETH, OPTIMISM, SCROLL, and ZKSYNCERA.
   // The rebalancer support list below stays narrower until we intentionally enable more of those networks. We filter
   // this further by limiting to chains where we have an Atomic Depositor contract.
-  WETH: [
-    CHAIN_IDs.MAINNET
-  ],
+  WETH: [CHAIN_IDs.MAINNET],
 };
 
 const REBALANCE_CHAINS_BY_SYMBOL: Record<SupportedToken, readonly number[]> = {

--- a/src/rebalancer/buildRebalanceRoutes.ts
+++ b/src/rebalancer/buildRebalanceRoutes.ts
@@ -26,6 +26,10 @@ const SAME_ASSET_BRIDGE_ADAPTER_BY_SYMBOL: Record<StableToken, "cctp" | "oft"> =
   USDT: "oft",
 };
 
+function hasSameAssetBridgeAdapter(token: SupportedToken): token is StableToken {
+  return token in SAME_ASSET_BRIDGE_ADAPTER_BY_SYMBOL;
+}
+
 function configuredChainsForToken(rebalancerConfig: RebalancerConfig, token: SupportedToken): number[] {
   return REBALANCE_CHAINS_BY_SYMBOL[token].filter((chainId) => rebalancerConfig.chainIds.includes(chainId));
 }
@@ -41,7 +45,7 @@ function buildSameAssetRoutes(rebalancerConfig: RebalancerConfig, token: Support
         continue;
       }
 
-      if (token !== "WETH" && sourceChain !== CHAIN_IDs.BSC && destinationChain !== CHAIN_IDs.BSC) {
+      if (hasSameAssetBridgeAdapter(token) && sourceChain !== CHAIN_IDs.BSC && destinationChain !== CHAIN_IDs.BSC) {
         routes.push({
           sourceChain,
           sourceToken: token,
@@ -66,8 +70,8 @@ function buildSameAssetRoutes(rebalancerConfig: RebalancerConfig, token: Support
   return routes;
 }
 
-export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): RebalanceRoute[] {
-  const rebalanceRoutes: RebalanceRoute[] = [];
+function buildDifferentAssetRoutes(rebalancerConfig: RebalancerConfig): RebalanceRoute[] {
+  const routes: RebalanceRoute[] = [];
   const usdtChains = configuredChainsForToken(rebalancerConfig, "USDT");
   const usdcChains = configuredChainsForToken(rebalancerConfig, "USDC");
   const wethChains = configuredChainsForToken(rebalancerConfig, "WETH");
@@ -80,14 +84,14 @@ export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): Rebala
           continue;
         }
 
-        rebalanceRoutes.push({
+        routes.push({
           sourceChain: usdtChain,
           sourceToken: "USDT",
           destinationChain: usdcChain,
           destinationToken: "USDC",
           adapter,
         });
-        rebalanceRoutes.push({
+        routes.push({
           sourceChain: usdcChain,
           sourceToken: "USDC",
           destinationChain: usdtChain,
@@ -98,21 +102,18 @@ export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): Rebala
     }
   }
 
-  rebalanceRoutes.push(...buildSameAssetRoutes(rebalancerConfig, "USDT"));
-  rebalanceRoutes.push(...buildSameAssetRoutes(rebalancerConfig, "USDC"));
-
   // WETH<->stablecoin swap routes via Binance only. WETH chains are restricted to direct Binance deposit/withdrawal
   // networks for ETH.
   for (const wethChain of directBinanceWethChains) {
     for (const usdtChain of usdtChains) {
-      rebalanceRoutes.push({
+      routes.push({
         sourceChain: wethChain,
         sourceToken: "WETH",
         destinationChain: usdtChain,
         destinationToken: "USDT",
         adapter: "binance",
       });
-      rebalanceRoutes.push({
+      routes.push({
         sourceChain: usdtChain,
         sourceToken: "USDT",
         destinationChain: wethChain,
@@ -121,14 +122,14 @@ export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): Rebala
       });
     }
     for (const usdcChain of usdcChains) {
-      rebalanceRoutes.push({
+      routes.push({
         sourceChain: wethChain,
         sourceToken: "WETH",
         destinationChain: usdcChain,
         destinationToken: "USDC",
         adapter: "binance",
       });
-      rebalanceRoutes.push({
+      routes.push({
         sourceChain: usdcChain,
         sourceToken: "USDC",
         destinationChain: wethChain,
@@ -138,9 +139,16 @@ export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): Rebala
     }
   }
 
-  rebalanceRoutes.push(...buildSameAssetRoutes(rebalancerConfig, "WETH"));
+  return routes;
+}
 
-  return rebalanceRoutes;
+export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): RebalanceRoute[] {
+  return [
+    ...buildDifferentAssetRoutes(rebalancerConfig),
+    ...buildSameAssetRoutes(rebalancerConfig, "USDT"),
+    ...buildSameAssetRoutes(rebalancerConfig, "USDC"),
+    ...buildSameAssetRoutes(rebalancerConfig, "WETH"),
+  ];
 }
 
 export function dedupeRebalanceRoutes(routes: RebalanceRoute[]): RebalanceRoute[] {

--- a/src/rebalancer/buildRebalanceRoutes.ts
+++ b/src/rebalancer/buildRebalanceRoutes.ts
@@ -2,52 +2,79 @@ import { CHAIN_IDs } from "../utils";
 import { RebalancerConfig } from "./RebalancerConfig";
 import { RebalanceRoute } from "./utils/interfaces";
 
-const USDT_REBALANCE_CHAINS = [
-  CHAIN_IDs.HYPEREVM,
-  CHAIN_IDs.ARBITRUM,
-  CHAIN_IDs.OPTIMISM,
-  CHAIN_IDs.MAINNET,
-  CHAIN_IDs.UNICHAIN,
-  CHAIN_IDs.MONAD,
-  CHAIN_IDs.BSC,
-];
+type SupportedToken = "USDC" | "USDT" | "WETH";
+type StableToken = Exclude<SupportedToken, "WETH">;
 
-const USDC_REBALANCE_CHAINS = [
-  CHAIN_IDs.HYPEREVM,
-  CHAIN_IDs.ARBITRUM,
-  CHAIN_IDs.OPTIMISM,
-  CHAIN_IDs.MAINNET,
-  CHAIN_IDs.BASE,
-  CHAIN_IDs.UNICHAIN,
-  CHAIN_IDs.MONAD,
-  CHAIN_IDs.BSC,
-];
+// Direct Binance deposit/withdraw networks for each token. This is intentionally separate from the rebalancer route
+// set so we can track venue support without automatically enabling every listed network operationally.
+const BINANCE_NETWORKS_BY_SYMBOL: Record<SupportedToken, readonly number[]> = {
+  USDC: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.BASE, CHAIN_IDs.BSC],
+  USDT: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.BSC],
+  // Live Binance ETH networkList currently includes ARBITRUM, BASE, BSC, ETH, OPTIMISM, SCROLL, and ZKSYNCERA.
+  // The rebalancer support list below stays narrower until we intentionally enable more of those networks.
+  WETH: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.BASE, CHAIN_IDs.BSC, CHAIN_IDs.MAINNET, CHAIN_IDs.OPTIMISM, CHAIN_IDs.SCROLL, CHAIN_IDs.ZK_SYNC],
+};
 
-const WETH_REBALANCE_CHAINS = [
-  CHAIN_IDs.ARBITRUM,
-  CHAIN_IDs.BASE,
-  CHAIN_IDs.BSC,
-  CHAIN_IDs.MAINNET,
-  CHAIN_IDs.OPTIMISM,
-];
+const REBALANCE_CHAINS_BY_SYMBOL: Record<SupportedToken, readonly number[]> = {
+  USDT: [CHAIN_IDs.HYPEREVM, CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.UNICHAIN, CHAIN_IDs.MONAD, CHAIN_IDs.BSC],
+  USDC: [CHAIN_IDs.HYPEREVM, CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.BASE, CHAIN_IDs.UNICHAIN, CHAIN_IDs.MONAD, CHAIN_IDs.BSC],
+  WETH: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.BASE, CHAIN_IDs.BSC, CHAIN_IDs.MAINNET, CHAIN_IDs.OPTIMISM],
+};
 
-const DIRECT_BINANCE_USDT_CHAINS = [CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.BSC];
-const DIRECT_BINANCE_USDC_CHAINS = [
-  CHAIN_IDs.ARBITRUM,
-  CHAIN_IDs.OPTIMISM,
-  CHAIN_IDs.MAINNET,
-  CHAIN_IDs.BASE,
-  CHAIN_IDs.BSC,
-];
+const SAME_ASSET_BRIDGE_ADAPTER_BY_SYMBOL: Record<StableToken, "cctp" | "oft"> = {
+  USDC: "cctp",
+  USDT: "oft",
+};
+
+function configuredChainsForToken(rebalancerConfig: RebalancerConfig, token: SupportedToken): number[] {
+  return REBALANCE_CHAINS_BY_SYMBOL[token].filter((chainId) => rebalancerConfig.chainIds.includes(chainId));
+}
+
+function buildSameAssetRoutes(rebalancerConfig: RebalancerConfig, token: SupportedToken): RebalanceRoute[] {
+  const routes: RebalanceRoute[] = [];
+  const configuredChains = configuredChainsForToken(rebalancerConfig, token);
+  const directBinanceNetworks = new Set(BINANCE_NETWORKS_BY_SYMBOL[token]);
+
+  for (const sourceChain of configuredChains) {
+    for (const destinationChain of configuredChains) {
+      if (sourceChain === destinationChain) {
+        continue;
+      }
+
+      if (token !== "WETH" && sourceChain !== CHAIN_IDs.BSC && destinationChain !== CHAIN_IDs.BSC) {
+        routes.push({
+          sourceChain,
+          sourceToken: token,
+          destinationChain,
+          destinationToken: token,
+          adapter: SAME_ASSET_BRIDGE_ADAPTER_BY_SYMBOL[token],
+        });
+      }
+
+      if (directBinanceNetworks.has(sourceChain) && directBinanceNetworks.has(destinationChain)) {
+        routes.push({
+          sourceChain,
+          sourceToken: token,
+          destinationChain,
+          destinationToken: token,
+          adapter: "binance",
+        });
+      }
+    }
+  }
+
+  return routes;
+}
 
 export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): RebalanceRoute[] {
   const rebalanceRoutes: RebalanceRoute[] = [];
+  const usdtChains = configuredChainsForToken(rebalancerConfig, "USDT");
+  const usdcChains = configuredChainsForToken(rebalancerConfig, "USDC");
+  const wethChains = configuredChainsForToken(rebalancerConfig, "WETH");
+  const directBinanceWethChains = wethChains.filter((chainId) => BINANCE_NETWORKS_BY_SYMBOL.WETH.includes(chainId));
 
-  for (const usdtChain of USDT_REBALANCE_CHAINS) {
-    for (const usdcChain of USDC_REBALANCE_CHAINS) {
-      if (!rebalancerConfig.chainIds.includes(usdtChain) || !rebalancerConfig.chainIds.includes(usdcChain)) {
-        continue;
-      }
+  for (const usdtChain of usdtChains) {
+    for (const usdcChain of usdcChains) {
       for (const adapter of ["binance", "hyperliquid"]) {
         if (adapter !== "binance" && (usdtChain === CHAIN_IDs.BSC || usdcChain === CHAIN_IDs.BSC)) {
           continue;
@@ -71,80 +98,13 @@ export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): Rebala
     }
   }
 
-  for (const usdtChain of USDT_REBALANCE_CHAINS) {
-    for (const otherUsdtChain of USDT_REBALANCE_CHAINS) {
-      if (!rebalancerConfig.chainIds.includes(usdtChain) || !rebalancerConfig.chainIds.includes(otherUsdtChain)) {
-        continue;
-      }
-      if (usdtChain === otherUsdtChain) {
-        continue;
-      }
-      if (otherUsdtChain !== CHAIN_IDs.BSC) {
-        rebalanceRoutes.push({
-          sourceChain: usdtChain,
-          sourceToken: "USDT",
-          destinationChain: otherUsdtChain,
-          destinationToken: "USDT",
-          adapter: "oft",
-        });
-      }
-      if (
-        DIRECT_BINANCE_USDT_CHAINS.includes(usdtChain) &&
-        DIRECT_BINANCE_USDT_CHAINS.includes(otherUsdtChain)
-      ) {
-        rebalanceRoutes.push({
-          sourceChain: usdtChain,
-          sourceToken: "USDT",
-          destinationChain: otherUsdtChain,
-          destinationToken: "USDT",
-          adapter: "binance",
-        });
-      }
-    }
-  }
-
-  for (const usdcChain of USDC_REBALANCE_CHAINS) {
-    for (const otherUsdcChain of USDC_REBALANCE_CHAINS) {
-      if (!rebalancerConfig.chainIds.includes(usdcChain) || !rebalancerConfig.chainIds.includes(otherUsdcChain)) {
-        continue;
-      }
-      if (usdcChain === otherUsdcChain) {
-        continue;
-      }
-      if (otherUsdcChain !== CHAIN_IDs.BSC) {
-        rebalanceRoutes.push({
-          sourceChain: usdcChain,
-          sourceToken: "USDC",
-          destinationChain: otherUsdcChain,
-          destinationToken: "USDC",
-          adapter: "cctp",
-        });
-      }
-      if (
-        DIRECT_BINANCE_USDC_CHAINS.includes(usdcChain) &&
-        DIRECT_BINANCE_USDC_CHAINS.includes(otherUsdcChain)
-      ) {
-        rebalanceRoutes.push({
-          sourceChain: usdcChain,
-          sourceToken: "USDC",
-          destinationChain: otherUsdcChain,
-          destinationToken: "USDC",
-          adapter: "binance",
-        });
-      }
-    }
-  }
+  rebalanceRoutes.push(...buildSameAssetRoutes(rebalancerConfig, "USDT"));
+  rebalanceRoutes.push(...buildSameAssetRoutes(rebalancerConfig, "USDC"));
 
   // WETH<->stablecoin swap routes via Binance only. WETH chains are restricted to direct Binance deposit/withdrawal
   // networks for ETH.
-  for (const wethChain of WETH_REBALANCE_CHAINS) {
-    if (!rebalancerConfig.chainIds.includes(wethChain)) {
-      continue;
-    }
-    for (const usdtChain of USDT_REBALANCE_CHAINS) {
-      if (!rebalancerConfig.chainIds.includes(usdtChain)) {
-        continue;
-      }
+  for (const wethChain of directBinanceWethChains) {
+    for (const usdtChain of usdtChains) {
       rebalanceRoutes.push({
         sourceChain: wethChain,
         sourceToken: "WETH",
@@ -160,10 +120,7 @@ export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): Rebala
         adapter: "binance",
       });
     }
-    for (const usdcChain of USDC_REBALANCE_CHAINS) {
-      if (!rebalancerConfig.chainIds.includes(usdcChain)) {
-        continue;
-      }
+    for (const usdcChain of usdcChains) {
       rebalanceRoutes.push({
         sourceChain: wethChain,
         sourceToken: "WETH",
@@ -181,23 +138,7 @@ export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): Rebala
     }
   }
 
-  for (const sourceWethChain of WETH_REBALANCE_CHAINS) {
-    if (!rebalancerConfig.chainIds.includes(sourceWethChain)) {
-      continue;
-    }
-    for (const destinationWethChain of WETH_REBALANCE_CHAINS) {
-      if (!rebalancerConfig.chainIds.includes(destinationWethChain) || sourceWethChain === destinationWethChain) {
-        continue;
-      }
-      rebalanceRoutes.push({
-        sourceChain: sourceWethChain,
-        sourceToken: "WETH",
-        destinationChain: destinationWethChain,
-        destinationToken: "WETH",
-        adapter: "binance",
-      });
-    }
-  }
+  rebalanceRoutes.push(...buildSameAssetRoutes(rebalancerConfig, "WETH"));
 
   return rebalanceRoutes;
 }
@@ -213,4 +154,4 @@ export function dedupeRebalanceRoutes(routes: RebalanceRoute[]): RebalanceRoute[
   return Array.from(uniqueRoutes.values());
 }
 
-export { DIRECT_BINANCE_USDC_CHAINS, DIRECT_BINANCE_USDT_CHAINS, USDC_REBALANCE_CHAINS, USDT_REBALANCE_CHAINS };
+export { BINANCE_NETWORKS_BY_SYMBOL, REBALANCE_CHAINS_BY_SYMBOL };

--- a/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
+++ b/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
@@ -1,20 +1,37 @@
 import {
   assert,
+  acrossApi,
   BigNumber,
   bnZero,
+  coingecko,
   ConvertDecimals,
+  defiLlama,
   fromWei,
   getNetworkName,
   getTokenInfoFromSymbol,
   isDefined,
   mapAsync,
+  PriceClient,
   toBNWei,
 } from "../../utils";
 import { ExcessOrDeficit, RebalanceRoute } from "../utils/interfaces";
 import { sortDeficitFunction, sortExcessFunction } from "../utils/utils";
 import { BaseRebalancerClient } from "./BaseRebalancerClient";
+import { getAcrossHost } from "../../clients/AcrossAPIClient";
 
 export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
+  private readonly priceClient: PriceClient;
+  private readonly tokenPriceCache = new Map<string, BigNumber>();
+
+  constructor(...args: ConstructorParameters<typeof BaseRebalancerClient>) {
+    super(...args);
+    this.priceClient = new PriceClient(this.logger, [
+      new acrossApi.PriceFeed({ host: getAcrossHost(this.config.hubPoolChainId) }),
+      new coingecko.PriceFeed({ apiKey: process.env.COINGECKO_PRO_API_KEY }),
+      new defiLlama.PriceFeed(),
+    ]);
+  }
+
   /**
    * @notice Rebalances cumulative balances of tokens across chains where cumulative token balances are above
    * configured targets to to tokens that have cumulative balances below configured thresholds. Tokens are sourced
@@ -85,12 +102,9 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
       ),
     });
 
-    // Identify all tokens with cumulative balance deficits and sort them by size, assuming that 1 unit of each token
-    // is worth the same amount of USD. Deficits are ranked from most negative to least.
-    // @todo We would need to change this logic if we accept the user setting targets for tokens that are not all
-    // stablecoins.
     const sortedDeficits: ExcessOrDeficit[] = [];
     const sortedExcesses: ExcessOrDeficit[] = [];
+    const tokenPricesUsd = new Map<string, BigNumber>();
     for (const [token, cumulativeBalance] of Object.entries(cumulativeBalances)) {
       // If current balance is below threshold, we want to refill back to target balance.
       const { targetBalance, thresholdBalance, priorityTier } = cumulativeTargetBalances[token];
@@ -102,9 +116,9 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
         const excessAmount = currentCumulativeBalance.sub(targetBalance);
         sortedExcesses.push({ token, amount: excessAmount, chainId: this.config.hubPoolChainId, priorityTier });
       }
+      tokenPricesUsd.set(token, await this._getTokenPriceUsd(token));
     }
-    // Sort deficits by priority from highest to lowest and then by size from largest to smallest.
-    sortedDeficits.sort(sortDeficitFunction);
+    sortedDeficits.sort((deficitA, deficitB) => sortDeficitFunction(deficitA, deficitB, tokenPricesUsd));
     if (sortedDeficits.length > 0) {
       this.logger.debug({
         at: "CumulativeBalanceRebalancerClient.rebalanceInventory",
@@ -116,7 +130,7 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
       });
     }
     // Sort excesses by priority from lowest to highest and then by size from largest to smallest.
-    sortedExcesses.sort(sortExcessFunction);
+    sortedExcesses.sort((excessA, excessB) => sortExcessFunction(excessA, excessB, tokenPricesUsd));
     if (sortedExcesses.length > 0) {
       this.logger.debug({
         at: "CumulativeBalanceRebalancerClient.rebalanceInventory",
@@ -187,7 +201,12 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
           const chainDecimals = getTokenInfoFromSymbol(excessToken, Number(chainId)).decimals;
           const l1ToChainConverter = ConvertDecimals(l1TokenDecimals, chainDecimals);
           const excessRemainingConverted = l1ToChainConverter(excessRemaining);
-          const deficitRemainingConverted = l1ToChainConverter(deficitRemaining);
+          const deficitRemainingInExcessToken = await this._convertL1TokenAmountForComparison(
+            deficitRemaining,
+            deficitToken,
+            excessToken
+          );
+          const deficitRemainingConverted = l1ToChainConverter(deficitRemainingInExcessToken);
           // The max we can transfer is the minimum of {the remaining deficit, the remaining excess, the max amount to transfer, the current balance}
           const maxAmountToTransfer = this.config.maxAmountsToTransfer[excessToken]?.[chainId];
           let amountToTransferCapped =
@@ -285,8 +304,14 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
 
           // Initiate a new rebalance
           const chainToL1Converter = ConvertDecimals(chainDecimals, l1TokenDecimals);
-          deficitRemaining = deficitRemaining.sub(chainToL1Converter(amountToTransferCapped));
-          excessRemaining = excessRemaining.sub(chainToL1Converter(amountToTransferCapped));
+          const amountTransferredL1 = chainToL1Converter(amountToTransferCapped);
+          const deficitReduction = await this._convertL1TokenAmountForComparison(
+            amountTransferredL1,
+            excessToken,
+            deficitToken
+          );
+          deficitRemaining = deficitReduction.gte(deficitRemaining) ? bnZero : deficitRemaining.sub(deficitReduction);
+          excessRemaining = excessRemaining.sub(amountTransferredL1);
           const deficitTokenChainDecimals = getTokenInfoFromSymbol(
             deficitToken,
             cheapestCostRoute.route.destinationChain
@@ -324,5 +349,43 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
         }
       }
     }
+  }
+
+  private async _convertL1TokenAmountForComparison(
+    amount: BigNumber,
+    fromToken: string,
+    toToken: string
+  ): Promise<BigNumber> {
+    if (fromToken === toToken) {
+      return amount;
+    }
+
+    const fromTokenDecimals = getTokenInfoFromSymbol(fromToken, this.config.hubPoolChainId).decimals;
+    const toTokenDecimals = getTokenInfoFromSymbol(toToken, this.config.hubPoolChainId).decimals;
+
+    const [fromPriceUsd, toPriceUsd] = await Promise.all([
+      this._getTokenPriceUsd(fromToken),
+      this._getTokenPriceUsd(toToken),
+    ]);
+    const fromTokenUnit = toBNWei("1", fromTokenDecimals);
+    const toTokenUnit = toBNWei("1", toTokenDecimals);
+    const usdValue = amount.mul(fromPriceUsd).div(fromTokenUnit);
+    return usdValue.mul(toTokenUnit).div(toPriceUsd);
+  }
+
+  private async _getTokenPriceUsd(token: string): Promise<BigNumber> {
+    const cachedPrice = this.tokenPriceCache.get(token);
+    if (cachedPrice) {
+      return cachedPrice;
+    }
+
+    const hubTokenAddress = getTokenInfoFromSymbol(token, this.config.hubPoolChainId).address.toNative();
+    const fixedPriceEnv = process.env[`RELAYER_TOKEN_PRICE_FIXED_${hubTokenAddress}`];
+    const priceUsd = isDefined(fixedPriceEnv)
+      ? toBNWei(fixedPriceEnv)
+      : toBNWei((await this.priceClient.getPriceByAddress(hubTokenAddress)).price);
+    assert(priceUsd.gt(bnZero), `Unable to resolve positive USD price for ${token}`);
+    this.tokenPriceCache.set(token, priceUsd);
+    return priceUsd;
   }
 }

--- a/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
+++ b/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
@@ -327,17 +327,10 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
           const deficitTokenL1Decimals = getTokenInfoFromSymbol(deficitToken, this.config.hubPoolChainId).decimals;
           this.logger[this.config.sendingTransactionsEnabled ? "info" : "debug"]({
             at: "RebalanceClient.rebalanceCumulativeInventory",
-            message: `Initializing new ${cheapestCostRoute.route.adapter} rebalance from ${
-              cheapestCostRoute.route.sourceToken
-            } on ${getNetworkName(cheapestCostRoute.route.sourceChain)} to ${
-              cheapestCostRoute.route.destinationToken
-            } on ${getNetworkName(cheapestCostRoute.route.destinationChain)}`,
+            message: `Initializing new ${cheapestCostRoute.route.adapter} ${fromWei(amountToTransferCapped, chainDecimals)} ${excessToken} rebalance from ${getNetworkName(cheapestCostRoute.route.sourceChain)} to ${getNetworkName(cheapestCostRoute.route.destinationChain)} ${deficitToken}`,
             adapter: cheapestCostRoute.route.adapter,
-            amountToTransfer: fromWei(amountToTransferCapped, chainDecimals),
             expectedFees: fromWei(cheapestCostRoute.cost, chainDecimals),
-            excessTokenCumulativeBalance: fromWei(cumulativeBalances[excessToken], l1TokenDecimals),
-            deficitTokenCumulativeBalance: fromWei(cumulativeBalances[deficitToken], deficitTokenL1Decimals),
-            excessTokenCurrentBalance: fromWei(
+            sourceChainLeftoverBalance: fromWei(
               currentBalancesOnChain[cheapestCostRoute.route.sourceChain][excessToken],
               chainDecimals
             ),
@@ -345,7 +338,8 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
               currentBalancesOnChain[cheapestCostRoute.route.destinationChain][deficitToken],
               deficitTokenChainDecimals
             ),
-            deficitRemaining: fromWei(deficitRemaining, deficitTokenL1Decimals),
+            deficitTokenRemainingCumulativeBalance: fromWei(deficitRemaining, deficitTokenL1Decimals),
+            excessTokenRemainingCumulativeBalance: fromWei(excessRemaining, l1TokenDecimals),
           });
 
           if (this.config.sendingTransactionsEnabled) {

--- a/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
+++ b/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
@@ -112,11 +112,12 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
       if (currentCumulativeBalance.lt(thresholdBalance)) {
         const deficitAmount = targetBalance.sub(cumulativeBalance);
         sortedDeficits.push({ token, amount: deficitAmount, chainId: this.config.hubPoolChainId, priorityTier });
+        tokenPricesUsd.set(token, await this._getTokenPriceUsd(token));
       } else if (currentCumulativeBalance.gt(targetBalance)) {
         const excessAmount = currentCumulativeBalance.sub(targetBalance);
         sortedExcesses.push({ token, amount: excessAmount, chainId: this.config.hubPoolChainId, priorityTier });
+        tokenPricesUsd.set(token, await this._getTokenPriceUsd(token));
       }
-      tokenPricesUsd.set(token, await this._getTokenPriceUsd(token));
     }
     sortedDeficits.sort((deficitA, deficitB) => sortDeficitFunction(deficitA, deficitB, tokenPricesUsd));
     if (sortedDeficits.length > 0) {
@@ -308,7 +309,6 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
             continue;
           }
 
-          // Initiate a new rebalance
           const chainToL1Converter = ConvertDecimals(chainDecimals, l1TokenDecimals);
           const amountTransferredL1 = chainToL1Converter(amountToTransferCapped);
           const deficitReduction = await this._convertL1TokenAmountForComparison(
@@ -316,41 +316,39 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
             excessToken,
             deficitToken
           );
-
-          // Decrement the deficit remaining, the excess remaining for this token, and the current balance for this
-          // token.
-          deficitRemaining = deficitReduction.gte(deficitRemaining) ? bnZero : deficitRemaining.sub(deficitReduction);
-          excessRemaining = excessRemaining.sub(amountTransferredL1);
-          currentBalancesOnChain[cheapestCostRoute.route.sourceChain][excessToken] =
-            currentBalance.sub(amountToTransferCapped);
-          const deficitTokenChainDecimals = getTokenInfoFromSymbol(
-            deficitToken,
-            cheapestCostRoute.route.destinationChain
-          ).decimals;
-          const deficitTokenL1Decimals = getTokenInfoFromSymbol(deficitToken, this.config.hubPoolChainId).decimals;
+          const nextDeficitRemaining = deficitReduction.gte(deficitRemaining)
+            ? bnZero
+            : deficitRemaining.sub(deficitReduction);
+          const nextExcessRemaining = excessRemaining.sub(amountTransferredL1);
+          const nextSourceBalance = currentBalance.sub(amountToTransferCapped);
           this.logger[this.config.sendingTransactionsEnabled ? "info" : "debug"]({
             at: "RebalanceClient.rebalanceCumulativeInventory",
             message: `Initializing new ${cheapestCostRoute.route.adapter} ${fromWei(amountToTransferCapped, chainDecimals)} ${excessToken} rebalance from ${getNetworkName(cheapestCostRoute.route.sourceChain)} to ${getNetworkName(cheapestCostRoute.route.destinationChain)} ${deficitToken}`,
             adapter: cheapestCostRoute.route.adapter,
             expectedFees: fromWei(cheapestCostRoute.cost, chainDecimals),
-            sourceChainLeftoverBalance: fromWei(
-              currentBalancesOnChain[cheapestCostRoute.route.sourceChain][excessToken],
-              chainDecimals
-            ),
-            destinationChainCurrentBalance: fromWei(
-              currentBalancesOnChain[cheapestCostRoute.route.destinationChain][deficitToken],
-              deficitTokenChainDecimals
-            ),
-            deficitTokenRemainingCumulativeBalance: fromWei(deficitRemaining, deficitTokenL1Decimals),
-            excessTokenRemainingCumulativeBalance: fromWei(excessRemaining, l1TokenDecimals),
           });
 
           if (this.config.sendingTransactionsEnabled) {
-            await this.adapters[cheapestCostRoute.route.adapter].initializeRebalance(
+            const initializedAmount = await this.adapters[cheapestCostRoute.route.adapter].initializeRebalance(
               cheapestCostRoute.route,
               amountToTransferCapped
             );
+            if (initializedAmount.eq(bnZero)) {
+              this.logger.debug({
+                at: "CumulativeBalanceRebalancerClient.rebalanceInventory",
+                message: `Adapter ${cheapestCostRoute.route.adapter} declined to initialize rebalance; preserving remaining excess for later routes`,
+                route: cheapestCostRoute.route,
+                requestedAmountToTransfer: amountToTransferCapped.toString(),
+              });
+              continue;
+            }
           }
+
+          // Decrement the deficit remaining, the excess remaining for this token, and the current balance for this
+          // token only after the adapter successfully initializes the rebalance.
+          deficitRemaining = nextDeficitRemaining;
+          excessRemaining = nextExcessRemaining;
+          currentBalancesOnChain[cheapestCostRoute.route.sourceChain][excessToken] = nextSourceBalance;
         }
 
         // Overwrite the excess remaining for the token to decrement the excess for the next deficit to evaluate.

--- a/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
+++ b/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
@@ -182,7 +182,7 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
         for (const chainWithExcess of sortedExcessSourceChainsForToken) {
           const { chainId, amount: currentBalance } = chainWithExcess;
           // Invariants: If excess or deficit is depleted, exit.
-          if (deficitRemaining.lte(bnZero) || excessRemaining.lte(bnZero)) {
+          if (deficitRemaining.lte(1) || excessRemaining.lte(1)) {
             break;
           }
 

--- a/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
+++ b/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
@@ -142,6 +142,8 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
       });
     }
 
+    const startingExcesses = Object.fromEntries(sortedExcesses.map(({ token, amount }) => [token, amount]));
+
     // Iterate through the sorted deficits and try to fill as much of it as possible from the configured
     // excess token chain list.
     for (const deficit of sortedDeficits) {
@@ -149,8 +151,8 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
       // Keep track of how much of the deficit we need to fill and also how much excess we have available to send.
       let deficitRemaining = deficitAmount;
       for (const excess of sortedExcesses) {
-        const { token: excessToken, amount: excessAmount } = excess;
-        let excessRemaining = excessAmount;
+        const excessToken = excess.token;
+        let excessRemaining = startingExcesses[excess.token];
 
         // Sort all the chains with excess tokens by priority from lowest to highest and then by current balance from highest to lowest.
         const excessSourceChainsForToken: ExcessOrDeficit[] = Object.entries(
@@ -169,7 +171,7 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
         const sortedExcessSourceChainsForToken = excessSourceChainsForToken.sort(sortExcessFunction);
         this.logger.debug({
           at: "CumulativeBalanceRebalancerClient.rebalanceInventory",
-          message: `Sorted excess source chains for token ${excessToken}`,
+          message: `Sorted excess source chains for token ${excessToken} we can use to fill the deficit of ${deficitToken}`,
           excessSourceChainsForToken: sortedExcessSourceChainsForToken.map(({ chainId, amount }) => {
             return {
               [chainId]: amount.toString(),
@@ -278,6 +280,7 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
             currentBalance: currentBalance.toString(),
             deficitRemaining: deficitRemaining.toString(),
             excessRemaining: excessRemaining.toString(),
+            deficitRemainingConvertedToExcessToken: deficitRemainingConverted.toString(),
             maxAmountToTransfer: maxAmountToTransfer?.toString(),
             cheapestCostRoute: `[${cheapestCostRoute.route.adapter}] ${getNetworkName(
               cheapestCostRoute.route.sourceChain
@@ -310,8 +313,13 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
             excessToken,
             deficitToken
           );
+
+          // Decrement the deficit remaining, the excess remaining for this token, and the current balance for this
+          // token.
           deficitRemaining = deficitReduction.gte(deficitRemaining) ? bnZero : deficitRemaining.sub(deficitReduction);
           excessRemaining = excessRemaining.sub(amountTransferredL1);
+          currentBalancesOnChain[cheapestCostRoute.route.sourceChain][excessToken] =
+            currentBalance.sub(amountToTransferCapped);
           const deficitTokenChainDecimals = getTokenInfoFromSymbol(
             deficitToken,
             cheapestCostRoute.route.destinationChain
@@ -347,6 +355,9 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
             );
           }
         }
+
+        // Overwrite the excess remaining for the token to decrement the excess for the next deficit to evaluate.
+        startingExcesses[excessToken] = excessRemaining;
       }
     }
   }

--- a/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
+++ b/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
@@ -374,6 +374,8 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
   }
 
   private async _getTokenPriceUsd(token: string): Promise<BigNumber> {
+    // Assume that this client is never run in long lasting operations so we are safe to cache this price once
+    // per run.
     const cachedPrice = this.tokenPriceCache.get(token);
     if (cachedPrice) {
       return cachedPrice;

--- a/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
+++ b/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
@@ -221,6 +221,9 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
           amountToTransferCapped = amountToTransferCapped.gt(excessRemainingConverted)
             ? excessRemainingConverted
             : amountToTransferCapped;
+          if (amountToTransferCapped.lte(bnZero)) {
+            continue;
+          }
 
           // To determine which destination chain to receive the deficit token on, we check the estimated cost
           // for all possible destination chains and then select the chain with the lowest estimated cost.

--- a/src/rebalancer/utils/utils.ts
+++ b/src/rebalancer/utils/utils.ts
@@ -24,35 +24,50 @@ export async function getRedisCacheForRebalancerStatusTracking(
   return (await getRedisCache(logger, undefined, getRebalancerStatusTrackingNamespace())) as RedisCache;
 }
 
+function compareNormalizedAmounts(
+  excessA: ExcessOrDeficit,
+  excessB: ExcessOrDeficit,
+  tokenPricesUsd?: Map<string, BigNumber>
+): number {
+  const { token: tokenA, amount: amountA, chainId: chainIdA } = excessA;
+  const { token: tokenB, amount: amountB, chainId: chainIdB } = excessB;
+  const tokenADecimals = getTokenInfoFromSymbol(tokenA, Number(chainIdA)).decimals;
+  const tokenBDecimals = getTokenInfoFromSymbol(tokenB, Number(chainIdB)).decimals;
+  const converter = ConvertDecimals(tokenADecimals, tokenBDecimals);
+  const normalizedAmountA =
+    tokenPricesUsd && tokenPricesUsd.has(tokenA) ? amountA.mul(tokenPricesUsd.get(tokenA)) : amountA;
+  const normalizedAmountB =
+    tokenPricesUsd && tokenPricesUsd.has(tokenB) ? amountB.mul(tokenPricesUsd.get(tokenB)) : amountB;
+  if (converter(normalizedAmountA).eq(normalizedAmountB)) {
+    return 0;
+  }
+  return converter(normalizedAmountA).gt(normalizedAmountB) ? -1 : 1;
+}
 // Excesses are always sorted in priority from lowest to highest and then by amount from largest to smallest.
-export function sortExcessFunction(excessA: ExcessOrDeficit, excessB: ExcessOrDeficit): number {
-  const { token: tokenA, amount: amountA, priorityTier: priorityTierA, chainId: chainIdA } = excessA;
-  const { token: tokenB, amount: amountB, priorityTier: priorityTierB, chainId: chainIdB } = excessB;
+export function sortExcessFunction(
+  excessA: ExcessOrDeficit,
+  excessB: ExcessOrDeficit,
+  tokenPricesUsd?: Map<string, BigNumber>
+): number {
+  const { priorityTier: priorityTierA } = excessA;
+  const { priorityTier: priorityTierB } = excessB;
   if (priorityTierA !== priorityTierB) {
     return priorityTierA - priorityTierB;
   }
-  const tokenADecimals = getTokenInfoFromSymbol(tokenA, Number(chainIdA)).decimals;
-  const tokenBDecimals = getTokenInfoFromSymbol(tokenB, Number(chainIdB)).decimals;
-  const converter = ConvertDecimals(tokenADecimals, tokenBDecimals);
-  if (converter(amountA).eq(amountB)) {
-    return 0;
-  }
-  return converter(amountA).gt(amountB) ? -1 : 1;
+  return compareNormalizedAmounts(excessA, excessB, tokenPricesUsd);
 }
 // Deficits are always sorted in priority from highest to lowest and then by amount from largest to smallest.
-export function sortDeficitFunction(deficitA: ExcessOrDeficit, deficitB: ExcessOrDeficit): number {
-  const { token: tokenA, amount: amountA, priorityTier: priorityTierA, chainId: chainIdA } = deficitA;
-  const { token: tokenB, amount: amountB, priorityTier: priorityTierB, chainId: chainIdB } = deficitB;
+export function sortDeficitFunction(
+  deficitA: ExcessOrDeficit,
+  deficitB: ExcessOrDeficit,
+  tokenPricesUsd?: Map<string, BigNumber>
+): number {
+  const { priorityTier: priorityTierA } = deficitA;
+  const { priorityTier: priorityTierB } = deficitB;
   if (priorityTierA !== priorityTierB) {
     return priorityTierB - priorityTierA;
   }
-  const tokenADecimals = getTokenInfoFromSymbol(tokenA, Number(chainIdA)).decimals;
-  const tokenBDecimals = getTokenInfoFromSymbol(tokenB, Number(chainIdB)).decimals;
-  const converter = ConvertDecimals(tokenADecimals, tokenBDecimals);
-  if (converter(amountA).eq(amountB)) {
-    return 0;
-  }
-  return converter(amountA).gt(amountB) ? -1 : 1;
+  return compareNormalizedAmounts(deficitA, deficitB, tokenPricesUsd);
 }
 
 export function getCloidForAccount(account: string): string {

--- a/test/BinanceAdapter.conversions.ts
+++ b/test/BinanceAdapter.conversions.ts
@@ -97,6 +97,45 @@ describe("Binance adapter conversion sizing", function () {
     expect(cctpGetEstimatedCost.getCall(0).args[1].eq(toBNWei("102.040816", 6))).to.equal(true);
   });
 
+  it("does not inflate stablecoin withdrawal fees when source and destination decimals differ", async function () {
+    const route = makeStablecoinRoute({ sourceChain: CHAIN_IDs.BSC, destinationChain: CHAIN_IDs.BASE });
+    const adapter = await makeInitializedAdapter(route);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getTradeFees").resolves([{ symbol: "USDCUSDT", takerCommission: "0" }]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getLatestPrice").resolves({ latestPrice: 1, slippagePct: 0 });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getAccountCoins").callsFake(async (token: string) => {
+      return {
+        symbol: token,
+        balance: "0",
+        networkList: [
+          {
+            name: "BASE",
+            withdrawMin: "0.1",
+            withdrawMax: "1000000",
+            withdrawFee: "0.499695",
+          },
+          {
+            name: "BSC",
+            withdrawMin: "0.1",
+            withdrawMax: "1000000",
+            withdrawFee: "0",
+          },
+        ],
+      };
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getEntrypointNetwork").callsFake(async (chainId: number) => chainId);
+
+    const cost = await adapter.getEstimatedCost(route, toBNWei("308304.851912549672926661", 18), false);
+
+    expect(cost.eq(toBNWei("0.499695", 18))).to.equal(true);
+  });
+
   it("prices destination-to-source conversions using source-token precision", async function () {
     const route = makeStablecoinRoute();
     const adapter = await makeInitializedAdapter(route);

--- a/test/BinanceAdapter.conversions.ts
+++ b/test/BinanceAdapter.conversions.ts
@@ -140,15 +140,17 @@ describe("Binance adapter conversion sizing", function () {
     expect(cctpGetEstimatedCost.getCall(0).args[1].eq(toBNWei("102.040816", 6))).to.equal(true);
   });
 
-  it("does not inflate stablecoin withdrawal fees when source and destination decimals differ", async function () {
-    const route = makeStablecoinRoute({ sourceChain: CHAIN_IDs.BSC, destinationChain: CHAIN_IDs.BASE });
+  it("does not inflate same-asset stablecoin withdrawal fees when chain decimals differ", async function () {
+    const route = makeStablecoinRoute({
+      sourceChain: CHAIN_IDs.BSC,
+      destinationChain: CHAIN_IDs.BASE,
+      sourceToken: "USDC",
+      destinationToken: "USDC",
+    });
     const adapter = await makeInitializedAdapter(route);
-    const internals = withBinanceInternals(adapter);
 
-    sinon.stub(internals, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
-    sinon.stub(internals, "_getTradeFees").resolves([{ symbol: "USDCUSDT", takerCommission: "0" }]);
-    sinon.stub(internals, "_getLatestPrice").resolves({ latestPrice: 1, slippagePct: 0 });
-    sinon.stub(internals, "_getAccountCoins").callsFake(async (token: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getAccountCoins").callsFake(async (token: string) => {
       return {
         symbol: token,
         balance: "0",
@@ -168,7 +170,8 @@ describe("Binance adapter conversion sizing", function () {
         ],
       };
     });
-    sinon.stub(internals, "_getEntrypointNetwork").callsFake(async (chainId: number) => chainId);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getEntrypointNetwork").callsFake(async (chainId: number) => chainId);
 
     const cost = await adapter.getEstimatedCost(route, toBNWei("308304.851912549672926661", 18), false);
 

--- a/test/BinanceAdapter.conversions.ts
+++ b/test/BinanceAdapter.conversions.ts
@@ -1,8 +1,67 @@
 import { CHAIN_IDs } from "@across-protocol/constants";
+import winston from "winston";
 import { ethers, expect, sinon, toBNWei } from "./utils";
-import { EvmAddress } from "../src/utils";
+import { BigNumber, EvmAddress } from "../src/utils";
 import { BinanceStablecoinSwapAdapter } from "../src/rebalancer/adapters/binance";
+import { CctpAdapter } from "../src/rebalancer/adapters/cctpAdapter";
+import { OftAdapter } from "../src/rebalancer/adapters/oftAdapter";
+import { RebalancerConfig } from "../src/rebalancer/RebalancerConfig";
 import { RebalanceRoute } from "../src/rebalancer/utils/interfaces";
+
+type BinanceCoinStub = {
+  symbol?: string;
+  balance?: string;
+  networkList: Array<{
+    name: string;
+    withdrawMin: string;
+    withdrawMax: string;
+    withdrawFee: string;
+  }>;
+};
+
+type BinanceTradeFeeStub = { symbol: string; takerCommission: string };
+
+type IntermediateAdapterStub = Partial<Pick<CctpAdapter, "supportsRoute" | "getEstimatedCost">>;
+
+type BinanceAdapterInternals = BinanceStablecoinSwapAdapter & {
+  initialized: boolean;
+  availableRoutes: RebalanceRoute[];
+  baseSignerAddress: EvmAddress;
+  _getSpotMarketMetaForRoute: (
+    sourceToken: string,
+    destinationToken: string
+  ) => Promise<ReturnType<typeof makeSpotMeta>>;
+  _getLatestPrice: (
+    sourceToken: string,
+    destinationToken: string,
+    sourceChain: number,
+    amountToTransfer: BigNumber
+  ) => Promise<{ latestPrice: number; slippagePct: number }>;
+  _getAccountCoins: (token: string) => Promise<BinanceCoinStub>;
+  _getEntrypointNetwork: (chainId: number, token: string) => Promise<number>;
+  _redisGetNextCloid: () => Promise<string>;
+  _depositToBinance: (sourceToken: string, sourceChain: number, amountToDeposit: BigNumber) => Promise<void>;
+  _redisCreateOrder: (
+    cloid: string,
+    status: number,
+    rebalanceRoute: RebalanceRoute,
+    amountToTransfer: BigNumber,
+    account: EvmAddress,
+    ttlOverride?: number
+  ) => Promise<void>;
+  _getTradeFees: () => Promise<BinanceTradeFeeStub[]>;
+  _convertDestinationToSource: (
+    destinationToken: string,
+    destinationChain: number,
+    sourceToken: string,
+    sourceChain: number,
+    destinationAmount: BigNumber
+  ) => Promise<BigNumber>;
+};
+
+function withBinanceInternals(adapter: BinanceStablecoinSwapAdapter): BinanceAdapterInternals {
+  return adapter as unknown as BinanceAdapterInternals;
+}
 
 describe("Binance adapter conversion sizing", function () {
   afterEach(function () {
@@ -12,23 +71,17 @@ describe("Binance adapter conversion sizing", function () {
   it("uses converted withdrawal minimums when deciding whether to initialize a rebalance", async function () {
     const route = makeStablecoinRoute();
     const adapter = await makeInitializedAdapter(route);
+    const internals = withBinanceInternals(adapter);
     const depositStub = sinon.stub();
     const createOrderStub = sinon.stub().resolves();
     sinon.stub(adapter, "getEstimatedCost").resolves(toBNWei("0", 6));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getLatestPrice").resolves({ latestPrice: 0.99, slippagePct: 0 });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getAccountCoins").resolves(makeCoin("100", "1000000"));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getEntrypointNetwork").callsFake(async () => CHAIN_IDs.MAINNET);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_redisGetNextCloid").resolves("cloid");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_depositToBinance").callsFake(depositStub);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_redisCreateOrder").callsFake(createOrderStub);
+    sinon.stub(internals, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
+    sinon.stub(internals, "_getLatestPrice").resolves({ latestPrice: 0.99, slippagePct: 0 });
+    sinon.stub(internals, "_getAccountCoins").resolves(makeCoin("100", "1000000"));
+    sinon.stub(internals, "_getEntrypointNetwork").callsFake(async () => CHAIN_IDs.MAINNET);
+    sinon.stub(internals, "_redisGetNextCloid").resolves("cloid");
+    sinon.stub(internals, "_depositToBinance").callsFake(depositStub);
+    sinon.stub(internals, "_redisCreateOrder").callsFake(createOrderStub);
 
     const amount = toBNWei("100", 6);
     const result = await adapter.initializeRebalance(route, amount);
@@ -41,23 +94,17 @@ describe("Binance adapter conversion sizing", function () {
   it("uses converted buy-side minimum order sizes", async function () {
     const route = makeStablecoinRoute();
     const adapter = await makeInitializedAdapter(route);
+    const internals = withBinanceInternals(adapter);
     const depositStub = sinon.stub();
     const createOrderStub = sinon.stub().resolves();
     sinon.stub(adapter, "getEstimatedCost").resolves(toBNWei("0", 6));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 100));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getLatestPrice").resolves({ latestPrice: 0.99, slippagePct: 0 });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getAccountCoins").resolves(makeCoin("0", "1000000"));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getEntrypointNetwork").callsFake(async () => CHAIN_IDs.MAINNET);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_redisGetNextCloid").resolves("cloid");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_depositToBinance").callsFake(depositStub);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_redisCreateOrder").callsFake(createOrderStub);
+    sinon.stub(internals, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 100));
+    sinon.stub(internals, "_getLatestPrice").resolves({ latestPrice: 0.99, slippagePct: 0 });
+    sinon.stub(internals, "_getAccountCoins").resolves(makeCoin("0", "1000000"));
+    sinon.stub(internals, "_getEntrypointNetwork").callsFake(async () => CHAIN_IDs.MAINNET);
+    sinon.stub(internals, "_redisGetNextCloid").resolves("cloid");
+    sinon.stub(internals, "_depositToBinance").callsFake(depositStub);
+    sinon.stub(internals, "_redisCreateOrder").callsFake(createOrderStub);
 
     const amount = toBNWei("99.5", 6);
     const result = await adapter.initializeRebalance(route, amount);
@@ -76,17 +123,13 @@ describe("Binance adapter conversion sizing", function () {
         getEstimatedCost: cctpGetEstimatedCost,
       },
     });
+    const internals = withBinanceInternals(adapter);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getLatestPrice").resolves({ latestPrice: 0.98, slippagePct: 0 });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getAccountCoins").resolves(makeCoin("0", "1000000"));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getTradeFees").resolves([{ symbol: "USDCUSDT", takerCommission: "0" }]);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getEntrypointNetwork").callsFake(async (...args: [number, string]) => {
+    sinon.stub(internals, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
+    sinon.stub(internals, "_getLatestPrice").resolves({ latestPrice: 0.98, slippagePct: 0 });
+    sinon.stub(internals, "_getAccountCoins").resolves(makeCoin("0", "1000000"));
+    sinon.stub(internals, "_getTradeFees").resolves([{ symbol: "USDCUSDT", takerCommission: "0" }]);
+    sinon.stub(internals, "_getEntrypointNetwork").callsFake(async (...args: [number, string]) => {
       const [chainId, token] = args;
       return token === "USDC" && chainId === CHAIN_IDs.BASE ? CHAIN_IDs.MAINNET : chainId;
     });
@@ -100,15 +143,12 @@ describe("Binance adapter conversion sizing", function () {
   it("does not inflate stablecoin withdrawal fees when source and destination decimals differ", async function () {
     const route = makeStablecoinRoute({ sourceChain: CHAIN_IDs.BSC, destinationChain: CHAIN_IDs.BASE });
     const adapter = await makeInitializedAdapter(route);
+    const internals = withBinanceInternals(adapter);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getTradeFees").resolves([{ symbol: "USDCUSDT", takerCommission: "0" }]);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getLatestPrice").resolves({ latestPrice: 1, slippagePct: 0 });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getAccountCoins").callsFake(async (token: string) => {
+    sinon.stub(internals, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
+    sinon.stub(internals, "_getTradeFees").resolves([{ symbol: "USDCUSDT", takerCommission: "0" }]);
+    sinon.stub(internals, "_getLatestPrice").resolves({ latestPrice: 1, slippagePct: 0 });
+    sinon.stub(internals, "_getAccountCoins").callsFake(async (token: string) => {
       return {
         symbol: token,
         balance: "0",
@@ -128,8 +168,7 @@ describe("Binance adapter conversion sizing", function () {
         ],
       };
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getEntrypointNetwork").callsFake(async (chainId: number) => chainId);
+    sinon.stub(internals, "_getEntrypointNetwork").callsFake(async (chainId: number) => chainId);
 
     const cost = await adapter.getEstimatedCost(route, toBNWei("308304.851912549672926661", 18), false);
 
@@ -139,14 +178,12 @@ describe("Binance adapter conversion sizing", function () {
   it("prices destination-to-source conversions using source-token precision", async function () {
     const route = makeStablecoinRoute();
     const adapter = await makeInitializedAdapter(route);
+    const internals = withBinanceInternals(adapter);
     const latestPriceStub = sinon.stub().resolves({ latestPrice: 2500, slippagePct: 0 });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getLatestPrice").callsFake(latestPriceStub);
+    sinon.stub(internals, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
+    sinon.stub(internals, "_getLatestPrice").callsFake(latestPriceStub);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (adapter as any)._convertNumberToSource("WETH", CHAIN_IDs.MAINNET, "USDC", CHAIN_IDs.MAINNET, 1);
+    await internals._convertDestinationToSource("WETH", CHAIN_IDs.MAINNET, "USDC", CHAIN_IDs.MAINNET, toBNWei("1", 18));
 
     expect(latestPriceStub.calledOnce).to.equal(true);
     expect(latestPriceStub.getCall(0).args[0]).to.equal("USDC");
@@ -162,21 +199,22 @@ async function makeInitializedAdapter(
     cctpAdapter = {},
     oftAdapter = {},
   }: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    cctpAdapter?: any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    oftAdapter?: any;
+    cctpAdapter?: IntermediateAdapterStub;
+    oftAdapter?: IntermediateAdapterStub;
   } = {}
 ): Promise<BinanceStablecoinSwapAdapter> {
   const [signer] = await ethers.getSigners();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const adapter = new BinanceStablecoinSwapAdapter(TEST_LOGGER, {} as any, signer, cctpAdapter, oftAdapter);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (adapter as any).initialized = true;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (adapter as any).availableRoutes = [route];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (adapter as any).baseSignerAddress = EvmAddress.from(await signer.getAddress());
+  const adapter = new BinanceStablecoinSwapAdapter(
+    TEST_LOGGER,
+    {} as RebalancerConfig,
+    signer,
+    cctpAdapter as CctpAdapter,
+    oftAdapter as OftAdapter
+  );
+  const internals = withBinanceInternals(adapter);
+  internals.initialized = true;
+  internals.availableRoutes = [route];
+  internals.baseSignerAddress = EvmAddress.from(await signer.getAddress());
   return adapter;
 }
 
@@ -214,5 +252,4 @@ const TEST_LOGGER = {
   info: () => undefined,
   warn: () => undefined,
   error: () => undefined,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-} as any;
+} as unknown as winston.Logger;

--- a/test/BinanceAdapter.conversions.ts
+++ b/test/BinanceAdapter.conversions.ts
@@ -107,13 +107,7 @@ describe("Binance adapter conversion sizing", function () {
     sinon.stub(adapter as any, "_getLatestPrice").callsFake(latestPriceStub);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (adapter as any)._convertDestinationToSource(
-      "WETH",
-      CHAIN_IDs.MAINNET,
-      "USDC",
-      CHAIN_IDs.MAINNET,
-      toBNWei("1", 18)
-    );
+    await (adapter as any)._convertNumberToSource("WETH", CHAIN_IDs.MAINNET, "USDC", CHAIN_IDs.MAINNET, 1);
 
     expect(latestPriceStub.calledOnce).to.equal(true);
     expect(latestPriceStub.getCall(0).args[0]).to.equal("USDC");

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -1,0 +1,72 @@
+import { BigNumber } from "ethers";
+import { expect, toBNWei } from "./utils";
+import {
+  convertBinanceRouteAmount,
+  deriveBinanceSpotMarketMeta,
+  isSameBinanceCoinRoute,
+  resolveBinanceCoinSymbol,
+  supportsBinanceIntermediateBridgeToken,
+} from "../src/rebalancer/adapters/binance";
+
+describe("Binance adapter helpers", async function () {
+  it("aliases on-chain WETH to Binance ETH", async function () {
+    expect(resolveBinanceCoinSymbol("WETH")).to.equal("ETH");
+    expect(resolveBinanceCoinSymbol("USDC")).to.equal("USDC");
+  });
+
+  it("detects same-coin Binance routes that should skip the swap leg", async function () {
+    expect(isSameBinanceCoinRoute("WETH", "WETH")).to.equal(true);
+    expect(isSameBinanceCoinRoute("USDC", "USDC")).to.equal(true);
+    expect(isSameBinanceCoinRoute("WETH", "USDC")).to.equal(false);
+  });
+
+  it("only permits intermediate Binance bridge legs for assets we can actually bridge onchain", async function () {
+    expect(supportsBinanceIntermediateBridgeToken("USDC")).to.equal(true);
+    expect(supportsBinanceIntermediateBridgeToken("USDT")).to.equal(true);
+    expect(supportsBinanceIntermediateBridgeToken("WETH")).to.equal(false);
+  });
+
+  it("derives Binance spot market metadata for WETH/stable routes in both directions", async function () {
+    const ethUsdcSymbol = {
+      symbol: "ETHUSDC",
+      baseAsset: "ETH",
+      quoteAsset: "USDC",
+      filters: [
+        { filterType: "PRICE_FILTER", tickSize: "0.01000000" },
+        { filterType: "LOT_SIZE", stepSize: "0.00010000", minQty: "0.00010000" },
+      ],
+    } as const;
+
+    const wethToUsdc = deriveBinanceSpotMarketMeta("WETH", "USDC", ethUsdcSymbol as never);
+    const usdcToWeth = deriveBinanceSpotMarketMeta("USDC", "WETH", ethUsdcSymbol as never);
+
+    expect(wethToUsdc.symbol).to.equal("ETHUSDC");
+    expect(wethToUsdc.isBuy).to.equal(false);
+    expect(wethToUsdc.pxDecimals).to.equal(2);
+    expect(wethToUsdc.szDecimals).to.equal(4);
+    expect(usdcToWeth.isBuy).to.equal(true);
+  });
+
+  it("converts non-parity Binance route amounts without assuming a 1:1 market", async function () {
+    const oneWeth = toBNWei("1", 18);
+    const fifteenHundredUsdc = convertBinanceRouteAmount({
+      amount: oneWeth,
+      sourceTokenDecimals: 18,
+      destinationTokenDecimals: 6,
+      isBuy: false,
+      price: 1500,
+      direction: "source-to-destination",
+    });
+    const sourceEquivalent = convertBinanceRouteAmount({
+      amount: fifteenHundredUsdc,
+      sourceTokenDecimals: 18,
+      destinationTokenDecimals: 6,
+      isBuy: false,
+      price: 1500,
+      direction: "destination-to-source",
+    });
+
+    expect(fifteenHundredUsdc.eq(toBNWei("1500", 6))).to.equal(true);
+    expect(sourceEquivalent.eq(BigNumber.from(oneWeth.toString()))).to.equal(true);
+  });
+});

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -89,6 +89,34 @@ describe("Binance adapter helpers", async function () {
     expect(sourceEquivalent.eq(oneWeth)).to.equal(true);
   });
 
+  it("retries exchangeInfo lookups after transient failures", async function () {
+    const adapter = await makeAdapter();
+    const exchangeInfoStub = sinon.stub();
+    exchangeInfoStub.onCall(0).rejects(new Error("temporary outage"));
+    exchangeInfoStub.onCall(1).resolves({
+      symbols: [{ ...makeStablecoinSymbol() }],
+    });
+    const symbolAdapter = adapter as unknown as {
+      _getSymbol(sourceToken: string, destinationToken: string): Promise<{ symbol: string }>;
+      binanceApiClient: { exchangeInfo: typeof exchangeInfoStub };
+      exchangeInfoPromise?: Promise<unknown>;
+    };
+    symbolAdapter.binanceApiClient = { exchangeInfo: exchangeInfoStub };
+    symbolAdapter.exchangeInfoPromise = undefined;
+
+    try {
+      await symbolAdapter._getSymbol("USDT", "USDC");
+      expect.fail("expected the first _getSymbol call to propagate the exchangeInfo failure");
+    } catch (error) {
+      expect(String(error)).to.contain("temporary outage");
+    }
+
+    const symbol = await symbolAdapter._getSymbol("USDT", "USDC");
+
+    expect(symbol.symbol).to.equal("USDCUSDT");
+    expect(exchangeInfoStub.callCount).to.equal(2);
+  });
+
   it("retries tradeFee lookups after transient failures", async function () {
     const adapter = await makeAdapter();
     const tradeFeeStub = sinon.stub();

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -3,7 +3,7 @@ import { expect, toBNWei } from "./utils";
 import {
   convertBinanceRouteAmount,
   deriveBinanceSpotMarketMeta,
-  isSameBinanceCoinRoute,
+  isSameBinanceCoin,
   resolveBinanceCoinSymbol,
   supportsBinanceIntermediateBridgeToken,
 } from "../src/rebalancer/adapters/binance";
@@ -15,9 +15,9 @@ describe("Binance adapter helpers", async function () {
   });
 
   it("detects same-coin Binance routes that should skip the swap leg", async function () {
-    expect(isSameBinanceCoinRoute("WETH", "WETH")).to.equal(true);
-    expect(isSameBinanceCoinRoute("USDC", "USDC")).to.equal(true);
-    expect(isSameBinanceCoinRoute("WETH", "USDC")).to.equal(false);
+    expect(isSameBinanceCoin("WETH", "WETH")).to.equal(true);
+    expect(isSameBinanceCoin("USDC", "USDC")).to.equal(true);
+    expect(isSameBinanceCoin("WETH", "USDC")).to.equal(false);
   });
 
   it("only permits intermediate Binance bridge legs for assets we can actually bridge onchain", async function () {

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -11,6 +11,7 @@ import {
 import { CctpAdapter } from "../src/rebalancer/adapters/cctpAdapter";
 import { OftAdapter } from "../src/rebalancer/adapters/oftAdapter";
 import { RebalancerConfig } from "../src/rebalancer/RebalancerConfig";
+import { CHAIN_IDs, EvmAddress } from "../src/utils";
 
 describe("Binance adapter helpers", async function () {
   afterEach(function () {
@@ -143,6 +144,68 @@ describe("Binance adapter helpers", async function () {
 
     expect(fees[0].symbol).to.equal("USDCUSDT");
     expect(tradeFeeStub.callCount).to.equal(2);
+  });
+
+  it("keeps pending WETH credit until a finalized Binance withdrawal is wrapped", async function () {
+    const adapter = await makeAdapter();
+    const [signer] = await ethers.getSigners();
+    const adapterWithInternals = adapter as unknown as {
+      initialized: boolean;
+      _redisGetPendingBridgesPreDeposit(account: EvmAddress): Promise<string[]>;
+      _redisGetPendingOrders(account: EvmAddress): Promise<string[]>;
+      _redisGetPendingWithdrawals(account: EvmAddress): Promise<string[]>;
+      _redisGetOrderDetails(cloid: string, account: EvmAddress): Promise<{
+        sourceChain: number;
+        sourceToken: string;
+        destinationChain: number;
+        destinationToken: string;
+        amountToTransfer: ReturnType<typeof toBNWei>;
+      }>;
+      _getEntrypointNetwork(chainId: number, token: string): Promise<number>;
+      _convertSourceToDestination(
+        sourceToken: string,
+        sourceChain: number,
+        destinationToken: string,
+        destinationChain: number,
+        amount: ReturnType<typeof toBNWei>
+      ): Promise<ReturnType<typeof toBNWei>>;
+      _redisGetInitiatedWithdrawalId(cloid: string): Promise<string>;
+      _getBinanceWithdrawals(
+        token: string,
+        network: number,
+        since: number,
+        account: string
+      ): Promise<{
+        unfinalizedWithdrawals: Array<{ id: string }>;
+        finalizedWithdrawals: Array<{ id: string; amount: string }>;
+      }>;
+      _getTokenInfo(token: string, chainId: number): { decimals: number };
+    };
+    adapterWithInternals.initialized = true;
+
+    const amount = toBNWei("1", 18);
+    sinon.stub(adapterWithInternals, "_redisGetPendingBridgesPreDeposit").resolves([]);
+    sinon.stub(adapterWithInternals, "_redisGetPendingOrders").resolves(["cloid"]);
+    sinon.stub(adapterWithInternals, "_redisGetPendingWithdrawals").resolves(["cloid"]);
+    sinon.stub(adapterWithInternals, "_redisGetOrderDetails").resolves({
+      sourceChain: CHAIN_IDs.MAINNET,
+      sourceToken: "WETH",
+      destinationChain: CHAIN_IDs.MAINNET,
+      destinationToken: "WETH",
+      amountToTransfer: amount,
+    });
+    sinon.stub(adapterWithInternals, "_getEntrypointNetwork").resolves(CHAIN_IDs.MAINNET);
+    sinon.stub(adapterWithInternals, "_convertSourceToDestination").resolves(amount);
+    sinon.stub(adapterWithInternals, "_redisGetInitiatedWithdrawalId").resolves("withdrawal-id");
+    sinon.stub(adapterWithInternals, "_getBinanceWithdrawals").resolves({
+      unfinalizedWithdrawals: [],
+      finalizedWithdrawals: [{ id: "withdrawal-id", amount: "1" }],
+    });
+    sinon.stub(adapterWithInternals, "_getTokenInfo").returns({ decimals: 18 });
+
+    const pendingRebalances = await adapter.getPendingRebalances(EvmAddress.from(await signer.getAddress()));
+
+    expect(pendingRebalances[CHAIN_IDs.MAINNET].WETH.eq(amount)).to.equal(true);
   });
 });
 

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -154,7 +154,10 @@ describe("Binance adapter helpers", async function () {
       _redisGetPendingBridgesPreDeposit(account: EvmAddress): Promise<string[]>;
       _redisGetPendingOrders(account: EvmAddress): Promise<string[]>;
       _redisGetPendingWithdrawals(account: EvmAddress): Promise<string[]>;
-      _redisGetOrderDetails(cloid: string, account: EvmAddress): Promise<{
+      _redisGetOrderDetails(
+        cloid: string,
+        account: EvmAddress
+      ): Promise<{
         sourceChain: number;
         sourceToken: string;
         destinationChain: number;

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -1,4 +1,5 @@
 import { ethers, expect, sinon, toBNWei } from "./utils";
+import winston from "winston";
 import {
   BinanceStablecoinSwapAdapter,
   convertBinanceRouteAmount,
@@ -7,6 +8,9 @@ import {
   resolveBinanceCoinSymbol,
   supportsBinanceIntermediateBridgeToken,
 } from "../src/rebalancer/adapters/binance";
+import { CctpAdapter } from "../src/rebalancer/adapters/cctpAdapter";
+import { OftAdapter } from "../src/rebalancer/adapters/oftAdapter";
+import { RebalancerConfig } from "../src/rebalancer/RebalancerConfig";
 
 describe("Binance adapter helpers", async function () {
   afterEach(function () {
@@ -144,8 +148,13 @@ describe("Binance adapter helpers", async function () {
 
 async function makeAdapter(): Promise<BinanceStablecoinSwapAdapter> {
   const [signer] = await ethers.getSigners();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return new BinanceStablecoinSwapAdapter(TEST_LOGGER, {} as any, signer, {} as any, {} as any);
+  return new BinanceStablecoinSwapAdapter(
+    TEST_LOGGER,
+    {} as RebalancerConfig,
+    signer,
+    {} as CctpAdapter,
+    {} as OftAdapter
+  );
 }
 
 function makeStablecoinSymbol() {
@@ -177,5 +186,4 @@ const TEST_LOGGER = {
   info: () => undefined,
   warn: () => undefined,
   error: () => undefined,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-} as any;
+} as unknown as winston.Logger;

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -89,32 +89,6 @@ describe("Binance adapter helpers", async function () {
     expect(sourceEquivalent.eq(oneWeth)).to.equal(true);
   });
 
-  it("retries exchangeInfo lookups after transient failures", async function () {
-    const adapter = await makeAdapter();
-    const exchangeInfoStub = sinon.stub();
-    exchangeInfoStub.onCall(0).rejects(new Error("temporary outage"));
-    exchangeInfoStub.onCall(1).resolves({
-      symbols: [{ ...makeStablecoinSymbol() }],
-    });
-    const symbolAdapter = adapter as unknown as {
-      _getSymbol(sourceToken: string, destinationToken: string): Promise<{ symbol: string }>;
-      binanceApiClient: { exchangeInfo: typeof exchangeInfoStub };
-    };
-    symbolAdapter.binanceApiClient = { exchangeInfo: exchangeInfoStub };
-
-    try {
-      await symbolAdapter._getSymbol("USDT", "USDC");
-      expect.fail("expected the first _getSymbol call to propagate the exchangeInfo failure");
-    } catch (error) {
-      expect(String(error)).to.contain("temporary outage");
-    }
-
-    const symbol = await symbolAdapter._getSymbol("USDT", "USDC");
-
-    expect(symbol.symbol).to.equal("USDCUSDT");
-    expect(exchangeInfoStub.callCount).to.equal(2);
-  });
-
   it("retries tradeFee lookups after transient failures", async function () {
     const adapter = await makeAdapter();
     const tradeFeeStub = sinon.stub();

--- a/test/BinanceAdapter.quotes.ts
+++ b/test/BinanceAdapter.quotes.ts
@@ -65,7 +65,7 @@ describe("Binance adapter quotes", function () {
 
   it("throws a visible-depth error when the order book cannot satisfy the order size", async function () {
     const adapter = await makeAdapter();
-    const exchangeInfoStub = sinon.stub().resolves({
+    const exchangeInfo = {
       symbols: [
         {
           symbol: "USDCUSDT",
@@ -84,7 +84,7 @@ describe("Binance adapter quotes", function () {
           ],
         },
       ],
-    });
+    };
     const bookStub = sinon.stub().resolves(
       makeOrderBook({
         asks: [{ price: "1.0010", quantity: "10" }],
@@ -92,7 +92,9 @@ describe("Binance adapter quotes", function () {
       })
     );
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (adapter as any).binanceApiClient = { exchangeInfo: exchangeInfoStub, book: bookStub };
+    (adapter as any).exchangeInfoPromise = Promise.resolve(exchangeInfo);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (adapter as any).binanceApiClient = { book: bookStub };
 
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/BinanceAdapter.quotes.ts
+++ b/test/BinanceAdapter.quotes.ts
@@ -2,22 +2,43 @@ import { CHAIN_IDs } from "@across-protocol/constants";
 import { BinanceStablecoinSwapAdapter } from "../src/rebalancer/adapters/binance";
 import { ethers, expect, sinon, toBNWei } from "./utils";
 
+type OrderBook = ReturnType<typeof makeOrderBook>;
+type QuoteTestAdapter = {
+  binanceApiClient: {
+    book?: sinon.SinonStub;
+    exchangeInfo?: sinon.SinonStub;
+  };
+  exchangeInfoPromise?: Promise<{
+    symbols: Array<{
+      symbol: string;
+      baseAsset: string;
+      quoteAsset: string;
+      filters: Array<{ filterType: string; tickSize?: string; stepSize?: string; minQty?: string }>;
+    }>;
+  }>;
+  _getOrderBook(symbol: string): Promise<OrderBook>;
+  _fetchOrderBook(symbol: string, fromId: number, limit: number): Promise<OrderBook>;
+  _getLatestPrice(
+    sourceToken: string,
+    destinationToken: string,
+    sourceChain: number,
+    sourceAmount: ReturnType<typeof toBNWei>
+  ): Promise<unknown>;
+};
+
 describe("Binance adapter quotes", function () {
   afterEach(function () {
     sinon.restore();
   });
 
   it("reuses a cached order book snapshot within the TTL", async function () {
-    const adapter = await makeAdapter();
+    const adapter = asQuoteAdapter(await makeAdapter());
     const book = makeOrderBook({ asks: [{ price: "1.0001", quantity: "1000" }], bids: [] });
     const bookStub = sinon.stub().resolves(book);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (adapter as any).binanceApiClient = { book: bookStub };
+    adapter.binanceApiClient = { book: bookStub };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const first = await (adapter as any)._getOrderBook("USDCUSDT");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const second = await (adapter as any)._getOrderBook("USDCUSDT");
+    const first = await adapter._getOrderBook("USDCUSDT");
+    const second = await adapter._getOrderBook("USDCUSDT");
 
     expect(first).to.equal(book);
     expect(second).to.equal(book);
@@ -25,22 +46,15 @@ describe("Binance adapter quotes", function () {
   });
 
   it("deduplicates concurrent order book fetches for the same symbol", async function () {
-    const adapter = await makeAdapter();
+    const adapter = asQuoteAdapter(await makeAdapter());
     const book = makeOrderBook({ asks: [{ price: "1.0001", quantity: "1000" }], bids: [] });
     const bookStub = sinon.stub().callsFake(async () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
       return book;
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (adapter as any).binanceApiClient = { book: bookStub };
-    const quoteAdapter = adapter as unknown as {
-      _getOrderBook(symbol: string): Promise<ReturnType<typeof makeOrderBook>>;
-    };
+    adapter.binanceApiClient = { book: bookStub };
 
-    const [first, second] = await Promise.all([
-      quoteAdapter._getOrderBook("USDCUSDT"),
-      quoteAdapter._getOrderBook("USDCUSDT"),
-    ]);
+    const [first, second] = await Promise.all([adapter._getOrderBook("USDCUSDT"), adapter._getOrderBook("USDCUSDT")]);
 
     expect(first).to.equal(book);
     expect(second).to.equal(book);
@@ -48,23 +62,21 @@ describe("Binance adapter quotes", function () {
   });
 
   it("retries transient order book fetch failures", async function () {
-    const adapter = await makeAdapter();
+    const adapter = asQuoteAdapter(await makeAdapter());
     const book = makeOrderBook({ asks: [{ price: "1.0001", quantity: "1000" }], bids: [] });
     const bookStub = sinon.stub();
     bookStub.onCall(0).rejects(new Error("temporary outage"));
     bookStub.onCall(1).resolves(book);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (adapter as any).binanceApiClient = { book: bookStub };
+    adapter.binanceApiClient = { book: bookStub };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const fetched = await (adapter as any)._fetchOrderBook("USDCUSDT", 0, 1);
+    const fetched = await adapter._fetchOrderBook("USDCUSDT", 0, 1);
 
     expect(fetched).to.equal(book);
     expect(bookStub.callCount).to.equal(2);
   });
 
   it("throws a visible-depth error when the order book cannot satisfy the order size", async function () {
-    const adapter = await makeAdapter();
+    const adapter = asQuoteAdapter(await makeAdapter());
     const exchangeInfo = {
       symbols: [
         {
@@ -91,14 +103,11 @@ describe("Binance adapter quotes", function () {
         bids: [],
       })
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (adapter as any).exchangeInfoPromise = Promise.resolve(exchangeInfo);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (adapter as any).binanceApiClient = { book: bookStub };
+    adapter.exchangeInfoPromise = Promise.resolve(exchangeInfo);
+    adapter.binanceApiClient = { book: bookStub };
 
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await (adapter as any)._getLatestPrice("USDT", "USDC", CHAIN_IDs.MAINNET, toBNWei("1000", 6));
+      await adapter._getLatestPrice("USDT", "USDC", CHAIN_IDs.MAINNET, toBNWei("1000", 6));
       expect.fail("expected _getLatestPrice to throw when the order book is too shallow");
     } catch (error) {
       expect(String(error)).to.contain("exceeds visible Binance order book depth");
@@ -108,8 +117,11 @@ describe("Binance adapter quotes", function () {
 
 async function makeAdapter(): Promise<BinanceStablecoinSwapAdapter> {
   const [signer] = await ethers.getSigners();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return new BinanceStablecoinSwapAdapter(TEST_LOGGER, {} as any, signer, {} as any, {} as any);
+  return new BinanceStablecoinSwapAdapter(TEST_LOGGER as never, {} as never, signer, {} as never, {} as never);
+}
+
+function asQuoteAdapter(adapter: BinanceStablecoinSwapAdapter): QuoteTestAdapter {
+  return adapter as unknown as QuoteTestAdapter;
 }
 
 function makeOrderBook({
@@ -127,5 +139,4 @@ const TEST_LOGGER = {
   info: () => undefined,
   warn: () => undefined,
   error: () => undefined,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-} as any;
+};

--- a/test/BinanceAdapter.quotes.ts
+++ b/test/BinanceAdapter.quotes.ts
@@ -71,6 +71,17 @@ describe("Binance adapter quotes", function () {
           symbol: "USDCUSDT",
           baseAsset: "USDC",
           quoteAsset: "USDT",
+          filters: [
+            {
+              filterType: "PRICE_FILTER",
+              tickSize: "0.0001",
+            },
+            {
+              filterType: "LOT_SIZE",
+              stepSize: "0.01",
+              minQty: "0.01",
+            },
+          ],
         },
       ],
     });

--- a/test/RebalancerClient.buildRebalanceRoutes.ts
+++ b/test/RebalancerClient.buildRebalanceRoutes.ts
@@ -43,6 +43,48 @@ function buildSyntheticRebalancerConfig(): RebalancerConfig {
   });
 }
 
+function buildSyntheticRebalancerConfigWithMainnet(): RebalancerConfig {
+  return new RebalancerConfig({
+    HUB_CHAIN_ID: String(CHAIN_IDs.MAINNET),
+    REBALANCER_CONFIG: JSON.stringify({
+      cumulativeTargetBalances: {
+        USDT: {
+          targetBalance: "1000",
+          thresholdBalance: "500",
+          priorityTier: 0,
+          chains: {
+            [CHAIN_IDs.HYPEREVM]: 0,
+            [CHAIN_IDs.OPTIMISM]: 0,
+            [CHAIN_IDs.BSC]: 0,
+            [CHAIN_IDs.MAINNET]: 0,
+          },
+        },
+        USDC: {
+          targetBalance: "1000",
+          thresholdBalance: "500",
+          priorityTier: 0,
+          chains: {
+            [CHAIN_IDs.HYPEREVM]: 0,
+            [CHAIN_IDs.ARBITRUM]: 0,
+            [CHAIN_IDs.OPTIMISM]: 0,
+            [CHAIN_IDs.BSC]: 0,
+            [CHAIN_IDs.BASE]: 0,
+            [CHAIN_IDs.MAINNET]: 0,
+          },
+        },
+      },
+      maxAmountsToTransfer: {
+        USDT: "100",
+        USDC: "100",
+      },
+      maxPendingOrders: {
+        hyperliquid: 3,
+        binance: 3,
+      },
+    }),
+  });
+}
+
 describe("buildRebalanceRoutes", async function () {
   it("builds the exact stablecoin route families implied by synthetic config", async function () {
     const config = buildSyntheticRebalancerConfig();
@@ -78,7 +120,7 @@ describe("buildRebalanceRoutes", async function () {
     expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDC", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(false);
   });
 
-  it("builds WETH<->stablecoin routes via binance for direct Binance ETH networks", async function () {
+  it("does not build WETH Binance routes when mainnet is not configured", async function () {
     const config = buildSyntheticRebalancerConfig();
 
     const routes = buildRebalanceRoutes(config);
@@ -98,21 +140,14 @@ describe("buildRebalanceRoutes", async function () {
           route.adapter === adapter
       );
 
-    // WETH routes should exist for Binance-supported ETH chains paired with stablecoin chains.
-    expect(hasRoute(CHAIN_IDs.OPTIMISM, "WETH", CHAIN_IDs.HYPEREVM, "USDT", "binance")).to.equal(true);
-    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDT", CHAIN_IDs.OPTIMISM, "WETH", "binance")).to.equal(true);
-    expect(hasRoute(CHAIN_IDs.BSC, "WETH", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(true);
-    expect(hasRoute(CHAIN_IDs.BASE, "USDC", CHAIN_IDs.BSC, "WETH", "binance")).to.equal(true);
-
-    // WETH routes should only use binance, not hyperliquid.
-    expect(hasRoute(CHAIN_IDs.OPTIMISM, "WETH", CHAIN_IDs.HYPEREVM, "USDT", "hyperliquid")).to.equal(false);
-
-    // HyperEVM is not a direct Binance ETH network, so no WETH routes sourced from it.
+    expect(hasRoute(CHAIN_IDs.MAINNET, "WETH", CHAIN_IDs.HYPEREVM, "USDT", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDT", CHAIN_IDs.MAINNET, "WETH", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "WETH", CHAIN_IDs.HYPEREVM, "USDT", "binance")).to.equal(false);
     expect(hasRoute(CHAIN_IDs.HYPEREVM, "WETH", CHAIN_IDs.OPTIMISM, "USDT", "binance")).to.equal(false);
   });
 
-  it("builds direct WETH->WETH Binance transfer routes between supported ETH networks", async function () {
-    const config = buildSyntheticRebalancerConfig();
+  it("builds WETH<->stablecoin routes via binance only from mainnet when mainnet is configured", async function () {
+    const config = buildSyntheticRebalancerConfigWithMainnet();
 
     const routes = buildRebalanceRoutes(config);
     const hasRoute = (
@@ -131,8 +166,37 @@ describe("buildRebalanceRoutes", async function () {
           route.adapter === adapter
       );
 
-    expect(hasRoute(CHAIN_IDs.OPTIMISM, "WETH", CHAIN_IDs.ARBITRUM, "WETH", "binance")).to.equal(true);
-    expect(hasRoute(CHAIN_IDs.ARBITRUM, "WETH", CHAIN_IDs.BASE, "WETH", "binance")).to.equal(true);
-    expect(hasRoute(CHAIN_IDs.HYPEREVM, "WETH", CHAIN_IDs.OPTIMISM, "WETH", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.MAINNET, "WETH", CHAIN_IDs.HYPEREVM, "USDT", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDT", CHAIN_IDs.MAINNET, "WETH", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.MAINNET, "WETH", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.BASE, "USDC", CHAIN_IDs.MAINNET, "WETH", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "WETH", CHAIN_IDs.HYPEREVM, "USDT", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.BSC, "WETH", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.MAINNET, "WETH", CHAIN_IDs.HYPEREVM, "USDT", "hyperliquid")).to.equal(false);
+  });
+
+  it("does not build WETH->WETH Binance routes while WETH support is mainnet-only", async function () {
+    const config = buildSyntheticRebalancerConfigWithMainnet();
+
+    const routes = buildRebalanceRoutes(config);
+    const hasRoute = (
+      sourceChain: number,
+      sourceToken: string,
+      destinationChain: number,
+      destinationToken: string,
+      adapter: string
+    ) =>
+      routes.some(
+        (route) =>
+          route.sourceChain === sourceChain &&
+          route.sourceToken === sourceToken &&
+          route.destinationChain === destinationChain &&
+          route.destinationToken === destinationToken &&
+          route.adapter === adapter
+      );
+
+    expect(hasRoute(CHAIN_IDs.MAINNET, "WETH", CHAIN_IDs.MAINNET, "WETH", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "WETH", CHAIN_IDs.MAINNET, "WETH", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.MAINNET, "WETH", CHAIN_IDs.OPTIMISM, "WETH", "binance")).to.equal(false);
   });
 });

--- a/test/RebalancerClient.buildRebalanceRoutes.ts
+++ b/test/RebalancerClient.buildRebalanceRoutes.ts
@@ -1,0 +1,132 @@
+import { expect } from "./utils";
+import { CHAIN_IDs } from "../src/utils";
+import { RebalancerConfig } from "../src/rebalancer/RebalancerConfig";
+import { buildRebalanceRoutes } from "../src/rebalancer/buildRebalanceRoutes";
+
+function buildSyntheticRebalancerConfig(): RebalancerConfig {
+  return new RebalancerConfig({
+    HUB_CHAIN_ID: String(CHAIN_IDs.MAINNET),
+    REBALANCER_CONFIG: JSON.stringify({
+      cumulativeTargetBalances: {
+        USDT: {
+          targetBalance: "1000",
+          thresholdBalance: "500",
+          priorityTier: 0,
+          chains: {
+            [CHAIN_IDs.HYPEREVM]: 0,
+            [CHAIN_IDs.OPTIMISM]: 0,
+            [CHAIN_IDs.BSC]: 0,
+          },
+        },
+        USDC: {
+          targetBalance: "1000",
+          thresholdBalance: "500",
+          priorityTier: 0,
+          chains: {
+            [CHAIN_IDs.HYPEREVM]: 0,
+            [CHAIN_IDs.ARBITRUM]: 0,
+            [CHAIN_IDs.OPTIMISM]: 0,
+            [CHAIN_IDs.BSC]: 0,
+            [CHAIN_IDs.BASE]: 0,
+          },
+        },
+      },
+      maxAmountsToTransfer: {
+        USDT: "100",
+        USDC: "100",
+      },
+      maxPendingOrders: {
+        hyperliquid: 3,
+        binance: 3,
+      },
+    }),
+  });
+}
+
+describe("buildRebalanceRoutes", async function () {
+  it("builds the exact stablecoin route families implied by synthetic config", async function () {
+    const config = buildSyntheticRebalancerConfig();
+
+    const routes = buildRebalanceRoutes(config);
+    const hasRoute = (
+      sourceChain: number,
+      sourceToken: string,
+      destinationChain: number,
+      destinationToken: string,
+      adapter: string
+    ) =>
+      routes.some(
+        (route) =>
+          route.sourceChain === sourceChain &&
+          route.sourceToken === sourceToken &&
+          route.destinationChain === destinationChain &&
+          route.destinationToken === destinationToken &&
+          route.adapter === adapter
+      );
+
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDT", CHAIN_IDs.OPTIMISM, "USDC", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDT", CHAIN_IDs.OPTIMISM, "USDC", "hyperliquid")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.BSC, "USDT", CHAIN_IDs.OPTIMISM, "USDC", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.BSC, "USDT", CHAIN_IDs.OPTIMISM, "USDC", "hyperliquid")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDC", CHAIN_IDs.BASE, "USDC", "cctp")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDT", CHAIN_IDs.HYPEREVM, "USDT", "oft")).to.equal(true);
+  });
+
+  it("builds WETH<->stablecoin routes via binance for direct Binance ETH networks", async function () {
+    const config = buildSyntheticRebalancerConfig();
+
+    const routes = buildRebalanceRoutes(config);
+    const hasRoute = (
+      sourceChain: number,
+      sourceToken: string,
+      destinationChain: number,
+      destinationToken: string,
+      adapter: string
+    ) =>
+      routes.some(
+        (route) =>
+          route.sourceChain === sourceChain &&
+          route.sourceToken === sourceToken &&
+          route.destinationChain === destinationChain &&
+          route.destinationToken === destinationToken &&
+          route.adapter === adapter
+      );
+
+    // WETH routes should exist for Binance-supported ETH chains paired with stablecoin chains.
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "WETH", CHAIN_IDs.HYPEREVM, "USDT", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDT", CHAIN_IDs.OPTIMISM, "WETH", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.BSC, "WETH", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.BASE, "USDC", CHAIN_IDs.BSC, "WETH", "binance")).to.equal(true);
+
+    // WETH routes should only use binance, not hyperliquid.
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "WETH", CHAIN_IDs.HYPEREVM, "USDT", "hyperliquid")).to.equal(false);
+
+    // HyperEVM is not a direct Binance ETH network, so no WETH routes sourced from it.
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "WETH", CHAIN_IDs.OPTIMISM, "USDT", "binance")).to.equal(false);
+  });
+
+  it("builds direct WETH->WETH Binance transfer routes between supported ETH networks", async function () {
+    const config = buildSyntheticRebalancerConfig();
+
+    const routes = buildRebalanceRoutes(config);
+    const hasRoute = (
+      sourceChain: number,
+      sourceToken: string,
+      destinationChain: number,
+      destinationToken: string,
+      adapter: string
+    ) =>
+      routes.some(
+        (route) =>
+          route.sourceChain === sourceChain &&
+          route.sourceToken === sourceToken &&
+          route.destinationChain === destinationChain &&
+          route.destinationToken === destinationToken &&
+          route.adapter === adapter
+      );
+
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "WETH", CHAIN_IDs.ARBITRUM, "WETH", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.ARBITRUM, "WETH", CHAIN_IDs.BASE, "WETH", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "WETH", CHAIN_IDs.OPTIMISM, "WETH", "binance")).to.equal(false);
+  });
+});

--- a/test/RebalancerClient.buildRebalanceRoutes.ts
+++ b/test/RebalancerClient.buildRebalanceRoutes.ts
@@ -69,7 +69,11 @@ describe("buildRebalanceRoutes", async function () {
     expect(hasRoute(CHAIN_IDs.BSC, "USDT", CHAIN_IDs.OPTIMISM, "USDC", "binance")).to.equal(true);
     expect(hasRoute(CHAIN_IDs.BSC, "USDT", CHAIN_IDs.OPTIMISM, "USDC", "hyperliquid")).to.equal(false);
     expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDC", CHAIN_IDs.BASE, "USDC", "cctp")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDC", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(true);
     expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDT", CHAIN_IDs.HYPEREVM, "USDT", "oft")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDT", CHAIN_IDs.HYPEREVM, "USDT", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.BSC, "USDT", CHAIN_IDs.OPTIMISM, "USDT", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.BSC, "USDC", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(true);
   });
 
   it("builds WETH<->stablecoin routes via binance for direct Binance ETH networks", async function () {

--- a/test/RebalancerClient.buildRebalanceRoutes.ts
+++ b/test/RebalancerClient.buildRebalanceRoutes.ts
@@ -71,9 +71,11 @@ describe("buildRebalanceRoutes", async function () {
     expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDC", CHAIN_IDs.BASE, "USDC", "cctp")).to.equal(true);
     expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDC", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(true);
     expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDT", CHAIN_IDs.HYPEREVM, "USDT", "oft")).to.equal(true);
-    expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDT", CHAIN_IDs.HYPEREVM, "USDT", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDT", CHAIN_IDs.HYPEREVM, "USDT", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDT", CHAIN_IDs.OPTIMISM, "USDT", "binance")).to.equal(false);
     expect(hasRoute(CHAIN_IDs.BSC, "USDT", CHAIN_IDs.OPTIMISM, "USDT", "binance")).to.equal(true);
     expect(hasRoute(CHAIN_IDs.BSC, "USDC", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDC", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(false);
   });
 
   it("builds WETH<->stablecoin routes via binance for direct Binance ETH networks", async function () {

--- a/test/RebalancerClient.buildRebalanceRoutes.ts
+++ b/test/RebalancerClient.buildRebalanceRoutes.ts
@@ -93,7 +93,6 @@ function buildSyntheticRebalancerConfigWithMainnet(): RebalancerConfig {
     }),
   });
 }
-
 describe("buildRebalanceRoutes", async function () {
   it("builds the exact stablecoin route families implied by synthetic config", async function () {
     const config = buildSyntheticRebalancerConfig();

--- a/test/RebalancerClient.buildRebalanceRoutes.ts
+++ b/test/RebalancerClient.buildRebalanceRoutes.ts
@@ -72,10 +72,19 @@ function buildSyntheticRebalancerConfigWithMainnet(): RebalancerConfig {
             [CHAIN_IDs.MAINNET]: 0,
           },
         },
+        WETH: {
+          targetBalance: "1",
+          thresholdBalance: "0.5",
+          priorityTier: 0,
+          chains: {
+            [CHAIN_IDs.MAINNET]: 0,
+          },
+        },
       },
       maxAmountsToTransfer: {
         USDT: "100",
         USDC: "100",
+        WETH: "1",
       },
       maxPendingOrders: {
         hyperliquid: 3,

--- a/test/RebalancerClient.cumulativeRebalancing.ts
+++ b/test/RebalancerClient.cumulativeRebalancing.ts
@@ -416,6 +416,53 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     }
   });
 
+  it("Preserves excess for later deficits when an adapter declines to initialize", async function () {
+    const restorePrices = withFixedTokenPrices({
+      [USDC]: "1",
+      [USDT]: "1",
+      [DAI]: "1",
+    });
+    try {
+      const cumulativeBalances = {
+        [USDC]: bnZero,
+        [DAI]: bnZero,
+        [USDT]: amount(USDT, "100"),
+      };
+      const currentBalances = {
+        [CHAIN_A]: {
+          [USDC]: bnZero,
+          [DAI]: bnZero,
+          [USDT]: amount(USDT, "100"),
+        },
+      };
+      const usdtToUsdc = makeRoute(CHAIN_A, CHAIN_A, USDT, USDC, "adapter1");
+      const usdtToDai = makeRoute(CHAIN_A, CHAIN_A, USDT, DAI, "adapter1");
+      const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
+        [USDC]: buildTarget(USDC, "80", "70", 2, { [CHAIN_A]: 0 }),
+        [DAI]: buildTarget(DAI, "80", "70", 1, { [CHAIN_A]: 0 }),
+        [USDT]: buildTarget(USDT, "0", "0", 0, { [CHAIN_A]: 0 }),
+      };
+      const baseSigner = ethers.Wallet.createRandom();
+      const adapter1 = new MockRebalancerAdapter(baseSigner);
+      adapter1.setInitializeRebalanceResult(usdtToUsdc, bnZero);
+      const rebalancerClient = await createClient(
+        cumulativeTargetBalances,
+        { adapter1 },
+        [usdtToUsdc, usdtToDai],
+        {},
+        {},
+        baseSigner
+      );
+
+      await rebalancerClient.rebalanceInventory(cumulativeBalances, currentBalances, MAX_FEE_PCT);
+
+      expect(adapter1.rebalances.length).to.equal(1);
+      expect(adapter1.rebalances[0].route.destinationToken).to.equal(DAI);
+      expect(adapter1.rebalances[0].amount).to.equal(amount(USDT, "80"));
+    } finally {
+      restorePrices();
+    }
+  });
   it("Iterates through excesses in sorted order", async function () {
     const cumulativeBalances = {
       [USDC]: bnZero,
@@ -724,6 +771,7 @@ class MockRebalancerAdapter implements RebalancerAdapter {
   public baseSignerAddress!: EvmAddress;
   public rebalances: { route: RebalanceRoute; amount: BigNumber }[] = [];
   public estimatedCostMapping: { [route: string]: BigNumber } = {};
+  public initializeRebalanceResultMapping: { [route: string]: BigNumber } = {};
   private pendingOrders: string[] | undefined;
   private pendingRebalances: { [chainId: number]: { [token: string]: BigNumber } } = {};
   private readonly baseSigner: Signer;
@@ -741,8 +789,11 @@ class MockRebalancerAdapter implements RebalancerAdapter {
   }
 
   initializeRebalance(rebalanceRoute: RebalanceRoute, amountToTransfer: BigNumber): Promise<BigNumber> {
-    this.rebalances.push({ route: rebalanceRoute, amount: amountToTransfer });
-    return Promise.resolve(amountToTransfer);
+    const result = this.initializeRebalanceResultMapping[JSON.stringify(rebalanceRoute)] ?? amountToTransfer;
+    if (result.gt(bnZero)) {
+      this.rebalances.push({ route: rebalanceRoute, amount: amountToTransfer });
+    }
+    return Promise.resolve(result);
   }
 
   updateRebalanceStatuses(): Promise<void> {
@@ -771,6 +822,10 @@ class MockRebalancerAdapter implements RebalancerAdapter {
 
   setEstimatedCost(route: RebalanceRoute, cost: BigNumber): void {
     this.estimatedCostMapping[JSON.stringify(route)] = cost;
+  }
+
+  setInitializeRebalanceResult(route: RebalanceRoute, amount: BigNumber): void {
+    this.initializeRebalanceResultMapping[JSON.stringify(route)] = amount;
   }
 
   getEstimatedCost(rebalanceRoute: RebalanceRoute, amountToTransfer: BigNumber, debugLog: boolean): Promise<BigNumber> {

--- a/test/RebalancerClient.cumulativeRebalancing.ts
+++ b/test/RebalancerClient.cumulativeRebalancing.ts
@@ -311,6 +311,111 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     }
   });
 
+  it("Decrements excess remaining after each evaluated deficit", async function () {
+    const cumulativeBalances = {
+      [USDC]: bnZero,
+      [DAI]: bnZero,
+      [USDT]: amount(USDT, "100"),
+    };
+    const currentBalances = {
+      [CHAIN_A]: {
+        [USDC]: bnZero,
+        [DAI]: bnZero,
+        [USDT]: amount(USDT, "100"),
+      },
+    };
+    const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
+      [USDC]: buildTarget(USDC, "80", "70", 2, { [CHAIN_A]: 0 }),
+      [DAI]: buildTarget(DAI, "80", "70", 1, { [CHAIN_A]: 0 }),
+      [USDT]: buildTarget(USDT, "0", "0", 0, { [CHAIN_A]: 0 }),
+    };
+    const baseSigner = ethers.Wallet.createRandom();
+    const adapter1 = new MockRebalancerAdapter(baseSigner);
+    const rebalancerClient = await createClient(
+      cumulativeTargetBalances,
+      { adapter1 },
+      [makeRoute(CHAIN_A, CHAIN_A, USDT, USDC, "adapter1"), makeRoute(CHAIN_A, CHAIN_A, USDT, DAI, "adapter1")],
+      {},
+      {},
+      baseSigner
+    );
+
+    await rebalancerClient.rebalanceInventory(cumulativeBalances, currentBalances, MAX_FEE_PCT);
+
+    const usdcPrice = toBNWei(DEFAULT_FIXED_PRICES[USDC]);
+    const usdtPrice = toBNWei(DEFAULT_FIXED_PRICES[USDT]);
+    const expectedFirstAmount = amount(USDC, "80").mul(usdcPrice).div(usdtPrice);
+    const expectedSecondAmount = amount(USDT, "100").sub(expectedFirstAmount);
+
+    expect(adapter1.rebalances.length).to.equal(2);
+    expect(adapter1.rebalances[0].route.destinationToken).to.equal(USDC);
+    expect(adapter1.rebalances[0].amount).to.equal(expectedFirstAmount);
+    expect(adapter1.rebalances[1].route.destinationToken).to.equal(DAI);
+    expect(adapter1.rebalances[1].amount).to.equal(expectedSecondAmount);
+    const totalTransferred = adapter1.rebalances.reduce((acc, rebalance) => acc.add(rebalance.amount), bnZero);
+    expect(totalTransferred).to.equal(amount(USDT, "100"));
+  });
+
+  it("Uses updated excess source-chain balances after prior deficit transfers", async function () {
+    const restorePrices = withFixedTokenPrices({
+      [USDC]: "1",
+      [USDT]: "1",
+      [DAI]: "1",
+    });
+    try {
+      const cumulativeBalances = {
+        [USDC]: bnZero,
+        [DAI]: bnZero,
+        [USDT]: amount(USDT, "110"),
+      };
+      const currentBalances = {
+        [CHAIN_A]: {
+          [USDC]: bnZero,
+          [DAI]: bnZero,
+          [USDT]: amount(USDT, "60"),
+        },
+        [CHAIN_B]: {
+          [USDT]: amount(USDT, "50"),
+        },
+      };
+      const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
+        [USDC]: buildTarget(USDC, "60", "50", 2, { [CHAIN_A]: 0 }),
+        [DAI]: buildTarget(DAI, "60", "50", 1, { [CHAIN_A]: 0 }),
+        [USDT]: buildTarget(USDT, "0", "0", 0, {
+          [CHAIN_A]: 0,
+          [CHAIN_B]: 0,
+        }),
+      };
+      const baseSigner = ethers.Wallet.createRandom();
+      const adapter1 = new MockRebalancerAdapter(baseSigner);
+      const rebalancerClient = await createClient(
+        cumulativeTargetBalances,
+        { adapter1 },
+        [
+          makeRoute(CHAIN_A, CHAIN_A, USDT, USDC, "adapter1"),
+          makeRoute(CHAIN_B, CHAIN_A, USDT, USDC, "adapter1"),
+          makeRoute(CHAIN_A, CHAIN_A, USDT, DAI, "adapter1"),
+          makeRoute(CHAIN_B, CHAIN_A, USDT, DAI, "adapter1"),
+        ],
+        {},
+        {},
+        baseSigner
+      );
+
+      await rebalancerClient.rebalanceInventory(cumulativeBalances, currentBalances, MAX_FEE_PCT);
+
+      expect(adapter1.rebalances.length).to.equal(2);
+      expect(adapter1.rebalances[0].route.destinationToken).to.equal(USDC);
+      expect(adapter1.rebalances[0].route.sourceChain).to.equal(CHAIN_A);
+      expect(adapter1.rebalances[0].amount).to.equal(amount(USDT, "60"));
+      expect(adapter1.rebalances[1].route.destinationToken).to.equal(DAI);
+      expect(adapter1.rebalances[1].route.sourceChain).to.equal(CHAIN_B);
+      expect(adapter1.rebalances[1].amount).to.equal(amount(USDT, "50"));
+    } finally {
+      restorePrices();
+    }
+  });
+
   it("Iterates through excesses in sorted order", async function () {
     const cumulativeBalances = {
       [USDC]: bnZero,

--- a/test/RebalancerClient.cumulativeRebalancing.ts
+++ b/test/RebalancerClient.cumulativeRebalancing.ts
@@ -6,7 +6,7 @@ import {
   MaxPendingOrdersConfig,
   RebalancerConfig,
 } from "../src/rebalancer/RebalancerConfig";
-import { bnZero, EvmAddress, Signer, toBNWei } from "../src/utils";
+import { bnZero, EvmAddress, getTokenInfoFromSymbol, Signer, toBNWei } from "../src/utils";
 import { BigNumber, createSpyLogger, ethers, expect } from "./utils";
 
 describe("RebalancerClient.cumulativeRebalancing", () => {
@@ -27,6 +27,13 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     [DAI]: 18,
     [WETH]: 18,
   };
+  const DEFAULT_FIXED_PRICES = {
+    [USDC]: "1",
+    [USDT]: "0.98",
+    [DAI]: "1",
+    [WETH]: "2000",
+  } as const;
+  let restoreDefaultPrices: (() => void) | undefined;
 
   const amount = (token: string, humanAmount: string): BigNumber => toBNWei(humanAmount, TOKEN_DECIMALS[token]);
 
@@ -74,6 +81,34 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     await client.initialize(rebalanceRoutes);
     return client;
   }
+
+  function withFixedTokenPrices(prices: Record<string, string>): () => void {
+    const previousValues = new Map<string, string | undefined>();
+    for (const [token, price] of Object.entries(prices)) {
+      const address = getTokenInfoFromSymbol(token, HUB_POOL_CHAIN_ID).address.toNative();
+      const envKey = `RELAYER_TOKEN_PRICE_FIXED_${address}`;
+      previousValues.set(envKey, process.env[envKey]);
+      process.env[envKey] = price;
+    }
+    return () => {
+      previousValues.forEach((value, envKey) => {
+        if (value === undefined) {
+          delete process.env[envKey];
+        } else {
+          process.env[envKey] = value;
+        }
+      });
+    };
+  }
+
+  beforeEach(() => {
+    restoreDefaultPrices = withFixedTokenPrices(DEFAULT_FIXED_PRICES);
+  });
+
+  afterEach(() => {
+    restoreDefaultPrices?.();
+    restoreDefaultPrices = undefined;
+  });
 
   it("Caps rebalance amount at lesser of deficit and excess remaining", async function () {
     const deficitToken = USDC;
@@ -154,7 +189,12 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     expect(adapter1.rebalances[0].route.sourceChain).to.equal(CHAIN_A);
     expect(adapter1.rebalances[1].route.sourceChain).to.equal(CHAIN_B);
     expect(adapter1.rebalances[0].amount).to.equal(amount(excessToken, "60"));
-    expect(adapter1.rebalances[1].amount).to.equal(amount(excessToken, "40"));
+    const usdcPrice = toBNWei(DEFAULT_FIXED_PRICES[USDC]);
+    const usdtPrice = toBNWei(DEFAULT_FIXED_PRICES[USDT]);
+    const firstDeficitReduction = amount(excessToken, "60").mul(usdtPrice).div(usdcPrice);
+    const remainingDeficit = amount(deficitToken, "100").sub(firstDeficitReduction);
+    const expectedSecondAmount = remainingDeficit.mul(usdcPrice).div(usdtPrice);
+    expect(adapter1.rebalances[1].amount).to.equal(expectedSecondAmount);
   });
 
   it("Caps rebalance amount at configured max amount per rebalance", async function () {
@@ -224,6 +264,51 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     expect(adapter1.rebalances.length).to.equal(2);
     expect(adapter1.rebalances[0].route.destinationToken).to.equal(USDC);
     expect(adapter1.rebalances[1].route.destinationToken).to.equal(DAI);
+  });
+
+  it("Sorts mixed-asset deficits by USD-normalized size", async function () {
+    const restorePrices = withFixedTokenPrices({
+      [USDC]: "1",
+      [USDT]: "1",
+      [WETH]: "2000",
+    });
+    try {
+      const cumulativeBalances = {
+        [USDC]: amount(USDC, "500"),
+        [WETH]: amount(WETH, "0.5"),
+        [USDT]: amount(USDT, "10000"),
+      };
+      const currentBalances = {
+        [CHAIN_A]: {
+          [USDC]: amount(USDC, "500"),
+          [WETH]: amount(WETH, "0.5"),
+          [USDT]: amount(USDT, "10000"),
+        },
+      };
+      const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
+        [USDC]: buildTarget(USDC, "1000", "900", 0, { [CHAIN_A]: 0 }),
+        [WETH]: buildTarget(WETH, "1", "0.9", 0, { [CHAIN_A]: 0 }),
+        [USDT]: buildTarget(USDT, "0", "0", 0, { [CHAIN_A]: 0 }),
+      };
+      const baseSigner = ethers.Wallet.createRandom();
+      const adapter1 = new MockRebalancerAdapter(baseSigner);
+      const rebalancerClient = await createClient(
+        cumulativeTargetBalances,
+        { adapter1 },
+        [makeRoute(CHAIN_A, CHAIN_A, USDT, USDC, "adapter1"), makeRoute(CHAIN_A, CHAIN_A, USDT, WETH, "adapter1")],
+        {},
+        {},
+        baseSigner
+      );
+
+      await rebalancerClient.rebalanceInventory(cumulativeBalances, currentBalances, MAX_FEE_PCT);
+
+      expect(adapter1.rebalances.length).to.equal(2);
+      expect(adapter1.rebalances[0].route.destinationToken).to.equal(WETH);
+      expect(adapter1.rebalances[1].route.destinationToken).to.equal(USDC);
+    } finally {
+      restorePrices();
+    }
   });
 
   it("Iterates through excesses in sorted order", async function () {
@@ -336,6 +421,45 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     expect(adapter1.rebalances.length).to.equal(0);
     expect(adapter2.rebalances.length).to.equal(1);
     expect(adapter2.rebalances[0].route.destinationChain).to.equal(CHAIN_A);
+  });
+
+  it("Sizes WETH deficits using excess-token USD value instead of raw decimals", async function () {
+    const restorePrices = withFixedTokenPrices({
+      [USDC]: "1",
+      [WETH]: "2000",
+    });
+    try {
+      const cumulativeBalances = {
+        [USDC]: amount(USDC, "5000"),
+        [WETH]: bnZero,
+      };
+      const currentBalances = {
+        [CHAIN_A]: { [USDC]: amount(USDC, "5000"), [WETH]: bnZero },
+      };
+      const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
+        [USDC]: buildTarget(USDC, "0", "0", 0, { [CHAIN_A]: 0 }),
+        [WETH]: buildTarget(WETH, "2", "1.5", 0, { [CHAIN_A]: 0 }),
+      };
+      const baseSigner = ethers.Wallet.createRandom();
+      const adapter1 = new MockRebalancerAdapter(baseSigner);
+      const rebalancerClient = await createClient(
+        cumulativeTargetBalances,
+        { adapter1 },
+        [makeRoute(CHAIN_A, CHAIN_A, USDC, WETH, "adapter1")],
+        {},
+        {},
+        baseSigner
+      );
+
+      await rebalancerClient.rebalanceInventory(cumulativeBalances, currentBalances, MAX_FEE_PCT);
+
+      expect(adapter1.rebalances.length).to.equal(1);
+      expect(adapter1.rebalances[0].route.sourceToken).to.equal(USDC);
+      expect(adapter1.rebalances[0].route.destinationToken).to.equal(WETH);
+      expect(adapter1.rebalances[0].amount).to.equal(amount(USDC, "4000"));
+    } finally {
+      restorePrices();
+    }
   });
 
   it("Respects max pending orders per adapter limit", async function () {


### PR DESCRIPTION
## What changed
- extended the built-in rebalancer route generation in `src/rebalancer/buildRebalanceRoutes.ts` to add Binance `WETH <-> USDC` and `WETH <-> USDT` routes, but only when the `WETH` leg is on `MAINNET` and `WETH` is configured in `cumulativeTargetBalances`
- updated the Binance adapter to treat on-chain `WETH` as Binance `ETH`, enforce that intermediate bridge legs stay limited to bridgeable stablecoins, and skip the Binance spot swap leg when a route resolves to the same Binance coin
- added the mainnet-specific execution pieces needed for those routes: Atomic Depositor approval/deposit handling for `WETH -> Binance`, wrap-after-withdraw handling for `Binance -> WETH`, pending-balance accounting for finalized ETH withdrawals awaiting wrap, and the quote/fee/min-size precision fixes needed for mixed-asset routes
- refreshed rebalancer docs and expanded route-builder/Binance helper/quote/conversion coverage around the new WETH path and mixed-asset cumulative rebalancing behavior

## Supported WETH Routes For Now
- Only Binance `WETH <-> USDC` and `WETH <-> USDT` routes with the `WETH` leg on `MAINNET` are enabled right now. However this must be enabled at the configuration level in REBALANCER_CONFIG for this route to be executed in production.
- Reverse directions are supported, so examples include `MAINNET/WETH -> BASE/USDC`, `BASE/USDC -> MAINNET/WETH`, `MAINNET/WETH -> HYPEREVM/USDT`, and `HYPEREVM/USDT -> MAINNET/WETH`.