### PR TITLE
improve: Use route conversions for Binance sizing and fees

### DIFF
--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -96,6 +96,28 @@ export function deriveBinanceSpotMarketMeta(
   };
 }
 
+export function convertBinanceRouteAmount(params: {
+  amount: BigNumber;
+  sourceTokenDecimals: number;
+  destinationTokenDecimals: number;
+  isBuy: boolean;
+  price: number;
+  direction: "source-to-destination" | "destination-to-source";
+}): BigNumber {
+  const isSourceToDestination = params.direction === "source-to-destination";
+  const inputDecimals = isSourceToDestination ? params.sourceTokenDecimals : params.destinationTokenDecimals;
+  const outputDecimals = isSourceToDestination ? params.destinationTokenDecimals : params.sourceTokenDecimals;
+  const readableAmount = Number(fromWei(params.amount, inputDecimals));
+  const convertedAmount = isSourceToDestination
+    ? params.isBuy
+      ? readableAmount / params.price
+      : readableAmount * params.price
+    : params.isBuy
+      ? readableAmount * params.price
+      : readableAmount / params.price;
+
+  return toBNWei(truncate(convertedAmount, outputDecimals), outputDecimals);
+}
 function resolveStepPrecision(stepSize: string): number {
   const normalized = stepSize.replace(/0+$/, "").replace(/\.$/, "");
   const decimalPart = normalized.split(".")[1];
@@ -110,6 +132,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     string,
     { fetchedAtMs: number; book: Awaited<ReturnType<Binance["book"]>> }
   >();
+  private tradeFeesPromise?: ReturnType<Binance["tradeFee"]>;
 
   REDIS_PREFIX = "binance-stablecoin-swap:";
   private static readonly ORDER_BOOK_CACHE_TTL_MS = 30_000;
@@ -480,13 +503,13 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       const orderDetails = await this._redisGetOrderDetails(cloid, account);
       const { sourceChain, sourceToken, amountToTransfer } = orderDetails;
       const binanceDepositNetwork = await this._getEntrypointNetwork(sourceChain, sourceToken);
-      const amountConverter = this._getAmountConverter(
+      const convertedAmount = await this._convertSourceToDestination(
+        sourceToken,
         sourceChain,
-        this._getTokenInfo(sourceToken, sourceChain).address,
+        sourceToken,
         binanceDepositNetwork,
-        this._getTokenInfo(sourceToken, binanceDepositNetwork).address
+        amountToTransfer
       );
-      const convertedAmount = amountConverter(amountToTransfer);
       pendingRebalances[binanceDepositNetwork] ??= {};
       pendingRebalances[binanceDepositNetwork][sourceToken] = (
         pendingRebalances[binanceDepositNetwork][sourceToken] ?? bnZero
@@ -511,13 +534,13 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       const orderDetails = await this._redisGetOrderDetails(cloid, account);
       const { destinationChain, destinationToken, sourceChain, sourceToken, amountToTransfer } = orderDetails;
       // Convert amountToTransfer to destination chain precision:
-      const amountConverter = this._getAmountConverter(
+      const convertedAmount = await this._convertSourceToDestination(
+        sourceToken,
         sourceChain,
-        this._getTokenInfo(sourceToken, sourceChain).address,
+        destinationToken,
         destinationChain,
-        this._getTokenInfo(destinationToken, destinationChain).address
+        amountToTransfer
       );
-      const convertedAmount = amountConverter(amountToTransfer);
       this.logger.debug({
         at: "BinanceStablecoinSwapAdapter.getPendingRebalances",
         message: `Adding ${convertedAmount.toString()} for pending order cloid ${cloid} to destination chain ${destinationChain}`,
@@ -580,13 +603,13 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         });
         continue;
       }
-      const amountConverter = this._getAmountConverter(
+      const convertedAmount = await this._convertSourceToDestination(
+        sourceToken,
         sourceChain,
-        this._getTokenInfo(sourceToken, sourceChain).address,
+        destinationToken,
         destinationChain,
-        this._getTokenInfo(destinationToken, destinationChain).address
+        amountToTransfer
       );
-      const convertedAmount = amountConverter(amountToTransfer);
       this.logger.debug({
         at: "BinanceStablecoinSwapAdapter.getPendingRebalances",
         message: `Withdrawal for order ${cloid} has finalized, subtracting the order's virtual balance of ${convertedAmount.toString()} from binance withdrawal network ${binanceWithdrawalNetwork}`,
@@ -623,9 +646,21 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const expectedCost = await this.getEstimatedCost(rebalanceRoute, amountToTransfer, false);
     const expectedAmountToWithdraw = amountToTransfer.sub(expectedCost);
     const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
-    const minimumWithdrawalSize = toBNWei(Number(withdrawMin) + 1, sourceTokenInfo.decimals); // Add buffer to minimum to account
-    // for price volatility. For stablecoin swaps, this should be totally fine since price isn't volatile.
-    const maximumWithdrawalSize = toBNWei(withdrawMax, sourceTokenInfo.decimals);
+    const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationEntrypointNetwork);
+    const minimumWithdrawalSize = await this._convertDestinationToSource(
+      destinationToken,
+      destinationEntrypointNetwork,
+      sourceToken,
+      sourceChain,
+      toBNWei(Number(withdrawMin) + 1, destinationTokenInfo.decimals)
+    );
+    const maximumWithdrawalSize = await this._convertDestinationToSource(
+      destinationToken,
+      destinationEntrypointNetwork,
+      sourceToken,
+      sourceChain,
+      toBNWei(withdrawMax, destinationTokenInfo.decimals)
+    );
     if (expectedAmountToWithdraw.lt(minimumWithdrawalSize)) {
       this.logger.debug({
         at: "BinanceStablecoinSwapAdapter.initializeRebalance",
@@ -646,7 +681,15 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     // and the amount transferred in might be insufficient to place the order later on, producing more dust or an
     // error.
     const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
-    const minimumOrderSize = toBNWei(spotMarketMeta.minimumOrderSize, sourceTokenInfo.decimals);
+    const minimumOrderSize = spotMarketMeta.isBuy
+      ? await this._convertDestinationToSource(
+          destinationToken,
+          destinationChain,
+          sourceToken,
+          sourceChain,
+          toBNWei(spotMarketMeta.minimumOrderSize, this._getTokenInfo(destinationToken, destinationChain).decimals)
+        )
+      : toBNWei(spotMarketMeta.minimumOrderSize, sourceTokenInfo.decimals);
     if (amountToTransfer.lt(minimumOrderSize)) {
       this.logger.debug({
         at: "BinanceStablecoinSwapAdapter.initializeRebalance",
@@ -731,9 +774,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const { sourceToken, destinationToken, sourceChain, destinationChain } = rebalanceRoute;
     const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
     // Commission is denominated in percentage points.
-    const tradeFeePct = (await this.binanceApiClient.tradeFee()).find(
-      (fee) => fee.symbol === spotMarketMeta.symbol
-    ).takerCommission;
+    const tradeFeePct = (await this._getTradeFees()).find((fee) => fee.symbol === spotMarketMeta.symbol).takerCommission;
     const tradeFee = toBNWei(tradeFeePct, 18).mul(amountToTransfer).div(toBNWei(100, 18));
     const destinationCoin = await this._getAccountCoins(destinationToken);
     const destinationEntrypointNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
@@ -743,13 +784,13 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         .withdrawFee,
       destinationTokenInfo.decimals
     );
-    const amountConverter = this._getAmountConverter(
+    const withdrawFeeConvertedToSourceToken = await this._convertDestinationToSource(
+      destinationToken,
       destinationEntrypointNetwork,
-      this._getTokenInfo(destinationToken, destinationEntrypointNetwork).address,
+      sourceToken,
       sourceChain,
-      this._getTokenInfo(sourceToken, sourceChain).address
+      withdrawFee
     );
-    const withdrawFeeConvertedToSourceToken = amountConverter(withdrawFee);
 
     const { latestPrice } = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, amountToTransfer);
 
@@ -794,13 +835,20 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const binanceWithdrawNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
     if (binanceWithdrawNetwork !== destinationChain) {
       const _rebalanceRoute = { ...rebalanceRoute, sourceChain: binanceWithdrawNetwork };
+      const bridgeAmountConverted = await this._convertSourceToDestination(
+        sourceToken,
+        sourceChain,
+        destinationToken,
+        binanceWithdrawNetwork,
+        amountToTransfer
+      );
       if (
         destinationToken === "USDT" &&
         this.oftAdapter.supportsRoute({ ..._rebalanceRoute, sourceToken: "USDT", adapter: "oft" })
       ) {
         bridgeFromBinanceFee = await this.oftAdapter.getEstimatedCost(
           { ..._rebalanceRoute, sourceToken: "USDT", adapter: "oft" },
-          amountToTransfer
+          bridgeAmountConverted
         );
       } else if (
         destinationToken === "USDC" &&
@@ -808,7 +856,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       ) {
         bridgeFromBinanceFee = await this.cctpAdapter.getEstimatedCost(
           { ..._rebalanceRoute, sourceToken: "USDC", adapter: "cctp" },
-          amountToTransfer
+          bridgeAmountConverted
         );
       }
     }
@@ -1039,16 +1087,25 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     sourceToken: string,
     sourceChain: number,
     destinationToken: string,
+    destinationChain: number,
     amountToTransfer: BigNumber,
     price: number
   ): Promise<number> {
-    return this._getSpotMarketMetaForRoute(sourceToken, destinationToken).then((spotMarketMeta) => {
-      const sz = spotMarketMeta.isBuy
-        ? amountToTransfer.mul(10 ** spotMarketMeta.pxDecimals).div(toBNWei(price, spotMarketMeta.pxDecimals))
-        : amountToTransfer;
+    return this._getSpotMarketMetaForRoute(sourceToken, destinationToken).then(async (spotMarketMeta) => {
       const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
-      // Floor this number so we can guarantee that we have enough balance to place the order:
-      const szNumber = Number(fromWei(sz, sourceTokenInfo.decimals));
+      const amountToOrder = spotMarketMeta.isBuy
+        ? await this._convertSourceToDestination(
+            sourceToken,
+            sourceChain,
+            destinationToken,
+            destinationChain,
+            amountToTransfer
+          )
+        : amountToTransfer;
+      const decimals = spotMarketMeta.isBuy
+        ? this._getTokenInfo(destinationToken, destinationChain).decimals
+        : sourceTokenInfo.decimals;
+      const szNumber = Number(fromWei(amountToOrder, decimals));
       const szFormatted = truncate(szNumber, spotMarketMeta.szDecimals);
       assert(
         szFormatted >= spotMarketMeta.minimumOrderSize,
@@ -1059,11 +1116,70 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   }
 
   private async _getSpotMarketMetaForRoute(sourceToken: string, destinationToken: string): Promise<SPOT_MARKET_META> {
-    return deriveBinanceSpotMarketMeta(
-      sourceToken,
-      destinationToken,
-      await this._getSymbol(sourceToken, destinationToken)
-    );
+    return deriveBinanceSpotMarketMeta(sourceToken, destinationToken, await this._getSymbol(sourceToken, destinationToken));
+  }
+
+  private async _convertSourceToDestination(
+    sourceToken: string,
+    sourceChain: number,
+    destinationToken: string,
+    destinationChain: number,
+    sourceAmount: BigNumber
+  ): Promise<BigNumber> {
+    const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
+    const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationChain);
+    if (sourceToken === destinationToken) {
+      return this._getAmountConverter(
+        sourceChain,
+        sourceTokenInfo.address,
+        destinationChain,
+        destinationTokenInfo.address
+      )(sourceAmount);
+    }
+    const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
+    const priceData = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, sourceAmount);
+    return convertBinanceRouteAmount({
+      amount: sourceAmount,
+      sourceTokenDecimals: sourceTokenInfo.decimals,
+      destinationTokenDecimals: destinationTokenInfo.decimals,
+      isBuy: spotMarketMeta.isBuy,
+      price: priceData.latestPrice,
+      direction: "source-to-destination",
+    });
+  }
+
+  private async _convertDestinationToSource(
+    destinationToken: string,
+    destinationChain: number,
+    sourceToken: string,
+    sourceChain: number,
+    destinationAmount: BigNumber
+  ): Promise<BigNumber> {
+    const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
+    const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationChain);
+    if (sourceToken === destinationToken) {
+      return this._getAmountConverter(
+        destinationChain,
+        destinationTokenInfo.address,
+        sourceChain,
+        sourceTokenInfo.address
+      )(destinationAmount);
+    }
+    const priceData = await this._getLatestPrice(destinationToken, sourceToken, destinationChain, destinationAmount);
+    const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
+    return convertBinanceRouteAmount({
+      amount: destinationAmount,
+      sourceTokenDecimals: sourceTokenInfo.decimals,
+      destinationTokenDecimals: destinationTokenInfo.decimals,
+      isBuy: spotMarketMeta.isBuy,
+      price: priceData.latestPrice,
+      direction: "destination-to-source",
+    });
+  }
+
+  private async _getTradeFees(): ReturnType<Binance["tradeFee"]> {
+    this.tradeFeesPromise ??= this.binanceApiClient.tradeFee({ useServerTime: true });
+    return this.tradeFeesPromise;
   }
 
   private async _getMatchingFillForCloid(
@@ -1084,13 +1200,14 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   }
 
   private async _placeMarketOrder(cloid: string, orderDetails: OrderDetails): Promise<void> {
-    const { sourceToken, sourceChain, destinationToken, amountToTransfer } = orderDetails;
+    const { sourceToken, sourceChain, destinationToken, destinationChain, amountToTransfer } = orderDetails;
     const latestPx = (await this._getLatestPrice(sourceToken, destinationToken, sourceChain, amountToTransfer))
       .latestPrice;
     const szForOrder = await this._getQuantityForOrder(
       sourceToken,
       sourceChain,
       destinationToken,
+      destinationChain,
       amountToTransfer,
       latestPx
     );

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1170,7 +1170,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         sourceTokenInfo.address
       )(destinationAmount);
     }
-    const priceData = await this._getLatestPrice(destinationToken, sourceToken, destinationChain, destinationAmount);
+    const priceData = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, destinationAmount);
     const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
     return convertBinanceRouteAmount({
       amount: destinationAmount,

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -774,7 +774,9 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const { sourceToken, destinationToken, sourceChain, destinationChain } = rebalanceRoute;
     const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
     // Commission is denominated in percentage points.
-    const tradeFeePct = (await this._getTradeFees()).find((fee) => fee.symbol === spotMarketMeta.symbol).takerCommission;
+    const tradeFeePct = (await this._getTradeFees()).find(
+      (fee) => fee.symbol === spotMarketMeta.symbol
+    ).takerCommission;
     const tradeFee = toBNWei(tradeFeePct, 18).mul(amountToTransfer).div(toBNWei(100, 18));
     const destinationCoin = await this._getAccountCoins(destinationToken);
     const destinationEntrypointNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
@@ -1088,8 +1090,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     sourceChain: number,
     destinationToken: string,
     destinationChain: number,
-    amountToTransfer: BigNumber,
-    price: number
+    amountToTransfer: BigNumber
   ): Promise<number> {
     return this._getSpotMarketMetaForRoute(sourceToken, destinationToken).then(async (spotMarketMeta) => {
       const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
@@ -1116,7 +1117,11 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   }
 
   private async _getSpotMarketMetaForRoute(sourceToken: string, destinationToken: string): Promise<SPOT_MARKET_META> {
-    return deriveBinanceSpotMarketMeta(sourceToken, destinationToken, await this._getSymbol(sourceToken, destinationToken));
+    return deriveBinanceSpotMarketMeta(
+      sourceToken,
+      destinationToken,
+      await this._getSymbol(sourceToken, destinationToken)
+    );
   }
 
   private async _convertSourceToDestination(
@@ -1201,15 +1206,12 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
 
   private async _placeMarketOrder(cloid: string, orderDetails: OrderDetails): Promise<void> {
     const { sourceToken, sourceChain, destinationToken, destinationChain, amountToTransfer } = orderDetails;
-    const latestPx = (await this._getLatestPrice(sourceToken, destinationToken, sourceChain, amountToTransfer))
-      .latestPrice;
     const szForOrder = await this._getQuantityForOrder(
       sourceToken,
       sourceChain,
       destinationToken,
       destinationChain,
-      amountToTransfer,
-      latestPx
+      amountToTransfer
     );
     const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
     const orderStruct = {

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1170,7 +1170,18 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         sourceTokenInfo.address
       )(destinationAmount);
     }
-    const priceData = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, destinationAmount);
+    const destinationAmountInSourcePrecision = this._getAmountConverter(
+      destinationChain,
+      destinationTokenInfo.address,
+      sourceChain,
+      sourceTokenInfo.address
+    )(destinationAmount);
+    const priceData = await this._getLatestPrice(
+      sourceToken,
+      destinationToken,
+      sourceChain,
+      destinationAmountInSourcePrecision
+    );
     const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
     return convertBinanceRouteAmount({
       amount: destinationAmount,

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1189,7 +1189,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   }
 
   private async _getTradeFees(): ReturnType<Binance["tradeFee"]> {
-    this.tradeFeesPromise ??= this.binanceApiClient.tradeFee({ useServerTime: true });
+    this.tradeFeesPromise ??= this.binanceApiClient.tradeFee();
     try {
       return await this.tradeFeesPromise;
     } catch (error) {

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1184,7 +1184,12 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
 
   private async _getTradeFees(): ReturnType<Binance["tradeFee"]> {
     this.tradeFeesPromise ??= this.binanceApiClient.tradeFee({ useServerTime: true });
-    return this.tradeFeesPromise;
+    try {
+      return await this.tradeFeesPromise;
+    } catch (error) {
+      this.tradeFeesPromise = undefined;
+      throw error;
+    }
   }
 
   private async _getMatchingFillForCloid(

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1162,20 +1162,15 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   ): Promise<BigNumber> {
     const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
     const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationChain);
-    if (sourceToken === destinationToken) {
-      return this._getAmountConverter(
-        destinationChain,
-        destinationTokenInfo.address,
-        sourceChain,
-        sourceTokenInfo.address
-      )(destinationAmount);
-    }
     const destinationAmountInSourcePrecision = this._getAmountConverter(
       destinationChain,
       destinationTokenInfo.address,
       sourceChain,
       sourceTokenInfo.address
     )(destinationAmount);
+    if (sourceToken === destinationToken) {
+      return destinationAmountInSourcePrecision;
+    }
     const priceData = await this._getLatestPrice(
       sourceToken,
       destinationToken,

--- a/test/BinanceAdapter.conversions.ts
+++ b/test/BinanceAdapter.conversions.ts
@@ -96,6 +96,31 @@ describe("Binance adapter conversion sizing", function () {
     expect(cctpGetEstimatedCost.calledOnce).to.equal(true);
     expect(cctpGetEstimatedCost.getCall(0).args[1].eq(toBNWei("102.040816", 6))).to.equal(true);
   });
+
+  it("prices destination-to-source conversions using source-token precision", async function () {
+    const route = makeStablecoinRoute();
+    const adapter = await makeInitializedAdapter(route);
+    const latestPriceStub = sinon.stub().resolves({ latestPrice: 2500, slippagePct: 0 });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getLatestPrice").callsFake(latestPriceStub);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (adapter as any)._convertDestinationToSource(
+      "WETH",
+      CHAIN_IDs.MAINNET,
+      "USDC",
+      CHAIN_IDs.MAINNET,
+      toBNWei("1", 18)
+    );
+
+    expect(latestPriceStub.calledOnce).to.equal(true);
+    expect(latestPriceStub.getCall(0).args[0]).to.equal("USDC");
+    expect(latestPriceStub.getCall(0).args[1]).to.equal("WETH");
+    expect(latestPriceStub.getCall(0).args[2]).to.equal(CHAIN_IDs.MAINNET);
+    expect(latestPriceStub.getCall(0).args[3].eq(toBNWei("1", 6))).to.equal(true);
+  });
 });
 
 async function makeInitializedAdapter(

--- a/test/BinanceAdapter.conversions.ts
+++ b/test/BinanceAdapter.conversions.ts
@@ -86,12 +86,10 @@ describe("Binance adapter conversion sizing", function () {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     sinon.stub(adapter as any, "_getTradeFees").resolves([{ symbol: "USDCUSDT", takerCommission: "0" }]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon
-      .stub(adapter as any, "_getEntrypointNetwork")
-      .callsFake(async (...args: unknown[]) => {
-        const [chainId, token] = args as [number, string];
-        return token === "USDC" && chainId === CHAIN_IDs.BASE ? CHAIN_IDs.MAINNET : chainId;
-      });
+    sinon.stub(adapter as any, "_getEntrypointNetwork").callsFake(async (...args: [number, string]) => {
+      const [chainId, token] = args;
+      return token === "USDC" && chainId === CHAIN_IDs.BASE ? CHAIN_IDs.MAINNET : chainId;
+    });
 
     await adapter.getEstimatedCost(route, toBNWei("100", 6), false);
 

--- a/test/BinanceAdapter.conversions.ts
+++ b/test/BinanceAdapter.conversions.ts
@@ -1,0 +1,162 @@
+import { CHAIN_IDs } from "@across-protocol/constants";
+import { ethers, expect, sinon, toBNWei } from "./utils";
+import { EvmAddress } from "../src/utils";
+import { BinanceStablecoinSwapAdapter } from "../src/rebalancer/adapters/binance";
+import { RebalanceRoute } from "../src/rebalancer/utils/interfaces";
+
+describe("Binance adapter conversion sizing", function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("uses converted withdrawal minimums when deciding whether to initialize a rebalance", async function () {
+    const route = makeStablecoinRoute();
+    const adapter = await makeInitializedAdapter(route);
+    const depositStub = sinon.stub();
+    const createOrderStub = sinon.stub().resolves();
+    sinon.stub(adapter, "getEstimatedCost").resolves(toBNWei("0", 6));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getLatestPrice").resolves({ latestPrice: 0.99, slippagePct: 0 });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getAccountCoins").resolves(makeCoin("100", "1000000"));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getEntrypointNetwork").callsFake(async () => CHAIN_IDs.MAINNET);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_redisGetNextCloid").resolves("cloid");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_depositToBinance").callsFake(depositStub);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_redisCreateOrder").callsFake(createOrderStub);
+
+    const amount = toBNWei("100", 6);
+    const result = await adapter.initializeRebalance(route, amount);
+
+    expect(result.eq(amount)).to.equal(true);
+    expect(depositStub.calledOnce).to.equal(true);
+    expect(createOrderStub.calledOnce).to.equal(true);
+  });
+
+  it("uses converted buy-side minimum order sizes", async function () {
+    const route = makeStablecoinRoute();
+    const adapter = await makeInitializedAdapter(route);
+    const depositStub = sinon.stub();
+    const createOrderStub = sinon.stub().resolves();
+    sinon.stub(adapter, "getEstimatedCost").resolves(toBNWei("0", 6));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 100));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getLatestPrice").resolves({ latestPrice: 0.99, slippagePct: 0 });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getAccountCoins").resolves(makeCoin("0", "1000000"));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getEntrypointNetwork").callsFake(async () => CHAIN_IDs.MAINNET);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_redisGetNextCloid").resolves("cloid");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_depositToBinance").callsFake(depositStub);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_redisCreateOrder").callsFake(createOrderStub);
+
+    const amount = toBNWei("99.5", 6);
+    const result = await adapter.initializeRebalance(route, amount);
+
+    expect(result.eq(amount)).to.equal(true);
+    expect(depositStub.calledOnce).to.equal(true);
+    expect(createOrderStub.calledOnce).to.equal(true);
+  });
+
+  it("prices downstream bridge fees using destination-token amounts", async function () {
+    const route = makeStablecoinRoute({ destinationChain: CHAIN_IDs.BASE });
+    const cctpGetEstimatedCost = sinon.stub().resolves(toBNWei("0", 6));
+    const adapter = await makeInitializedAdapter(route, {
+      cctpAdapter: {
+        supportsRoute: sinon.stub().returns(true),
+        getEstimatedCost: cctpGetEstimatedCost,
+      },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getLatestPrice").resolves({ latestPrice: 0.98, slippagePct: 0 });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getAccountCoins").resolves(makeCoin("0", "1000000"));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getTradeFees").resolves([{ symbol: "USDCUSDT", takerCommission: "0" }]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon
+      .stub(adapter as any, "_getEntrypointNetwork")
+      .callsFake(async (...args: unknown[]) => {
+        const [chainId, token] = args as [number, string];
+        return token === "USDC" && chainId === CHAIN_IDs.BASE ? CHAIN_IDs.MAINNET : chainId;
+      });
+
+    await adapter.getEstimatedCost(route, toBNWei("100", 6), false);
+
+    expect(cctpGetEstimatedCost.calledOnce).to.equal(true);
+    expect(cctpGetEstimatedCost.getCall(0).args[1].eq(toBNWei("102.040816", 6))).to.equal(true);
+  });
+});
+
+async function makeInitializedAdapter(
+  route: RebalanceRoute,
+  {
+    cctpAdapter = {},
+    oftAdapter = {},
+  }: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    cctpAdapter?: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    oftAdapter?: any;
+  } = {}
+): Promise<BinanceStablecoinSwapAdapter> {
+  const [signer] = await ethers.getSigners();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const adapter = new BinanceStablecoinSwapAdapter(TEST_LOGGER, {} as any, signer, cctpAdapter, oftAdapter);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (adapter as any).initialized = true;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (adapter as any).availableRoutes = [route];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (adapter as any).baseSignerAddress = EvmAddress.from(await signer.getAddress());
+  return adapter;
+}
+
+function makeStablecoinRoute(overrides: Partial<RebalanceRoute> = {}): RebalanceRoute {
+  return {
+    sourceChain: CHAIN_IDs.MAINNET,
+    destinationChain: CHAIN_IDs.MAINNET,
+    sourceToken: "USDT",
+    destinationToken: "USDC",
+    adapter: "binance",
+    ...overrides,
+  };
+}
+
+function makeSpotMeta(isBuy: boolean, minimumOrderSize: number) {
+  return {
+    symbol: "USDCUSDT",
+    baseAssetName: "USDC",
+    quoteAssetName: "USDT",
+    pxDecimals: 4,
+    szDecimals: 0,
+    minimumOrderSize,
+    isBuy,
+  };
+}
+
+function makeCoin(withdrawMin: string, withdrawMax: string) {
+  return {
+    networkList: [{ name: "ETH", withdrawMin, withdrawMax, withdrawFee: "0" }],
+  };
+}
+
+const TEST_LOGGER = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -1,5 +1,9 @@
-import { BinanceStablecoinSwapAdapter, deriveBinanceSpotMarketMeta } from "../src/rebalancer/adapters/binance";
-import { ethers, expect, sinon } from "./utils";
+import {
+  BinanceStablecoinSwapAdapter,
+  convertBinanceRouteAmount,
+  deriveBinanceSpotMarketMeta,
+} from "../src/rebalancer/adapters/binance";
+import { ethers, expect, sinon, toBNWei } from "./utils";
 
 describe("Binance adapter helpers", async function () {
   afterEach(function () {
@@ -7,17 +11,7 @@ describe("Binance adapter helpers", async function () {
   });
 
   it("derives buy-side market metadata for USDT -> USDC routes", async function () {
-    const usdcUsdtSymbol = {
-      symbol: "USDCUSDT",
-      baseAsset: "USDC",
-      quoteAsset: "USDT",
-      filters: [
-        { filterType: "PRICE_FILTER", tickSize: "0.00010000" },
-        { filterType: "LOT_SIZE", stepSize: "1.00000000", minQty: "1.00000000" },
-      ],
-    } as const;
-
-    const meta = deriveBinanceSpotMarketMeta("USDT", "USDC", usdcUsdtSymbol as never);
+    const meta = deriveBinanceSpotMarketMeta("USDT", "USDC", makeStablecoinSymbol() as never);
 
     expect(meta.symbol).to.equal("USDCUSDT");
     expect(meta.baseAssetName).to.equal("USDC");
@@ -29,17 +23,7 @@ describe("Binance adapter helpers", async function () {
   });
 
   it("derives sell-side market metadata for USDC -> USDT routes", async function () {
-    const usdcUsdtSymbol = {
-      symbol: "USDCUSDT",
-      baseAsset: "USDC",
-      quoteAsset: "USDT",
-      filters: [
-        { filterType: "PRICE_FILTER", tickSize: "0.00010000" },
-        { filterType: "LOT_SIZE", stepSize: "1.00000000", minQty: "1.00000000" },
-      ],
-    } as const;
-
-    const meta = deriveBinanceSpotMarketMeta("USDC", "USDT", usdcUsdtSymbol as never);
+    const meta = deriveBinanceSpotMarketMeta("USDC", "USDT", makeStablecoinSymbol() as never);
 
     expect(meta.symbol).to.equal("USDCUSDT");
     expect(meta.baseAssetName).to.equal("USDC");
@@ -50,12 +34,34 @@ describe("Binance adapter helpers", async function () {
     expect(meta.isBuy).to.equal(false);
   });
 
+  it("converts route amounts using non-parity prices", async function () {
+    const converted = convertBinanceRouteAmount({
+      amount: toBNWei("100", 6),
+      sourceTokenDecimals: 6,
+      destinationTokenDecimals: 6,
+      isBuy: true,
+      price: 0.98,
+      direction: "source-to-destination",
+    });
+    const sourceEquivalent = convertBinanceRouteAmount({
+      amount: converted,
+      sourceTokenDecimals: 6,
+      destinationTokenDecimals: 6,
+      isBuy: true,
+      price: 0.98,
+      direction: "destination-to-source",
+    });
+
+    expect(converted.eq(toBNWei("102.040816", 6))).to.equal(true);
+    expect(sourceEquivalent.eq(toBNWei("99.999999", 6))).to.equal(true);
+  });
+
   it("retries exchangeInfo lookups after transient failures", async function () {
     const adapter = await makeAdapter();
     const exchangeInfoStub = sinon.stub();
     exchangeInfoStub.onCall(0).rejects(new Error("temporary outage"));
     exchangeInfoStub.onCall(1).resolves({
-      symbols: [{ symbol: "USDCUSDT", baseAsset: "USDC", quoteAsset: "USDT" }],
+      symbols: [{ ...makeStablecoinSymbol() }],
     });
     const symbolAdapter = adapter as unknown as {
       _getSymbol(sourceToken: string, destinationToken: string): Promise<{ symbol: string }>;
@@ -81,6 +87,18 @@ async function makeAdapter(): Promise<BinanceStablecoinSwapAdapter> {
   const [signer] = await ethers.getSigners();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return new BinanceStablecoinSwapAdapter(TEST_LOGGER, {} as any, signer, {} as any, {} as any);
+}
+
+function makeStablecoinSymbol() {
+  return {
+    symbol: "USDCUSDT",
+    baseAsset: "USDC",
+    quoteAsset: "USDT",
+    filters: [
+      { filterType: "PRICE_FILTER", tickSize: "0.00010000" },
+      { filterType: "LOT_SIZE", stepSize: "1.00000000", minQty: "1.00000000" },
+    ],
+  } as const;
 }
 
 const TEST_LOGGER = {

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -81,6 +81,30 @@ describe("Binance adapter helpers", async function () {
     expect(symbol.symbol).to.equal("USDCUSDT");
     expect(exchangeInfoStub.callCount).to.equal(2);
   });
+
+  it("retries tradeFee lookups after transient failures", async function () {
+    const adapter = await makeAdapter();
+    const tradeFeeStub = sinon.stub();
+    tradeFeeStub.onCall(0).rejects(new Error("temporary outage"));
+    tradeFeeStub.onCall(1).resolves([{ symbol: "USDCUSDT", takerCommission: "0.1" }]);
+    const feeAdapter = adapter as unknown as {
+      _getTradeFees(): Promise<Array<{ symbol: string; takerCommission: string }>>;
+      binanceApiClient: { tradeFee: typeof tradeFeeStub };
+    };
+    feeAdapter.binanceApiClient = { tradeFee: tradeFeeStub };
+
+    try {
+      await feeAdapter._getTradeFees();
+      expect.fail("expected the first _getTradeFees call to propagate the tradeFee failure");
+    } catch (error) {
+      expect(String(error)).to.contain("temporary outage");
+    }
+
+    const fees = await feeAdapter._getTradeFees();
+
+    expect(fees[0].symbol).to.equal("USDCUSDT");
+    expect(tradeFeeStub.callCount).to.equal(2);
+  });
 });
 
 async function makeAdapter(): Promise<BinanceStablecoinSwapAdapter> {


### PR DESCRIPTION
## What changed
- added reusable Binance route conversion helpers for source-to-destination and destination-to-source sizing
- memoized `exchangeInfo()` and cached `tradeFee({ useServerTime: true })`
- updated pending rebalance accounting to use converted route amounts instead of 1:1 assumptions
- updated withdrawal minimum checks, buy-side minimum order sizing, pending order sizing, and bridge-fee sizing to use converted amounts
- added focused helper and conversion tests covering non-parity pricing behavior

## Why
The stablecoin adapter still assumed 1:1 pricing in several sizing and fee paths. This makes those paths use route-aware conversions so the adapter remains correct when price is not exactly 1.0, without enabling any new route types yet.

## Impact
- no public config changes
- no route-construction changes
- no WETH or same-coin behavior included in this PR

## Validation
- `yarn test test/BinanceAdapter.withdrawals.ts test/BinanceAdapter.helpers.ts test/BinanceAdapter.conversions.ts`
- `yarn build:test` still fails on the existing repo-wide TypeScript test baseline outside this change