### PR TITLE
improve(Rebalancer): Cache and retry Binance order-book quotes

### DIFF
--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -10,6 +10,7 @@ import {
   CHAIN_IDs,
   Coin,
   Contract,
+  delay,
   ERC20,
   EvmAddress,
   forEachAsync,
@@ -72,8 +73,14 @@ export function isTerminalBinanceWithdrawal(status?: number): boolean {
 
 export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   private binanceApiClient: Binance;
+  private orderBookPromiseBySymbol = new Map<string, Promise<Awaited<ReturnType<Binance["book"]>>>>();
+  private orderBookSnapshotBySymbol = new Map<
+    string,
+    { fetchedAtMs: number; book: Awaited<ReturnType<Binance["book"]>> }
+  >();
 
   REDIS_PREFIX = "binance-stablecoin-swap:";
+  private static readonly ORDER_BOOK_CACHE_TTL_MS = 30_000;
 
   REDIS_KEY_INITIATED_WITHDRAWALS = this.REDIS_PREFIX + "initiated-withdrawals";
   private spotMarketMeta: { [name: string]: SPOT_MARKET_META } = {
@@ -935,9 +942,10 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   ): Promise<{ latestPrice: number; slippagePct: number }> {
     const symbol = await this._getSymbol(sourceToken, destinationToken);
     const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
-    const book = await this.binanceApiClient.book({ symbol: symbol.symbol });
+    const book = await this._getOrderBook(symbol.symbol);
     const spotMarketMeta = this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
     const sideOfBookToTraverse = spotMarketMeta.isBuy ? book.asks : book.bids;
+    assert(sideOfBookToTraverse.length > 0, `Order book is empty for ${symbol.symbol}`);
     const bestPx = Number(sideOfBookToTraverse[0].price);
     let szFilledSoFar = bnZero;
     const maxPxReached = sideOfBookToTraverse.find((level) => {
@@ -951,14 +959,60 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       }
       szFilledSoFar = szFilledSoFar.add(szWei);
     });
+    const terminalLevel = maxPxReached ?? sideOfBookToTraverse[sideOfBookToTraverse.length - 1];
     if (!maxPxReached) {
       throw new Error(
-        `Cannot find price in order book that satisfies an order for size ${amountToTransfer.toString()} of ${destinationToken} on the market "${sourceToken}-${destinationToken}"`
+        `Order size ${amountToTransfer.toString()} exceeds visible Binance order book depth ${szFilledSoFar.toString()}, reduce amountToTransfer`
       );
     }
-    const latestPrice = Number(Number(maxPxReached.price).toFixed(spotMarketMeta.pxDecimals));
+    const latestPrice = Number(Number(terminalLevel.price).toFixed(spotMarketMeta.pxDecimals));
     const slippagePct = Math.abs((latestPrice - bestPx) / bestPx) * 100;
     return { latestPrice, slippagePct };
+  }
+
+  private async _getOrderBook(symbol: string): Promise<Awaited<ReturnType<Binance["book"]>>> {
+    const cachedBook = this.orderBookSnapshotBySymbol.get(symbol);
+    if (cachedBook && Date.now() - cachedBook.fetchedAtMs <= BinanceStablecoinSwapAdapter.ORDER_BOOK_CACHE_TTL_MS) {
+      return cachedBook.book;
+    }
+
+    const existingPromise = this.orderBookPromiseBySymbol.get(symbol);
+    if (existingPromise !== undefined) {
+      return existingPromise;
+    }
+
+    const promise = this._fetchOrderBook(symbol).then((book) => {
+      this.orderBookSnapshotBySymbol.set(symbol, {
+        fetchedAtMs: Date.now(),
+        book,
+      });
+      return book;
+    });
+    this.orderBookPromiseBySymbol.set(symbol, promise);
+    void promise.finally(() => {
+      if (this.orderBookPromiseBySymbol.get(symbol) === promise) {
+        this.orderBookPromiseBySymbol.delete(symbol);
+      }
+    });
+
+    return promise;
+  }
+
+  private async _fetchOrderBook(
+    symbol: string,
+    nRetries = 0,
+    maxRetries = 3
+  ): Promise<Awaited<ReturnType<Binance["book"]>>> {
+    try {
+      return await this.binanceApiClient.book({ symbol, limit: 5000 });
+    } catch (error) {
+      if (nRetries >= maxRetries) {
+        throw error;
+      }
+
+      await delay(2 ** nRetries + Math.random());
+      return this._fetchOrderBook(symbol, nRetries + 1, maxRetries);
+    }
   }
 
   private _getQuantityForOrder(

--- a/test/BinanceAdapter.quotes.ts
+++ b/test/BinanceAdapter.quotes.ts
@@ -33,11 +33,13 @@ describe("Binance adapter quotes", function () {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (adapter as any).binanceApiClient = { book: bookStub };
+    const quoteAdapter = adapter as unknown as {
+      _getOrderBook(symbol: string): Promise<ReturnType<typeof makeOrderBook>>;
+    };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const [first, second] = await Promise.all([
-      (adapter as any)._getOrderBook("USDCUSDT"),
-      (adapter as any)._getOrderBook("USDCUSDT"),
+      quoteAdapter._getOrderBook("USDCUSDT"),
+      quoteAdapter._getOrderBook("USDCUSDT"),
     ]);
 
     expect(first).to.equal(book);

--- a/test/BinanceAdapter.quotes.ts
+++ b/test/BinanceAdapter.quotes.ts
@@ -1,0 +1,116 @@
+import { CHAIN_IDs } from "@across-protocol/constants";
+import { BinanceStablecoinSwapAdapter } from "../src/rebalancer/adapters/binance";
+import { ethers, expect, sinon, toBNWei } from "./utils";
+
+describe("Binance adapter quotes", function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("reuses a cached order book snapshot within the TTL", async function () {
+    const adapter = await makeAdapter();
+    const book = makeOrderBook({ asks: [{ price: "1.0001", quantity: "1000" }], bids: [] });
+    const bookStub = sinon.stub().resolves(book);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (adapter as any).binanceApiClient = { book: bookStub };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const first = await (adapter as any)._getOrderBook("USDCUSDT");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const second = await (adapter as any)._getOrderBook("USDCUSDT");
+
+    expect(first).to.equal(book);
+    expect(second).to.equal(book);
+    expect(bookStub.callCount).to.equal(1);
+  });
+
+  it("deduplicates concurrent order book fetches for the same symbol", async function () {
+    const adapter = await makeAdapter();
+    const book = makeOrderBook({ asks: [{ price: "1.0001", quantity: "1000" }], bids: [] });
+    const bookStub = sinon.stub().callsFake(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return book;
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (adapter as any).binanceApiClient = { book: bookStub };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const [first, second] = await Promise.all([
+      (adapter as any)._getOrderBook("USDCUSDT"),
+      (adapter as any)._getOrderBook("USDCUSDT"),
+    ]);
+
+    expect(first).to.equal(book);
+    expect(second).to.equal(book);
+    expect(bookStub.callCount).to.equal(1);
+  });
+
+  it("retries transient order book fetch failures", async function () {
+    const adapter = await makeAdapter();
+    const book = makeOrderBook({ asks: [{ price: "1.0001", quantity: "1000" }], bids: [] });
+    const bookStub = sinon.stub();
+    bookStub.onCall(0).rejects(new Error("temporary outage"));
+    bookStub.onCall(1).resolves(book);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (adapter as any).binanceApiClient = { book: bookStub };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fetched = await (adapter as any)._fetchOrderBook("USDCUSDT", 0, 1);
+
+    expect(fetched).to.equal(book);
+    expect(bookStub.callCount).to.equal(2);
+  });
+
+  it("throws a visible-depth error when the order book cannot satisfy the order size", async function () {
+    const adapter = await makeAdapter();
+    const exchangeInfoStub = sinon.stub().resolves({
+      symbols: [
+        {
+          symbol: "USDCUSDT",
+          baseAsset: "USDC",
+          quoteAsset: "USDT",
+        },
+      ],
+    });
+    const bookStub = sinon.stub().resolves(
+      makeOrderBook({
+        asks: [{ price: "1.0010", quantity: "10" }],
+        bids: [],
+      })
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (adapter as any).binanceApiClient = { exchangeInfo: exchangeInfoStub, book: bookStub };
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (adapter as any)._getLatestPrice("USDT", "USDC", CHAIN_IDs.MAINNET, toBNWei("1000", 6));
+      expect.fail("expected _getLatestPrice to throw when the order book is too shallow");
+    } catch (error) {
+      expect(String(error)).to.contain("exceeds visible Binance order book depth");
+    }
+  });
+});
+
+async function makeAdapter(): Promise<BinanceStablecoinSwapAdapter> {
+  const [signer] = await ethers.getSigners();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new BinanceStablecoinSwapAdapter(TEST_LOGGER, {} as any, signer, {} as any, {} as any);
+}
+
+function makeOrderBook({
+  asks,
+  bids,
+}: {
+  asks: Array<{ price: string; quantity: string }>;
+  bids: Array<{ price: string; quantity: string }>;
+}) {
+  return { asks, bids };
+}
+
+const TEST_LOGGER = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;


### PR DESCRIPTION
## What changed
- added cached Binance order-book snapshots with a short TTL
- deduplicated concurrent in-flight `book()` fetches per symbol
- added bounded retry behavior for transient order-book fetch failures
- changed quote failures to raise an explicit visible-depth error when the requested size exceeds the available book
- added quote-path tests for cache reuse, deduplication, retries, and insufficient-depth failures

## Why
Order-book lookups were repeated aggressively and failed with vague errors when the visible book could not satisfy the requested order size. This makes quote fetching more resilient and makes failures easier to reason about.

## Impact
- no route changes
- no conversion logic changes
- no WETH or same-coin behavior included in this PR

## Validation
- `yarn test test/BinanceAdapter.withdrawals.ts test/BinanceAdapter.quotes.ts`
- `yarn build:test` still fails on the existing repo-wide TypeScript test baseline outside this change