### PR TITLE
feat: add mainnet Binance WETH rebalance routes

### DIFF
--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -21,6 +21,24 @@ A `RebalanceRoute` defines:
 
 Routes are assembled by the rebalancer construction layer and passed at client initialization time (`initialize(rebalanceRoutes)`). The mode clients then filter to routes that are valid for current balances/config.
 
+The built-in production route set is generated in `src/rebalancer/buildRebalanceRoutes.ts`. It covers:
+
+- stablecoin swap routes between `USDC` and `USDT` on Binance and Hyperliquid,
+- same-asset routes for `USDC` via CCTP and for `USDT` via OFT,
+- Binance-only `WETH <-> USDC` and `WETH <-> USDT` routes sourced or settled through mainnet. `WETH <-> WETH` route handling exists in the adapter, but no cross-chain `WETH <-> WETH` routes are generated while WETH Binance support is limited to mainnet.
+
+Route construction keeps two token-keyed chain maps:
+
+- `BINANCE_NETWORKS_BY_SYMBOL`: direct Binance deposit/withdraw networks known for each token.
+- `REBALANCE_CHAINS_BY_SYMBOL`: the narrower set of chains this repo currently enables for rebalancing that token.
+
+Operational note:
+
+- Updating Binance venue support for a token does not automatically widen rebalancer support. New chains should usually be added to both maps intentionally after inventory/config/runtime review.
+- Current route construction limits Binance `WETH` support to mainnet because the rebalancer's native-ETH deposit path relies on the mainnet Atomic Depositor and transfer proxy wiring.
+- If additional direct Binance ETH networks are enabled later, same-coin `WETH <-> WETH` routes skip the spot swap leg and treat on-chain `WETH` as Binance `ETH`.
+- Intermediate on-chain bridge legs into or out of Binance remain restricted to `USDC` and `USDT`; current `WETH` routes therefore source or settle through mainnet rather than bridging WETH into another Binance ETH network.
+
 ### Rebalancer Adapter
 
 Adapters in `src/rebalancer/adapters/` initiate and progress multi-stage swap workflows. The interface currently is:
@@ -162,13 +180,13 @@ Inputs:
 High-level flow:
 
 1. Compute cumulative deficits (`current < threshold`, target refill amount `target - current`) and cumulative excesses (`current > target`, excess amount `current - target`).
-2. Sort cumulative deficits by token `priorityTier` (higher first), then larger deficits first.
-3. Sort cumulative excesses by token `priorityTier` (lower first), then larger excesses first.
+2. Sort cumulative deficits by token `priorityTier` (higher first), then larger USD-normalized deficits first.
+3. Sort cumulative excesses by token `priorityTier` (lower first), then larger USD-normalized excesses first.
 4. For each excess token used to fill a deficit token, sort source chains from `cumulativeTargetBalances[excessToken].chains` by:
    - chain `priorityTier` ascending,
    - then current chain balance descending.
 5. For each candidate source chain, evaluate all destination chains configured for the deficit token that have valid routes, then choose the route with the lowest `getEstimatedCost`.
-6. Cap transfer amount by remaining deficit, remaining excess, chain balance, and configured `maxAmountsToTransfer`.
+6. Cap transfer amount by remaining deficit, remaining excess, chain balance, and configured `maxAmountsToTransfer`. For mixed-asset routes such as `WETH <-> stablecoin`, the client converts between source and destination token amounts through hub-chain USD prices before capping and decrementing the remaining deficit.
 7. Enforce max fee pct and adapter pending-order caps before calling `initializeRebalance`.
 
 Design tradeoff:

--- a/src/rebalancer/RebalancerClientHelper.ts
+++ b/src/rebalancer/RebalancerClientHelper.ts
@@ -8,10 +8,12 @@ import { ReadOnlyRebalancerClient } from "./clients/ReadOnlyRebalancerClient";
 
 import { RebalancerConfig } from "./RebalancerConfig";
 import { RebalancerAdapter, RebalanceRoute } from "./utils/interfaces";
