### PR TITLE
feat: add direct Binance same-asset stablecoin rebalance routes

### DIFF
--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -21,6 +21,21 @@ A `RebalanceRoute` defines:
 
 Routes are assembled by the rebalancer construction layer and passed at client initialization time (`initialize(rebalanceRoutes)`). The mode clients then filter to routes that are valid for current balances/config.
 
+The built-in production route set is generated in `src/rebalancer/buildRebalanceRoutes.ts`. For the current stablecoin route families, it covers:
+
+- `USDC <-> USDT` swap routes on Binance and Hyperliquid
+- same-asset `USDC <-> USDC` routes on CCTP and direct Binance USDC networks
+- same-asset `USDT <-> USDT` routes on OFT and direct Binance USDT networks
+
+Route construction keeps two token-keyed chain maps:
+
+- `BINANCE_NETWORKS_BY_SYMBOL`: direct Binance deposit and withdrawal networks known for each token
+- `REBALANCE_CHAINS_BY_SYMBOL`: the narrower set of chains this repo currently enables for rebalancing that token
+
+Operational note:
+
+- Same-asset `USDC <-> USDC` and `USDT <-> USDT` Binance routes are included deliberately so they can compete on estimated cost against CCTP and OFT paths, but they are only generated when both sides are direct Binance networks for that asset.
+
 ### Rebalancer Adapter
 
 Adapters in `src/rebalancer/adapters/` initiate and progress multi-stage swap workflows. The interface currently is:

--- a/src/rebalancer/RebalancerClientHelper.ts
+++ b/src/rebalancer/RebalancerClientHelper.ts
@@ -7,6 +7,7 @@ import { CumulativeBalanceRebalancerClient } from "./clients/CumulativeBalanceRe
 import { ReadOnlyRebalancerClient } from "./clients/ReadOnlyRebalancerClient";
 
 import { RebalancerConfig } from "./RebalancerConfig";
