### PR TITLE
feat(gasless): authenticate swap API requests with SWAP_API_KEY

### DIFF
--- a/src/gasless/GaslessRelayer.ts
+++ b/src/gasless/GaslessRelayer.ts
@@ -134,7 +134,7 @@ export class GaslessRelayer {
     readonly baseSigner: Signer,
     readonly depositSigners: Signer[]
   ) {
-    this.api = new AcrossSwapApiClient(this.logger, this.config.apiTimeoutOverride);
+    this.api = new AcrossSwapApiClient(this.logger, this.config.apiTimeoutOverride, this.config.swapApiKey);
     this.transactionClient = new TransactionClient(this.logger, depositSigners);
   }
 

--- a/src/gasless/GaslessRelayerConfig.ts
+++ b/src/gasless/GaslessRelayerConfig.ts
@@ -12,6 +12,7 @@ export type AllowedPeggedPairs = { [inputSymbol: string]: Set<string> };
 export class GaslessRelayerConfig extends CommonConfig {
   apiPollingInterval: number;
   apiEndpoint: string;
+  swapApiKey: string;
 
   relayerOriginChains: number[];
   relayerDestinationChains: number[];
@@ -40,9 +41,12 @@ export class GaslessRelayerConfig extends CommonConfig {
       RELAYER_GASLESS_REFUND_FLOW_TEST_ENABLED,
       SPOKE_POOL_PERIPHERY_OVERRIDES,
       GASLESS_ALLOWED_PEGGED_PAIRS,
+      SWAP_API_KEY,
     } = env;
     this.apiPollingInterval = Number(API_POLLING_INTERVAL ?? 1); // Default to 1s
     this.apiEndpoint = String(API_GASLESS_ENDPOINT);
+
+    this.swapApiKey = SWAP_API_KEY?.trim() ?? "";
 
     const relayerOriginChains = new Set(parseJson.numberArray(RELAYER_ORIGIN_CHAINS));
     this.relayerOriginChains = Array.from(relayerOriginChains);


### PR DESCRIPTION
The quote-api gasless relayer-liveness gate (across-protocol/quote-api#2592) records a heartbeat when the poller presents a Bearer token with the gasless-relayer permission. Without authentication, /api/gasless/submit will eventually reject deposits with NO_RELAYER_AVAILABLE.

Forward SWAP_API_KEY through GaslessRelayerConfig into AcrossSwapApiClient; the base client already attaches Authorization: Bearer <key> when set.