### PR TITLE
fix(cctp-finalizer): await txn receipts

### DIFF
--- a/src/cctp-finalizer/utils/evmUtils.ts
+++ b/src/cctp-finalizer/utils/evmUtils.ts
@@ -70,7 +70,7 @@ export async function createHyperCoreAccountIfNotExists(
     });
     const transactionClient = new TransactionClient(logger);
     const fundingToken = TOKEN_SYMBOLS_MAP.USDC.addresses[chainId];
-    const activationReceipt = await submitTransaction(
+    const activationTx = await submitTransaction(
       {
         contract,
         method: "activateUserAccount",
@@ -84,7 +84,7 @@ export async function createHyperCoreAccountIfNotExists(
       at: "evmUtils#createHyperCoreAccountIfNotExists",
       message: "Account activation confirmed",
       finalRecipient: hookData.finalRecipient,
-      txHash: activationReceipt.hash,
+      txHash: activationTx.hash,
     });
   }
 }

--- a/src/cctp-finalizer/utils/evmUtils.ts
+++ b/src/cctp-finalizer/utils/evmUtils.ts
@@ -79,11 +79,12 @@ export async function createHyperCoreAccountIfNotExists(
       },
       transactionClient
     );
+    const activationReceipt = await activationTx.wait();
     logger.info({
       at: "evmUtils#createHyperCoreAccountIfNotExists",
-      message: "Account activation submitted",
+      message: "Account activation confirmed",
       finalRecipient: hookData.finalRecipient,
-      txHash: activationTx.hash,
+      txHash: activationReceipt.transactionHash,
     });
   }
 }
@@ -184,11 +185,13 @@ export async function processMintEvm(
     transactionClient
   );
 
+  const mintTxReceipt = await mintTx.wait();
+
   logger.info({
     at: "evmUtils#processMintEvm",
     message: "Mint transaction confirmed",
-    txHash: mintTx.hash,
+    txHash: mintTxReceipt.transactionHash,
   });
 
-  return { txHash: mintTx.hash };
+  return { txHash: mintTxReceipt.transactionHash };
 }

--- a/src/cctp-finalizer/utils/evmUtils.ts
+++ b/src/cctp-finalizer/utils/evmUtils.ts
@@ -70,21 +70,21 @@ export async function createHyperCoreAccountIfNotExists(
     });
     const transactionClient = new TransactionClient(logger);
     const fundingToken = TOKEN_SYMBOLS_MAP.USDC.addresses[chainId];
-    const activationTx = await submitTransaction(
+    const activationReceipt = await submitTransaction(
       {
         contract,
         method: "activateUserAccount",
         args: [hookData.nonce, hookData.finalRecipient, fundingToken],
         chainId,
+        ensureConfirmation: true,
       },
       transactionClient
     );
-    const activationReceipt = await activationTx.wait();
     logger.info({
       at: "evmUtils#createHyperCoreAccountIfNotExists",
       message: "Account activation confirmed",
       finalRecipient: hookData.finalRecipient,
-      txHash: activationReceipt.transactionHash,
+      txHash: activationReceipt.hash,
     });
   }
 }
@@ -181,17 +181,16 @@ export async function processMintEvm(
       method,
       args: receiveMessageArgs,
       chainId,
+      ensureConfirmation: true,
     },
     transactionClient
   );
 
-  const mintTxReceipt = await mintTx.wait();
-
   logger.info({
     at: "evmUtils#processMintEvm",
     message: "Mint transaction confirmed",
-    txHash: mintTxReceipt.transactionHash,
+    txHash: mintTx.hash,
   });
 
-  return { txHash: mintTxReceipt.transactionHash };
+  return { txHash: mintTx.hash };
 }


### PR DESCRIPTION
The cctp finalizer is considering txns to be completed even if they are not mined.

See, for example, this log for a mint executed on Base:
```
{
    "message": "Burn transaction processed successfully",
    "mintTxHash": "0x4ce09edcb8c77ebb6a8b01344c88a9ba616002a31ea5ec85625982fbe99cde05",
    "at": "CCTPFinalizer#processMessage",
    "burnTransactionHash": "0xe296f82af606fe4160791214db9f782fb8f4cf1a4f30d00e0e9fcd3152f52eea",
    "timestamp": "2026-04-09T19:46:19.659Z"
}
```

But txn does not exist on Base: https://basescan.org/tx/0x4ce09edcb8c77ebb6a8b01344c88a9ba616002a31ea5ec85625982fbe99cde05