### PR TITLE
chore: cast tvm addresses in ContractUtils

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@across-protocol/constants": "^3.1.109",
-    "@across-protocol/contracts": "5.0.6",
-    "@across-protocol/sdk": "4.3.142",
+    "@across-protocol/contracts": "5.0.7",
+    "@across-protocol/sdk": "4.3.143-alpha.0",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -625,6 +625,15 @@ export const CONTRACT_ADDRESSES: {
       abi: ZKSTACK_USDC_BRIDGE_ABI,
     },
   },
+  [CHAIN_IDs.TRON]: {
+    permit2: {
+      address: "TTJxU3P8rHycAyFY4kVtGNfmnMH4ezcuM9",
+      abi: PERMIT2_ABI,
+    },
+    spokePoolPeriphery: {
+      abi: SPOKE_POOL_PERIPHERY_ABI,
+    },
+  },
   [CHAIN_IDs.LINEA]: {
     cctpV2MessageTransmitter: {
       address: "0x81D40F21F12A8F0E3252Bccb954D722d4c464B64",

--- a/src/utils/ContractUtils.ts
+++ b/src/utils/ContractUtils.ts
@@ -30,10 +30,10 @@ import COUNTERFACTUAL_DEPOSIT_FACTORY_ABI from "../common/abi/CounterfactualDepo
 // Return an ethers contract instance for a deployed contract, imported from the Across-protocol contracts repo.
 export function getDeployedContract(contractName: string, networkId: number, signer?: Signer): Contract {
   try {
-    const address = getDeployedAddress(contractName, networkId);
+    const address = toAddressType(getDeployedAddress(contractName, networkId), networkId);
     // If the contractName is SpokePool then we need to modify it to find the correct contract factory artifact.
     const abi = getTypechainAbi(contractName);
-    return new Contract(address, abi, signer);
+    return new Contract(address.toEvmAddress(), abi, signer);
   } catch (error) {
     throw new Error(`Could not find address for contract ${contractName} on ${networkId} (${error})`);
   }
@@ -53,13 +53,15 @@ export function getSpokePool(chainId: number, address?: string): Contract {
 // For a chain ID and optional SpokePoolPeriphery address, return a Contract instance with the corresponding ABI.
 export function getSpokePoolPeriphery(chainId: number, address?: string): Contract {
   address ??= getDeployedAddress("SpokePoolPeriphery", chainId);
-  return new Contract(address, CONTRACT_ADDRESSES[chainId].spokePoolPeriphery.abi);
+  const addressType = toAddressType(address, chainId);
+  return new Contract(addressType.toEvmAddress(), CONTRACT_ADDRESSES[chainId].spokePoolPeriphery.abi);
 }
 
 // Uniswap Permit2 (same deployment address on supported EVM chains). Falls back to mainnet metadata when `chainId` has no entry.
 export function getPermit2(chainId: number, address?: string): Contract {
   const permit2 = CONTRACT_ADDRESSES[chainId].permit2;
-  return new Contract(address ?? permit2.address, permit2.abi);
+  const permit2Address = toAddressType(address ?? permit2.address, chainId);
+  return new Contract(permit2Address.toEvmAddress(), permit2.abi);
 }
 
 export function getSpokePoolAddress(chainId: number): Address {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.109.tgz#3a7e9f7581405cd09dbbdc480800d4a775051c46"
   integrity sha512-Mt0wYTzMPbfNSEWZFuGdMTn8N4z9+yNWJ0HDFaZwVlaiW8m9F1uK5SWHsc6TAZURTvrC2T98nIDGm+ibPgwEYA==
 
-"@across-protocol/contracts@5.0.6":
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-5.0.6.tgz#5aa1101201ac581bbf96ce29712c2da42cf96675"
-  integrity sha512-JS68PqktXYLQlBDminUXmuVPcXh6tKHMDS8fQbrcObL8/tWOxyY6dFgcydBUWi9WEkocvKjQ9KpJIbsfx7zs7w==
+"@across-protocol/contracts@5.0.7":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-5.0.7.tgz#158b2d3bd0f765f82349d9017c5eba133f0c6839"
+  integrity sha512-6/+kmuzFqm0ajSemzD4GvVceWVGBCuiSfbJxhxrnhy3zuhCfVaonAqMRS09G7I36mc7uXkx4hA1BjbB5ehrYnQ==
   dependencies:
     "@across-protocol/constants" "^3.1.107"
     "@coral-xyz/anchor" "^0.31.1"
@@ -34,13 +34,13 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.3.142":
-  version "4.3.142"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.142.tgz#e5222d4d97686fec377125ea30be5544cc9eecac"
-  integrity sha512-nBcmDVq17Iy2kt9d8SNYSUG9+Q0y5suxtuxVL9avaB62RRBeVWjQmcnFPuX+oWaoHuM0SND2Moi4+mTX6/t9HQ==
+"@across-protocol/sdk@4.3.143-alpha.0":
+  version "4.3.143-alpha.0"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.143-alpha.0.tgz#ced095eb9052d102edcc9b36bfcb955593bd9f95"
+  integrity sha512-zCsfLCpMxJNnMfoRZeBJBMNmvBA2pGf7X5qx2s9cRHtdcPcvPhR1zl7uLRZsvbU26lXkzkGXa9B6Myo7RXsk4A==
   dependencies:
     "@across-protocol/constants" "^3.1.109"
-    "@across-protocol/contracts" "5.0.6"
+    "@across-protocol/contracts" "5.0.7"
     "@coral-xyz/anchor" "^0.30.1"
     "@eth-optimism/sdk" "^3.3.1"
     "@ethersproject/bignumber" "^5.7.0"


### PR DESCRIPTION
This is necessary to run some auxiliary bots like the gasless relayer.