### PR TITLE
fix: use l1 nullifier in new zksync withdrawal call

### DIFF
--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -66,6 +66,14 @@ export const CONTRACT_ADDRESSES: {
       address: "0x8829AD80E425C646DAB305381ff105169FeEcE56",
       abi: ZKSTACK_SHARED_BRIDGE_ABI,
     },
+    // The L1Nullifier is the contract that actually verifies withdrawal proofs and processes
+    // finalizeDeposit calls. The L1AssetRouter (aka zkStackSharedBridge) forwards to it, but
+    // its own finalizeDeposit has a different signature, so withdrawal finalizations must be
+    // sent directly to the L1Nullifier.
+    zkStackL1Nullifier: {
+      address: "0xD7f9f54194C633F36CCD5F3da84ad4a1c38cB2cB",
+      abi: ZKSTACK_SHARED_BRIDGE_ABI,
+    },
     zkStackBridgeHub: {
       address: "0x303a465B659cBB0ab36eE643eA362c509EEb5213",
       abi: ZKSTACK_BRIDGE_HUB_ABI,
@@ -738,6 +746,12 @@ export const CONTRACT_ADDRESSES: {
     // need its contract address so that we may approve it.
     zkStackSharedBridge: {
       address: "0xfD3130Ea0e8B7Dd61Ac3663328a66d97eb02f84b",
+      abi: ZKSTACK_SHARED_BRIDGE_ABI,
+    },
+    // The L1Nullifier is where withdrawal finalizations (finalizeDeposit) must be sent; see
+    // mainnet note above.
+    zkStackL1Nullifier: {
+      address: "0x6f03861D12E6401623854E494BeAcD66BC46e6F0",
       abi: ZKSTACK_SHARED_BRIDGE_ABI,
     },
     zkStackNativeTokenVault: {

--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -246,9 +246,37 @@ async function prepareFinalizations(
   );
 
   return await sdkUtils.mapAsync(withdrawalParams, async (withdrawal, idx) => {
-    const sharedBridge = getSharedBridge(l1ChainId, tokensBridged[idx].chainId, tokensBridged[idx].l2TokenAddress);
-    return prepareFinalization(withdrawal, l2ChainId, sharedBridge);
+    const finalizationContract = getFinalizationContract(
+      l1ChainId,
+      tokensBridged[idx].chainId,
+      tokensBridged[idx].l2TokenAddress
+    );
+    return prepareFinalization(withdrawal, l2ChainId, finalizationContract);
   });
+}
+
+/**
+ * Returns the L1 contract that finalizes a withdrawal. For USDC withdrawals from chains that use
+ * the custom ZkStack USDC bridge, that is the standalone USDC bridge. For all other withdrawals
+ * (notably ETH), it is the L1Nullifier -- the L1AssetRouter (zkStackSharedBridge) has a
+ * finalizeDeposit with a different signature and cannot be called here.
+ */
+function getFinalizationContract(
+  l1ChainId: number,
+  l2ChainId: number,
+  l2TokenAddress: Address,
+  l1Provider?: Provider
+): Contract {
+  const contract =
+    CONTRACT_ADDRESSES[l1ChainId]?.[
+      withdrawalRequiresCustomUsdcBridge(l1ChainId, l2ChainId, l2TokenAddress)
+        ? `zkStackUSDCBridge_${l2ChainId}`
+        : "zkStackL1Nullifier"
+    ];
+  if (!contract) {
+    throw new Error(`zkStack finalization contract data not found for chain ${l1ChainId}`);
+  }
+  return new Contract(contract.address, contract.abi, l1Provider);
 }
 
 function getSharedBridge(


### PR DESCRIPTION
We need to use the L1Nullifier contract in the new `finalizeDeposit` call and not the shared bridge.