### PR TITLE
chore: add deposit address tx info to warn logs

### DIFF
--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -290,6 +290,10 @@ export class DepositAddressHandler {
           at: "DepositAddressHandler#initiateDeposit",
           message: "Failed to submit deploy tx",
           depositKey,
+          deployTx: {
+            ...deployTx,
+            contract: deployTx.contract.address,
+          },
         });
         return;
       }
@@ -326,6 +330,10 @@ export class DepositAddressHandler {
         at: "DepositAddressHandler#initiateDeposit",
         message: "Failed to submit execute tx",
         depositKey,
+        executeTx: {
+          ...executeTx,
+          contract: executeTx.contract.address,
+        },
       });
       this.observedExecutedDeposits[originChainId].delete(depositKey);
       return;


### PR DESCRIPTION
To improve visibility on failed transactions in the deposit address handler.