### PR TITLE
improve: Reset inventory running balance promises after failures

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -989,7 +989,14 @@ export class InventoryClient {
   ): Promise<{ [chainId: number]: BigNumber }> {
     if (!isDefined(this.excessRunningBalancePromises[l1Token.toNative()])) {
       // @dev Save this as a promise so that other parallel calls to this function don't make the same call.
-      this.excessRunningBalancePromises[l1Token.toNative()] = this._getLatestRunningBalances(l1Token, chainsToEvaluate);
+      const cacheKey = l1Token.toNative();
+      const runningBalancePromise = this._getLatestRunningBalances(l1Token, chainsToEvaluate).catch((error) => {
+        if (this.excessRunningBalancePromises[cacheKey] === runningBalancePromise) {
+          delete this.excessRunningBalancePromises[cacheKey];
+        }
+        throw error;
+      });
+      this.excessRunningBalancePromises[cacheKey] = runningBalancePromise;
     }
     const excessRunningBalances = lodash.cloneDeep(await this.excessRunningBalancePromises[l1Token.toNative()]);
     return this._getExcessRunningBalancePcts(excessRunningBalances, l1Token, refundAmountInL1TokenDecimals);


### PR DESCRIPTION
## What changed
- clears the per-token `excessRunningBalancePromises` cache entry when `_getLatestRunningBalances()` rejects
- keeps successful promises cached for the rest of the run as before

## Why
`InventoryClient` memoizes running-balance lookups by token. If the first lookup rejects, the rejected promise stays in the cache and every later caller for that token fails immediately without retrying.

## Impact
Transient running-balance lookup failures no longer poison the inventory client for the lifetime of the process.

## Validation
- `yarn build`
