### PR TITLE
improve: Reset Binance bootstrap promises after failures

### DIFF
--- a/src/adapter/bridges/BinanceCEXBridge.ts
+++ b/src/adapter/bridges/BinanceCEXBridge.ts
@@ -33,7 +33,7 @@ import ERC20_ABI from "../../common/abi/MinimalERC20.json";
 
 export class BinanceCEXBridge extends BaseBridgeAdapter {
   // Only store the promise in the constructor and evaluate the promise in async blocks.
-  protected readonly binanceApiClientPromise;
+  protected binanceApiClientPromise: Promise<BinanceApi> | undefined;
   protected binanceApiClient: BinanceApi | undefined;
   protected tokenSymbol: string;
   protected l2Provider: Provider;
@@ -53,7 +53,7 @@ export class BinanceCEXBridge extends BaseBridgeAdapter {
     // No L1 gateways needed since no L1 bridge transfers tokens from the EOA.
     super(l2chainId, hubChainId, l1Signer, []);
     // Pull the binance API key from environment and throw if we cannot instantiate this bridge.
-    this.binanceApiClientPromise = getBinanceApiClient(process.env["BINANCE_API_BASE"]);
+    this.binanceApiClientPromise = this._getOrCreateBinanceClientPromise();
 
     // Pass in the WETH ABI as the ERC20 ABI. This is fine to do since we only call `transfer` on `this.l1Bridge`.
     this.l1Bridge = new Contract(l1Token.toNative(), ERC20_ABI, l1Signer);
@@ -195,6 +195,20 @@ export class BinanceCEXBridge extends BaseBridgeAdapter {
   }
 
   protected async getBinanceClient() {
-    return (this.binanceApiClient ??= await this.binanceApiClientPromise);
+    return (this.binanceApiClient ??= await this._getOrCreateBinanceClientPromise());
+  }
+
+  private _getOrCreateBinanceClientPromise(): Promise<BinanceApi> {
+    if (this.binanceApiClientPromise) {
+      return this.binanceApiClientPromise;
+    }
+    const promise = getBinanceApiClient(process.env["BINANCE_API_BASE"]).catch((error) => {
+      if (this.binanceApiClientPromise === promise) {
+        this.binanceApiClientPromise = undefined;
+      }
+      throw error;
+    });
+    this.binanceApiClientPromise = promise;
+    return promise;
   }
 }

--- a/src/adapter/bridges/BinanceCEXBridge.ts
+++ b/src/adapter/bridges/BinanceCEXBridge.ts
@@ -199,7 +199,7 @@ export class BinanceCEXBridge extends BaseBridgeAdapter {
   }
 
   private _getOrCreateBinanceClientPromise(): Promise<BinanceApi> {
-    if (this.binanceApiClientPromise) {
+    if (this.binanceApiClientPromise !== undefined) {
       return this.binanceApiClientPromise;
     }
     const promise = getBinanceApiClient(process.env["BINANCE_API_BASE"]).catch((error) => {

--- a/src/adapter/l2Bridges/BinanceCEXBridge.ts
+++ b/src/adapter/l2Bridges/BinanceCEXBridge.ts
@@ -128,7 +128,7 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
   }
 
   private _getOrCreateBinanceClientPromise(): Promise<BinanceApi> {
-    if (this.binanceApiClientPromise) {
+    if (this.binanceApiClientPromise !== undefined) {
       return this.binanceApiClientPromise;
     }
     const promise = getBinanceApiClient(process.env["BINANCE_API_BASE"]).catch((error) => {

--- a/src/adapter/l2Bridges/BinanceCEXBridge.ts
+++ b/src/adapter/l2Bridges/BinanceCEXBridge.ts
@@ -32,7 +32,7 @@ import { AugmentedTransaction } from "../../clients/TransactionClient";
 
 export class BinanceCEXBridge extends BaseL2BridgeAdapter {
   // Store the promise to be evaluated when needed so that we can construct the bridge synchronously.
-  protected readonly binanceApiClientPromise;
+  protected binanceApiClientPromise: Promise<BinanceApi> | undefined;
   protected binanceApiClient: BinanceApi | undefined;
   // Store the token info for the bridge so we can reference the L1 decimals and L1 token symbol.
   protected l1TokenInfo: L1Token;
@@ -56,7 +56,7 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
 
     this.depositNetwork = BINANCE_NETWORKS[l2chainId];
 
-    this.binanceApiClientPromise = getBinanceApiClient(process.env["BINANCE_API_BASE"]);
+    this.binanceApiClientPromise = this._getOrCreateBinanceClientPromise();
   }
 
   async constructWithdrawToL1Txns(
@@ -124,7 +124,21 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
   }
 
   protected async getBinanceClient() {
-    return (this.binanceApiClient ??= await this.binanceApiClientPromise);
+    return (this.binanceApiClient ??= await this._getOrCreateBinanceClientPromise());
+  }
+
+  private _getOrCreateBinanceClientPromise(): Promise<BinanceApi> {
+    if (this.binanceApiClientPromise) {
+      return this.binanceApiClientPromise;
+    }
+    const promise = getBinanceApiClient(process.env["BINANCE_API_BASE"]).catch((error) => {
+      if (this.binanceApiClientPromise === promise) {
+        this.binanceApiClientPromise = undefined;
+      }
+      throw error;
+    });
+    this.binanceApiClientPromise = promise;
+    return promise;
   }
 
   public pendingWithdrawalLookbackPeriodSeconds(): number {

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -113,7 +113,10 @@ export async function getBinanceApiClient(url = "https://api.binance.com") {
  * @returns A base64 encoded secret key, or undefined if the key is not present in GCKMS.
  */
 async function getBinanceSecretKey(): Promise<string | undefined> {
-  binanceSecretKeyPromise ??= retrieveBinanceSecretKeyFromCLIArgs();
+  binanceSecretKeyPromise ??= retrieveBinanceSecretKeyFromCLIArgs().catch((error) => {
+    binanceSecretKeyPromise = undefined;
+    throw error;
+  });
   return binanceSecretKeyPromise;
 }
 


### PR DESCRIPTION
## What changed
- clears the global Binance secret-key lookup promise when key retrieval rejects
- clears cached Binance bridge client bootstrap promises on failure in both EVM and L2 Binance bridge adapters
- preserves the existing success-path caching behavior

## Why
These call sites memoize one bootstrap promise per process or bridge instance. If the first attempt fails, every later caller reuses the same rejected promise and cannot recover without restarting.

## Impact
Transient Binance bootstrap failures no longer permanently poison secret-key retrieval or Binance bridge client initialization.

## Validation
- `yarn build`