+import { buildRebalanceRoutes } from "./buildRebalanceRoutes";
 
 function constructRebalancerDependencies(
   logger: winston.Logger,
-  baseSigner: Signer
+  baseSigner: Signer,
+  rebalanceRoutesOverride?: RebalanceRoute[]
 ): {
   rebalancerConfig: RebalancerConfig;
   adapters: { [name: string]: RebalancerAdapter };
@@ -37,91 +39,7 @@ function constructRebalancerDependencies(
     oftAdapter
   );
   const adapterMap = { hyperliquid: hyperliquidAdapter, binance: binanceAdapter, cctp: cctpAdapter, oft: oftAdapter };
-
-  // Following two variables are hardcoded to aid testing:
-  const usdtChains = [
-    CHAIN_IDs.HYPEREVM,
-    CHAIN_IDs.ARBITRUM,
-    CHAIN_IDs.OPTIMISM,
-    CHAIN_IDs.MAINNET,
-    CHAIN_IDs.UNICHAIN,
-    CHAIN_IDs.MONAD,
-    CHAIN_IDs.BSC,
-  ];
-  const usdcChains = [
-    CHAIN_IDs.HYPEREVM,
-    CHAIN_IDs.ARBITRUM,
-    CHAIN_IDs.OPTIMISM,
-    CHAIN_IDs.MAINNET,
-    CHAIN_IDs.BASE,
-    CHAIN_IDs.UNICHAIN,
-    CHAIN_IDs.MONAD,
-    CHAIN_IDs.BSC,
-  ];
-  const rebalanceRoutes: RebalanceRoute[] = [];
-  for (const usdtChain of usdtChains) {
-    for (const usdcChain of usdcChains) {
-      if (!rebalancerConfig.chainIds.includes(usdtChain) || !rebalancerConfig.chainIds.includes(usdcChain)) {
-        continue;
-      }
-      for (const adapter of ["binance", "hyperliquid"]) {
-        // Handle exceptions:
-        if (adapter !== "binance" && (usdtChain === CHAIN_IDs.BSC || usdcChain === CHAIN_IDs.BSC)) {
-          continue;
-        }
-
-        rebalanceRoutes.push({
-          sourceChain: usdtChain,
-          sourceToken: "USDT",
-          destinationChain: usdcChain,
-          destinationToken: "USDC",
-          adapter,
-        });
-        rebalanceRoutes.push({
-          sourceChain: usdcChain,
-          sourceToken: "USDC",
-          destinationChain: usdtChain,
-          destinationToken: "USDT",
-          adapter,
-        });
-      }
-    }
-  }
-
-  for (const usdtChain of usdtChains.filter((chain) => chain !== CHAIN_IDs.BSC)) {
-    for (const otherUsdtChain of usdtChains.filter((chain) => chain !== CHAIN_IDs.BSC)) {
-      if (!rebalancerConfig.chainIds.includes(usdtChain) || !rebalancerConfig.chainIds.includes(otherUsdtChain)) {
-        continue;
-      }
-      if (usdtChain === otherUsdtChain) {
-        continue;
-      }
-      rebalanceRoutes.push({
-        sourceChain: usdtChain,
-        sourceToken: "USDT",
-        destinationChain: otherUsdtChain,
-        destinationToken: "USDT",
-        adapter: "oft",
-      });
-    }
-  }
-  for (const usdcChain of usdcChains.filter((chain) => chain !== CHAIN_IDs.BSC)) {
-    for (const otherUsdcChain of usdcChains.filter((chain) => chain !== CHAIN_IDs.BSC)) {
-      if (!rebalancerConfig.chainIds.includes(usdcChain) || !rebalancerConfig.chainIds.includes(otherUsdcChain)) {
-        continue;
-      }
-      if (usdcChain === otherUsdcChain) {
-        continue;
-      }
-      rebalanceRoutes.push({
-        sourceChain: usdcChain,
-        sourceToken: "USDC",
-        destinationChain: otherUsdcChain,
-        destinationToken: "USDC",
-        adapter: "cctp",
-      });
-    }
-  }
+  const rebalanceRoutes = rebalanceRoutesOverride ?? buildRebalanceRoutes(rebalancerConfig);
 
   // @todo: Add test-net support for this client. For now, we only support production and we do not construct
   // any adapters or routes when running on test net.
@@ -133,9 +51,14 @@ function constructRebalancerDependencies(
 
 export async function constructCumulativeBalanceRebalancerClient(
   logger: winston.Logger,
-  baseSigner: Signer
+  baseSigner: Signer,
+  rebalanceRoutesOverride?: RebalanceRoute[]
 ): Promise<CumulativeBalanceRebalancerClient> {
-  const { rebalancerConfig, adapters, rebalanceRoutes } = constructRebalancerDependencies(logger, baseSigner);
+  const { rebalancerConfig, adapters, rebalanceRoutes } = constructRebalancerDependencies(
+    logger,
+    baseSigner,
+    rebalanceRoutesOverride
+  );
   const isReadonly = false;
   const rebalancerClient = new CumulativeBalanceRebalancerClient(
     logger,

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -185,7 +185,6 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   >();
   private tradeFeesPromise?: ReturnType<Binance["tradeFee"]>;
   private spotMarketMetaPromiseByRoute = new Map<string, Promise<SPOT_MARKET_META>>();
-  private readonly priceClient: PriceClient;
   private readonly tokenPriceCache = new Map<string, BigNumber>();
 
   REDIS_PREFIX = "binance-stablecoin-swap:";

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1,5 +1,6 @@
 import { Binance, NewOrderSpot, OrderType, OrderType_LT, QueryOrderResult, Symbol } from "binance-api-node";
 import {
+  acrossApi,
   assert,
   BigNumber,
   BINANCE_NETWORKS,
@@ -9,8 +10,10 @@ import {
   bnZero,
   CHAIN_IDs,
   Coin,
+  coingecko,
   Contract,
   delay,
+  defiLlama,
   ERC20,
   EvmAddress,
   forEachAsync,
@@ -19,13 +22,17 @@ import {
   getBinanceApiClient,
   getBinanceTransactionTypeKey,
   getBinanceWithdrawals,
+  getCurrentTime,
   getNetworkName,
   getProvider,
+  getTokenInfoFromSymbol,
   isDefined,
-  paginatedEventQuery,
+  MAX_SAFE_ALLOWANCE,
+  PriceClient,
   setBinanceDepositType,
   setBinanceWithdrawalType,
   Signer,
+  toBN,
   toBNWei,
   truncate,
   winston,
@@ -33,10 +40,13 @@ import {
 import { OrderDetails, RebalanceRoute } from "../utils/interfaces";
 import { STATUS } from "../utils/utils";
 import { BaseAdapter } from "./baseAdapter";
-import { AugmentedTransaction } from "../../clients";
+import { AugmentedTransaction, MultiCallerClient } from "../../clients";
 import { RebalancerConfig } from "../RebalancerConfig";
 import { CctpAdapter } from "./cctpAdapter";
 import { OftAdapter } from "./oftAdapter";
+import { CONTRACT_ADDRESSES } from "../../common";
+import WETH_ABI from "../../common/abi/Weth.json";
+import { getAcrossHost } from "../../clients/AcrossAPIClient";
 
 interface SPOT_MARKET_META {
   symbol: string;
@@ -75,13 +85,50 @@ export function resolveBinanceCoinSymbol(token: string): string {
   return token === "WETH" ? "ETH" : token;
 }
 
+export function isSameBinanceCoin(sourceToken: string, destinationToken: string): boolean {
+  return resolveBinanceCoinSymbol(sourceToken) === resolveBinanceCoinSymbol(destinationToken);
+}
+
+export function supportsBinanceIntermediateBridgeToken(token: string): boolean {
+  return token === "USDC" || token === "USDT";
+}
+
+function getAtomicDepositorContracts(chainId: number):
+  | {
+      atomicDepositorAddress: string;
+      atomicDepositorAbi: unknown[];
+      transferProxyAddress: string;
+      transferProxyAbi: unknown[];
+    }
+  | undefined {
+  const chainContracts = CONTRACT_ADDRESSES[chainId];
+  const atomicDepositorAddress = chainContracts?.atomicDepositor?.address;
+  const atomicDepositorAbi = chainContracts?.atomicDepositor?.abi;
+  const transferProxyAddress = chainContracts?.atomicDepositorTransferProxy?.address;
+  const transferProxyAbi = chainContracts?.atomicDepositorTransferProxy?.abi;
+  if (
+    !isDefined(atomicDepositorAddress) ||
+    !isDefined(atomicDepositorAbi) ||
+    !isDefined(transferProxyAddress) ||
+    !isDefined(transferProxyAbi)
+  ) {
+    return undefined;
+  }
+  return { atomicDepositorAddress, atomicDepositorAbi, transferProxyAddress, transferProxyAbi };
+}
+
+function usesBinanceAtomicDepositorTransfer(token: string, chainId: number): boolean {
+  return token === "WETH" && isDefined(getAtomicDepositorContracts(chainId));
+}
 export function deriveBinanceSpotMarketMeta(
   sourceToken: string,
   destinationToken: string,
   symbol: Symbol<OrderType_LT>
 ): SPOT_MARKET_META {
-  const isBuy = symbol.baseAsset === destinationToken && symbol.quoteAsset === sourceToken;
-  const isSell = symbol.baseAsset === sourceToken && symbol.quoteAsset === destinationToken;
+  const sourceAsset = resolveBinanceCoinSymbol(sourceToken);
+  const destinationAsset = resolveBinanceCoinSymbol(destinationToken);
+  const isBuy = symbol.baseAsset === destinationAsset && symbol.quoteAsset === sourceAsset;
+  const isSell = symbol.baseAsset === sourceAsset && symbol.quoteAsset === destinationAsset;
   assert(isBuy || isSell, `No spot market meta found for route: ${sourceToken}-${destinationToken}`);
 
   const priceFilter = symbol.filters.find((filter) => filter.filterType === "PRICE_FILTER");
@@ -137,6 +184,9 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     { fetchedAtMs: number; book: Awaited<ReturnType<Binance["book"]>> }
   >();
   private tradeFeesPromise?: ReturnType<Binance["tradeFee"]>;
+  private spotMarketMetaPromiseByRoute = new Map<string, Promise<SPOT_MARKET_META>>();
+  private readonly priceClient: PriceClient;
+  private readonly tokenPriceCache = new Map<string, BigNumber>();
 
   REDIS_PREFIX = "binance-stablecoin-swap:";
   private static readonly ORDER_BOOK_CACHE_TTL_MS = 30_000;
@@ -150,6 +200,11 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     readonly oftAdapter: OftAdapter
   ) {
     super(logger, config, baseSigner);
+    this.priceClient = new PriceClient(this.logger, [
+      new acrossApi.PriceFeed({ host: getAcrossHost(this.config.hubPoolChainId) }),
+      new coingecko.PriceFeed({ apiKey: process.env.COINGECKO_PRO_API_KEY }),
+      new defiLlama.PriceFeed(),
+    ]);
   }
 
   // ////////////////////////////////////////////////////////////
@@ -180,6 +235,12 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       const getIntermediateAdapterName = (token: string) => (token === "USDT" ? "oft" : "cctp");
       // Validate that route can be supported using intermediate bridges to get to/from Arbitrum to access Binance.
       if (destinationEntrypointNetwork !== destinationChain) {
+        assert(
+          supportsBinanceIntermediateBridgeToken(destinationToken),
+          `Destination chain ${getNetworkName(
+            destinationChain
+          )} is not a direct Binance withdrawal network for ${destinationToken}; this token cannot use intermediate bridge legs`
+        );
         const intermediateRoute = {
           ...route,
           sourceChain: destinationEntrypointNetwork,
@@ -196,6 +257,12 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         );
       }
       if (sourceEntrypointNetwork !== sourceChain) {
+        assert(
+          supportsBinanceIntermediateBridgeToken(sourceToken),
+          `Source chain ${getNetworkName(
+            sourceChain
+          )} is not a direct Binance deposit network for ${sourceToken}; this token cannot use intermediate bridge legs`
+        );
         const intermediateRoute = {
           ...route,
           destinationChain: sourceEntrypointNetwork,
@@ -211,6 +278,13 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
           )} bridge route to the Binance entrypoint network ${sourceEntrypointNetwork}`
         );
       }
+      // Enforce that if source token is WETH that the source chain has an atomic depositor contract.
+      if (sourceToken === "WETH") {
+        assert(
+          isDefined(getAtomicDepositorContracts(sourceEntrypointNetwork)),
+          `Atomic depositor contracts missing for ${getNetworkName(sourceEntrypointNetwork)}`
+        );
+      }
       assert(
         sourceCoin.networkList.find((network) => network.name === BINANCE_NETWORKS[sourceEntrypointNetwork]),
         `Source token ${sourceToken} network list does not contain Binance source entrypoint network "${
@@ -224,6 +298,51 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         }", available networks: ${destinationCoin.networkList.map((network) => network.name).join(", ")}`
       );
     });
+  }
+
+  async setApprovals(): Promise<void> {
+    this._assertInitialized();
+    const approvalChains = Array.from(
+      new Set(
+        this.availableRoutes
+          .filter(({ sourceToken, sourceChain }) => usesBinanceAtomicDepositorTransfer(sourceToken, sourceChain))
+          .map(({ sourceChain }) => sourceChain)
+      )
+    );
+    if (approvalChains.length === 0) {
+      return;
+    }
+
+    this.multicallerClient = new MultiCallerClient(this.logger, this.config.multiCallChunkSize, this.baseSigner);
+
+    await forEachAsync(approvalChains, async (sourceChain) => {
+      const connectedSigner = this.baseSigner.connect(await getProvider(sourceChain));
+      const weth = new Contract(this._getTokenInfo("WETH", sourceChain).address.toNative(), ERC20.abi, connectedSigner);
+      const atomicDepositorContracts = getAtomicDepositorContracts(sourceChain);
+      assert(
+        isDefined(atomicDepositorContracts),
+        `Atomic depositor contracts missing for ${getNetworkName(sourceChain)}`
+      );
+      const allowance = await weth.allowance(
+        this.baseSignerAddress.toNative(),
+        atomicDepositorContracts.atomicDepositorAddress
+      );
+      if (allowance.lt(toBN(MAX_SAFE_ALLOWANCE).div(2))) {
+        this.multicallerClient.enqueueTransaction({
+          contract: weth,
+          chainId: sourceChain,
+          method: "approve",
+          nonMulticall: true,
+          unpermissioned: false,
+          args: [atomicDepositorContracts.atomicDepositorAddress, MAX_SAFE_ALLOWANCE],
+          message: "Approved WETH for AtomicDepositor",
+          mrkdwn: "Approved WETH for AtomicDepositor",
+        });
+      }
+    });
+
+    const simMode = !this.config.sendingTransactionsEnabled;
+    await this.multicallerClient.executeTxnQueues(simMode);
   }
 
   async updateRebalanceStatuses(): Promise<void> {
@@ -289,7 +408,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     }
     for (const cloid of pendingDeposits) {
       const orderDetails = await this._redisGetOrderDetails(cloid, this.baseSignerAddress);
-      const { sourceToken, sourceChain, amountToTransfer } = orderDetails;
+      const { sourceToken, sourceChain, destinationToken, destinationChain, amountToTransfer } = orderDetails;
 
       const binanceBalance = await this._getBinanceBalance(sourceToken);
       const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
@@ -307,11 +426,26 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         availableBalance: binanceBalanceWei.toString(),
         requiredBalance: amountToTransfer.toString(),
       });
-      await this._placeMarketOrder(cloid, orderDetails);
-      await this._redisUpdateOrderStatus(cloid, STATUS.PENDING_DEPOSIT, STATUS.PENDING_SWAP, this.baseSignerAddress);
+      if (this._routeRequiresSwap(sourceToken, destinationToken)) {
+        await this._placeMarketOrder(cloid, orderDetails);
+        await this._redisUpdateOrderStatus(cloid, STATUS.PENDING_DEPOSIT, STATUS.PENDING_SWAP, this.baseSignerAddress);
+      } else {
+        await this._withdraw(
+          cloid,
+          Number(fromWei(amountToTransfer, sourceTokenInfo.decimals)),
+          destinationToken,
+          destinationChain
+        );
+        await this._redisUpdateOrderStatus(
+          cloid,
+          STATUS.PENDING_DEPOSIT,
+          STATUS.PENDING_WITHDRAWAL,
+          this.baseSignerAddress
+        );
+      }
       // Delay a bit before checking balances to withdraw so we can give this function a chance to successively place
-      // a market order successfully and subsequently withdraw the filled order. It takes a short time for the just filled
-      // order to be reflected in the balance.
+      // a market order successfully and subsequently withdraw the filled order. It also gives direct same-coin
+      // withdrawals a short time to be reflected in Binance/accounting state.
       await this._wait(10);
     }
 
@@ -375,8 +509,10 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
 
       const orderDetails = await this._redisGetOrderDetails(cloid, this.baseSignerAddress);
       const { destinationToken, destinationChain } = orderDetails;
-      const { matchingFill } = await this._getMatchingFillForCloid(cloid, this.baseSignerAddress);
-      if (!matchingFill) {
+      const matchingFill = this._routeRequiresSwap(orderDetails.sourceToken, orderDetails.destinationToken)
+        ? (await this._getMatchingFillForCloid(cloid, this.baseSignerAddress))?.matchingFill
+        : undefined;
+      if (this._routeRequiresSwap(orderDetails.sourceToken, orderDetails.destinationToken) && !matchingFill) {
         throw new Error(`No matching fill found for cloid ${cloid} that has status PENDING_WITHDRAWAL`);
       }
       const binanceWithdrawalNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
@@ -384,7 +520,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       if (!initiatedWithdrawalId) {
         this.logger.debug({
           at: "BinanceStablecoinSwapAdapter.updateRebalanceStatuses",
-          message: `Cannot find initiated withdrawal for cloid ${cloid} which filled at ${matchingFill.time}, waiting`,
+          message: `Cannot find initiated withdrawal for cloid ${cloid}, waiting`,
           cloid: cloid,
           matchingFill: matchingFill,
         });
@@ -394,8 +530,10 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       const { unfinalizedWithdrawals, finalizedWithdrawals, failedWithdrawals } = await this._getBinanceWithdrawals(
         orderDetails.destinationToken,
         binanceWithdrawalNetwork,
-        Math.floor(matchingFill.time / 1000) - 5 * 60, // Floor this so we can grab the initiated withdrawal data whose
-        // ID we've already saved into Redis
+        isDefined(matchingFill) ? Math.floor(matchingFill.time / 1000) - 5 * 60 : getCurrentTime() - 6 * 60 * 60,
+        // If there is a matching fill, then look up withdrawals after the fill time. If there is no fill because
+        // its not a swap route, then use a conservative lookback period. If the withdrawal is older than this lookback
+        // period then it should have already been deleted from the Redis DB.
         this.baseSignerAddress.toNative()
       );
       const failedWithdrawal = failedWithdrawals.find((withdrawal) => withdrawal.id === initiatedWithdrawalId);
@@ -411,7 +549,9 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         await this._redisUpdateOrderStatus(
           cloid,
           STATUS.PENDING_WITHDRAWAL,
-          STATUS.PENDING_SWAP,
+          this._routeRequiresSwap(orderDetails.sourceToken, orderDetails.destinationToken)
+            ? STATUS.PENDING_SWAP
+            : STATUS.PENDING_DEPOSIT,
           this.baseSignerAddress
         );
         continue;
@@ -434,23 +574,47 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       if (!withdrawalDetails) {
         this.logger.debug({
           at: "BinanceStablecoinSwapAdapter.updateRebalanceStatuses",
-          message: `Cannot find withdrawal details in Binance API response for withdrawal history for cloid ${cloid} which filled at ${matchingFill.time}, waiting....`,
+          message: `Cannot find withdrawal details in Binance API response for withdrawal history for cloid ${cloid}, waiting....`,
         });
         continue;
+      }
+
+      const binanceWithdrawalNetworkTokenInfo = this._getTokenInfo(destinationToken, binanceWithdrawalNetwork);
+      const withdrawAmountWei = toBNWei(
+        truncate(withdrawalDetails.amount, binanceWithdrawalNetworkTokenInfo.decimals),
+        binanceWithdrawalNetworkTokenInfo.decimals
+      );
+
+      // Check if we need to wrap the withdrawal to WETH:
+      if (destinationToken === "WETH") {
+        const wrapGasCostWei = await this._estimateWrapEthGasCost(binanceWithdrawalNetwork, withdrawAmountWei);
+        const requiredBalanceWei = withdrawAmountWei.add(wrapGasCostWei);
+        const balance = await this.baseSigner.connect(await getProvider(binanceWithdrawalNetwork)).getBalance();
+        if (balance.lt(requiredBalanceWei)) {
+          this.logger.debug({
+            at: "BinanceStablecoinSwapAdapter.updateRebalanceStatuses",
+            message: `Order ${cloid} has finalized withdrawing to ${binanceWithdrawalNetwork} and needs to be wrapped to WETH, but there is not enough balance on ${binanceWithdrawalNetwork} to cover the withdrawn amount plus wrap gas, waiting...`,
+            balance: balance.toString(),
+            requiredWithdrawAmount: withdrawAmountWei.toString(),
+            requiredBalanceWei: requiredBalanceWei.toString(),
+            wrapGasCostWei: wrapGasCostWei.toString(),
+          });
+          continue;
+        }
+        await this._wrapEth(binanceWithdrawalNetwork, withdrawAmountWei);
       }
 
       // Check if we need to bridge the withdrawal to the final destination chain:
       const requiresBridgeAfterWithdrawal = binanceWithdrawalNetwork !== destinationChain;
       if (requiresBridgeAfterWithdrawal) {
+        assert(
+          supportsBinanceIntermediateBridgeToken(destinationToken),
+          `Destination token ${destinationToken} cannot use an intermediate bridge leg out of Binance`
+        );
         const balance = await this._getERC20Balance(
           binanceWithdrawalNetwork,
           this._getTokenInfo(destinationToken, binanceWithdrawalNetwork).address.toNative(),
           this.baseSignerAddress
-        );
-        const binanceWithdrawalNetworkTokenInfo = this._getTokenInfo(destinationToken, binanceWithdrawalNetwork);
-        const withdrawAmountWei = toBNWei(
-          truncate(withdrawalDetails.amount, binanceWithdrawalNetworkTokenInfo.decimals),
-          binanceWithdrawalNetworkTokenInfo.decimals
         );
         if (balance.lt(withdrawAmountWei)) {
           this.logger.debug({
@@ -489,7 +653,6 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     // Finalizer because we set the TTL to 30 minutes when we deposited the funds and called
     // setBinanceDepositType().
   }
-
   async getPendingRebalances(account: EvmAddress): Promise<{ [chainId: number]: { [token: string]: BigNumber } }> {
     this._assertInitialized();
     const pendingRebalances: { [chainId: number]: { [token: string]: BigNumber } } = {};
@@ -537,23 +700,36 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     for (const cloid of pendingOrders) {
       const orderDetails = await this._redisGetOrderDetails(cloid, account);
       const { destinationChain, destinationToken, sourceChain, sourceToken, amountToTransfer } = orderDetails;
-      // Convert amountToTransfer to destination chain precision:
-      const convertedAmount = await this._convertSourceToDestination(
-        sourceToken,
-        sourceChain,
-        destinationToken,
-        destinationChain,
-        amountToTransfer
-      );
+
+      let expectedAmountToReceive: BigNumber;
+
+      const matchingFill = this._routeRequiresSwap(sourceToken, destinationToken)
+        ? await this._getMatchingFillForCloid(cloid, account)
+        : undefined;
+      if (matchingFill) {
+        const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationChain);
+        expectedAmountToReceive = toBNWei(
+          truncate(Number(matchingFill.expectedAmountToReceive), destinationTokenInfo.decimals),
+          destinationTokenInfo.decimals
+        );
+      } else {
+        expectedAmountToReceive = await this._convertSourceToDestination(
+          sourceToken,
+          sourceChain,
+          destinationToken,
+          destinationChain,
+          amountToTransfer
+        );
+      }
       this.logger.debug({
         at: "BinanceStablecoinSwapAdapter.getPendingRebalances",
-        message: `Adding ${convertedAmount.toString()} for pending order cloid ${cloid} to destination chain ${destinationChain}`,
+        message: `Adding ${expectedAmountToReceive.toString()} for pending order cloid ${cloid} to destination chain ${destinationChain}`,
         cloid: cloid,
       });
       pendingRebalances[destinationChain] ??= {};
       pendingRebalances[destinationChain][destinationToken] = (
         pendingRebalances[destinationChain][destinationToken] ?? bnZero
-      ).add(convertedAmount);
+      ).add(expectedAmountToReceive);
     }
 
     // Similar to how we treat orders that are in the state of being bridged to a Binance deposit network, we need to
@@ -563,16 +739,20 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const pendingWithdrawals = await this._redisGetPendingWithdrawals(account);
     for (const cloid of pendingWithdrawals) {
       const orderDetails = await this._redisGetOrderDetails(cloid, account);
-      const { destinationChain, destinationToken, sourceChain, sourceToken, amountToTransfer } = orderDetails;
-      const { matchingFill } = await this._getMatchingFillForCloid(cloid, account);
-      assert(isDefined(matchingFill), "Matching fill should be defined for order with status PENDING_WITHDRAWAL");
+      const { destinationChain, destinationToken, sourceToken } = orderDetails;
+      const matchingFill = this._routeRequiresSwap(sourceToken, destinationToken)
+        ? (await this._getMatchingFillForCloid(cloid, account))?.matchingFill
+        : undefined;
+      if (this._routeRequiresSwap(sourceToken, destinationToken)) {
+        assert(isDefined(matchingFill), "Matching fill should be defined for order with status PENDING_WITHDRAWAL");
+      }
 
       const binanceWithdrawalNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
       const initiatedWithdrawalId = await this._redisGetInitiatedWithdrawalId(cloid);
       if (!initiatedWithdrawalId) {
         this.logger.debug({
           at: "BinanceStablecoinSwapAdapter.getPendingRebalances",
-          message: `Cannot find initiated withdrawal for cloid ${cloid} which filled at ${matchingFill.time}, waiting`,
+          message: `Cannot find initiated withdrawal for cloid ${cloid}, waiting`,
           cloid: cloid,
           matchingFill: matchingFill,
         });
@@ -581,8 +761,10 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       const { unfinalizedWithdrawals, finalizedWithdrawals } = await this._getBinanceWithdrawals(
         destinationToken,
         binanceWithdrawalNetwork,
-        Math.floor(matchingFill.time / 1000) - 5 * 60, // Floor this so we can grab the initiated withdrawal data whose
-        // ID we've already saved into Redis
+        isDefined(matchingFill) ? Math.floor(matchingFill.time / 1000) - 5 * 60 : getCurrentTime() - 6 * 60 * 60,
+        // If there is a matching fill, then look up withdrawals after the fill time. If there is no fill because
+        // its not a swap route, then use a conservative lookback period. If the withdrawal is older than this lookback
+        // period then it should have already been deleted from the Redis DB.
         account.toNative()
       );
       const initiatedWithdrawalIsUnfinalized = unfinalizedWithdrawals.find(
@@ -603,20 +785,18 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       if (!withdrawalDetails) {
         this.logger.debug({
           at: "BinanceStablecoinSwapAdapter.getPendingRebalances",
-          message: `Cannot find withdrawal details for cloid ${cloid} which filled at ${matchingFill.time}, waiting...`,
+          message: `Cannot find withdrawal details for cloid ${cloid}, waiting...`,
         });
         continue;
       }
-      const convertedAmount = await this._convertSourceToDestination(
-        sourceToken,
-        sourceChain,
-        destinationToken,
-        destinationChain,
-        amountToTransfer
+      const binanceWithdrawalNetworkTokenInfo = this._getTokenInfo(destinationToken, binanceWithdrawalNetwork);
+      const withdrawAmountWei = toBNWei(
+        truncate(withdrawalDetails.amount, binanceWithdrawalNetworkTokenInfo.decimals),
+        binanceWithdrawalNetworkTokenInfo.decimals
       );
       this.logger.debug({
         at: "BinanceStablecoinSwapAdapter.getPendingRebalances",
-        message: `Withdrawal for order ${cloid} has finalized, subtracting the order's virtual balance of ${convertedAmount.toString()} from binance withdrawal network ${binanceWithdrawalNetwork}`,
+        message: `Withdrawal for order ${cloid} has finalized, subtracting the order's virtual balance of ${withdrawAmountWei.toString()} from binance withdrawal network ${binanceWithdrawalNetwork}`,
         cloid: cloid,
         orderDetails: orderDetails,
         withdrawalDetails,
@@ -624,7 +804,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       pendingRebalances[binanceWithdrawalNetwork] ??= {};
       pendingRebalances[binanceWithdrawalNetwork][destinationToken] = (
         pendingRebalances[binanceWithdrawalNetwork][destinationToken] ?? bnZero
-      ).sub(convertedAmount);
+      ).sub(withdrawAmountWei);
     }
 
     return pendingRebalances;
@@ -638,6 +818,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     this._assertInitialized();
     this._assertRouteIsSupported(rebalanceRoute);
     const { sourceChain, sourceToken, destinationToken, destinationChain } = rebalanceRoute;
+    const routeRequiresSwap = this._routeRequiresSwap(sourceToken, destinationToken);
 
     const destinationCoin = await this._getAccountCoins(destinationToken);
     const destinationEntrypointNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
@@ -648,22 +829,24 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
 
     // Make sure that the amount to transfer will be larger than the minimum withdrawal size after expected fees.
     const expectedCost = await this.getEstimatedCost(rebalanceRoute, amountToTransfer, false);
-    const expectedAmountToWithdraw = amountToTransfer.sub(expectedCost);
     const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
     const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationEntrypointNetwork);
+    const expectedAmountToWithdraw = amountToTransfer.sub(expectedCost);
     const minimumWithdrawalSize = await this._convertDestinationToSource(
       destinationToken,
       destinationEntrypointNetwork,
       sourceToken,
       sourceChain,
-      toBNWei(Number(withdrawMin) + 1, destinationTokenInfo.decimals)
+      // add 1% buffer to minimum withdrawal size to account for any precision loss due to the conversion from
+      // destination to source token precision.
+      toBNWei(truncate(Number(withdrawMin) * 1.01, destinationTokenInfo.decimals), destinationTokenInfo.decimals)
     );
     const maximumWithdrawalSize = await this._convertDestinationToSource(
       destinationToken,
       destinationEntrypointNetwork,
       sourceToken,
       sourceChain,
-      toBNWei(withdrawMax, destinationTokenInfo.decimals)
+      toBNWei(truncate(Number(withdrawMax), destinationTokenInfo.decimals), destinationTokenInfo.decimals)
     );
     if (expectedAmountToWithdraw.lt(minimumWithdrawalSize)) {
       this.logger.debug({
@@ -684,22 +867,28 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     // tick size. We try not to precompute the size required to place an order here because the price might change
     // and the amount transferred in might be insufficient to place the order later on, producing more dust or an
     // error.
-    const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
-    const minimumOrderSize = spotMarketMeta.isBuy
-      ? await this._convertDestinationToSource(
-          destinationToken,
-          destinationChain,
-          sourceToken,
-          sourceChain,
-          toBNWei(spotMarketMeta.minimumOrderSize, this._getTokenInfo(destinationToken, destinationChain).decimals)
-        )
-      : toBNWei(spotMarketMeta.minimumOrderSize, sourceTokenInfo.decimals);
-    if (amountToTransfer.lt(minimumOrderSize)) {
-      this.logger.debug({
-        at: "BinanceStablecoinSwapAdapter.initializeRebalance",
-        message: `Amount to transfer ${amountToTransfer.toString()} is less than minimum order size ${minimumOrderSize.toString()}`,
-      });
-      return bnZero;
+    if (routeRequiresSwap) {
+      const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
+      const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationChain);
+      const minimumOrderSize = spotMarketMeta.isBuy
+        ? await this._convertDestinationToSource(
+            destinationToken,
+            destinationChain,
+            sourceToken,
+            sourceChain,
+            toBNWei(
+              truncate(spotMarketMeta.minimumOrderSize, destinationTokenInfo.decimals),
+              destinationTokenInfo.decimals
+            )
+          )
+        : toBNWei(truncate(spotMarketMeta.minimumOrderSize, sourceTokenInfo.decimals), sourceTokenInfo.decimals);
+      if (amountToTransfer.lt(minimumOrderSize)) {
+        this.logger.debug({
+          at: "BinanceStablecoinSwapAdapter.initializeRebalance",
+          message: `Amount to transfer ${amountToTransfer.toString()} is less than minimum order size ${minimumOrderSize.toString()}`,
+        });
+        return bnZero;
+      }
     }
 
     const cloid = await this._redisGetNextCloid();
@@ -711,6 +900,10 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const binanceDepositNetwork = await this._getEntrypointNetwork(sourceChain, sourceToken);
     const requiresBridgeBeforeDeposit = binanceDepositNetwork !== sourceChain;
     if (requiresBridgeBeforeDeposit) {
+      assert(
+        supportsBinanceIntermediateBridgeToken(sourceToken),
+        `Source token ${sourceToken} cannot use an intermediate bridge leg into Binance`
+      );
       const balance = await this._getERC20Balance(
         sourceChain,
         this._getTokenInfo(sourceToken, sourceChain).address.toNative(),
@@ -776,46 +969,52 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   ): Promise<BigNumber> {
     this._assertRouteIsSupported(rebalanceRoute);
     const { sourceToken, destinationToken, sourceChain, destinationChain } = rebalanceRoute;
-    const spotMarketMeta = await this._getSpotMarketMetaForRoute(sourceToken, destinationToken);
+    const routeRequiresSwap = this._routeRequiresSwap(sourceToken, destinationToken);
+    const spotMarketMeta = routeRequiresSwap
+      ? await this._getSpotMarketMetaForRoute(sourceToken, destinationToken)
+      : undefined;
     // Commission is denominated in percentage points.
-    const tradeFeePct = (await this._getTradeFees()).find(
-      (fee) => fee.symbol === spotMarketMeta.symbol
-    ).takerCommission;
-    const tradeFee = toBNWei(tradeFeePct, 18).mul(amountToTransfer).div(toBNWei(100, 18));
+    const tradeFeePct = routeRequiresSwap
+      ? (await this._getTradeFees()).find((fee) => fee.symbol === spotMarketMeta.symbol).takerCommission
+      : "0";
+    const tradeFee = toBNWei(truncate(Number(tradeFeePct), 18), 18)
+      .mul(amountToTransfer)
+      .div(toBNWei(100, 18));
     const destinationCoin = await this._getAccountCoins(destinationToken);
     const destinationEntrypointNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
+    const withdrawFee = destinationCoin.networkList.find(
+      (network) => network.name === BINANCE_NETWORKS[destinationEntrypointNetwork]
+    ).withdrawFee;
+
+    const latestPrice = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, amountToTransfer);
     const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationEntrypointNetwork);
-    const withdrawFee = toBNWei(
-      destinationCoin.networkList.find((network) => network.name === BINANCE_NETWORKS[destinationEntrypointNetwork])
-        .withdrawFee,
-      destinationTokenInfo.decimals
-    );
     const withdrawFeeConvertedToSourceToken = await this._convertDestinationToSource(
       destinationToken,
       destinationEntrypointNetwork,
       sourceToken,
       sourceChain,
-      withdrawFee
+      toBNWei(truncate(Number(withdrawFee), destinationTokenInfo.decimals), destinationTokenInfo.decimals)
     );
-
-    const { latestPrice } = await this._getLatestPrice(sourceToken, destinationToken, sourceChain, amountToTransfer);
-
-    // Bridge fee
-
-    const isBuy = spotMarketMeta.isBuy;
-    let spreadPct = 0;
-    if (isBuy) {
-      // if is buy, the fee is positive if the price is over 1
-      spreadPct = latestPrice - 1;
-    } else {
-      spreadPct = 1 - latestPrice;
-    }
-    const spreadFee = toBNWei(spreadPct.toFixed(18), 18).mul(amountToTransfer).div(toBNWei(1, 18));
+    const executionLossInSourceToken = routeRequiresSwap
+      ? await this._getExecutionLossInSourceToken(
+          sourceToken,
+          sourceChain,
+          destinationToken,
+          destinationChain,
+          amountToTransfer,
+          spotMarketMeta,
+          latestPrice.latestPrice
+        )
+      : bnZero;
 
     // Bridge to Binance deposit network Fee:
     let bridgeToBinanceFee = bnZero;
     const binanceDepositNetwork = await this._getEntrypointNetwork(sourceChain, sourceToken);
     if (binanceDepositNetwork !== sourceChain) {
+      assert(
+        supportsBinanceIntermediateBridgeToken(sourceToken),
+        `Source token ${sourceToken} cannot use an intermediate bridge leg into Binance`
+      );
       const _rebalanceRoute = { ...rebalanceRoute, destinationChain: binanceDepositNetwork };
       if (
         sourceToken === "USDT" &&
@@ -840,6 +1039,10 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     let bridgeFromBinanceFee = bnZero;
     const binanceWithdrawNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
     if (binanceWithdrawNetwork !== destinationChain) {
+      assert(
+        supportsBinanceIntermediateBridgeToken(destinationToken),
+        `Destination token ${destinationToken} cannot use an intermediate bridge leg out of Binance`
+      );
       const _rebalanceRoute = { ...rebalanceRoute, sourceChain: binanceWithdrawNetwork };
       const bridgeAmountConverted = await this._convertSourceToDestination(
         sourceToken,
@@ -879,13 +1082,13 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const opportunityCostOfCapitalPct = requiresOftBridgeFromHyperevm
       ? this._getOpportunityCostOfCapitalPctForRebalanceTime(11 * 60 * 60 * 1000)
       : bnZero;
-    const opportunityCostOfCapitalFixed = toBNWei(opportunityCostOfCapitalPct, 18)
+    const opportunityCostOfCapitalFixed = toBNWei(truncate(Number(opportunityCostOfCapitalPct), 18), 18)
       .mul(amountToTransfer)
       .div(toBNWei(100, 18));
 
     const totalFee = tradeFee
       .add(withdrawFeeConvertedToSourceToken)
-      .add(spreadFee)
+      .add(executionLossInSourceToken)
       .add(bridgeToBinanceFee)
       .add(bridgeFromBinanceFee)
       .add(opportunityCostOfCapitalFixed);
@@ -893,17 +1096,13 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     if (debugLog) {
       this.logger.debug({
         at: "BinanceStablecoinSwapAdapter.getEstimatedCost",
-        message: `Calculating total fees for rebalance route ${sourceToken} on ${getNetworkName(
-          sourceChain
-        )} to ${destinationToken} on ${getNetworkName(
-          destinationChain
-        )} with amount to transfer ${amountToTransfer.toString()}`,
+        message: `Calculating total fees for rebalance route ${sourceToken} on ${getNetworkName(sourceChain)} to ${destinationToken} on ${getNetworkName(destinationChain)} with amount to transfer ${amountToTransfer.toString()}`,
         tradeFeePct,
         tradeFee: tradeFee.toString(),
         withdrawFeeConvertedToSourceToken: withdrawFeeConvertedToSourceToken.toString(),
         estimatedTakerPrice: latestPrice,
-        spreadPct: spreadPct * 100,
-        spreadFee: spreadFee.toString(),
+        bookSlippagePct: latestPrice.slippagePct,
+        executionLossInSourceToken: executionLossInSourceToken.toString(),
         opportunityCostOfCapitalFixed: opportunityCostOfCapitalFixed.toString(),
         bridgeToBinanceFee: bridgeToBinanceFee.toString(),
         bridgeFromBinanceFee: bridgeFromBinanceFee.toString(),
@@ -919,6 +1118,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   // ////////////////////////////////////////////////////////////
 
   private async _getAccountCoins(symbol: string, skipCache = false): Promise<Coin> {
+    const binanceSymbol = resolveBinanceCoinSymbol(symbol);
     const cacheKey = "binance-account-coins";
 
     type ParsedAccountCoins = Awaited<ReturnType<typeof getAccountCoins>>;
@@ -936,8 +1136,8 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       // the entry for this coin is not expected to change frequently.
     }
 
-    const coin = accountCoins.find((coin) => coin.symbol === symbol);
-    assert(coin, `Coin ${symbol} not found in account coins`);
+    const coin = accountCoins.find((coin) => coin.symbol === binanceSymbol);
+    assert(coin, `Coin ${binanceSymbol} not found in account coins`);
     return coin;
   }
 
@@ -955,26 +1155,41 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
 
   private async _depositToBinance(sourceToken: string, sourceChain: number, amountToDeposit: BigNumber): Promise<void> {
     assert(isDefined(BINANCE_NETWORKS[sourceChain]), "Source chain should be a Binance network");
+    assert(
+      sourceToken !== "WETH" || isDefined(getAtomicDepositorContracts(sourceChain)),
+      `Atomic depositor contracts missing for WETH source chain ${getNetworkName(sourceChain)}`
+    );
     const depositAddress = await this.binanceApiClient.depositAddress({
-      coin: sourceToken,
+      coin: resolveBinanceCoinSymbol(sourceToken),
       network: BINANCE_NETWORKS[sourceChain],
     });
     const sourceProvider = await getProvider(sourceChain);
     const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
-    const erc20 = new Contract(sourceTokenInfo.address.toNative(), ERC20.abi, this.baseSigner.connect(sourceProvider));
     const amountReadable = fromWei(amountToDeposit, sourceTokenInfo.decimals);
-    const txn: AugmentedTransaction = {
-      contract: erc20,
-      method: "transfer",
-      args: [depositAddress.address, amountToDeposit],
-      chainId: sourceChain,
-      nonMulticall: true,
-      unpermissioned: false,
-      ensureConfirmation: true,
-      message: `Deposited ${amountReadable} ${sourceToken} to Binance on chain ${getNetworkName(sourceChain)}`,
-      mrkdwn: `Deposited ${amountReadable} ${sourceToken} to Binance on chain ${getNetworkName(sourceChain)}`,
-    };
-    const txnHash = await this._submitTransaction(txn);
+    const connectedSigner = this.baseSigner.connect(sourceProvider);
+
+    let txnHash: string;
+    if (usesBinanceAtomicDepositorTransfer(sourceToken, sourceChain)) {
+      txnHash = await this._depositNativeEthToBinanceViaAtomicDepositor(
+        sourceChain,
+        depositAddress.address,
+        amountToDeposit
+      );
+    } else {
+      const erc20 = new Contract(sourceTokenInfo.address.toNative(), ERC20.abi, connectedSigner);
+      const txn: AugmentedTransaction = {
+        contract: erc20,
+        method: "transfer",
+        args: [depositAddress.address, amountToDeposit],
+        chainId: sourceChain,
+        nonMulticall: true,
+        unpermissioned: false,
+        ensureConfirmation: true,
+        message: `Deposited ${amountReadable} ${sourceToken} to Binance on chain ${getNetworkName(sourceChain)}`,
+        mrkdwn: `Deposited ${amountReadable} ${sourceToken} to Binance on chain ${getNetworkName(sourceChain)}`,
+      };
+      txnHash = await this._submitTransaction(txn);
+    }
     // Set the TTL to 30 minutes so that the Binance sweeper finalizer only attempts to pull back these deposited
     // funds after 30 minutes. If the swap hasn't occurred in 30 mins then something has gone wrong.
     await setBinanceDepositType(sourceChain, txnHash, BinanceTransactionType.SWAP, 30 * 60);
@@ -982,6 +1197,46 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       at: "BinanceStablecoinSwapAdapter._depositToBinance",
       message: `Deposited ${amountReadable} ${sourceToken} to Binance from chain ${getNetworkName(sourceChain)}`,
       redisDepositTypeKey: getBinanceTransactionTypeKey(sourceChain, txnHash),
+    });
+  }
+
+  private async _depositNativeEthToBinanceViaAtomicDepositor(
+    sourceChain: number,
+    depositAddress: string,
+    amountToDeposit: BigNumber
+  ): Promise<string> {
+    const sourceProvider = await getProvider(sourceChain);
+    const connectedSigner = this.baseSigner.connect(sourceProvider);
+    const atomicDepositorContracts = getAtomicDepositorContracts(sourceChain);
+    assert(
+      isDefined(atomicDepositorContracts),
+      `Atomic depositor contracts missing for ${getNetworkName(sourceChain)}`
+    );
+    const atomicDepositor = new Contract(
+      atomicDepositorContracts.atomicDepositorAddress,
+      atomicDepositorContracts.atomicDepositorAbi,
+      connectedSigner
+    );
+    const transferProxy = new Contract(
+      atomicDepositorContracts.transferProxyAddress,
+      atomicDepositorContracts.transferProxyAbi
+    );
+    const bridgeCalldata = transferProxy.interface.encodeFunctionData("transfer", [depositAddress]);
+    const binanceDepositNetwork = await this._getEntrypointNetwork(sourceChain, "WETH");
+    return this._submitTransaction({
+      contract: atomicDepositor,
+      method: "bridgeWeth",
+      args: [binanceDepositNetwork, amountToDeposit, amountToDeposit, bnZero, bridgeCalldata],
+      chainId: sourceChain,
+      nonMulticall: true,
+      unpermissioned: false,
+      ensureConfirmation: true,
+      message: `Deposited ${fromWei(amountToDeposit, 18)} WETH to Binance via native ETH on chain ${getNetworkName(
+        sourceChain
+      )}`,
+      mrkdwn: `Deposited ${fromWei(amountToDeposit, 18)} WETH to Binance via native ETH on chain ${getNetworkName(
+        sourceChain
+      )}`,
     });
   }
 
@@ -1019,6 +1274,9 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     sourceChain: number,
     amountToTransfer: BigNumber
   ): Promise<{ latestPrice: number; slippagePct: number }> {
+    if (!this._routeRequiresSwap(sourceToken, destinationToken)) {
+      return { latestPrice: 1, slippagePct: 0 };
+    }
     const symbol = await this._getSymbol(sourceToken, destinationToken);
     const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
     const book = await this._getOrderBook(symbol.symbol);
@@ -1126,11 +1384,26 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   }
 
   private async _getSpotMarketMetaForRoute(sourceToken: string, destinationToken: string): Promise<SPOT_MARKET_META> {
-    return deriveBinanceSpotMarketMeta(
-      sourceToken,
-      destinationToken,
-      await this._getSymbol(sourceToken, destinationToken)
+    assert(
+      this._routeRequiresSwap(sourceToken, destinationToken),
+      `Route ${sourceToken}-${destinationToken} does not require a Binance spot market`
     );
+    const routeName = `${sourceToken}-${destinationToken}`;
+    const existingPromise = this.spotMarketMetaPromiseByRoute.get(routeName);
+    if (existingPromise !== undefined) {
+      return existingPromise;
+    }
+
+    const promise = this._getSymbol(sourceToken, destinationToken).then((symbol) =>
+      deriveBinanceSpotMarketMeta(sourceToken, destinationToken, symbol)
+    );
+    this.spotMarketMetaPromiseByRoute.set(routeName, promise);
+    void promise.finally(() => {
+      if (this.spotMarketMetaPromiseByRoute.get(routeName) === promise) {
+        this.spotMarketMetaPromiseByRoute.delete(routeName);
+      }
+    });
+    return promise;
   }
 
   private async _convertSourceToDestination(
@@ -1142,7 +1415,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   ): Promise<BigNumber> {
     const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
     const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationChain);
-    if (sourceToken === destinationToken) {
+    if (!this._routeRequiresSwap(sourceToken, destinationToken)) {
       return this._getAmountConverter(
         sourceChain,
         sourceTokenInfo.address,
@@ -1177,7 +1450,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       sourceChain,
       sourceTokenInfo.address
     )(destinationAmount);
-    if (sourceToken === destinationToken) {
+    if (!this._routeRequiresSwap(sourceToken, destinationToken)) {
       return destinationAmountInSourcePrecision;
     }
     const priceData = await this._getLatestPrice(
@@ -1195,6 +1468,88 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       price: priceData.latestPrice,
       direction: "destination-to-source",
     });
+  }
+
+  private async _getExecutionLossInSourceToken(
+    sourceToken: string,
+    sourceChain: number,
+    destinationToken: string,
+    destinationChain: number,
+    amountToTransfer: BigNumber,
+    spotMarketMeta: SPOT_MARKET_META,
+    executedPrice: number
+  ): Promise<BigNumber> {
+    const sourceTokenInfo = this._getTokenInfo(sourceToken, sourceChain);
+    const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationChain);
+    const actualDestinationAmount = convertBinanceRouteAmount({
+      amount: amountToTransfer,
+      sourceTokenDecimals: sourceTokenInfo.decimals,
+      destinationTokenDecimals: destinationTokenInfo.decimals,
+      isBuy: spotMarketMeta.isBuy,
+      price: executedPrice,
+      direction: "source-to-destination",
+    });
+    const oracleDestinationAmount = await this._convertByOraclePrice(
+      amountToTransfer,
+      sourceToken,
+      sourceChain,
+      destinationToken,
+      destinationChain
+    );
+    if (actualDestinationAmount.gte(oracleDestinationAmount)) {
+      return bnZero;
+    }
+    return this._convertByOraclePrice(
+      oracleDestinationAmount.sub(actualDestinationAmount),
+      destinationToken,
+      destinationChain,
+      sourceToken,
+      sourceChain
+    );
+  }
+
+  private async _convertByOraclePrice(
+    amount: BigNumber,
+    fromToken: string,
+    fromChain: number,
+    toToken: string,
+    toChain: number
+  ): Promise<BigNumber> {
+    if (fromToken === toToken) {
+      return this._getAmountConverter(
+        fromChain,
+        this._getTokenInfo(fromToken, fromChain).address,
+        toChain,
+        this._getTokenInfo(toToken, toChain).address
+      )(amount);
+    }
+
+    const fromTokenDecimals = this._getTokenInfo(fromToken, fromChain).decimals;
+    const toTokenDecimals = this._getTokenInfo(toToken, toChain).decimals;
+    const [fromPriceUsd, toPriceUsd] = await Promise.all([
+      this._getTokenPriceUsd(fromToken),
+      this._getTokenPriceUsd(toToken),
+    ]);
+    const fromTokenUnit = toBNWei("1", fromTokenDecimals);
+    const toTokenUnit = toBNWei("1", toTokenDecimals);
+    const usdValue = amount.mul(fromPriceUsd).div(fromTokenUnit);
+    return usdValue.mul(toTokenUnit).div(toPriceUsd);
+  }
+
+  private async _getTokenPriceUsd(token: string): Promise<BigNumber> {
+    const cachedPrice = this.tokenPriceCache.get(token);
+    if (cachedPrice) {
+      return cachedPrice;
+    }
+
+    const hubTokenAddress = getTokenInfoFromSymbol(token, this.config.hubPoolChainId).address.toNative();
+    const fixedPriceEnv = process.env[`RELAYER_TOKEN_PRICE_FIXED_${hubTokenAddress}`];
+    const priceUsd = isDefined(fixedPriceEnv)
+      ? toBNWei(fixedPriceEnv)
+      : toBNWei((await this.priceClient.getPriceByAddress(hubTokenAddress)).price);
+    assert(priceUsd.gt(bnZero), `Unable to resolve positive USD price for ${token}`);
+    this.tokenPriceCache.set(token, priceUsd);
+    return priceUsd;
   }
 
   private async _getTradeFees(): ReturnType<Binance["tradeFee"]> {
@@ -1220,8 +1575,15 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       symbol: spotMarketMeta.symbol,
     });
     const matchingFill = allOrders.find((order) => order.clientOrderId === cloid && order.status === "FILLED");
+    if (!matchingFill) {
+      return undefined;
+    }
     const expectedAmountToReceive = spotMarketMeta.isBuy ? matchingFill.executedQty : matchingFill.cummulativeQuoteQty;
     return { matchingFill, expectedAmountToReceive };
+  }
+
+  private _routeRequiresSwap(sourceToken: string, destinationToken: string): boolean {
+    return !isSameBinanceCoin(sourceToken, destinationToken);
   }
 
   private async _placeMarketOrder(cloid: string, orderDetails: OrderDetails): Promise<void> {
@@ -1265,10 +1627,11 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     startTime: number,
     account: string
   ): Promise<BinanceWithdrawal[]> {
+    const binanceToken = resolveBinanceCoinSymbol(token);
     assert(isDefined(BINANCE_NETWORKS[chain]), "Chain should be a Binance network");
-    return (await getBinanceWithdrawals(this.binanceApiClient, token, startTime)).filter(
+    return (await getBinanceWithdrawals(this.binanceApiClient, binanceToken, startTime)).filter(
       (withdrawal) =>
-        withdrawal.coin === token &&
+        withdrawal.coin === binanceToken &&
         withdrawal.network === BINANCE_NETWORKS[chain] &&
         withdrawal.recipient.toLowerCase() === account.toLowerCase() &&
         isTerminalBinanceWithdrawal(withdrawal.status)
@@ -1286,24 +1649,6 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     failedWithdrawals: BinanceWithdrawal[];
   }> {
     assert(isDefined(BINANCE_NETWORKS[destinationChain]), "Destination chain should be a Binance network");
-    const provider = await getProvider(destinationChain);
-    // @dev Binance withdrawals are fast, so setting a lookback of 6 hours should capture any unfinalized withdrawals.
-    const withdrawalInitiatedLookbackPeriodSeconds = 6 * 60 * 60;
-    const withdrawalInitiatedFromTimestampSeconds = startTimeSeconds - withdrawalInitiatedLookbackPeriodSeconds;
-    const eventSearchConfig = await this._getEventSearchConfig(
-      destinationChain,
-      withdrawalInitiatedFromTimestampSeconds
-    );
-    const destinationTokenContract = new Contract(
-      this._getTokenInfo(destinationToken, destinationChain).address.toNative(),
-      ERC20.abi,
-      this.baseSigner.connect(provider)
-    );
-    const destinationChainTransferEvents = await paginatedEventQuery(
-      destinationTokenContract,
-      destinationTokenContract.filters.Transfer(null, account),
-      eventSearchConfig
-    );
     const initiatedWithdrawals = await this._getInitiatedBinanceWithdrawals(
       destinationToken,
       destinationChain,
@@ -1319,17 +1664,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         failedWithdrawals.push(initiated);
         continue;
       }
-      const withdrawalAmount = toBNWei(
-        initiated.amount, // @dev This should be the post-withdrawal fee amount so it should match perfectly
-        // with the finalized amount.
-        this._getTokenInfo(destinationToken, destinationChain).decimals
-      );
-      const matchingFinalizedAmount = destinationChainTransferEvents.find(
-        (finalized) =>
-          !finalizedWithdrawals.some((finalizedWithdrawal) => finalizedWithdrawal.txId === finalized.transactionHash) &&
-          finalized.args.value.toString() === withdrawalAmount.toString()
-      );
-      if (matchingFinalizedAmount) {
+      if (initiated.status === BINANCE_WITHDRAWAL_STATUS.COMPLETED) {
         finalizedWithdrawals.push(initiated);
       } else {
         unfinalizedWithdrawals.push(initiated);
@@ -1399,7 +1734,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationEntrypointNetwork);
     const amountToWithdraw = truncate(quantity, destinationTokenInfo.decimals);
     const withdrawalId = await this.binanceApiClient.withdraw({
-      coin: destinationToken,
+      coin: resolveBinanceCoinSymbol(destinationToken),
       address: this.baseSignerAddress.toNative(),
       amount: Number(amountToWithdraw),
       network: BINANCE_NETWORKS[destinationEntrypointNetwork],
@@ -1416,6 +1751,47 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       redisWithdrawalIdKey: initiatedWithdrawalKey,
       redisWithdrawalTypeKey: getBinanceTransactionTypeKey(destinationEntrypointNetwork, withdrawalId.id),
       finalDestinationChain: destinationChain,
+    });
+  }
+
+  private async _estimateWrapEthGasCost(chainId: number, amount: BigNumber): Promise<BigNumber> {
+    const tokenInfo = getTokenInfoFromSymbol("WETH", chainId);
+    const provider = await getProvider(chainId);
+    const connectedSigner = this.baseSigner.connect(provider);
+    const contract = new Contract(tokenInfo.address.toEvmAddress(), WETH_ABI, connectedSigner);
+    const estimatedGas = await contract.estimateGas.deposit({ value: amount });
+    const feeData = await provider.getFeeData();
+    const gasPrice = feeData.maxFeePerGas ?? feeData.gasPrice ?? bnZero;
+    const estimatedCost = estimatedGas.mul(gasPrice);
+    // Add a 20% buffer so the relayer does not flap on small fee changes between estimation and submission.
+    return estimatedCost.mul(12).div(10);
+  }
+
+  private async _wrapEth(chainId: number, amount: BigNumber): Promise<void> {
+    const tokenInfo = getTokenInfoFromSymbol("WETH", chainId);
+    const contract = new Contract(
+      tokenInfo.address.toEvmAddress(),
+      WETH_ABI,
+      this.baseSigner.connect(await getProvider(chainId))
+    );
+    const amountReadable = fromWei(amount, tokenInfo.decimals);
+    const txn: AugmentedTransaction = {
+      contract,
+      method: "deposit",
+      args: [],
+      value: amount,
+      chainId: chainId,
+      nonMulticall: true,
+      unpermissioned: false,
+      ensureConfirmation: true,
+      message: `Wrapped ${amountReadable} WETH on chain ${getNetworkName(chainId)} to finalize withdrawal`,
+      mrkdwn: `Wrapped ${amountReadable} WETH on chain ${getNetworkName(chainId)} to finalize withdrawal`,
+    };
+    const txnHash = await this._submitTransaction(txn);
+    this.logger.debug({
+      at: "BinanceStablecoinSwapAdapter._wrapEth",
+      message: `Wrapped ${amountReadable} WETH on chain ${getNetworkName(chainId)} to finalize withdrawal`,
+      txnHash,
     });
   }
 }

--- a/src/rebalancer/buildRebalanceRoutes.ts
+++ b/src/rebalancer/buildRebalanceRoutes.ts
@@ -1,0 +1,209 @@
+import { CHAIN_IDs } from "../utils";
+import { RebalancerConfig } from "./RebalancerConfig";
+import { RebalanceRoute } from "./utils/interfaces";
+
+type SupportedToken = "USDC" | "USDT" | "WETH";
+type StableToken = Exclude<SupportedToken, "WETH">;
+type DifferentAssetAdapter = "binance" | "hyperliquid";
+type ChainSelector = (rebalancerConfig: RebalancerConfig) => number[];
+
+// Direct Binance deposit/withdraw networks for each token. This is intentionally separate from the rebalancer route
+// set so we can track venue support without automatically enabling every listed network operationally.
+const BINANCE_NETWORKS_BY_SYMBOL: Record<SupportedToken, readonly number[]> = {
+  USDC: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.BASE, CHAIN_IDs.BSC],
+  USDT: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.BSC],
+  // Live Binance ETH networkList currently includes ARBITRUM, BASE, BSC, ETH, OPTIMISM, SCROLL, and ZKSYNCERA.
+  // The rebalancer support list below stays narrower until we intentionally enable more of those networks. We filter
+  // this further by limiting to chains where we have an Atomic Depositor contract.
+  WETH: [CHAIN_IDs.MAINNET],
+};
+
+const REBALANCE_CHAINS_BY_SYMBOL: Record<SupportedToken, readonly number[]> = {
+  USDT: [
+    CHAIN_IDs.HYPEREVM,
+    CHAIN_IDs.ARBITRUM,
+    CHAIN_IDs.OPTIMISM,
+    CHAIN_IDs.MAINNET,
+    CHAIN_IDs.UNICHAIN,
+    CHAIN_IDs.MONAD,
+    CHAIN_IDs.BSC,
+  ],
+  USDC: [
+    CHAIN_IDs.HYPEREVM,
+    CHAIN_IDs.ARBITRUM,
+    CHAIN_IDs.OPTIMISM,
+    CHAIN_IDs.MAINNET,
+    CHAIN_IDs.BASE,
+    CHAIN_IDs.UNICHAIN,
+    CHAIN_IDs.MONAD,
+    CHAIN_IDs.BSC,
+  ],
+  WETH: [CHAIN_IDs.MAINNET],
+};
+
+const SAME_ASSET_BRIDGE_ADAPTER_BY_SYMBOL: Record<StableToken, "cctp" | "oft"> = {
+  USDC: "cctp",
+  USDT: "oft",
+};
+
+function hasSameAssetBridgeAdapter(token: SupportedToken): token is StableToken {
+  return token in SAME_ASSET_BRIDGE_ADAPTER_BY_SYMBOL;
+}
+
+function configuredChainsForToken(rebalancerConfig: RebalancerConfig, token: SupportedToken): number[] {
+  return REBALANCE_CHAINS_BY_SYMBOL[token].filter((chainId) => rebalancerConfig.chainIds.includes(chainId));
+}
+
+function configuredDirectBinanceChainsForToken(rebalancerConfig: RebalancerConfig, token: SupportedToken): number[] {
+  return configuredChainsForToken(rebalancerConfig, token).filter((chainId) =>
+    BINANCE_NETWORKS_BY_SYMBOL[token].includes(chainId)
+  );
+}
+
+function configuredChains(token: SupportedToken): ChainSelector {
+  return (rebalancerConfig) => configuredChainsForToken(rebalancerConfig, token);
+}
+
+function configuredDirectBinanceChains(token: SupportedToken): ChainSelector {
+  return (rebalancerConfig) => configuredDirectBinanceChainsForToken(rebalancerConfig, token);
+}
+
+function canUseHyperliquidStablecoinRoute({
+  sourceChain,
+  destinationChain,
+}: {
+  sourceChain: number;
+  destinationChain: number;
+}): boolean {
+  return sourceChain !== CHAIN_IDs.BSC && destinationChain !== CHAIN_IDs.BSC;
+}
+
+function buildSameAssetRoutes(rebalancerConfig: RebalancerConfig, token: SupportedToken): RebalanceRoute[] {
+  if (!rebalancerConfig.cumulativeTargetBalances[token]?.targetBalance || !hasSameAssetBridgeAdapter(token)) {
+    return [];
+  }
+  const routes: RebalanceRoute[] = [];
+  const configuredChains = configuredChainsForToken(rebalancerConfig, token);
+
+  for (const sourceChain of configuredChains) {
+    for (const destinationChain of configuredChains) {
+      if (sourceChain === destinationChain) {
+        continue;
+      }
+
+      if (hasSameAssetBridgeAdapter(token) && sourceChain !== CHAIN_IDs.BSC && destinationChain !== CHAIN_IDs.BSC) {
+        routes.push({
+          sourceChain,
+          sourceToken: token,
+          destinationChain,
+          destinationToken: token,
+          adapter: SAME_ASSET_BRIDGE_ADAPTER_BY_SYMBOL[token],
+        });
+      }
+    }
+  }
+
+  return routes;
+}
+
+type DifferentAssetPairRule = {
+  tokenA: SupportedToken;
+  tokenB: SupportedToken;
+  adapter: DifferentAssetAdapter;
+  chainsA: ChainSelector;
+  chainsB: ChainSelector;
+  allow?: (params: { sourceChain: number; destinationChain: number }) => boolean;
+};
+
+const DIFFERENT_ASSET_ROUTE_RULES: readonly DifferentAssetPairRule[] = [
+  {
+    tokenA: "USDT",
+    tokenB: "USDC",
+    adapter: "binance",
+    chainsA: configuredChains("USDT"),
+    chainsB: configuredChains("USDC"),
+  },
+  {
+    tokenA: "USDT",
+    tokenB: "USDC",
+    adapter: "hyperliquid",
+    chainsA: configuredChains("USDT"),
+    chainsB: configuredChains("USDC"),
+    allow: canUseHyperliquidStablecoinRoute,
+  },
+  {
+    tokenA: "WETH",
+    tokenB: "USDT",
+    adapter: "binance",
+    chainsA: configuredDirectBinanceChains("WETH"),
+    chainsB: configuredChains("USDT"),
+  },
+  {
+    tokenA: "WETH",
+    tokenB: "USDC",
+    adapter: "binance",
+    chainsA: configuredDirectBinanceChains("WETH"),
+    chainsB: configuredChains("USDC"),
+  },
+];
+
+function pushDirectedDifferentAssetRoutes(
+  routes: RebalanceRoute[],
+  rule: DifferentAssetPairRule,
+  sourceToken: SupportedToken,
+  sourceChains: readonly number[],
+  destinationToken: SupportedToken,
+  destinationChains: readonly number[]
+): void {
+  for (const sourceChain of sourceChains) {
+    for (const destinationChain of destinationChains) {
+      if (rule.allow && !rule.allow({ sourceChain, destinationChain })) {
+        continue;
+      }
+
+      routes.push({
+        sourceChain,
+        sourceToken,
+        destinationChain,
+        destinationToken,
+        adapter: rule.adapter,
+      });
+    }
+  }
+}
+
+function buildDifferentAssetRoutes(rebalancerConfig: RebalancerConfig): RebalanceRoute[] {
+  const routes: RebalanceRoute[] = [];
+  for (const rule of DIFFERENT_ASSET_ROUTE_RULES) {
+    const chainsA = rule.chainsA(rebalancerConfig);
+    const chainsB = rule.chainsB(rebalancerConfig);
+
+    if (
+      !rebalancerConfig.cumulativeTargetBalances[rule.tokenA]?.targetBalance ||
+      !rebalancerConfig.cumulativeTargetBalances[rule.tokenB]?.targetBalance
+    ) {
+      continue;
+    }
+    pushDirectedDifferentAssetRoutes(routes, rule, rule.tokenA, chainsA, rule.tokenB, chainsB);
+    pushDirectedDifferentAssetRoutes(routes, rule, rule.tokenB, chainsB, rule.tokenA, chainsA);
+  }
+
+  return routes;
+}
+
+export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): RebalanceRoute[] {
+  return [...buildDifferentAssetRoutes(rebalancerConfig), ...buildSameAssetRoutes(rebalancerConfig, "USDT"), ...buildSameAssetRoutes(rebalancerConfig, "USDC")];
+}
+
+export function dedupeRebalanceRoutes(routes: RebalanceRoute[]): RebalanceRoute[] {
+  const uniqueRoutes = new Map<string, RebalanceRoute>();
+  for (const route of routes) {
+    uniqueRoutes.set(
+      [route.sourceChain, route.sourceToken, route.destinationChain, route.destinationToken, route.adapter].join("|"),
+      route
+    );
+  }
+  return Array.from(uniqueRoutes.values());
+}
+
+export { BINANCE_NETWORKS_BY_SYMBOL, REBALANCE_CHAINS_BY_SYMBOL };

--- a/test/BinanceAdapter.conversions.ts
+++ b/test/BinanceAdapter.conversions.ts
@@ -1,8 +1,68 @@
 import { CHAIN_IDs } from "@across-protocol/constants";
+import winston from "winston";
 import { ethers, expect, sinon, toBNWei } from "./utils";
-import { EvmAddress } from "../src/utils";
+import { BigNumber, EvmAddress } from "../src/utils";
 import { BinanceStablecoinSwapAdapter } from "../src/rebalancer/adapters/binance";
+import { CctpAdapter } from "../src/rebalancer/adapters/cctpAdapter";
+import { OftAdapter } from "../src/rebalancer/adapters/oftAdapter";
+import { RebalancerConfig } from "../src/rebalancer/RebalancerConfig";
 import { RebalanceRoute } from "../src/rebalancer/utils/interfaces";
+
+type BinanceCoinStub = {
+  symbol?: string;
+  balance?: string;
+  networkList: Array<{
+    name: string;
+    withdrawMin: string;
+    withdrawMax: string;
+    withdrawFee: string;
+  }>;
+};
+
+type BinanceTradeFeeStub = { symbol: string; takerCommission: string };
+
+type IntermediateAdapterStub = Partial<Pick<CctpAdapter, "supportsRoute" | "getEstimatedCost">>;
+
+type BinanceAdapterInternals = BinanceStablecoinSwapAdapter & {
+  initialized: boolean;
+  availableRoutes: RebalanceRoute[];
+  baseSignerAddress: EvmAddress;
+  _getSpotMarketMetaForRoute: (
+    sourceToken: string,
+    destinationToken: string
+  ) => Promise<ReturnType<typeof makeSpotMeta>>;
+  _getLatestPrice: (
+    sourceToken: string,
+    destinationToken: string,
+    sourceChain: number,
+    amountToTransfer: BigNumber
+  ) => Promise<{ latestPrice: number; slippagePct: number }>;
+  _getAccountCoins: (token: string) => Promise<BinanceCoinStub>;
+  _getEntrypointNetwork: (chainId: number, token: string) => Promise<number>;
+  _redisGetNextCloid: () => Promise<string>;
+  _depositToBinance: (sourceToken: string, sourceChain: number, amountToDeposit: BigNumber) => Promise<void>;
+  _redisCreateOrder: (
+    cloid: string,
+    status: number,
+    rebalanceRoute: RebalanceRoute,
+    amountToTransfer: BigNumber,
+    account: EvmAddress,
+    ttlOverride?: number
+  ) => Promise<void>;
+  _getTradeFees: () => Promise<BinanceTradeFeeStub[]>;
+  _getTokenPriceUsd: (token: string) => Promise<BigNumber>;
+  _convertDestinationToSource: (
+    destinationToken: string,
+    destinationChain: number,
+    sourceToken: string,
+    sourceChain: number,
+    destinationAmount: BigNumber
+  ) => Promise<BigNumber>;
+};
+
+function withBinanceInternals(adapter: BinanceStablecoinSwapAdapter): BinanceAdapterInternals {
+  return adapter as unknown as BinanceAdapterInternals;
+}
 
 describe("Binance adapter conversion sizing", function () {
   afterEach(function () {
@@ -12,23 +72,17 @@ describe("Binance adapter conversion sizing", function () {
   it("uses converted withdrawal minimums when deciding whether to initialize a rebalance", async function () {
     const route = makeStablecoinRoute();
     const adapter = await makeInitializedAdapter(route);
+    const internals = withBinanceInternals(adapter);
     const depositStub = sinon.stub();
     const createOrderStub = sinon.stub().resolves();
     sinon.stub(adapter, "getEstimatedCost").resolves(toBNWei("0", 6));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getLatestPrice").resolves({ latestPrice: 0.99, slippagePct: 0 });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getAccountCoins").resolves(makeCoin("100", "1000000"));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getEntrypointNetwork").callsFake(async () => CHAIN_IDs.MAINNET);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_redisGetNextCloid").resolves("cloid");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_depositToBinance").callsFake(depositStub);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_redisCreateOrder").callsFake(createOrderStub);
+    sinon.stub(internals, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
+    sinon.stub(internals, "_getLatestPrice").resolves({ latestPrice: 0.99, slippagePct: 0 });
+    sinon.stub(internals, "_getAccountCoins").resolves(makeCoin("100", "1000000"));
+    sinon.stub(internals, "_getEntrypointNetwork").callsFake(async () => CHAIN_IDs.MAINNET);
+    sinon.stub(internals, "_redisGetNextCloid").resolves("cloid");
+    sinon.stub(internals, "_depositToBinance").callsFake(depositStub);
+    sinon.stub(internals, "_redisCreateOrder").callsFake(createOrderStub);
 
     const amount = toBNWei("100", 6);
     const result = await adapter.initializeRebalance(route, amount);
@@ -41,23 +95,17 @@ describe("Binance adapter conversion sizing", function () {
   it("uses converted buy-side minimum order sizes", async function () {
     const route = makeStablecoinRoute();
     const adapter = await makeInitializedAdapter(route);
+    const internals = withBinanceInternals(adapter);
     const depositStub = sinon.stub();
     const createOrderStub = sinon.stub().resolves();
     sinon.stub(adapter, "getEstimatedCost").resolves(toBNWei("0", 6));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 100));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getLatestPrice").resolves({ latestPrice: 0.99, slippagePct: 0 });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getAccountCoins").resolves(makeCoin("0", "1000000"));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getEntrypointNetwork").callsFake(async () => CHAIN_IDs.MAINNET);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_redisGetNextCloid").resolves("cloid");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_depositToBinance").callsFake(depositStub);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_redisCreateOrder").callsFake(createOrderStub);
+    sinon.stub(internals, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 100));
+    sinon.stub(internals, "_getLatestPrice").resolves({ latestPrice: 0.99, slippagePct: 0 });
+    sinon.stub(internals, "_getAccountCoins").resolves(makeCoin("0", "1000000"));
+    sinon.stub(internals, "_getEntrypointNetwork").callsFake(async () => CHAIN_IDs.MAINNET);
+    sinon.stub(internals, "_redisGetNextCloid").resolves("cloid");
+    sinon.stub(internals, "_depositToBinance").callsFake(depositStub);
+    sinon.stub(internals, "_redisCreateOrder").callsFake(createOrderStub);
 
     const amount = toBNWei("99.5", 6);
     const result = await adapter.initializeRebalance(route, amount);
@@ -76,17 +124,14 @@ describe("Binance adapter conversion sizing", function () {
         getEstimatedCost: cctpGetEstimatedCost,
       },
     });
+    const internals = withBinanceInternals(adapter);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getLatestPrice").resolves({ latestPrice: 0.98, slippagePct: 0 });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getAccountCoins").resolves(makeCoin("0", "1000000"));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getTradeFees").resolves([{ symbol: "USDCUSDT", takerCommission: "0" }]);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getEntrypointNetwork").callsFake(async (...args: [number, string]) => {
+    sinon.stub(internals, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
+    sinon.stub(internals, "_getLatestPrice").resolves({ latestPrice: 0.98, slippagePct: 0 });
+    sinon.stub(internals, "_getAccountCoins").resolves(makeCoin("0", "1000000"));
+    sinon.stub(internals, "_getTradeFees").resolves([{ symbol: "USDCUSDT", takerCommission: "0" }]);
+    sinon.stub(internals, "_getTokenPriceUsd").callsFake(async () => toBNWei("1"));
+    sinon.stub(internals, "_getEntrypointNetwork").callsFake(async (...args: [number, string]) => {
       const [chainId, token] = args;
       return token === "USDC" && chainId === CHAIN_IDs.BASE ? CHAIN_IDs.MAINNET : chainId;
     });
@@ -97,23 +142,70 @@ describe("Binance adapter conversion sizing", function () {
     expect(cctpGetEstimatedCost.getCall(0).args[1].eq(toBNWei("102.040816", 6))).to.equal(true);
   });
 
+  it("does not inflate stablecoin withdrawal fees when source and destination decimals differ", async function () {
+    const route = makeStablecoinRoute({ sourceChain: CHAIN_IDs.BSC, destinationChain: CHAIN_IDs.BASE });
+    const adapter = await makeInitializedAdapter(route);
+    const internals = withBinanceInternals(adapter);
+
+    sinon.stub(internals, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
+    sinon.stub(internals, "_getTradeFees").resolves([{ symbol: "USDCUSDT", takerCommission: "0" }]);
+    sinon.stub(internals, "_getLatestPrice").resolves({ latestPrice: 1, slippagePct: 0 });
+    sinon.stub(internals, "_getTokenPriceUsd").callsFake(async () => toBNWei("1"));
+    sinon.stub(internals, "_getAccountCoins").callsFake(async (token: string) => {
+      return {
+        symbol: token,
+        balance: "0",
+        networkList: [
+          {
+            name: "BASE",
+            withdrawMin: "0.1",
+            withdrawMax: "1000000",
+            withdrawFee: "0.499695",
+          },
+          {
+            name: "BSC",
+            withdrawMin: "0.1",
+            withdrawMax: "1000000",
+            withdrawFee: "0",
+          },
+        ],
+      };
+    });
+    sinon.stub(internals, "_getEntrypointNetwork").callsFake(async (chainId: number) => chainId);
+
+    const cost = await adapter.getEstimatedCost(route, toBNWei("308304.851912549672926661", 18), false);
+
+    expect(cost.eq(toBNWei("0.499695", 18))).to.equal(true);
+  });
+
+  it("prices mixed-asset execution against oracle value, not just book slippage", async function () {
+    const route = makeStablecoinRoute({ sourceToken: "USDC", destinationToken: "WETH" });
+    const adapter = await makeInitializedAdapter(route);
+    const internals = withBinanceInternals(adapter);
+
+    sinon.stub(internals, "_getSpotMarketMetaForRoute").resolves(makeEthUsdcSpotMeta(true, 0.0001));
+    sinon.stub(internals, "_getTradeFees").resolves([{ symbol: "ETHUSDC", takerCommission: "0" }]);
+    sinon.stub(internals, "_getLatestPrice").resolves({ latestPrice: 2200, slippagePct: 0 });
+    sinon.stub(internals, "_getAccountCoins").resolves(makeCoin("0", "1000000"));
+    sinon.stub(internals, "_getEntrypointNetwork").callsFake(async (chainId: number) => chainId);
+    sinon.stub(internals, "_getTokenPriceUsd").callsFake(async (token: string) => {
+      return token === "WETH" ? toBNWei("2000") : toBNWei("1");
+    });
+
+    const cost = await adapter.getEstimatedCost(route, toBNWei("2200", 6), false);
+
+    expect(cost.eq(toBNWei("200", 6))).to.equal(true);
+  });
+
   it("prices destination-to-source conversions using source-token precision", async function () {
     const route = makeStablecoinRoute();
     const adapter = await makeInitializedAdapter(route);
+    const internals = withBinanceInternals(adapter);
     const latestPriceStub = sinon.stub().resolves({ latestPrice: 2500, slippagePct: 0 });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sinon.stub(adapter as any, "_getLatestPrice").callsFake(latestPriceStub);
+    sinon.stub(internals, "_getSpotMarketMetaForRoute").resolves(makeSpotMeta(true, 1));
+    sinon.stub(internals, "_getLatestPrice").callsFake(latestPriceStub);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (adapter as any)._convertDestinationToSource(
-      "WETH",
-      CHAIN_IDs.MAINNET,
-      "USDC",
-      CHAIN_IDs.MAINNET,
-      toBNWei("1", 18)
-    );
+    await internals._convertDestinationToSource("WETH", CHAIN_IDs.MAINNET, "USDC", CHAIN_IDs.MAINNET, toBNWei("1", 18));
 
     expect(latestPriceStub.calledOnce).to.equal(true);
     expect(latestPriceStub.getCall(0).args[0]).to.equal("USDC");
@@ -129,21 +221,22 @@ async function makeInitializedAdapter(
     cctpAdapter = {},
     oftAdapter = {},
   }: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    cctpAdapter?: any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    oftAdapter?: any;
+    cctpAdapter?: IntermediateAdapterStub;
+    oftAdapter?: IntermediateAdapterStub;
   } = {}
 ): Promise<BinanceStablecoinSwapAdapter> {
   const [signer] = await ethers.getSigners();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const adapter = new BinanceStablecoinSwapAdapter(TEST_LOGGER, {} as any, signer, cctpAdapter, oftAdapter);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (adapter as any).initialized = true;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (adapter as any).availableRoutes = [route];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (adapter as any).baseSignerAddress = EvmAddress.from(await signer.getAddress());
+  const adapter = new BinanceStablecoinSwapAdapter(
+    TEST_LOGGER,
+    { hubPoolChainId: CHAIN_IDs.MAINNET } as RebalancerConfig,
+    signer,
+    cctpAdapter as CctpAdapter,
+    oftAdapter as OftAdapter
+  );
+  const internals = withBinanceInternals(adapter);
+  internals.initialized = true;
+  internals.availableRoutes = [route];
+  internals.baseSignerAddress = EvmAddress.from(await signer.getAddress());
   return adapter;
 }
 
@@ -170,6 +263,18 @@ function makeSpotMeta(isBuy: boolean, minimumOrderSize: number) {
   };
 }
 
+function makeEthUsdcSpotMeta(isBuy: boolean, minimumOrderSize: number) {
+  return {
+    symbol: "ETHUSDC",
+    baseAssetName: "ETH",
+    quoteAssetName: "USDC",
+    pxDecimals: 2,
+    szDecimals: 4,
+    minimumOrderSize,
+    isBuy,
+  };
+}
+
 function makeCoin(withdrawMin: string, withdrawMax: string) {
   return {
     networkList: [{ name: "ETH", withdrawMin, withdrawMax, withdrawFee: "0" }],
@@ -181,5 +286,4 @@ const TEST_LOGGER = {
   info: () => undefined,
   warn: () => undefined,
   error: () => undefined,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-} as any;
+} as unknown as winston.Logger;

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -1,13 +1,38 @@
+import { ethers, expect, sinon, toBNWei } from "./utils";
+import winston from "winston";
 import {
   BinanceStablecoinSwapAdapter,
   convertBinanceRouteAmount,
   deriveBinanceSpotMarketMeta,
+  isSameBinanceCoin,
+  resolveBinanceCoinSymbol,
+  supportsBinanceIntermediateBridgeToken,
 } from "../src/rebalancer/adapters/binance";
-import { ethers, expect, sinon, toBNWei } from "./utils";
+import { CctpAdapter } from "../src/rebalancer/adapters/cctpAdapter";
+import { OftAdapter } from "../src/rebalancer/adapters/oftAdapter";
+import { RebalancerConfig } from "../src/rebalancer/RebalancerConfig";
+import { CHAIN_IDs } from "../src/utils";
 
 describe("Binance adapter helpers", async function () {
   afterEach(function () {
     sinon.restore();
+  });
+
+  it("aliases on-chain WETH to Binance ETH", async function () {
+    expect(resolveBinanceCoinSymbol("WETH")).to.equal("ETH");
+    expect(resolveBinanceCoinSymbol("USDC")).to.equal("USDC");
+  });
+
+  it("detects same-coin Binance routes that should skip the swap leg", async function () {
+    expect(isSameBinanceCoin("WETH", "WETH")).to.equal(true);
+    expect(isSameBinanceCoin("USDC", "USDC")).to.equal(true);
+    expect(isSameBinanceCoin("WETH", "USDC")).to.equal(false);
+  });
+
+  it("only permits intermediate Binance bridge legs for assets we can actually bridge onchain", async function () {
+    expect(supportsBinanceIntermediateBridgeToken("USDC")).to.equal(true);
+    expect(supportsBinanceIntermediateBridgeToken("USDT")).to.equal(true);
+    expect(supportsBinanceIntermediateBridgeToken("WETH")).to.equal(false);
   });
 
   it("derives buy-side market metadata for USDT -> USDC routes", async function () {
@@ -34,26 +59,39 @@ describe("Binance adapter helpers", async function () {
     expect(meta.isBuy).to.equal(false);
   });
 
-  it("converts route amounts using non-parity prices", async function () {
-    const converted = convertBinanceRouteAmount({
-      amount: toBNWei("100", 6),
-      sourceTokenDecimals: 6,
+  it("derives Binance spot market metadata for WETH/stable routes in both directions", async function () {
+    const wethToUsdc = deriveBinanceSpotMarketMeta("WETH", "USDC", makeWethUsdcSymbol() as never);
+    const usdcToWeth = deriveBinanceSpotMarketMeta("USDC", "WETH", makeWethUsdcSymbol() as never);
+
+    expect(wethToUsdc.symbol).to.equal("ETHUSDC");
+    expect(wethToUsdc.isBuy).to.equal(false);
+    expect(wethToUsdc.pxDecimals).to.equal(2);
+    expect(wethToUsdc.szDecimals).to.equal(4);
+    expect(wethToUsdc.minimumOrderSize).to.equal(0.0001);
+    expect(usdcToWeth.isBuy).to.equal(true);
+  });
+
+  it("converts non-parity Binance route amounts without assuming a 1:1 market", async function () {
+    const oneWeth = toBNWei("1", 18);
+    const fifteenHundredUsdc = convertBinanceRouteAmount({
+      amount: oneWeth,
+      sourceTokenDecimals: 18,
       destinationTokenDecimals: 6,
-      isBuy: true,
-      price: 0.98,
+      isBuy: false,
+      price: 1500,
       direction: "source-to-destination",
     });
     const sourceEquivalent = convertBinanceRouteAmount({
-      amount: converted,
-      sourceTokenDecimals: 6,
+      amount: fifteenHundredUsdc,
+      sourceTokenDecimals: 18,
       destinationTokenDecimals: 6,
-      isBuy: true,
-      price: 0.98,
+      isBuy: false,
+      price: 1500,
       direction: "destination-to-source",
     });
 
-    expect(converted.eq(toBNWei("102.040816", 6))).to.equal(true);
-    expect(sourceEquivalent.eq(toBNWei("99.999999", 6))).to.equal(true);
+    expect(fifteenHundredUsdc.eq(toBNWei("1500", 6))).to.equal(true);
+    expect(sourceEquivalent.eq(oneWeth)).to.equal(true);
   });
 
   it("retries exchangeInfo lookups after transient failures", async function () {
@@ -111,8 +149,13 @@ describe("Binance adapter helpers", async function () {
 
 async function makeAdapter(): Promise<BinanceStablecoinSwapAdapter> {
   const [signer] = await ethers.getSigners();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return new BinanceStablecoinSwapAdapter(TEST_LOGGER, {} as any, signer, {} as any, {} as any);
+  return new BinanceStablecoinSwapAdapter(
+    TEST_LOGGER,
+    { hubPoolChainId: CHAIN_IDs.MAINNET } as RebalancerConfig,
+    signer,
+    {} as CctpAdapter,
+    {} as OftAdapter
+  );
 }
 
 function makeStablecoinSymbol() {
@@ -127,10 +170,21 @@ function makeStablecoinSymbol() {
   } as const;
 }
 
+function makeWethUsdcSymbol() {
+  return {
+    symbol: "ETHUSDC",
+    baseAsset: "ETH",
+    quoteAsset: "USDC",
+    filters: [
+      { filterType: "PRICE_FILTER", tickSize: "0.01000000" },
+      { filterType: "LOT_SIZE", stepSize: "0.00010000", minQty: "0.00010000" },
+    ],
+  } as const;
+}
+
 const TEST_LOGGER = {
   debug: () => undefined,
   info: () => undefined,
   warn: () => undefined,
   error: () => undefined,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-} as any;
+} as unknown as winston.Logger;

--- a/test/BinanceAdapter.quotes.ts
+++ b/test/BinanceAdapter.quotes.ts
@@ -2,22 +2,43 @@ import { CHAIN_IDs } from "@across-protocol/constants";
 import { BinanceStablecoinSwapAdapter } from "../src/rebalancer/adapters/binance";
 import { ethers, expect, sinon, toBNWei } from "./utils";
 
+type OrderBook = ReturnType<typeof makeOrderBook>;
+type QuoteTestAdapter = {
+  binanceApiClient: {
+    book?: sinon.SinonStub;
+    exchangeInfo?: sinon.SinonStub;
+  };
+  exchangeInfoPromise?: Promise<{
+    symbols: Array<{
+      symbol: string;
+      baseAsset: string;
+      quoteAsset: string;
+      filters: Array<{ filterType: string; tickSize?: string; stepSize?: string; minQty?: string }>;
+    }>;
+  }>;
+  _getOrderBook(symbol: string): Promise<OrderBook>;
+  _fetchOrderBook(symbol: string, fromId: number, limit: number): Promise<OrderBook>;
+  _getLatestPrice(
+    sourceToken: string,
+    destinationToken: string,
+    sourceChain: number,
+    sourceAmount: ReturnType<typeof toBNWei>
+  ): Promise<unknown>;
+};
+
 describe("Binance adapter quotes", function () {
   afterEach(function () {
     sinon.restore();
   });
 
   it("reuses a cached order book snapshot within the TTL", async function () {
-    const adapter = await makeAdapter();
+    const adapter = asQuoteAdapter(await makeAdapter());
     const book = makeOrderBook({ asks: [{ price: "1.0001", quantity: "1000" }], bids: [] });
     const bookStub = sinon.stub().resolves(book);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (adapter as any).binanceApiClient = { book: bookStub };
+    adapter.binanceApiClient = { book: bookStub };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const first = await (adapter as any)._getOrderBook("USDCUSDT");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const second = await (adapter as any)._getOrderBook("USDCUSDT");
+    const first = await adapter._getOrderBook("USDCUSDT");
+    const second = await adapter._getOrderBook("USDCUSDT");
 
     expect(first).to.equal(book);
     expect(second).to.equal(book);
@@ -25,22 +46,15 @@ describe("Binance adapter quotes", function () {
   });
 
   it("deduplicates concurrent order book fetches for the same symbol", async function () {
-    const adapter = await makeAdapter();
+    const adapter = asQuoteAdapter(await makeAdapter());
     const book = makeOrderBook({ asks: [{ price: "1.0001", quantity: "1000" }], bids: [] });
     const bookStub = sinon.stub().callsFake(async () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
       return book;
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (adapter as any).binanceApiClient = { book: bookStub };
-    const quoteAdapter = adapter as unknown as {
-      _getOrderBook(symbol: string): Promise<ReturnType<typeof makeOrderBook>>;
-    };
+    adapter.binanceApiClient = { book: bookStub };
 
-    const [first, second] = await Promise.all([
-      quoteAdapter._getOrderBook("USDCUSDT"),
-      quoteAdapter._getOrderBook("USDCUSDT"),
-    ]);
+    const [first, second] = await Promise.all([adapter._getOrderBook("USDCUSDT"), adapter._getOrderBook("USDCUSDT")]);
 
     expect(first).to.equal(book);
     expect(second).to.equal(book);
@@ -48,24 +62,22 @@ describe("Binance adapter quotes", function () {
   });
 
   it("retries transient order book fetch failures", async function () {
-    const adapter = await makeAdapter();
+    const adapter = asQuoteAdapter(await makeAdapter());
     const book = makeOrderBook({ asks: [{ price: "1.0001", quantity: "1000" }], bids: [] });
     const bookStub = sinon.stub();
     bookStub.onCall(0).rejects(new Error("temporary outage"));
     bookStub.onCall(1).resolves(book);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (adapter as any).binanceApiClient = { book: bookStub };
+    adapter.binanceApiClient = { book: bookStub };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const fetched = await (adapter as any)._fetchOrderBook("USDCUSDT", 0, 1);
+    const fetched = await adapter._fetchOrderBook("USDCUSDT", 0, 1);
 
     expect(fetched).to.equal(book);
     expect(bookStub.callCount).to.equal(2);
   });
 
   it("throws a visible-depth error when the order book cannot satisfy the order size", async function () {
-    const adapter = await makeAdapter();
-    const exchangeInfoStub = sinon.stub().resolves({
+    const adapter = asQuoteAdapter(await makeAdapter());
+    const exchangeInfo = {
       symbols: [
         {
           symbol: "USDCUSDT",
@@ -84,19 +96,18 @@ describe("Binance adapter quotes", function () {
           ],
         },
       ],
-    });
+    };
     const bookStub = sinon.stub().resolves(
       makeOrderBook({
         asks: [{ price: "1.0010", quantity: "10" }],
         bids: [],
       })
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (adapter as any).binanceApiClient = { exchangeInfo: exchangeInfoStub, book: bookStub };
+    adapter.exchangeInfoPromise = Promise.resolve(exchangeInfo);
+    adapter.binanceApiClient = { book: bookStub };
 
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await (adapter as any)._getLatestPrice("USDT", "USDC", CHAIN_IDs.MAINNET, toBNWei("1000", 6));
+      await adapter._getLatestPrice("USDT", "USDC", CHAIN_IDs.MAINNET, toBNWei("1000", 6));
       expect.fail("expected _getLatestPrice to throw when the order book is too shallow");
     } catch (error) {
       expect(String(error)).to.contain("exceeds visible Binance order book depth");
@@ -106,8 +117,17 @@ describe("Binance adapter quotes", function () {
 
 async function makeAdapter(): Promise<BinanceStablecoinSwapAdapter> {
   const [signer] = await ethers.getSigners();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return new BinanceStablecoinSwapAdapter(TEST_LOGGER, {} as any, signer, {} as any, {} as any);
+  return new BinanceStablecoinSwapAdapter(
+    TEST_LOGGER as never,
+    { hubPoolChainId: CHAIN_IDs.MAINNET } as never,
+    signer,
+    {} as never,
+    {} as never
+  );
+}
+
+function asQuoteAdapter(adapter: BinanceStablecoinSwapAdapter): QuoteTestAdapter {
+  return adapter as unknown as QuoteTestAdapter;
 }
 
 function makeOrderBook({
@@ -125,5 +145,4 @@ const TEST_LOGGER = {
   info: () => undefined,
   warn: () => undefined,
   error: () => undefined,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-} as any;
+};

--- a/test/RebalancerClient.buildRebalanceRoutes.ts
+++ b/test/RebalancerClient.buildRebalanceRoutes.ts
@@ -1,0 +1,211 @@
+import { expect } from "./utils";
+import { CHAIN_IDs } from "../src/utils";
+import { RebalancerConfig } from "../src/rebalancer/RebalancerConfig";
+import { buildRebalanceRoutes } from "../src/rebalancer/buildRebalanceRoutes";
+
+function buildSyntheticRebalancerConfig(): RebalancerConfig {
+  return new RebalancerConfig({
+    HUB_CHAIN_ID: String(CHAIN_IDs.MAINNET),
+    REBALANCER_CONFIG: JSON.stringify({
+      cumulativeTargetBalances: {
+        USDT: {
+          targetBalance: "1000",
+          thresholdBalance: "500",
+          priorityTier: 0,
+          chains: {
+            [CHAIN_IDs.HYPEREVM]: 0,
+            [CHAIN_IDs.OPTIMISM]: 0,
+            [CHAIN_IDs.BSC]: 0,
+          },
+        },
+        USDC: {
+          targetBalance: "1000",
+          thresholdBalance: "500",
+          priorityTier: 0,
+          chains: {
+            [CHAIN_IDs.HYPEREVM]: 0,
+            [CHAIN_IDs.ARBITRUM]: 0,
+            [CHAIN_IDs.OPTIMISM]: 0,
+            [CHAIN_IDs.BSC]: 0,
+            [CHAIN_IDs.BASE]: 0,
+          },
+        },
+      },
+      maxAmountsToTransfer: {
+        USDT: "100",
+        USDC: "100",
+      },
+      maxPendingOrders: {
+        hyperliquid: 3,
+        binance: 3,
+      },
+    }),
+  });
+}
+
+function buildSyntheticRebalancerConfigWithMainnet(): RebalancerConfig {
+  return new RebalancerConfig({
+    HUB_CHAIN_ID: String(CHAIN_IDs.MAINNET),
+    REBALANCER_CONFIG: JSON.stringify({
+      cumulativeTargetBalances: {
+        USDT: {
+          targetBalance: "1000",
+          thresholdBalance: "500",
+          priorityTier: 0,
+          chains: {
+            [CHAIN_IDs.HYPEREVM]: 0,
+            [CHAIN_IDs.OPTIMISM]: 0,
+            [CHAIN_IDs.BSC]: 0,
+            [CHAIN_IDs.MAINNET]: 0,
+          },
+        },
+        USDC: {
+          targetBalance: "1000",
+          thresholdBalance: "500",
+          priorityTier: 0,
+          chains: {
+            [CHAIN_IDs.HYPEREVM]: 0,
+            [CHAIN_IDs.ARBITRUM]: 0,
+            [CHAIN_IDs.OPTIMISM]: 0,
+            [CHAIN_IDs.BSC]: 0,
+            [CHAIN_IDs.BASE]: 0,
+            [CHAIN_IDs.MAINNET]: 0,
+          },
+        },
+        WETH: {
+          targetBalance: "1",
+          thresholdBalance: "0.5",
+          priorityTier: 0,
+          chains: {
+            [CHAIN_IDs.MAINNET]: 0,
+          },
+        },
+      },
+      maxAmountsToTransfer: {
+        USDT: "100",
+        USDC: "100",
+        WETH: "1",
+      },
+      maxPendingOrders: {
+        hyperliquid: 3,
+        binance: 3,
+      },
+    }),
+  });
+}
+
+describe("buildRebalanceRoutes", async function () {
+  it("builds the exact stablecoin route families implied by synthetic config", async function () {
+    const config = buildSyntheticRebalancerConfig();
+
+    const routes = buildRebalanceRoutes(config);
+    const hasRoute = (
+      sourceChain: number,
+      sourceToken: string,
+      destinationChain: number,
+      destinationToken: string,
+      adapter: string
+    ) =>
+      routes.some(
+        (route) =>
+          route.sourceChain === sourceChain &&
+          route.sourceToken === sourceToken &&
+          route.destinationChain === destinationChain &&
+          route.destinationToken === destinationToken &&
+          route.adapter === adapter
+      );
+
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDT", CHAIN_IDs.OPTIMISM, "USDC", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDT", CHAIN_IDs.OPTIMISM, "USDC", "hyperliquid")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.BSC, "USDT", CHAIN_IDs.OPTIMISM, "USDC", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.BSC, "USDT", CHAIN_IDs.OPTIMISM, "USDC", "hyperliquid")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDC", CHAIN_IDs.BASE, "USDC", "cctp")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDC", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDT", CHAIN_IDs.HYPEREVM, "USDT", "oft")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDT", CHAIN_IDs.HYPEREVM, "USDT", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDT", CHAIN_IDs.OPTIMISM, "USDT", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.BSC, "USDT", CHAIN_IDs.OPTIMISM, "USDT", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.BSC, "USDC", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDC", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(false);
+  });
+
+  it("does not build WETH Binance routes when mainnet is not configured", async function () {
+    const config = buildSyntheticRebalancerConfig();
+
+    const routes = buildRebalanceRoutes(config);
+    const hasRoute = (
+      sourceChain: number,
+      sourceToken: string,
+      destinationChain: number,
+      destinationToken: string,
+      adapter: string
+    ) =>
+      routes.some(
+        (route) =>
+          route.sourceChain === sourceChain &&
+          route.sourceToken === sourceToken &&
+          route.destinationChain === destinationChain &&
+          route.destinationToken === destinationToken &&
+          route.adapter === adapter
+      );
+
+    expect(hasRoute(CHAIN_IDs.MAINNET, "WETH", CHAIN_IDs.HYPEREVM, "USDT", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDT", CHAIN_IDs.MAINNET, "WETH", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "WETH", CHAIN_IDs.HYPEREVM, "USDT", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "WETH", CHAIN_IDs.OPTIMISM, "USDT", "binance")).to.equal(false);
+  });
+
+  it("builds WETH<->stablecoin routes via binance only from mainnet when mainnet is configured", async function () {
+    const config = buildSyntheticRebalancerConfigWithMainnet();
+
+    const routes = buildRebalanceRoutes(config);
+    const hasRoute = (
+      sourceChain: number,
+      sourceToken: string,
+      destinationChain: number,
+      destinationToken: string,
+      adapter: string
+    ) =>
+      routes.some(
+        (route) =>
+          route.sourceChain === sourceChain &&
+          route.sourceToken === sourceToken &&
+          route.destinationChain === destinationChain &&
+          route.destinationToken === destinationToken &&
+          route.adapter === adapter
+      );
+
+    expect(hasRoute(CHAIN_IDs.MAINNET, "WETH", CHAIN_IDs.HYPEREVM, "USDT", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.HYPEREVM, "USDT", CHAIN_IDs.MAINNET, "WETH", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.MAINNET, "WETH", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.BASE, "USDC", CHAIN_IDs.MAINNET, "WETH", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "WETH", CHAIN_IDs.HYPEREVM, "USDT", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.BSC, "WETH", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.MAINNET, "WETH", CHAIN_IDs.HYPEREVM, "USDT", "hyperliquid")).to.equal(false);
+  });
+
+  it("does not build WETH->WETH Binance routes while WETH support is mainnet-only", async function () {
+    const config = buildSyntheticRebalancerConfigWithMainnet();
+
+    const routes = buildRebalanceRoutes(config);
+    const hasRoute = (
+      sourceChain: number,
+      sourceToken: string,
+      destinationChain: number,
+      destinationToken: string,
+      adapter: string
+    ) =>
+      routes.some(
+        (route) =>
+          route.sourceChain === sourceChain &&
+          route.sourceToken === sourceToken &&
+          route.destinationChain === destinationChain &&
+          route.destinationToken === destinationToken &&
+          route.adapter === adapter
+      );
+
+    expect(hasRoute(CHAIN_IDs.MAINNET, "WETH", CHAIN_IDs.MAINNET, "WETH", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "WETH", CHAIN_IDs.MAINNET, "WETH", "binance")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.MAINNET, "WETH", CHAIN_IDs.OPTIMISM, "WETH", "binance")).to.equal(false);
+  });
+});


### PR DESCRIPTION
## What changed
- add mainnet-scoped `WETH <-> USDC` and `WETH <-> USDT` route generation for the rebalancer
- treat on-chain `WETH` as Binance `ETH` for market metadata, deposits, and withdrawals
- add the atomic-depositor-based native ETH deposit path and WETH approval handling for mainnet
- wrap finalized ETH withdrawals back into WETH before marking a rebalance complete
- price Binance execution against oracle value in `getEstimatedCost()` instead of relying only on book slippage
- reserve ETH for wrap gas before finalizing WETH withdrawals
- add WETH-focused route-builder and Binance adapter test coverage

## Why
- mainnet WETH flows need explicit symbol aliasing, native deposit handling, oracle-aware cost checks, and withdrawal finalization support in order to rebalance through Binance safely

## Impact
- WETH can participate in Binance rebalances through mainnet-only routes
- route selection rejects materially off-oracle execution even when book slippage is low
- withdrawal finalization waits until there is enough ETH to both wrap the withdrawn amount and pay gas

## Validation
- `yarn test --bail test/BinanceAdapter.helpers.ts test/BinanceAdapter.quotes.ts test/BinanceAdapter.conversions.ts test/RebalancerClient.buildRebalanceRoutes.ts`