### PR TITLE
fix: normalize mixed-asset cumulative rebalancing by USD value

### DIFF
--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -162,13 +162,13 @@ Inputs:
 High-level flow:
 
 1. Compute cumulative deficits (`current < threshold`, target refill amount `target - current`) and cumulative excesses (`current > target`, excess amount `current - target`).
-2. Sort cumulative deficits by token `priorityTier` (higher first), then larger deficits first.
-3. Sort cumulative excesses by token `priorityTier` (lower first), then larger excesses first.
+2. Sort cumulative deficits by token `priorityTier` (higher first), then larger USD-normalized deficits first.
+3. Sort cumulative excesses by token `priorityTier` (lower first), then larger USD-normalized excesses first.
 4. For each excess token used to fill a deficit token, sort source chains from `cumulativeTargetBalances[excessToken].chains` by:
    - chain `priorityTier` ascending,
    - then current chain balance descending.
 5. For each candidate source chain, evaluate all destination chains configured for the deficit token that have valid routes, then choose the route with the lowest `getEstimatedCost`.
-6. Cap transfer amount by remaining deficit, remaining excess, chain balance, and configured `maxAmountsToTransfer`.
+6. Cap transfer amount by remaining deficit, remaining excess, chain balance, and configured `maxAmountsToTransfer`. For mixed-asset routes, the client converts between source and destination token amounts through hub-chain USD prices before capping and decrementing remaining deficits.
 7. Enforce max fee pct and adapter pending-order caps before calling `initializeRebalance`.
 
 Design tradeoff:

--- a/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
+++ b/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
@@ -1,20 +1,37 @@
 import {
   assert,
+  acrossApi,
   BigNumber,
   bnZero,
+  coingecko,
   ConvertDecimals,
+  defiLlama,
   fromWei,
   getNetworkName,
   getTokenInfoFromSymbol,
   isDefined,
   mapAsync,
+  PriceClient,
   toBNWei,
 } from "../../utils";
 import { ExcessOrDeficit, RebalanceRoute } from "../utils/interfaces";
 import { sortDeficitFunction, sortExcessFunction } from "../utils/utils";
 import { BaseRebalancerClient } from "./BaseRebalancerClient";
+import { getAcrossHost } from "../../clients/AcrossAPIClient";
 
 export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
