### PR TITLE
[codex] Reset Binance trade fee promise after failures

### DIFF
--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1431,7 +1431,10 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   }
 
   private async _getTradeFees(): ReturnType<Binance["tradeFee"]> {
-    this.tradeFeesPromise ??= this.binanceApiClient.tradeFee({ useServerTime: true });
+    this.tradeFeesPromise ??= this.binanceApiClient.tradeFee({ useServerTime: true }).catch((error) => {
+      this.tradeFeesPromise = undefined;
+      throw error;
+    });
     return this.tradeFeesPromise;
   }
 


### PR DESCRIPTION
## What changed
- clears the cached Binance trade-fee promise when the request rejects
- allows later rebalancer calls to retry `tradeFee()` instead of reusing a permanently failed promise

## Why
The current branch memoizes `tradeFeesPromise`, but if the first Binance trade-fee request fails, every later caller gets the same rejected promise for the lifetime of the adapter instance.

## Impact
Rebalancer Binance routes can recover from transient trade-fee API failures without restarting the process.

## Validation
- `yarn build`
