### PR TITLE
fix: Pass shouldSponsorAccountCreation to quote-api

### DIFF
--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -385,6 +385,7 @@ export class DepositAddressHandler {
       recipient,
       depositAddress,
       executionFeeRecipient: this.signerAddress.toNative(),
+      shouldSponsorAccountCreation: String(depositMessage.shouldSponsorAccountCreation),
     };
     try {
       return await this.api.get<SwapApiResponse>(this.config.apiEndpoint, params);

--- a/src/interfaces/DepositAddress.ts
+++ b/src/interfaces/DepositAddress.ts
@@ -23,6 +23,7 @@ export interface DepositAddressMessage {
   salt: string;
   counterfactualDepositContractAddress: string;
   counterfactualFactoryContractAddress: string;
+  shouldSponsorAccountCreation: boolean;
 }
 
 // TODO: Add schema for SwapAPI response.


### PR DESCRIPTION
## Summary
- Adds `shouldSponsorAccountCreation: boolean` to the `DepositAddressMessage` interface
- Passes it through to the quote-api in `_getSwapApiQuote`, converting to string for the query param

## Related PRs
- across-protocol/quote-api#2572
- across-protocol/quote-api#2590
- across-protocol/indexer#860
- across-protocol/relayer#3179

🤖 Generated with [Claude Code](https://claude.com/claude-code)