### PR TITLE
improve(TransactionClient): Avoid using txnClient.submit() directly

### DIFF
--- a/scripts/zkSyncDemo.ts
+++ b/scripts/zkSyncDemo.ts
@@ -11,6 +11,7 @@ import {
   isDefined,
   TransactionSimulationResult,
   type EvmGasPriceEstimate,
+  submitTransaction,
 } from "../src/utils";
 import { askYesNoQuestion } from "./utils";
 import minimist from "minimist";
@@ -171,7 +172,7 @@ export async function run(): Promise<void> {
   }
 
   if (simulationResult.succeed) {
-    await txnClient.submit(args.chainId, [simulationResult.transaction]);
+    await submitTransaction(simulationResult.transaction, txnClient);
   } else {
     console.log("Simulation failed", simulationResult);
   }

--- a/src/adapter/BaseChainAdapter.ts
+++ b/src/adapter/BaseChainAdapter.ts
@@ -533,7 +533,7 @@ export class BaseChainAdapter {
       );
       return { hash: ZERO_BYTES } as TransactionResponse;
     }
-    return (await this.transactionClient.submit(this.chainId, [augmentedTxn]))[0];
+    return submitTransaction(augmentedTxn, this.transactionClient);
   }
 
   async getOutstandingCrossChainTransfers(l1Tokens: EvmAddress[]): Promise<OutstandingTransfers> {

--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -183,6 +183,9 @@ export class TransactionClient {
     return txnPromise;
   }
 
+  // This function should essentially never be used except by the MulticallerClient or indirectly via
+  // submitTransaction. This is because this transaction can return an empty list of transction responses
+  // if they fail, rather than throwing an error, which is often against the user's expectations.
   async submit(chainId: number, txns: AugmentedTransaction[]): Promise<TransactionResponse[]> {
     const networkName = getNetworkName(chainId);
     const txnResponses: TransactionResponse[] = [];

--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -183,9 +183,6 @@ export class TransactionClient {
     return txnPromise;
   }
 
-  // This function should essentially never be used except by the MulticallerClient or indirectly via
-  // submitTransaction. This is because this transaction can return an empty list of transction responses
-  // if they fail, rather than throwing an error, which is often against the user's expectations.
   async submit(chainId: number, txns: AugmentedTransaction[]): Promise<TransactionResponse[]> {
     const networkName = getNetworkName(chainId);
     const txnResponses: TransactionResponse[] = [];

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -214,7 +214,7 @@ export async function submitTransaction(
   return response[0];
 }
 
-export async function dispatchTransaction(
+async function dispatchTransaction(
   transaction: AugmentedTransaction,
   dispatcher: TransactionClient
 ): Promise<TransactionResponse> {


### PR DESCRIPTION
The TransactionClient.submit() is not designed for general use because it can return undefined rather than throw if a txn succeeds which is usually not the caller's intuition. `submitTransaction` should be used instead.
