### PR TITLE
fix: remove commas from request amounts to Bridge API

### DIFF
--- a/src/adapter/bridges/BridgeApi.ts
+++ b/src/adapter/bridges/BridgeApi.ts
@@ -91,7 +91,7 @@ export class BridgeApi extends BaseBridgeAdapter {
       toAddress,
       this.l1TokenInfo.symbol,
       BRIDGE_API_DESTINATION_TOKEN_SYMBOLS[this.getL2Bridge().address],
-      formatter(amount)
+      formatter(amount).replace(/,/g, "")
     );
     return Promise.resolve({
       contract: this.getL1Bridge(),

--- a/src/adapter/l2Bridges/BridgeApi.ts
+++ b/src/adapter/l2Bridges/BridgeApi.ts
@@ -81,7 +81,7 @@ export class BridgeApi extends BaseL2BridgeAdapter {
       toAddress,
       l2TokenSymbol,
       this.l1TokenInfo.symbol,
-      formatter(amount)
+      formatter(amount).replace(/,/g, "")
     );
     const l2TokenContract = new Contract(l2Token.toNative(), ERC20_ABI, this.l2Signer);
     const transferTxn = {


### PR DESCRIPTION
The formatter is adding commas to amounts >= 1000, which is causing 400 errors when posting to the Bridge API. We need to send amounts which do not have the commas.