+import { buildRebalanceRoutes } from "./buildRebalanceRoutes";
 import { RebalancerAdapter, RebalanceRoute } from "./utils/interfaces";
 
 function constructRebalancerDependencies(
@@ -37,91 +38,7 @@ function constructRebalancerDependencies(
     oftAdapter
   );
   const adapterMap = { hyperliquid: hyperliquidAdapter, binance: binanceAdapter, cctp: cctpAdapter, oft: oftAdapter };
-
-  // Following two variables are hardcoded to aid testing:
-  const usdtChains = [
-    CHAIN_IDs.HYPEREVM,
-    CHAIN_IDs.ARBITRUM,
-    CHAIN_IDs.OPTIMISM,
-    CHAIN_IDs.MAINNET,
-    CHAIN_IDs.UNICHAIN,
-    CHAIN_IDs.MONAD,
-    CHAIN_IDs.BSC,
-  ];
-  const usdcChains = [
-    CHAIN_IDs.HYPEREVM,
-    CHAIN_IDs.ARBITRUM,
-    CHAIN_IDs.OPTIMISM,
-    CHAIN_IDs.MAINNET,
-    CHAIN_IDs.BASE,
-    CHAIN_IDs.UNICHAIN,
-    CHAIN_IDs.MONAD,
-    CHAIN_IDs.BSC,
-  ];
-  const rebalanceRoutes: RebalanceRoute[] = [];
-  for (const usdtChain of usdtChains) {
-    for (const usdcChain of usdcChains) {
-      if (!rebalancerConfig.chainIds.includes(usdtChain) || !rebalancerConfig.chainIds.includes(usdcChain)) {
-        continue;
-      }
-      for (const adapter of ["binance", "hyperliquid"]) {
-        // Handle exceptions:
-        if (adapter !== "binance" && (usdtChain === CHAIN_IDs.BSC || usdcChain === CHAIN_IDs.BSC)) {
-          continue;
-        }
-
-        rebalanceRoutes.push({
-          sourceChain: usdtChain,
-          sourceToken: "USDT",
-          destinationChain: usdcChain,
-          destinationToken: "USDC",
-          adapter,
-        });
-        rebalanceRoutes.push({
-          sourceChain: usdcChain,
-          sourceToken: "USDC",
-          destinationChain: usdtChain,
-          destinationToken: "USDT",
-          adapter,
-        });
-      }
-    }
-  }
-
-  for (const usdtChain of usdtChains.filter((chain) => chain !== CHAIN_IDs.BSC)) {
-    for (const otherUsdtChain of usdtChains.filter((chain) => chain !== CHAIN_IDs.BSC)) {
-      if (!rebalancerConfig.chainIds.includes(usdtChain) || !rebalancerConfig.chainIds.includes(otherUsdtChain)) {
-        continue;
-      }
-      if (usdtChain === otherUsdtChain) {
-        continue;
-      }
-      rebalanceRoutes.push({
-        sourceChain: usdtChain,
-        sourceToken: "USDT",
-        destinationChain: otherUsdtChain,
-        destinationToken: "USDT",
-        adapter: "oft",
-      });
-    }
-  }
-  for (const usdcChain of usdcChains.filter((chain) => chain !== CHAIN_IDs.BSC)) {
-    for (const otherUsdcChain of usdcChains.filter((chain) => chain !== CHAIN_IDs.BSC)) {
-      if (!rebalancerConfig.chainIds.includes(usdcChain) || !rebalancerConfig.chainIds.includes(otherUsdcChain)) {
-        continue;
-      }
-      if (usdcChain === otherUsdcChain) {
-        continue;
-      }
-      rebalanceRoutes.push({
-        sourceChain: usdcChain,
-        sourceToken: "USDC",
-        destinationChain: otherUsdcChain,
-        destinationToken: "USDC",
-        adapter: "cctp",
-      });
-    }
-  }
+  const rebalanceRoutes: RebalanceRoute[] = buildRebalanceRoutes(rebalancerConfig);
 
   // @todo: Add test-net support for this client. For now, we only support production and we do not construct
   // any adapters or routes when running on test net.

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -19,6 +19,7 @@ import {
   getBinanceApiClient,
   getBinanceTransactionTypeKey,
   getBinanceWithdrawals,
+  getCurrentTime,
   getNetworkName,
   getProvider,
   isDefined,
@@ -69,6 +70,10 @@ export function isTerminalBinanceWithdrawal(status?: number): boolean {
     default:
       return false;
   }
+}
+
+function supportsBinanceIntermediateBridgeToken(token: string): boolean {
+  return token === "USDC" || token === "USDT";
 }
 
 export function deriveBinanceSpotMarketMeta(
@@ -285,7 +290,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     }
     for (const cloid of pendingDeposits) {
       const orderDetails = await this._redisGetOrderDetails(cloid, this.baseSignerAddress);
-      const { sourceToken, sourceChain, amountToTransfer } = orderDetails;
+      const { sourceToken, sourceChain, destinationToken, destinationChain, amountToTransfer } = orderDetails;
 
       const binanceBalance = await this._getBinanceBalance(sourceToken);
       const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
@@ -303,11 +308,26 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         availableBalance: binanceBalanceWei.toString(),
         requiredBalance: amountToTransfer.toString(),
       });
-      await this._placeMarketOrder(cloid, orderDetails);
-      await this._redisUpdateOrderStatus(cloid, STATUS.PENDING_DEPOSIT, STATUS.PENDING_SWAP, this.baseSignerAddress);
+      if (this._routeRequiresSwap(sourceToken, destinationToken)) {
+        await this._placeMarketOrder(cloid, orderDetails);
+        await this._redisUpdateOrderStatus(cloid, STATUS.PENDING_DEPOSIT, STATUS.PENDING_SWAP, this.baseSignerAddress);
+      } else {
+        await this._withdraw(
+          cloid,
+          Number(fromWei(amountToTransfer, sourceTokenInfo.decimals)),
+          destinationToken,
+          destinationChain
+        );
+        await this._redisUpdateOrderStatus(
+          cloid,
+          STATUS.PENDING_DEPOSIT,
+          STATUS.PENDING_WITHDRAWAL,
+          this.baseSignerAddress
+        );
+      }
       // Delay a bit before checking balances to withdraw so we can give this function a chance to successively place
-      // a market order successfully and subsequently withdraw the filled order. It takes a short time for the just filled
-      // order to be reflected in the balance.
+      // a market order successfully and subsequently withdraw the filled order. It also gives direct same-coin
+      // withdrawals a short time to be reflected in Binance/accounting state.
       await this._wait(10);
     }
 
@@ -370,9 +390,11 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       // a bridge to the final non-Binance network destination chain if necessary.
 
       const orderDetails = await this._redisGetOrderDetails(cloid, this.baseSignerAddress);
