### PR TITLE
fix: add SponsoredCCTPDstPeriphery for Base Sepolia

### DIFF
--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -816,6 +816,10 @@ export const CONTRACT_ADDRESSES: {
       address: "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA",
       abi: CCTP_V2_TOKEN_MESSENGER_ABI,
     },
+    sponsoredCCTPDstPeriphery: {
+      address: "0xA2cBA9cFcD2427C1201df51c19422E043c5bDe7a",
+      abi: SPONSORED_CCTP_DST_PERIPHERY_ABI,
+    },
     spokePoolPeriphery: {
       abi: SPOKE_POOL_PERIPHERY_ABI,
     },


### PR DESCRIPTION
## Summary
- Add `sponsoredCCTPDstPeriphery` address (`0xA2cBA9cFcD2427C1201df51c19422E043c5bDe7a`) and ABI to Base Sepolia config in `ContractAddresses.ts`
- Without this, the CCTP finalizer bot fails with: `SponsoredCCTPDstPeriphery ABI not configured for chain 84532`

## Context
Testing sponsored CCTP gasless flow from Arb Sepolia -> Base Sepolia. The indexer publishes the burn event to PubSub with a signature, but the finalizer bot can't process it because it doesn't know the `SponsoredCCTPDstPeriphery` contract on Base Sepolia.

Related PRs:
- across-protocol/indexer#872 — fix testnet indexing (SrcPeriphery address, whitelist, destinationChainId)
- across-protocol/indexer#873 — fix gasless deposit destinationChainId metadata

## Test plan
- [ ] Deploy finalizer bot with this change
- [ ] Run gasless CCTP test: Arb Sepolia USDC -> Base Sepolia USDC
- [ ] Verify finalizer processes the burn and calls `receiveMessage` on Base Sepolia

🤖 Generated with [Claude Code](https://claude.com/claude-code)