+  private readonly priceClient: PriceClient;
+  private readonly tokenPriceCache = new Map<string, BigNumber>();
+
+  constructor(...args: ConstructorParameters<typeof BaseRebalancerClient>) {
+    super(...args);
+    this.priceClient = new PriceClient(this.logger, [
+      new acrossApi.PriceFeed({ host: getAcrossHost(this.config.hubPoolChainId) }),
+      new coingecko.PriceFeed({ apiKey: process.env.COINGECKO_PRO_API_KEY }),
+      new defiLlama.PriceFeed(),
+    ]);
+  }
+
   /**
    * @notice Rebalances cumulative balances of tokens across chains where cumulative token balances are above
    * configured targets to to tokens that have cumulative balances below configured thresholds. Tokens are sourced
@@ -85,12 +102,9 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
       ),
     });
 
-    // Identify all tokens with cumulative balance deficits and sort them by size, assuming that 1 unit of each token
-    // is worth the same amount of USD. Deficits are ranked from most negative to least.
-    // @todo We would need to change this logic if we accept the user setting targets for tokens that are not all
-    // stablecoins.
     const sortedDeficits: ExcessOrDeficit[] = [];
     const sortedExcesses: ExcessOrDeficit[] = [];
+    const tokenPricesUsd = new Map<string, BigNumber>();
     for (const [token, cumulativeBalance] of Object.entries(cumulativeBalances)) {
       // If current balance is below threshold, we want to refill back to target balance.
       const { targetBalance, thresholdBalance, priorityTier } = cumulativeTargetBalances[token];
@@ -102,9 +116,9 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
         const excessAmount = currentCumulativeBalance.sub(targetBalance);
         sortedExcesses.push({ token, amount: excessAmount, chainId: this.config.hubPoolChainId, priorityTier });
       }
+      tokenPricesUsd.set(token, await this._getTokenPriceUsd(token));
     }
-    // Sort deficits by priority from highest to lowest and then by size from largest to smallest.
-    sortedDeficits.sort(sortDeficitFunction);
+    sortedDeficits.sort((deficitA, deficitB) => sortDeficitFunction(deficitA, deficitB, tokenPricesUsd));
     if (sortedDeficits.length > 0) {
       this.logger.debug({
         at: "CumulativeBalanceRebalancerClient.rebalanceInventory",
@@ -116,7 +130,7 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
       });
     }
     // Sort excesses by priority from lowest to highest and then by size from largest to smallest.
-    sortedExcesses.sort(sortExcessFunction);
+    sortedExcesses.sort((excessA, excessB) => sortExcessFunction(excessA, excessB, tokenPricesUsd));
     if (sortedExcesses.length > 0) {
       this.logger.debug({
         at: "CumulativeBalanceRebalancerClient.rebalanceInventory",
@@ -128,6 +142,8 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
       });
     }
 
+    const startingExcesses = Object.fromEntries(sortedExcesses.map(({ token, amount }) => [token, amount]));
+
     // Iterate through the sorted deficits and try to fill as much of it as possible from the configured
     // excess token chain list.
     for (const deficit of sortedDeficits) {
@@ -135,8 +151,8 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
       // Keep track of how much of the deficit we need to fill and also how much excess we have available to send.
       let deficitRemaining = deficitAmount;
       for (const excess of sortedExcesses) {
-        const { token: excessToken, amount: excessAmount } = excess;
-        let excessRemaining = excessAmount;
+        const excessToken = excess.token;
+        let excessRemaining = startingExcesses[excess.token];
 
         // Sort all the chains with excess tokens by priority from lowest to highest and then by current balance from highest to lowest.
         const excessSourceChainsForToken: ExcessOrDeficit[] = Object.entries(
@@ -155,7 +171,7 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
         const sortedExcessSourceChainsForToken = excessSourceChainsForToken.sort(sortExcessFunction);
         this.logger.debug({
           at: "CumulativeBalanceRebalancerClient.rebalanceInventory",
-          message: `Sorted excess source chains for token ${excessToken}`,
+          message: `Sorted excess source chains for token ${excessToken} we can use to fill the deficit of ${deficitToken}`,
           excessSourceChainsForToken: sortedExcessSourceChainsForToken.map(({ chainId, amount }) => {
             return {
               [chainId]: amount.toString(),
@@ -168,7 +184,7 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
         for (const chainWithExcess of sortedExcessSourceChainsForToken) {
           const { chainId, amount: currentBalance } = chainWithExcess;
           // Invariants: If excess or deficit is depleted, exit.
-          if (deficitRemaining.lte(bnZero) || excessRemaining.lte(bnZero)) {
+          if (deficitRemaining.lte(1) || excessRemaining.lte(1)) {
             break;
           }
 
@@ -187,7 +203,12 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
           const chainDecimals = getTokenInfoFromSymbol(excessToken, Number(chainId)).decimals;
           const l1ToChainConverter = ConvertDecimals(l1TokenDecimals, chainDecimals);
           const excessRemainingConverted = l1ToChainConverter(excessRemaining);
-          const deficitRemainingConverted = l1ToChainConverter(deficitRemaining);
+          const deficitRemainingInExcessToken = await this._convertL1TokenAmountForComparison(
+            deficitRemaining,
+            deficitToken,
+            excessToken
+          );
+          const deficitRemainingConverted = l1ToChainConverter(deficitRemainingInExcessToken);
           // The max we can transfer is the minimum of {the remaining deficit, the remaining excess, the max amount to transfer, the current balance}
           const maxAmountToTransfer = this.config.maxAmountsToTransfer[excessToken]?.[chainId];
           let amountToTransferCapped =
@@ -259,6 +280,7 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
             currentBalance: currentBalance.toString(),
             deficitRemaining: deficitRemaining.toString(),
             excessRemaining: excessRemaining.toString(),
+            deficitRemainingConvertedToExcessToken: deficitRemainingConverted.toString(),
             maxAmountToTransfer: maxAmountToTransfer?.toString(),
             cheapestCostRoute: `[${cheapestCostRoute.route.adapter}] ${getNetworkName(
               cheapestCostRoute.route.sourceChain
@@ -283,10 +305,19 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
             continue;
           }
 
-          // Initiate a new rebalance
           const chainToL1Converter = ConvertDecimals(chainDecimals, l1TokenDecimals);
-          deficitRemaining = deficitRemaining.sub(chainToL1Converter(amountToTransferCapped));
-          excessRemaining = excessRemaining.sub(chainToL1Converter(amountToTransferCapped));
+          const amountTransferredL1 = chainToL1Converter(amountToTransferCapped);
+          const deficitReduction = await this._convertL1TokenAmountForComparison(
+            amountTransferredL1,
+            excessToken,
+            deficitToken
+          );
+          const nextDeficitRemaining = deficitReduction.gte(deficitRemaining)
+            ? bnZero
+            : deficitRemaining.sub(deficitReduction);
+          const nextExcessRemaining = excessRemaining.sub(amountTransferredL1);
+          const nextSourceBalance = currentBalance.sub(amountToTransferCapped);
+
           const deficitTokenChainDecimals = getTokenInfoFromSymbol(
             deficitToken,
             cheapestCostRoute.route.destinationChain
@@ -304,25 +335,80 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
             expectedFees: fromWei(cheapestCostRoute.cost, chainDecimals),
             excessTokenCumulativeBalance: fromWei(cumulativeBalances[excessToken], l1TokenDecimals),
             deficitTokenCumulativeBalance: fromWei(cumulativeBalances[deficitToken], deficitTokenL1Decimals),
-            excessTokenCurrentBalance: fromWei(
-              currentBalancesOnChain[cheapestCostRoute.route.sourceChain][excessToken],
-              chainDecimals
-            ),
+            excessTokenCurrentBalance: fromWei(nextSourceBalance, chainDecimals),
             destinationChainCurrentBalance: fromWei(
               currentBalancesOnChain[cheapestCostRoute.route.destinationChain][deficitToken],
               deficitTokenChainDecimals
             ),
-            deficitRemaining: fromWei(deficitRemaining, deficitTokenL1Decimals),
+            deficitRemaining: fromWei(nextDeficitRemaining, deficitTokenL1Decimals),
           });
 
           if (this.config.sendingTransactionsEnabled) {
-            await this.adapters[cheapestCostRoute.route.adapter].initializeRebalance(
+            const initializedAmount = await this.adapters[cheapestCostRoute.route.adapter].initializeRebalance(
               cheapestCostRoute.route,
               amountToTransferCapped
             );
+            if (initializedAmount.eq(bnZero)) {
+              this.logger.debug({
+                at: "CumulativeBalanceRebalancerClient.rebalanceInventory",
+                message: `Adapter ${cheapestCostRoute.route.adapter} declined to initialize rebalance; preserving remaining excess for later routes`,
+                route: cheapestCostRoute.route,
+                requestedAmountToTransfer: amountToTransferCapped.toString(),
+              });
+              continue;
+            }
           }
+
+          // Decrement the deficit remaining, the excess remaining for this token, and the current balance for this
+          // token only after the adapter successfully initializes the rebalance.
+          deficitRemaining = nextDeficitRemaining;
+          excessRemaining = nextExcessRemaining;
+          currentBalancesOnChain[cheapestCostRoute.route.sourceChain][excessToken] = nextSourceBalance;
         }
+
+        // Overwrite the excess remaining for the token to decrement the excess for the next deficit to evaluate.
+        startingExcesses[excessToken] = excessRemaining;
       }
     }
+  }
+
+  private async _convertL1TokenAmountForComparison(
+    amount: BigNumber,
+    fromToken: string,
+    toToken: string
+  ): Promise<BigNumber> {
+    if (fromToken === toToken) {
+      return amount;
+    }
+
+    const fromTokenDecimals = getTokenInfoFromSymbol(fromToken, this.config.hubPoolChainId).decimals;
+    const toTokenDecimals = getTokenInfoFromSymbol(toToken, this.config.hubPoolChainId).decimals;
+
+    const [fromPriceUsd, toPriceUsd] = await Promise.all([
+      this._getTokenPriceUsd(fromToken),
+      this._getTokenPriceUsd(toToken),
+    ]);
+    const fromTokenUnit = toBNWei("1", fromTokenDecimals);
+    const toTokenUnit = toBNWei("1", toTokenDecimals);
+    const usdValue = amount.mul(fromPriceUsd).div(fromTokenUnit);
+    return usdValue.mul(toTokenUnit).div(toPriceUsd);
+  }
+
+  private async _getTokenPriceUsd(token: string): Promise<BigNumber> {
+    // Assume that this client is never run in long lasting operations so we are safe to cache this price once
+    // per run.
+    const cachedPrice = this.tokenPriceCache.get(token);
+    if (cachedPrice) {
+      return cachedPrice;
+    }
+
+    const hubTokenAddress = getTokenInfoFromSymbol(token, this.config.hubPoolChainId).address.toNative();
+    const fixedPriceEnv = process.env[`RELAYER_TOKEN_PRICE_FIXED_${hubTokenAddress}`];
+    const priceUsd = isDefined(fixedPriceEnv)
+      ? toBNWei(fixedPriceEnv)
+      : toBNWei((await this.priceClient.getPriceByAddress(hubTokenAddress)).price);
+    assert(priceUsd.gt(bnZero), `Unable to resolve positive USD price for ${token}`);
+    this.tokenPriceCache.set(token, priceUsd);
+    return priceUsd;
   }
 }

--- a/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
+++ b/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
@@ -112,11 +112,12 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
       if (currentCumulativeBalance.lt(thresholdBalance)) {
         const deficitAmount = targetBalance.sub(cumulativeBalance);
         sortedDeficits.push({ token, amount: deficitAmount, chainId: this.config.hubPoolChainId, priorityTier });
+        tokenPricesUsd.set(token, await this._getTokenPriceUsd(token));
       } else if (currentCumulativeBalance.gt(targetBalance)) {
         const excessAmount = currentCumulativeBalance.sub(targetBalance);
         sortedExcesses.push({ token, amount: excessAmount, chainId: this.config.hubPoolChainId, priorityTier });
+        tokenPricesUsd.set(token, await this._getTokenPriceUsd(token));
       }
-      tokenPricesUsd.set(token, await this._getTokenPriceUsd(token));
     }
     sortedDeficits.sort((deficitA, deficitB) => sortDeficitFunction(deficitA, deficitB, tokenPricesUsd));
     if (sortedDeficits.length > 0) {

--- a/src/rebalancer/utils/utils.ts
+++ b/src/rebalancer/utils/utils.ts
@@ -24,35 +24,50 @@ export async function getRedisCacheForRebalancerStatusTracking(
   return (await getRedisCache(logger, undefined, getRebalancerStatusTrackingNamespace())) as RedisCache;
 }
 
+function compareNormalizedAmounts(
+  excessA: ExcessOrDeficit,
+  excessB: ExcessOrDeficit,
+  tokenPricesUsd?: Map<string, BigNumber>
+): number {
+  const { token: tokenA, amount: amountA, chainId: chainIdA } = excessA;
+  const { token: tokenB, amount: amountB, chainId: chainIdB } = excessB;
+  const tokenADecimals = getTokenInfoFromSymbol(tokenA, Number(chainIdA)).decimals;
+  const tokenBDecimals = getTokenInfoFromSymbol(tokenB, Number(chainIdB)).decimals;
+  const converter = ConvertDecimals(tokenADecimals, tokenBDecimals);
+  const normalizedAmountA =
+    tokenPricesUsd && tokenPricesUsd.has(tokenA) ? amountA.mul(tokenPricesUsd.get(tokenA)) : amountA;
+  const normalizedAmountB =
+    tokenPricesUsd && tokenPricesUsd.has(tokenB) ? amountB.mul(tokenPricesUsd.get(tokenB)) : amountB;
+  if (converter(normalizedAmountA).eq(normalizedAmountB)) {
+    return 0;
+  }
+  return converter(normalizedAmountA).gt(normalizedAmountB) ? -1 : 1;
+}
 // Excesses are always sorted in priority from lowest to highest and then by amount from largest to smallest.
-export function sortExcessFunction(excessA: ExcessOrDeficit, excessB: ExcessOrDeficit): number {
-  const { token: tokenA, amount: amountA, priorityTier: priorityTierA, chainId: chainIdA } = excessA;
-  const { token: tokenB, amount: amountB, priorityTier: priorityTierB, chainId: chainIdB } = excessB;
+export function sortExcessFunction(
+  excessA: ExcessOrDeficit,
+  excessB: ExcessOrDeficit,
+  tokenPricesUsd?: Map<string, BigNumber>
+): number {
+  const { priorityTier: priorityTierA } = excessA;
+  const { priorityTier: priorityTierB } = excessB;
   if (priorityTierA !== priorityTierB) {
     return priorityTierA - priorityTierB;
   }
-  const tokenADecimals = getTokenInfoFromSymbol(tokenA, Number(chainIdA)).decimals;
-  const tokenBDecimals = getTokenInfoFromSymbol(tokenB, Number(chainIdB)).decimals;
-  const converter = ConvertDecimals(tokenADecimals, tokenBDecimals);
-  if (converter(amountA).eq(amountB)) {
-    return 0;
-  }
-  return converter(amountA).gt(amountB) ? -1 : 1;
+  return compareNormalizedAmounts(excessA, excessB, tokenPricesUsd);
 }
 // Deficits are always sorted in priority from highest to lowest and then by amount from largest to smallest.
-export function sortDeficitFunction(deficitA: ExcessOrDeficit, deficitB: ExcessOrDeficit): number {
-  const { token: tokenA, amount: amountA, priorityTier: priorityTierA, chainId: chainIdA } = deficitA;
-  const { token: tokenB, amount: amountB, priorityTier: priorityTierB, chainId: chainIdB } = deficitB;
+export function sortDeficitFunction(
+  deficitA: ExcessOrDeficit,
+  deficitB: ExcessOrDeficit,
+  tokenPricesUsd?: Map<string, BigNumber>
+): number {
+  const { priorityTier: priorityTierA } = deficitA;
+  const { priorityTier: priorityTierB } = deficitB;
   if (priorityTierA !== priorityTierB) {
     return priorityTierB - priorityTierA;
   }
-  const tokenADecimals = getTokenInfoFromSymbol(tokenA, Number(chainIdA)).decimals;
-  const tokenBDecimals = getTokenInfoFromSymbol(tokenB, Number(chainIdB)).decimals;
-  const converter = ConvertDecimals(tokenADecimals, tokenBDecimals);
-  if (converter(amountA).eq(amountB)) {
-    return 0;
-  }
-  return converter(amountA).gt(amountB) ? -1 : 1;
+  return compareNormalizedAmounts(deficitA, deficitB, tokenPricesUsd);
 }
 
 export function getCloidForAccount(account: string): string {

--- a/test/RebalancerClient.cumulativeRebalancing.ts
+++ b/test/RebalancerClient.cumulativeRebalancing.ts
@@ -6,7 +6,7 @@ import {
   MaxPendingOrdersConfig,
   RebalancerConfig,
 } from "../src/rebalancer/RebalancerConfig";
-import { bnZero, EvmAddress, Signer, toBNWei } from "../src/utils";
+import { bnZero, EvmAddress, getTokenInfoFromSymbol, Signer, toBNWei } from "../src/utils";
 import { BigNumber, createSpyLogger, ethers, expect } from "./utils";
 
 describe("RebalancerClient.cumulativeRebalancing", () => {
@@ -27,6 +27,13 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     [DAI]: 18,
     [WETH]: 18,
   };
+  const DEFAULT_FIXED_PRICES = {
+    [USDC]: "1",
+    [USDT]: "0.98",
+    [DAI]: "1",
+    [WETH]: "2000",
+  } as const;
+  let restoreDefaultPrices: (() => void) | undefined;
 
   const amount = (token: string, humanAmount: string): BigNumber => toBNWei(humanAmount, TOKEN_DECIMALS[token]);
 
@@ -74,6 +81,34 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     await client.initialize(rebalanceRoutes);
     return client;
   }
+
+  function withFixedTokenPrices(prices: Record<string, string>): () => void {
+    const previousValues = new Map<string, string | undefined>();
+    for (const [token, price] of Object.entries(prices)) {
+      const address = getTokenInfoFromSymbol(token, HUB_POOL_CHAIN_ID).address.toNative();
+      const envKey = `RELAYER_TOKEN_PRICE_FIXED_${address}`;
+      previousValues.set(envKey, process.env[envKey]);
+      process.env[envKey] = price;
+    }
+    return () => {
+      previousValues.forEach((value, envKey) => {
+        if (value === undefined) {
+          delete process.env[envKey];
+        } else {
+          process.env[envKey] = value;
+        }
+      });
+    };
+  }
+
+  beforeEach(() => {
+    restoreDefaultPrices = withFixedTokenPrices(DEFAULT_FIXED_PRICES);
+  });
+
+  afterEach(() => {
+    restoreDefaultPrices?.();
+    restoreDefaultPrices = undefined;
+  });
 
   it("Caps rebalance amount at lesser of deficit and excess remaining", async function () {
     const deficitToken = USDC;
@@ -154,7 +189,12 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     expect(adapter1.rebalances[0].route.sourceChain).to.equal(CHAIN_A);
     expect(adapter1.rebalances[1].route.sourceChain).to.equal(CHAIN_B);
     expect(adapter1.rebalances[0].amount).to.equal(amount(excessToken, "60"));
-    expect(adapter1.rebalances[1].amount).to.equal(amount(excessToken, "40"));
+    const usdcPrice = toBNWei(DEFAULT_FIXED_PRICES[USDC]);
+    const usdtPrice = toBNWei(DEFAULT_FIXED_PRICES[USDT]);
+    const firstDeficitReduction = amount(excessToken, "60").mul(usdtPrice).div(usdcPrice);
+    const remainingDeficit = amount(deficitToken, "100").sub(firstDeficitReduction);
+    const expectedSecondAmount = remainingDeficit.mul(usdcPrice).div(usdtPrice);
+    expect(adapter1.rebalances[1].amount).to.equal(expectedSecondAmount);
   });
 
   it("Caps rebalance amount at configured max amount per rebalance", async function () {
@@ -224,6 +264,204 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     expect(adapter1.rebalances.length).to.equal(2);
     expect(adapter1.rebalances[0].route.destinationToken).to.equal(USDC);
     expect(adapter1.rebalances[1].route.destinationToken).to.equal(DAI);
+  });
+
+  it("Sorts mixed-asset deficits by USD-normalized size", async function () {
+    const restorePrices = withFixedTokenPrices({
+      [USDC]: "1",
+      [USDT]: "1",
+      [WETH]: "2000",
+    });
+    try {
+      const cumulativeBalances = {
+        [USDC]: amount(USDC, "500"),
+        [WETH]: amount(WETH, "0.5"),
+        [USDT]: amount(USDT, "10000"),
+      };
+      const currentBalances = {
+        [CHAIN_A]: {
+          [USDC]: amount(USDC, "500"),
+          [WETH]: amount(WETH, "0.5"),
+          [USDT]: amount(USDT, "10000"),
+        },
+      };
+      const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
+        [USDC]: buildTarget(USDC, "1000", "900", 0, { [CHAIN_A]: 0 }),
+        [WETH]: buildTarget(WETH, "1", "0.9", 0, { [CHAIN_A]: 0 }),
+        [USDT]: buildTarget(USDT, "0", "0", 0, { [CHAIN_A]: 0 }),
+      };
+      const baseSigner = ethers.Wallet.createRandom();
+      const adapter1 = new MockRebalancerAdapter(baseSigner);
+      const rebalancerClient = await createClient(
+        cumulativeTargetBalances,
+        { adapter1 },
+        [makeRoute(CHAIN_A, CHAIN_A, USDT, USDC, "adapter1"), makeRoute(CHAIN_A, CHAIN_A, USDT, WETH, "adapter1")],
+        {},
+        {},
+        baseSigner
+      );
+
+      await rebalancerClient.rebalanceInventory(cumulativeBalances, currentBalances, MAX_FEE_PCT);
+
+      expect(adapter1.rebalances.length).to.equal(2);
+      expect(adapter1.rebalances[0].route.destinationToken).to.equal(WETH);
+      expect(adapter1.rebalances[1].route.destinationToken).to.equal(USDC);
+    } finally {
+      restorePrices();
+    }
+  });
+
+  it("Decrements excess remaining after each evaluated deficit", async function () {
+    const cumulativeBalances = {
+      [USDC]: bnZero,
+      [DAI]: bnZero,
+      [USDT]: amount(USDT, "100"),
+    };
+    const currentBalances = {
+      [CHAIN_A]: {
+        [USDC]: bnZero,
+        [DAI]: bnZero,
+        [USDT]: amount(USDT, "100"),
+      },
+    };
+    const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
+      [USDC]: buildTarget(USDC, "80", "70", 2, { [CHAIN_A]: 0 }),
+      [DAI]: buildTarget(DAI, "80", "70", 1, { [CHAIN_A]: 0 }),
+      [USDT]: buildTarget(USDT, "0", "0", 0, { [CHAIN_A]: 0 }),
+    };
+    const baseSigner = ethers.Wallet.createRandom();
+    const adapter1 = new MockRebalancerAdapter(baseSigner);
+    const rebalancerClient = await createClient(
+      cumulativeTargetBalances,
+      { adapter1 },
+      [makeRoute(CHAIN_A, CHAIN_A, USDT, USDC, "adapter1"), makeRoute(CHAIN_A, CHAIN_A, USDT, DAI, "adapter1")],
+      {},
+      {},
+      baseSigner
+    );
+
+    await rebalancerClient.rebalanceInventory(cumulativeBalances, currentBalances, MAX_FEE_PCT);
+
+    const usdcPrice = toBNWei(DEFAULT_FIXED_PRICES[USDC]);
+    const usdtPrice = toBNWei(DEFAULT_FIXED_PRICES[USDT]);
+    const expectedFirstAmount = amount(USDC, "80").mul(usdcPrice).div(usdtPrice);
+    const expectedSecondAmount = amount(USDT, "100").sub(expectedFirstAmount);
+
+    expect(adapter1.rebalances.length).to.equal(2);
+    expect(adapter1.rebalances[0].route.destinationToken).to.equal(USDC);
+    expect(adapter1.rebalances[0].amount).to.equal(expectedFirstAmount);
+    expect(adapter1.rebalances[1].route.destinationToken).to.equal(DAI);
+    expect(adapter1.rebalances[1].amount).to.equal(expectedSecondAmount);
+    const totalTransferred = adapter1.rebalances.reduce((acc, rebalance) => acc.add(rebalance.amount), bnZero);
+    expect(totalTransferred).to.equal(amount(USDT, "100"));
+  });
+
+  it("Uses updated excess source-chain balances after prior deficit transfers", async function () {
+    const restorePrices = withFixedTokenPrices({
+      [USDC]: "1",
+      [USDT]: "1",
+      [DAI]: "1",
+    });
+    try {
+      const cumulativeBalances = {
+        [USDC]: bnZero,
+        [DAI]: bnZero,
+        [USDT]: amount(USDT, "110"),
+      };
+      const currentBalances = {
+        [CHAIN_A]: {
+          [USDC]: bnZero,
+          [DAI]: bnZero,
+          [USDT]: amount(USDT, "60"),
+        },
+        [CHAIN_B]: {
+          [USDT]: amount(USDT, "50"),
+        },
+      };
+      const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
+        [USDC]: buildTarget(USDC, "60", "50", 2, { [CHAIN_A]: 0 }),
+        [DAI]: buildTarget(DAI, "60", "50", 1, { [CHAIN_A]: 0 }),
+        [USDT]: buildTarget(USDT, "0", "0", 0, {
+          [CHAIN_A]: 0,
+          [CHAIN_B]: 0,
+        }),
+      };
+      const baseSigner = ethers.Wallet.createRandom();
+      const adapter1 = new MockRebalancerAdapter(baseSigner);
+      const rebalancerClient = await createClient(
+        cumulativeTargetBalances,
+        { adapter1 },
+        [
+          makeRoute(CHAIN_A, CHAIN_A, USDT, USDC, "adapter1"),
+          makeRoute(CHAIN_B, CHAIN_A, USDT, USDC, "adapter1"),
+          makeRoute(CHAIN_A, CHAIN_A, USDT, DAI, "adapter1"),
+          makeRoute(CHAIN_B, CHAIN_A, USDT, DAI, "adapter1"),
+        ],
+        {},
+        {},
+        baseSigner
+      );
+
+      await rebalancerClient.rebalanceInventory(cumulativeBalances, currentBalances, MAX_FEE_PCT);
+
+      expect(adapter1.rebalances.length).to.equal(2);
+      expect(adapter1.rebalances[0].route.destinationToken).to.equal(USDC);
+      expect(adapter1.rebalances[0].route.sourceChain).to.equal(CHAIN_A);
+      expect(adapter1.rebalances[0].amount).to.equal(amount(USDT, "60"));
+      expect(adapter1.rebalances[1].route.destinationToken).to.equal(DAI);
+      expect(adapter1.rebalances[1].route.sourceChain).to.equal(CHAIN_B);
+      expect(adapter1.rebalances[1].amount).to.equal(amount(USDT, "50"));
+    } finally {
+      restorePrices();
+    }
+  });
+
+  it("Preserves excess for later deficits when an adapter declines to initialize", async function () {
+    const restorePrices = withFixedTokenPrices({
+      [USDC]: "1",
+      [USDT]: "1",
+      [DAI]: "1",
+    });
+    try {
+      const cumulativeBalances = {
+        [USDC]: bnZero,
+        [DAI]: bnZero,
+        [USDT]: amount(USDT, "100"),
+      };
+      const currentBalances = {
+        [CHAIN_A]: {
+          [USDC]: bnZero,
+          [DAI]: bnZero,
+          [USDT]: amount(USDT, "100"),
+        },
+      };
+      const usdtToUsdc = makeRoute(CHAIN_A, CHAIN_A, USDT, USDC, "adapter1");
+      const usdtToDai = makeRoute(CHAIN_A, CHAIN_A, USDT, DAI, "adapter1");
+      const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
+        [USDC]: buildTarget(USDC, "80", "70", 2, { [CHAIN_A]: 0 }),
+        [DAI]: buildTarget(DAI, "80", "70", 1, { [CHAIN_A]: 0 }),
+        [USDT]: buildTarget(USDT, "0", "0", 0, { [CHAIN_A]: 0 }),
+      };
+      const baseSigner = ethers.Wallet.createRandom();
+      const adapter1 = new MockRebalancerAdapter(baseSigner);
+      adapter1.setInitializeRebalanceResult(usdtToUsdc, bnZero);
+      const rebalancerClient = await createClient(
+        cumulativeTargetBalances,
+        { adapter1 },
+        [usdtToUsdc, usdtToDai],
+        {},
+        {},
+        baseSigner
+      );
+
+      await rebalancerClient.rebalanceInventory(cumulativeBalances, currentBalances, MAX_FEE_PCT);
+
+      expect(adapter1.rebalances.length).to.equal(1);
+      expect(adapter1.rebalances[0].route.destinationToken).to.equal(DAI);
+      expect(adapter1.rebalances[0].amount).to.equal(amount(USDT, "80"));
+    } finally {
+      restorePrices();
+    }
   });
 
   it("Iterates through excesses in sorted order", async function () {
@@ -336,6 +574,45 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     expect(adapter1.rebalances.length).to.equal(0);
     expect(adapter2.rebalances.length).to.equal(1);
     expect(adapter2.rebalances[0].route.destinationChain).to.equal(CHAIN_A);
+  });
+
+  it("Sizes WETH deficits using excess-token USD value instead of raw decimals", async function () {
+    const restorePrices = withFixedTokenPrices({
+      [USDC]: "1",
+      [WETH]: "2000",
+    });
+    try {
+      const cumulativeBalances = {
+        [USDC]: amount(USDC, "5000"),
+        [WETH]: bnZero,
+      };
+      const currentBalances = {
+        [CHAIN_A]: { [USDC]: amount(USDC, "5000"), [WETH]: bnZero },
+      };
+      const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
+        [USDC]: buildTarget(USDC, "0", "0", 0, { [CHAIN_A]: 0 }),
+        [WETH]: buildTarget(WETH, "2", "1.5", 0, { [CHAIN_A]: 0 }),
+      };
+      const baseSigner = ethers.Wallet.createRandom();
+      const adapter1 = new MockRebalancerAdapter(baseSigner);
+      const rebalancerClient = await createClient(
+        cumulativeTargetBalances,
+        { adapter1 },
+        [makeRoute(CHAIN_A, CHAIN_A, USDC, WETH, "adapter1")],
+        {},
+        {},
+        baseSigner
+      );
+
+      await rebalancerClient.rebalanceInventory(cumulativeBalances, currentBalances, MAX_FEE_PCT);
+
+      expect(adapter1.rebalances.length).to.equal(1);
+      expect(adapter1.rebalances[0].route.sourceToken).to.equal(USDC);
+      expect(adapter1.rebalances[0].route.destinationToken).to.equal(WETH);
+      expect(adapter1.rebalances[0].amount).to.equal(amount(USDC, "4000"));
+    } finally {
+      restorePrices();
+    }
   });
 
   it("Respects max pending orders per adapter limit", async function () {
@@ -495,6 +772,7 @@ class MockRebalancerAdapter implements RebalancerAdapter {
   public baseSignerAddress!: EvmAddress;
   public rebalances: { route: RebalanceRoute; amount: BigNumber }[] = [];
   public estimatedCostMapping: { [route: string]: BigNumber } = {};
+  public initializeRebalanceResultMapping: { [route: string]: BigNumber } = {};
   private pendingOrders: string[] | undefined;
   private pendingRebalances: { [chainId: number]: { [token: string]: BigNumber } } = {};
   private readonly baseSigner: Signer;
@@ -512,8 +790,11 @@ class MockRebalancerAdapter implements RebalancerAdapter {
   }
 
   initializeRebalance(rebalanceRoute: RebalanceRoute, amountToTransfer: BigNumber): Promise<BigNumber> {
-    this.rebalances.push({ route: rebalanceRoute, amount: amountToTransfer });
-    return Promise.resolve(amountToTransfer);
+    const result = this.initializeRebalanceResultMapping[JSON.stringify(rebalanceRoute)] ?? amountToTransfer;
+    if (result.gt(bnZero)) {
+      this.rebalances.push({ route: rebalanceRoute, amount: amountToTransfer });
+    }
+    return Promise.resolve(result);
   }
 
   updateRebalanceStatuses(): Promise<void> {
@@ -542,6 +823,10 @@ class MockRebalancerAdapter implements RebalancerAdapter {
 
   setEstimatedCost(route: RebalanceRoute, cost: BigNumber): void {
     this.estimatedCostMapping[JSON.stringify(route)] = cost;
+  }
+
+  setInitializeRebalanceResult(route: RebalanceRoute, amount: BigNumber): void {
+    this.initializeRebalanceResultMapping[JSON.stringify(route)] = amount;
   }
 
   getEstimatedCost(rebalanceRoute: RebalanceRoute, amountToTransfer: BigNumber, debugLog: boolean): Promise<BigNumber> {


### PR DESCRIPTION
## What changed
- added hub-chain USD price lookups to cumulative rebalancing so deficits and excesses can be compared across non-parity assets
- updated mixed-asset sizing to convert remaining deficits into the excess token before capping transfer amounts
- decremented shared excess only after an adapter actually initializes a rebalance, preserving later routing attempts when `initializeRebalance()` returns `0`
- added regression coverage for USD-normalized sorting, mixed-asset sizing, shared excess depletion across multiple deficits, and zero-init adapter behavior
- documented the USD-normalized ordering and mixed-asset sizing behavior in the rebalancer README

## Why
The cumulative rebalancer previously assumed that one unit of every configured token had the same value. That works for same-asset or near-parity stablecoin flows, but it mis-sizes mixed-asset rebalances such as `USDC -> WETH` and can rank deficits and excesses incorrectly. It also carried decremented shared excess forward even when an adapter declined to open the rebalance.

## Impact
- mixed-asset deficits and excesses are prioritized by USD-normalized size instead of raw token units
- mixed-asset rebalance sizing is based on value conversion rather than decimal conversion alone
- failed late-stage initialization checks no longer consume shared excess for later deficits in the same run

## Validation
- `yarn test --bail test/RebalancerClient.cumulativeRebalancing.ts`