### PR TITLE
improve: Clear relayer pending txn promises after failures

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -893,10 +893,11 @@ export class Relayer {
     pendingTxnHashes[chainId] = (async () => {
       return (await fillExecutorClient.executeTxnQueue(chainId, simulate)).map((response) => response.hash);
     })();
-    const txnReceipts = await pendingTxnHashes[chainId];
-    delete pendingTxnHashes[chainId];
-
-    return txnReceipts;
+    try {
+      return await pendingTxnHashes[chainId];
+    } finally {
+      delete pendingTxnHashes[chainId];
+    }
   }
 
   async checkForUnfilledDepositsAndFill(simulate = false): Promise<{ [chainId: number]: Promise<string[]> }> {


### PR DESCRIPTION
## What changed
- wraps `pendingTxnHashes[chainId]` cleanup in `finally`
- ensures a rejected fill execution does not leave a permanently cached rejected promise for that chain

## Why
`Relayer.executeFills()` memoizes an in-flight per-chain transaction queue. If queue execution rejects, the code never deletes the cached promise, so later runs keep thinking the chain still has pending fills and skip execution forever.

## Impact
A transient fill-execution failure no longer wedges relaying on that chain until process restart.

## Validation
- `yarn build`