-      const { destinationToken, destinationChain } = orderDetails;
-      const { matchingFill } = await this._getMatchingFillForCloid(cloid, this.baseSignerAddress);
-      if (!matchingFill) {
+      const { sourceToken, destinationToken, destinationChain } = orderDetails;
+      const matchingFill = this._routeRequiresSwap(sourceToken, destinationToken)
+        ? (await this._getMatchingFillForCloid(cloid, this.baseSignerAddress))?.matchingFill
+        : undefined;
+      if (this._routeRequiresSwap(sourceToken, destinationToken) && !matchingFill) {
         throw new Error(`No matching fill found for cloid ${cloid} that has status PENDING_WITHDRAWAL`);
       }
       const binanceWithdrawalNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
@@ -380,7 +402,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       if (!initiatedWithdrawalId) {
         this.logger.debug({
           at: "BinanceStablecoinSwapAdapter.updateRebalanceStatuses",
-          message: `Cannot find initiated withdrawal for cloid ${cloid} which filled at ${matchingFill.time}, waiting`,
+          message: `Cannot find initiated withdrawal for cloid ${cloid}, waiting`,
           cloid: cloid,
           matchingFill: matchingFill,
         });
@@ -390,8 +412,9 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       const { unfinalizedWithdrawals, finalizedWithdrawals, failedWithdrawals } = await this._getBinanceWithdrawals(
         orderDetails.destinationToken,
         binanceWithdrawalNetwork,
-        Math.floor(matchingFill.time / 1000) - 5 * 60, // Floor this so we can grab the initiated withdrawal data whose
-        // ID we've already saved into Redis
+        isDefined(matchingFill) ? Math.floor(matchingFill.time / 1000) - 5 * 60 : getCurrentTime() - 6 * 60 * 60,
+        // If there is a matching fill, then look up withdrawals after the fill time. If there is no fill because
+        // it's not a swap route, then use a conservative lookback period.
         this.baseSignerAddress.toNative()
       );
       const failedWithdrawal = failedWithdrawals.find((withdrawal) => withdrawal.id === initiatedWithdrawalId);
@@ -407,7 +430,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         await this._redisUpdateOrderStatus(
           cloid,
           STATUS.PENDING_WITHDRAWAL,
-          STATUS.PENDING_SWAP,
+          this._routeRequiresSwap(sourceToken, destinationToken) ? STATUS.PENDING_SWAP : STATUS.PENDING_DEPOSIT,
           this.baseSignerAddress
         );
         continue;
@@ -430,7 +453,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       if (!withdrawalDetails) {
         this.logger.debug({
           at: "BinanceStablecoinSwapAdapter.updateRebalanceStatuses",
-          message: `Cannot find withdrawal details in Binance API response for withdrawal history for cloid ${cloid} which filled at ${matchingFill.time}, waiting....`,
+          message: `Cannot find withdrawal details in Binance API response for withdrawal history for cloid ${cloid}, waiting....`,
         });
         continue;
       }
@@ -438,6 +461,10 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       // Check if we need to bridge the withdrawal to the final destination chain:
       const requiresBridgeAfterWithdrawal = binanceWithdrawalNetwork !== destinationChain;
       if (requiresBridgeAfterWithdrawal) {
+        assert(
+          supportsBinanceIntermediateBridgeToken(destinationToken),
+          `Destination token ${destinationToken} cannot use an intermediate bridge leg out of Binance`
+        );
         const balance = await this._getERC20Balance(
           binanceWithdrawalNetwork,
           this._getTokenInfo(destinationToken, binanceWithdrawalNetwork).address.toNative(),
@@ -559,16 +586,20 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const pendingWithdrawals = await this._redisGetPendingWithdrawals(account);
     for (const cloid of pendingWithdrawals) {
       const orderDetails = await this._redisGetOrderDetails(cloid, account);
-      const { destinationChain, destinationToken, sourceChain, sourceToken, amountToTransfer } = orderDetails;
-      const { matchingFill } = await this._getMatchingFillForCloid(cloid, account);
-      assert(isDefined(matchingFill), "Matching fill should be defined for order with status PENDING_WITHDRAWAL");
+      const { destinationChain, destinationToken, sourceToken } = orderDetails;
+      const matchingFill = this._routeRequiresSwap(sourceToken, destinationToken)
+        ? (await this._getMatchingFillForCloid(cloid, account))?.matchingFill
+        : undefined;
+      if (this._routeRequiresSwap(sourceToken, destinationToken)) {
+        assert(isDefined(matchingFill), "Matching fill should be defined for order with status PENDING_WITHDRAWAL");
+      }
 
       const binanceWithdrawalNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
       const initiatedWithdrawalId = await this._redisGetInitiatedWithdrawalId(cloid);
       if (!initiatedWithdrawalId) {
         this.logger.debug({
           at: "BinanceStablecoinSwapAdapter.getPendingRebalances",
-          message: `Cannot find initiated withdrawal for cloid ${cloid} which filled at ${matchingFill.time}, waiting`,
+          message: `Cannot find initiated withdrawal for cloid ${cloid}, waiting`,
           cloid: cloid,
           matchingFill: matchingFill,
         });
@@ -577,8 +608,9 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       const { unfinalizedWithdrawals, finalizedWithdrawals } = await this._getBinanceWithdrawals(
         destinationToken,
         binanceWithdrawalNetwork,
-        Math.floor(matchingFill.time / 1000) - 5 * 60, // Floor this so we can grab the initiated withdrawal data whose
-        // ID we've already saved into Redis
+        isDefined(matchingFill) ? Math.floor(matchingFill.time / 1000) - 5 * 60 : getCurrentTime() - 6 * 60 * 60,
+        // If there is a matching fill, then look up withdrawals after the fill time. If there is no fill because
+        // it's not a swap route, then use a conservative lookback period.
         account.toNative()
       );
       const initiatedWithdrawalIsUnfinalized = unfinalizedWithdrawals.find(
@@ -599,20 +631,18 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       if (!withdrawalDetails) {
         this.logger.debug({
           at: "BinanceStablecoinSwapAdapter.getPendingRebalances",
-          message: `Cannot find withdrawal details for cloid ${cloid} which filled at ${matchingFill.time}, waiting...`,
+          message: `Cannot find withdrawal details for cloid ${cloid}, waiting...`,
         });
         continue;
       }
-      const convertedAmount = await this._convertSourceToDestination(
-        sourceToken,
-        sourceChain,
-        destinationToken,
-        destinationChain,
-        amountToTransfer
+      const binanceWithdrawalNetworkTokenInfo = this._getTokenInfo(destinationToken, binanceWithdrawalNetwork);
+      const withdrawAmountWei = toBNWei(
+        truncate(withdrawalDetails.amount, binanceWithdrawalNetworkTokenInfo.decimals),
+        binanceWithdrawalNetworkTokenInfo.decimals
       );
       this.logger.debug({
         at: "BinanceStablecoinSwapAdapter.getPendingRebalances",
-        message: `Withdrawal for order ${cloid} has finalized, subtracting the order's virtual balance of ${convertedAmount.toString()} from binance withdrawal network ${binanceWithdrawalNetwork}`,
+        message: `Withdrawal for order ${cloid} has finalized, subtracting the order's virtual balance of ${withdrawAmountWei.toString()} from binance withdrawal network ${binanceWithdrawalNetwork}`,
         cloid: cloid,
         orderDetails: orderDetails,
         withdrawalDetails,
@@ -620,7 +650,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       pendingRebalances[binanceWithdrawalNetwork] ??= {};
       pendingRebalances[binanceWithdrawalNetwork][destinationToken] = (
         pendingRebalances[binanceWithdrawalNetwork][destinationToken] ?? bnZero
-      ).sub(convertedAmount);
+      ).sub(withdrawAmountWei);
     }
 
     return pendingRebalances;
@@ -634,6 +664,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     this._assertInitialized();
     this._assertRouteIsSupported(rebalanceRoute);
     const { sourceChain, sourceToken, destinationToken, destinationChain } = rebalanceRoute;
+    const routeRequiresSwap = this._routeRequiresSwap(sourceToken, destinationToken);
 
     const destinationCoin = await this._getAccountCoins(destinationToken);
     const destinationEntrypointNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
@@ -680,22 +711,24 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     // tick size. We try not to precompute the size required to place an order here because the price might change
     // and the amount transferred in might be insufficient to place the order later on, producing more dust or an
     // error.
-    const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
-    const minimumOrderSize = spotMarketMeta.isBuy
-      ? await this._convertDestinationToSource(
-          destinationToken,
-          destinationChain,
-          sourceToken,
-          sourceChain,
-          toBNWei(spotMarketMeta.minimumOrderSize, this._getTokenInfo(destinationToken, destinationChain).decimals)
-        )
-      : toBNWei(spotMarketMeta.minimumOrderSize, sourceTokenInfo.decimals);
-    if (amountToTransfer.lt(minimumOrderSize)) {
-      this.logger.debug({
-        at: "BinanceStablecoinSwapAdapter.initializeRebalance",
-        message: `Amount to transfer ${amountToTransfer.toString()} is less than minimum order size ${minimumOrderSize.toString()}`,
-      });
-      return bnZero;
+    if (routeRequiresSwap) {
+      const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
+      const minimumOrderSize = spotMarketMeta.isBuy
+        ? await this._convertDestinationToSource(
+            destinationToken,
+            destinationChain,
+            sourceToken,
+            sourceChain,
+            toBNWei(spotMarketMeta.minimumOrderSize, this._getTokenInfo(destinationToken, destinationChain).decimals)
+          )
+        : toBNWei(spotMarketMeta.minimumOrderSize, sourceTokenInfo.decimals);
+      if (amountToTransfer.lt(minimumOrderSize)) {
+        this.logger.debug({
+          at: "BinanceStablecoinSwapAdapter.initializeRebalance",
+          message: `Amount to transfer ${amountToTransfer.toString()} is less than minimum order size ${minimumOrderSize.toString()}`,
+        });
+        return bnZero;
+      }
     }
 
     const cloid = await this._redisGetNextCloid();
@@ -772,11 +805,14 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   ): Promise<BigNumber> {
     this._assertRouteIsSupported(rebalanceRoute);
     const { sourceToken, destinationToken, sourceChain, destinationChain } = rebalanceRoute;
-    const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
+    const routeRequiresSwap = this._routeRequiresSwap(sourceToken, destinationToken);
+    const spotMarketMeta = routeRequiresSwap
+      ? await this._getSpotMarketMetaForRoute(sourceToken, destinationToken)
+      : undefined;
     // Commission is denominated in percentage points.
-    const tradeFeePct = (await this._getTradeFees()).find(
-      (fee) => fee.symbol === spotMarketMeta.symbol
-    ).takerCommission;
+    const tradeFeePct = routeRequiresSwap
+      ? (await this._getTradeFees()).find((fee) => fee.symbol === spotMarketMeta.symbol).takerCommission
+      : "0";
     const tradeFee = toBNWei(tradeFeePct, 18).mul(amountToTransfer).div(toBNWei(100, 18));
     const destinationCoin = await this._getAccountCoins(destinationToken);
     const destinationEntrypointNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
@@ -794,19 +830,22 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       withdrawFee
     );
 
-    const { latestPrice } = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, amountToTransfer);
+    const { latestPrice } = routeRequiresSwap
+      ? await this._getLatestPrice(sourceToken, destinationToken, sourceChain, amountToTransfer)
+      : { latestPrice: 1 };
 
-    // Bridge fee
-
-    const isBuy = spotMarketMeta.isBuy;
     let spreadPct = 0;
-    if (isBuy) {
-      // if is buy, the fee is positive if the price is over 1
-      spreadPct = latestPrice - 1;
-    } else {
-      spreadPct = 1 - latestPrice;
+    let spreadFee = bnZero;
+    if (routeRequiresSwap) {
+      const isBuy = spotMarketMeta.isBuy;
+      if (isBuy) {
+        // if is buy, the fee is positive if the price is over 1
+        spreadPct = latestPrice - 1;
+      } else {
+        spreadPct = 1 - latestPrice;
+      }
+      spreadFee = toBNWei(spreadPct.toFixed(18), 18).mul(amountToTransfer).div(toBNWei(1, 18));
     }
-    const spreadFee = toBNWei(spreadPct.toFixed(18), 18).mul(amountToTransfer).div(toBNWei(1, 18));
 
     // Bridge to Binance deposit network Fee:
     let bridgeToBinanceFee = bnZero;
@@ -1213,6 +1252,10 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const matchingFill = allOrders.find((order) => order.clientOrderId === cloid && order.status === "FILLED");
     const expectedAmountToReceive = spotMarketMeta.isBuy ? matchingFill.executedQty : matchingFill.cummulativeQuoteQty;
     return { matchingFill, expectedAmountToReceive };
+  }
+
+  private _routeRequiresSwap(sourceToken: string, destinationToken: string): boolean {
+    return sourceToken !== destinationToken;
   }
 
   private async _placeMarketOrder(cloid: string, orderDetails: OrderDetails): Promise<void> {

--- a/src/rebalancer/buildRebalanceRoutes.ts
+++ b/src/rebalancer/buildRebalanceRoutes.ts
@@ -1,0 +1,190 @@
+import { CHAIN_IDs } from "../utils";
+import { RebalancerConfig } from "./RebalancerConfig";
+import { RebalanceRoute } from "./utils/interfaces";
+
+type SupportedToken = "USDC" | "USDT";
+type DifferentAssetAdapter = "binance" | "hyperliquid";
+type ChainSelector = (rebalancerConfig: RebalancerConfig) => number[];
+
+// Direct Binance deposit/withdraw networks for each token. This is intentionally separate from the rebalancer route
+// set so we can track venue support without automatically enabling every listed network operationally.
+const BINANCE_NETWORKS_BY_SYMBOL: Record<SupportedToken, readonly number[]> = {
+  USDC: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.BASE, CHAIN_IDs.BSC],
+  USDT: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.BSC],
+};
+
+const REBALANCE_CHAINS_BY_SYMBOL: Record<SupportedToken, readonly number[]> = {
+  USDT: [
+    CHAIN_IDs.HYPEREVM,
+    CHAIN_IDs.ARBITRUM,
+    CHAIN_IDs.OPTIMISM,
+    CHAIN_IDs.MAINNET,
+    CHAIN_IDs.UNICHAIN,
+    CHAIN_IDs.MONAD,
+    CHAIN_IDs.BSC,
+  ],
+  USDC: [
+    CHAIN_IDs.HYPEREVM,
+    CHAIN_IDs.ARBITRUM,
+    CHAIN_IDs.OPTIMISM,
+    CHAIN_IDs.MAINNET,
+    CHAIN_IDs.BASE,
+    CHAIN_IDs.UNICHAIN,
+    CHAIN_IDs.MONAD,
+    CHAIN_IDs.BSC,
+  ],
+};
+
+const SAME_ASSET_BRIDGE_ADAPTER_BY_SYMBOL: Record<SupportedToken, "cctp" | "oft"> = {
+  USDC: "cctp",
+  USDT: "oft",
+};
+
+function configuredChainsForToken(rebalancerConfig: RebalancerConfig, token: SupportedToken): number[] {
+  return REBALANCE_CHAINS_BY_SYMBOL[token].filter((chainId) => rebalancerConfig.chainIds.includes(chainId));
+}
+
+function configuredChains(token: SupportedToken): ChainSelector {
+  return (rebalancerConfig) => configuredChainsForToken(rebalancerConfig, token);
+}
+
+function canUseHyperliquidStablecoinRoute({
+  sourceChain,
+  destinationChain,
+}: {
+  sourceChain: number;
+  destinationChain: number;
+}): boolean {
+  return sourceChain !== CHAIN_IDs.BSC && destinationChain !== CHAIN_IDs.BSC;
+}
+
+function buildSameAssetRoutes(rebalancerConfig: RebalancerConfig, token: SupportedToken): RebalanceRoute[] {
+  if (!rebalancerConfig.cumulativeTargetBalances[token]?.targetBalance) {
+    return [];
+  }
+  const routes: RebalanceRoute[] = [];
+  const configuredChains = configuredChainsForToken(rebalancerConfig, token);
+  const directBinanceNetworks = new Set(BINANCE_NETWORKS_BY_SYMBOL[token]);
+
+  for (const sourceChain of configuredChains) {
+    for (const destinationChain of configuredChains) {
+      if (sourceChain === destinationChain) {
+        continue;
+      }
+
+      if (sourceChain !== CHAIN_IDs.BSC && destinationChain !== CHAIN_IDs.BSC) {
+        routes.push({
+          sourceChain,
+          sourceToken: token,
+          destinationChain,
+          destinationToken: token,
+          adapter: SAME_ASSET_BRIDGE_ADAPTER_BY_SYMBOL[token],
+        });
+      }
+
+      if (directBinanceNetworks.has(sourceChain) && directBinanceNetworks.has(destinationChain)) {
+        routes.push({
+          sourceChain,
+          sourceToken: token,
+          destinationChain,
+          destinationToken: token,
+          adapter: "binance",
+        });
+      }
+    }
+  }
+
+  return routes;
+}
+
+type DifferentAssetPairRule = {
+  tokenA: SupportedToken;
+  tokenB: SupportedToken;
+  adapter: DifferentAssetAdapter;
+  chainsA: ChainSelector;
+  chainsB: ChainSelector;
+  allow?: (params: { sourceChain: number; destinationChain: number }) => boolean;
+};
+
+const DIFFERENT_ASSET_ROUTE_RULES: readonly DifferentAssetPairRule[] = [
+  {
+    tokenA: "USDT",
+    tokenB: "USDC",
+    adapter: "binance",
+    chainsA: configuredChains("USDT"),
+    chainsB: configuredChains("USDC"),
+  },
+  {
+    tokenA: "USDT",
+    tokenB: "USDC",
+    adapter: "hyperliquid",
+    chainsA: configuredChains("USDT"),
+    chainsB: configuredChains("USDC"),
+    allow: canUseHyperliquidStablecoinRoute,
+  },
+];
+
+function pushDirectedDifferentAssetRoutes(
+  routes: RebalanceRoute[],
+  rule: DifferentAssetPairRule,
+  sourceToken: SupportedToken,
+  sourceChains: readonly number[],
+  destinationToken: SupportedToken,
+  destinationChains: readonly number[]
+): void {
+  for (const sourceChain of sourceChains) {
+    for (const destinationChain of destinationChains) {
+      if (rule.allow && !rule.allow({ sourceChain, destinationChain })) {
+        continue;
+      }
+
+      routes.push({
+        sourceChain,
+        sourceToken,
+        destinationChain,
+        destinationToken,
+        adapter: rule.adapter,
+      });
+    }
+  }
+}
+
+function buildDifferentAssetRoutes(rebalancerConfig: RebalancerConfig): RebalanceRoute[] {
+  const routes: RebalanceRoute[] = [];
+  for (const rule of DIFFERENT_ASSET_ROUTE_RULES) {
+    const chainsA = rule.chainsA(rebalancerConfig);
+    const chainsB = rule.chainsB(rebalancerConfig);
+
+    if (
+      !rebalancerConfig.cumulativeTargetBalances[rule.tokenA]?.targetBalance ||
+      !rebalancerConfig.cumulativeTargetBalances[rule.tokenB]?.targetBalance
+    ) {
+      continue;
+    }
+    pushDirectedDifferentAssetRoutes(routes, rule, rule.tokenA, chainsA, rule.tokenB, chainsB);
+    pushDirectedDifferentAssetRoutes(routes, rule, rule.tokenB, chainsB, rule.tokenA, chainsA);
+  }
+
+  return routes;
+}
+
+export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): RebalanceRoute[] {
+  return [
+    ...buildDifferentAssetRoutes(rebalancerConfig),
+    ...buildSameAssetRoutes(rebalancerConfig, "USDT"),
+    ...buildSameAssetRoutes(rebalancerConfig, "USDC"),
+  ];
+}
+
+export function dedupeRebalanceRoutes(routes: RebalanceRoute[]): RebalanceRoute[] {
+  const uniqueRoutes = new Map<string, RebalanceRoute>();
+  for (const route of routes) {
+    uniqueRoutes.set(
+      [route.sourceChain, route.sourceToken, route.destinationChain, route.destinationToken, route.adapter].join("|"),
+      route
+    );
+  }
+  return Array.from(uniqueRoutes.values());
+}
+
+export { BINANCE_NETWORKS_BY_SYMBOL, REBALANCE_CHAINS_BY_SYMBOL };

--- a/test/BinanceAdapter.conversions.ts
+++ b/test/BinanceAdapter.conversions.ts
@@ -97,6 +97,44 @@ describe("Binance adapter conversion sizing", function () {
     expect(cctpGetEstimatedCost.getCall(0).args[1].eq(toBNWei("102.040816", 6))).to.equal(true);
   });
 
+  it("does not inflate same-asset stablecoin withdrawal fees when chain decimals differ", async function () {
+    const route = makeStablecoinRoute({
+      sourceChain: CHAIN_IDs.BSC,
+      destinationChain: CHAIN_IDs.BASE,
+      sourceToken: "USDC",
+      destinationToken: "USDC",
+    });
+    const adapter = await makeInitializedAdapter(route);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getAccountCoins").callsFake(async (token: string) => {
+      return {
+        symbol: token,
+        balance: "0",
+        networkList: [
+          {
+            name: "BASE",
+            withdrawMin: "0.1",
+            withdrawMax: "1000000",
+            withdrawFee: "0.499695",
+          },
+          {
+            name: "BSC",
+            withdrawMin: "0.1",
+            withdrawMax: "1000000",
+            withdrawFee: "0",
+          },
+        ],
+      };
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(adapter as any, "_getEntrypointNetwork").callsFake(async (chainId: number) => chainId);
+
+    const cost = await adapter.getEstimatedCost(route, toBNWei("308304.851912549672926661", 18), false);
+
+    expect(cost.eq(toBNWei("0.499695", 18))).to.equal(true);
+  });
+
   it("prices destination-to-source conversions using source-token precision", async function () {
     const route = makeStablecoinRoute();
     const adapter = await makeInitializedAdapter(route);

--- a/test/RebalancerClient.buildRebalanceRoutes.ts
+++ b/test/RebalancerClient.buildRebalanceRoutes.ts
@@ -1,0 +1,80 @@
+import { expect } from "./utils";
+import { CHAIN_IDs } from "../src/utils";
+import { RebalancerConfig } from "../src/rebalancer/RebalancerConfig";
+import { buildRebalanceRoutes } from "../src/rebalancer/buildRebalanceRoutes";
+
+function buildSyntheticRebalancerConfig(): RebalancerConfig {
+  return new RebalancerConfig({
+    HUB_CHAIN_ID: String(CHAIN_IDs.MAINNET),
+    REBALANCER_CONFIG: JSON.stringify({
+      cumulativeTargetBalances: {
+        USDT: {
+          targetBalance: "1000",
+          thresholdBalance: "500",
+          priorityTier: 0,
+          chains: {
+            [CHAIN_IDs.HYPEREVM]: 0,
+            [CHAIN_IDs.OPTIMISM]: 0,
+            [CHAIN_IDs.BSC]: 0,
+          },
+        },
+        USDC: {
+          targetBalance: "1000",
+          thresholdBalance: "500",
+          priorityTier: 0,
+          chains: {
+            [CHAIN_IDs.HYPEREVM]: 0,
+            [CHAIN_IDs.ARBITRUM]: 0,
+            [CHAIN_IDs.OPTIMISM]: 0,
+            [CHAIN_IDs.BSC]: 0,
+            [CHAIN_IDs.BASE]: 0,
+          },
+        },
+      },
+      maxAmountsToTransfer: {
+        USDT: "100",
+        USDC: "100",
+      },
+      maxPendingOrders: {
+        hyperliquid: 3,
+        binance: 3,
+      },
+    }),
+  });
+}
+
+describe("buildRebalanceRoutes", async function () {
+  it("builds the exact stablecoin route families implied by synthetic config", async function () {
+    const config = buildSyntheticRebalancerConfig();
+
+    const routes = buildRebalanceRoutes(config);
+    const hasRoute = (
+      sourceChain: number,
+      sourceToken: string,
+      destinationChain: number,
+      destinationToken: string,
+      adapter: string
+    ) =>
+      routes.some(
+        (route) =>
+          route.sourceChain === sourceChain &&
+          route.sourceToken === sourceToken &&
+          route.destinationChain === destinationChain &&
+          route.destinationToken === destinationToken &&
+          route.adapter === adapter
+      );
+
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDT", CHAIN_IDs.OPTIMISM, "USDC", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDT", CHAIN_IDs.OPTIMISM, "USDC", "hyperliquid")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.BSC, "USDT", CHAIN_IDs.OPTIMISM, "USDC", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.BSC, "USDT", CHAIN_IDs.OPTIMISM, "USDC", "hyperliquid")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDC", CHAIN_IDs.BASE, "USDC", "cctp")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDC", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDT", CHAIN_IDs.HYPEREVM, "USDT", "oft")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDT", CHAIN_IDs.HYPEREVM, "USDT", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDT", CHAIN_IDs.OPTIMISM, "USDT", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.BSC, "USDT", CHAIN_IDs.OPTIMISM, "USDT", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.BSC, "USDC", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDC", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(false);
+  });
+});


### PR DESCRIPTION
## What changed
- extracted the built-in production route generation into `src/rebalancer/buildRebalanceRoutes.ts`
- added direct Binance same-asset routes for `USDC -> USDC` and `USDT -> USDT` when both sides are direct Binance networks for that asset
- kept the existing bridge-backed same-asset routes (`USDC` via CCTP and `USDT` via OFT) and the existing `USDC <-> USDT` swap routes on Binance and Hyperliquid
- updated the Binance adapter to skip the spot swap leg for same-asset routes and move directly from deposit to withdrawal
- taught pending-withdrawal accounting to handle same-asset routes that never produce a Binance fill record
- added focused coverage for route generation and same-asset stablecoin withdrawal fee accounting
- documented the built-in stablecoin route families in the rebalancer README

## Why
The route set previously only let Binance compete on `USDC <-> USDT` swap routes. Same-asset stablecoin rebalances still had to use CCTP or OFT even when both chains were direct Binance networks and a deposit-then-withdraw path was available.

## Impact
- the rebalancer can now compare direct Binance same-asset stablecoin paths against existing bridge-backed routes
- same-asset Binance routes avoid placing an unnecessary spot order and instead finalize as deposit-plus-withdraw flows
- route generation lives in a dedicated module with direct unit coverage

## Validation
- `yarn test --bail test/BinanceAdapter.conversions.ts test/RebalancerClient.buildRebalanceRoutes.ts`