### PR TITLE
improve: Reset Solana bridge bootstrap promises after failures

### DIFF
--- a/src/adapter/bridges/SolanaUsdcCCTPBridge.ts
+++ b/src/adapter/bridges/SolanaUsdcCCTPBridge.ts
@@ -34,9 +34,10 @@ export class SolanaUsdcCCTPBridge extends BaseBridgeAdapter {
   private readonly l1UsdcTokenAddress: EvmAddress;
   private readonly l2UsdcTokenAddress: SvmAddress;
   private readonly solanaMessageTransmitter: SvmAddress;
+  private readonly l2Provider: SVMProvider;
   // We need the constructor to operate in a synchronous context, but the call to construct an event client is asynchronous, so
   // this bridge holds onto the client promise and lazily evaluates it for when it needs to use it (in `queryL2BridgeFinalizationEvents`).
-  private readonly solanaEventsClientPromise: Promise<arch.svm.SvmCpiEventsClient>;
+  private solanaEventsClientPromise: Promise<arch.svm.SvmCpiEventsClient> | undefined;
   private solanaEventsClient: arch.svm.SvmCpiEventsClient;
   private svmAddress: string;
 
@@ -62,12 +63,9 @@ export class SolanaUsdcCCTPBridge extends BaseBridgeAdapter {
     this.l1Bridge = new Contract(l1Address, l1Abi, l1Signer);
 
     const { address: l2Address } = getCctpV1TokenMessenger(l2chainId);
+    this.l2Provider = l2Provider;
     this.solanaMessageTransmitter = SvmAddress.from(l2Address);
-    this.solanaEventsClientPromise = arch.svm.SvmCpiEventsClient.createFor(
-      l2Provider,
-      l2Address,
-      TokenMessengerMinterIdl
-    );
+    this.solanaEventsClientPromise = this._getOrCreateSolanaEventsClientPromise();
     this.l1UsdcTokenAddress = EvmAddress.from(TOKEN_SYMBOLS_MAP.USDC.addresses[this.hubChainId]);
     this.l2UsdcTokenAddress = SvmAddress.from(TOKEN_SYMBOLS_MAP.USDC.addresses[this.l2chainId]);
   }
@@ -137,7 +135,7 @@ export class SolanaUsdcCCTPBridge extends BaseBridgeAdapter {
     const associatedTokenAddress = await this._getAssociatedTokenAddress();
 
     // Lazily evaluate the events client.
-    this.solanaEventsClient ??= await this.solanaEventsClientPromise;
+    this.solanaEventsClient ??= await this._getOrCreateSolanaEventsClientPromise();
     assert(compareAddressesSimple(l1Token.toNative(), TOKEN_SYMBOLS_MAP.USDC.addresses[this.hubChainId]));
     const l2FinalizationEvents = await this.solanaEventsClient.queryDerivedAddressEvents(
       "MintAndWithdraw",
@@ -172,5 +170,23 @@ export class SolanaUsdcCCTPBridge extends BaseBridgeAdapter {
       this.l2UsdcTokenAddress
     );
     return SvmAddress.from(associatedTokenAddress as string);
+  }
+
+  private _getOrCreateSolanaEventsClientPromise(): Promise<arch.svm.SvmCpiEventsClient> {
+    if (this.solanaEventsClientPromise) {
+      return this.solanaEventsClientPromise;
+    }
+    const promise = arch.svm.SvmCpiEventsClient.createFor(
+      this.l2Provider,
+      this.solanaMessageTransmitter.toNative(),
+      TokenMessengerMinterIdl
+    ).catch((error) => {
+      if (this.solanaEventsClientPromise === promise) {
+        this.solanaEventsClientPromise = undefined;
+      }
+      throw error;
+    });
+    this.solanaEventsClientPromise = promise;
+    return promise;
   }
 }

--- a/src/adapter/bridges/SolanaUsdcCCTPBridge.ts
+++ b/src/adapter/bridges/SolanaUsdcCCTPBridge.ts
@@ -173,7 +173,7 @@ export class SolanaUsdcCCTPBridge extends BaseBridgeAdapter {
   }
 
   private _getOrCreateSolanaEventsClientPromise(): Promise<arch.svm.SvmCpiEventsClient> {
-    if (this.solanaEventsClientPromise) {
+    if (this.solanaEventsClientPromise !== undefined) {
       return this.solanaEventsClientPromise;
     }
     const promise = arch.svm.SvmCpiEventsClient.createFor(

--- a/src/adapter/l2Bridges/SolanaUsdcCCTPBridge.ts
+++ b/src/adapter/l2Bridges/SolanaUsdcCCTPBridge.ts
@@ -187,7 +187,7 @@ export class SolanaUsdcCCTPBridge extends BaseL2BridgeAdapter {
   }
 
   private _getOrCreateSolanaEventsClientPromise(): Promise<arch.svm.SvmCpiEventsClient> {
-    if (this.solanaEventsClientPromise) {
+    if (this.solanaEventsClientPromise !== undefined) {
       return this.solanaEventsClientPromise;
     }
     assert(isDefined(this.svmProvider), "SVM provider should be defined for SolanaUsdcCCTPBridge");
@@ -206,7 +206,7 @@ export class SolanaUsdcCCTPBridge extends BaseL2BridgeAdapter {
   }
 
   private _getOrCreateSvmSignerPromise(): Promise<KeyPairSigner> {
-    if (this.svmSignerPromise) {
+    if (this.svmSignerPromise !== undefined) {
       return this.svmSignerPromise;
     }
     const promise = getKitKeypairFromEvmSigner(this.l1Signer).catch((error) => {

--- a/src/adapter/l2Bridges/SolanaUsdcCCTPBridge.ts
+++ b/src/adapter/l2Bridges/SolanaUsdcCCTPBridge.ts
@@ -48,10 +48,10 @@ export class SolanaUsdcCCTPBridge extends BaseL2BridgeAdapter {
   private IS_CCTP_V2 = false;
   private readonly l1UsdcTokenAddress: EvmAddress;
   private readonly l2UsdcTokenAddress: SvmAddress;
-  private readonly solanaEventsClientPromise: Promise<arch.svm.SvmCpiEventsClient>;
+  private solanaEventsClientPromise: Promise<arch.svm.SvmCpiEventsClient> | undefined;
   private readonly tokenMessengerMinter: Address;
   private readonly messageTransmitter: Address;
-  private readonly svmSignerPromise: Promise<KeyPairSigner>;
+  private svmSignerPromise: Promise<KeyPairSigner> | undefined;
   private svmSigner: KeyPairSigner;
   private solanaEventsClient: arch.svm.SvmCpiEventsClient;
 
@@ -70,13 +70,8 @@ export class SolanaUsdcCCTPBridge extends BaseL2BridgeAdapter {
     this.tokenMessengerMinter = address(l2TokenMessengerAddress);
     this.messageTransmitter = address(l2MessageTransmitterAddress);
 
-    this.solanaEventsClientPromise = arch.svm.SvmCpiEventsClient.createFor(
-      l2Provider,
-      this.tokenMessengerMinter,
-      TokenMessengerMinterIdl
-    );
-
-    this.svmSignerPromise = getKitKeypairFromEvmSigner(this.l1Signer);
+    this.solanaEventsClientPromise = this._getOrCreateSolanaEventsClientPromise();
+    this.svmSignerPromise = this._getOrCreateSvmSignerPromise();
   }
 
   private get l1DestinationDomain(): number {
@@ -91,7 +86,7 @@ export class SolanaUsdcCCTPBridge extends BaseL2BridgeAdapter {
   ): Promise<SolanaTransaction[]> {
     assert(l1Token.eq(this.l1UsdcTokenAddress));
     assert(l2Token.eq(this.l2UsdcTokenAddress));
-    this.svmSigner ??= await this.svmSignerPromise;
+    this.svmSigner ??= await this._getOrCreateSvmSignerPromise();
 
     amount = amount.gt(CCTP_MAX_SEND_AMOUNT) ? CCTP_MAX_SEND_AMOUNT : amount;
     const [cctpDepositAccounts, burnTokenAccount, messageSentEventData] = await Promise.all([
@@ -148,8 +143,8 @@ export class SolanaUsdcCCTPBridge extends BaseL2BridgeAdapter {
     if (!l2Token.eq(this.l2UsdcTokenAddress)) {
       return bnZero;
     }
-    this.svmSigner ??= await this.svmSignerPromise;
-    this.solanaEventsClient ??= await this.solanaEventsClientPromise;
+    this.svmSigner ??= await this._getOrCreateSvmSignerPromise();
+    this.solanaEventsClient ??= await this._getOrCreateSolanaEventsClientPromise();
 
     // @dev: First parameter in MintAndWithdraw is mintRecipient, this should be the same as the fromAddress
     // for all use cases of this adapter.
@@ -189,5 +184,38 @@ export class SolanaUsdcCCTPBridge extends BaseL2BridgeAdapter {
 
   async _getAssociatedTokenAddress(address: Address): Promise<Address> {
     return await getAssociatedTokenAddress(SvmAddress.from(address as string), this.l2UsdcTokenAddress);
+  }
+
+  private _getOrCreateSolanaEventsClientPromise(): Promise<arch.svm.SvmCpiEventsClient> {
+    if (this.solanaEventsClientPromise) {
+      return this.solanaEventsClientPromise;
+    }
+    assert(isDefined(this.svmProvider), "SVM provider should be defined for SolanaUsdcCCTPBridge");
+    const promise = arch.svm.SvmCpiEventsClient.createFor(
+      this.svmProvider,
+      this.tokenMessengerMinter,
+      TokenMessengerMinterIdl
+    ).catch((error) => {
+      if (this.solanaEventsClientPromise === promise) {
+        this.solanaEventsClientPromise = undefined;
+      }
+      throw error;
+    });
+    this.solanaEventsClientPromise = promise;
+    return promise;
+  }
+
+  private _getOrCreateSvmSignerPromise(): Promise<KeyPairSigner> {
+    if (this.svmSignerPromise) {
+      return this.svmSignerPromise;
+    }
+    const promise = getKitKeypairFromEvmSigner(this.l1Signer).catch((error) => {
+      if (this.svmSignerPromise === promise) {
+        this.svmSignerPromise = undefined;
+      }
+      throw error;
+    });
+    this.svmSignerPromise = promise;
+    return promise;
   }
 }


### PR DESCRIPTION
## What changed
- clears cached Solana CCTP event-client bootstrap promises after failures in both bridge variants
- clears the L2 Solana CCTP signer bootstrap promise after failures
- keeps successful initialized clients/signers cached as before

## Why
These bridge classes memoize async Solana bootstrap work for the lifetime of the instance. If the first event-client or signer initialization fails, every later caller gets the same rejected promise and cannot recover without recreating the bridge.

## Impact
Transient Solana bootstrap failures no longer permanently poison the bridge adapters.

## Validation
- `yarn build`
