### PR TITLE
improve(rebalancer): use ensureConfirmation

### DIFF
--- a/src/rebalancer/adapters/baseAdapter.ts
+++ b/src/rebalancer/adapters/baseAdapter.ts
@@ -362,12 +362,6 @@ export abstract class BaseAdapter implements RebalancerAdapter {
     }
   }
 
-  // @todo: Add retry logic here! Or replace with the multicaller client. However, we can't easily swap in the MulticallerClient
-  // because of the interplay between tracking order statuses in the RedisCache and confirming on chain transactions. Often times
-  // we can only update an order status once its corresponding transaction has confirmed, which is different from how we use
-  // the multicaller client normally where we enqueue txns in the core logic and execute all transactions optimistically once we
-  // exit the core clients. In the Rebalancer use case we need to confirm transactions, but I've had trouble getting .wait()
-  // to work, due to what seems like on-chain timeouts while waiting for txns to confirm.
   protected async _submitTransaction(transaction: AugmentedTransaction): Promise<string> {
     return (await submitTransaction(transaction, this.transactionClient)).hash;
   }

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -897,6 +897,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       chainId: sourceChain,
       nonMulticall: true,
       unpermissioned: false,
+      ensureConfirmation: true,
       message: `Deposited ${amountReadable} ${sourceToken} to Binance on chain ${getNetworkName(sourceChain)}`,
       mrkdwn: `Deposited ${amountReadable} ${sourceToken} to Binance on chain ${getNetworkName(sourceChain)}`,
     };

--- a/src/rebalancer/adapters/cctpAdapter.ts
+++ b/src/rebalancer/adapters/cctpAdapter.ts
@@ -258,6 +258,7 @@ export class CctpAdapter extends BaseAdapter {
       method: "depositForBurn",
       unpermissioned: false,
       nonMulticall: true,
+      ensureConfirmation: true,
       args: [
         amountToBridge,
         getCctpDomainForChainId(destinationChain),

--- a/src/rebalancer/adapters/hyperliquid.ts
+++ b/src/rebalancer/adapters/hyperliquid.ts
@@ -1255,6 +1255,7 @@ export class HyperliquidStablecoinSwapAdapter extends BaseAdapter {
         mrkdwn: `Deposited ${amountReadable} USDC into Hypercore via CoreDepositWallet from ${getNetworkName(
           HYPEREVM
         )}`,
+        ensureConfirmation: true,
       };
     } else {
       const tokenMeta = this._getTokenMeta(sourceToken);

--- a/src/rebalancer/adapters/oftAdapter.ts
+++ b/src/rebalancer/adapters/oftAdapter.ts
@@ -264,6 +264,7 @@ export class OftAdapter extends BaseAdapter {
       method: "send",
       unpermissioned: false,
       nonMulticall: true,
+      ensureConfirmation: true,
       args: [sendParamStruct, feeStruct, refundAddress],
       value: BigNumber.from(feeStruct.nativeFee),
       message: `🎰 Withdrew USDT0 from ${getNetworkName(originChain)} to ${getNetworkName(destinationChain)} via OFT`,


### PR DESCRIPTION
Is safer so that we don't modify Redis state, for example, until the txn is mined