### PR TITLE
Retry empty Arweave lookups before persisting dataworker artifacts

### DIFF
--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -21,6 +21,7 @@ import {
   bnZero,
   buildRelayerRefundTree,
   buildSlowRelayTree,
+  delay,
   fixedPointAdjustment,
   getRefundsFromBundle,
   getTimestampsForBundleStartBlocks,
@@ -454,6 +455,37 @@ export function l2TokensToCountTowardsSpokePoolLeafExecutionCapital(
   return nativeTokens.some((token) => token.eq(l2TokenAddress)) ? nativeTokens : [l2TokenAddress];
 }
 
+// Retry an empty lookup once before writing, to avoid turning transient read failures into duplicate persists.
+async function getArweaveTransactionsByTag<T>(
+  client: caching.ArweaveClient,
+  tag: string,
+  logger: winston.Logger
+): Promise<{ data: T; hash: string }[]> {
+  const matchingTxns = await client.getByTopic(tag, any());
+  if (matchingTxns.length > 0) {
+    return matchingTxns;
+  }
+
+  logger.debug({
+    at: "DataworkerUtils#persistDataToArweave",
+    message: "No Arweave data found on first lookup, retrying before persist",
+    tag,
+  });
+  await delay(0);
+
+  const retriedMatchingTxns = await client.getByTopic(tag, any());
+  if (retriedMatchingTxns.length > 0) {
+    logger.warn({
+      at: "DataworkerUtils#persistDataToArweave",
+      message: "Arweave data appeared on retry, skipping duplicate persist",
+      tag,
+      hash: retriedMatchingTxns.map((txn) => txn.hash),
+    });
+  }
+
+  return retriedMatchingTxns;
+}
+
 /**
  * Persists data to Arweave with a given tag, given that the data doesn't
  * already exist on Arweave with the tag.
@@ -466,7 +498,7 @@ export async function persistDataToArweave(
   client: caching.ArweaveClient,
   data: Record<string, unknown>,
   logger: winston.Logger,
-  tag?: string
+  tag: string
 ): Promise<void> {
   assert(
     Buffer.from(tag).length <= ARWEAVE_TAG_BYTE_LIMIT,
@@ -482,7 +514,7 @@ export async function persistDataToArweave(
   // Check if data already exists on Arweave with the given tag.
   // If so, we don't need to persist it again.
   const [matchingTxns, address, balance] = await Promise.all([
-    client.getByTopic(tag, any()),
+    getArweaveTransactionsByTag(client, tag, logger),
     client.getAddress(),
     client.getBalance(),
   ]);

--- a/test/DataworkerUtils.ts
+++ b/test/DataworkerUtils.ts
@@ -1,5 +1,5 @@
-import { MockConfigStoreClient, MockHubPoolClient } from "./mocks";
-import { _buildSlowRelayRoot, _getRefundLeaves } from "../src/dataworker/DataworkerUtils";
+import { MockArweaveClient, MockConfigStoreClient, MockHubPoolClient } from "./mocks";
+import { _buildSlowRelayRoot, _getRefundLeaves, persistDataToArweave } from "../src/dataworker/DataworkerUtils";
 import { BundleDepositsV3, BundleFillsV3, BundleSlowFills, DepositWithBlock } from "../src/interfaces";
 import {
   _buildPoolRebalanceRoot,
@@ -162,6 +162,34 @@ describe("SlowFill utils", function () {
     expect(leaves.length).to.equal(1);
     // updatedOutputAmount should be equal to inputAmount * (1 - lpFee) so 4 * (1 - 0.25) = 3
     expect(leaves[0].updatedOutputAmount).to.equal(toBNWei("3"));
+  });
+});
+
+describe("Arweave persistence utils", function () {
+  const tag = "bundles-test-tag";
+  const data = { test: "payload" };
+
+  it("retries an empty lookup before skipping a duplicate persist", async function () {
+    const { spyLogger } = createSpyLogger();
+    const client = new MockArweaveClient("", spyLogger);
+    client._queueGetByTopicResponses(tag, [[], [{ data, hash: "existing-arweave-hash" }]]);
+
+    await persistDataToArweave(client, data, spyLogger, tag);
+
+    expect(client.getByTopicCalls[tag]).to.equal(2);
+    expect(client.setCalls.length).to.equal(0);
+  });
+
+  it("persists after two empty lookups", async function () {
+    const { spyLogger } = createSpyLogger();
+    const client = new MockArweaveClient("", spyLogger);
+    client._queueGetByTopicResponses(tag, [[], []]);
+
+    await persistDataToArweave(client, data, spyLogger, tag);
+
+    expect(client.getByTopicCalls[tag]).to.equal(2);
+    expect(client.setCalls.length).to.equal(1);
+    expect(client.setCalls[0].tag).to.equal(tag);
   });
 });
 

--- a/test/mocks/MockArweaveClient.ts
+++ b/test/mocks/MockArweaveClient.ts
@@ -1,10 +1,20 @@
 import { caching } from "@across-protocol/sdk";
+import { Struct } from "superstruct";
+import { BigNumber, winston } from "../../src/utils";
+
+type MockArweaveTopicResponse<T> = { data: T; hash: string }[];
 
 export class MockArweaveClient extends caching.ArweaveClient {
   // Map from arweave key to JSON object stored as a string.
   protected cache: { [key: string]: string } = {};
+  protected queuedTopicResponses: { [key: string]: string[] } = {};
+  protected address = "mock-arweave-address";
+  protected balance = BigNumber.from("1000000000000000000");
 
-  constructor(arweaveJWT: string, logger: winston.logger, gatewayURL = "", protocol = "https", port = 443) {
+  readonly getByTopicCalls: { [key: string]: number } = {};
+  readonly setCalls: { data: unknown; tag?: string; hash: string }[] = [];
+
+  constructor(arweaveJWT: string, logger: winston.Logger, gatewayURL = "", protocol = "https", port = 443) {
     super(arweaveJWT, logger, gatewayURL, protocol, port);
   }
 
@@ -15,7 +25,45 @@ export class MockArweaveClient extends caching.ArweaveClient {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _originQueryAddress?: string
   ): Promise<{ data: T; hash: string }[]> {
-    return Promise.resolve(JSON.parse(this.cache[tag]));
+    this.getByTopicCalls[tag] = (this.getByTopicCalls[tag] ?? 0) + 1;
+
+    const queuedResponse = this.queuedTopicResponses[tag]?.shift();
+    if (queuedResponse !== undefined) {
+      return Promise.resolve(JSON.parse(queuedResponse));
+    }
+
+    return Promise.resolve(this.cache[tag] ? JSON.parse(this.cache[tag]) : []);
+  }
+
+  async getAddress(): Promise<string> {
+    return Promise.resolve(this.address);
+  }
+
+  async getBalance(): Promise<BigNumber> {
+    return Promise.resolve(this.balance);
+  }
+
+  async set<T>(data: T, tag?: string): Promise<string> {
+    const hash = `mock-arweave-hash-${this.setCalls.length}`;
+    this.setCalls.push({ data, tag, hash });
+
+    if (tag !== undefined) {
+      this._setCache(tag, [{ data, hash }]);
+    }
+
+    return Promise.resolve(hash);
+  }
+
+  _queueGetByTopicResponses<T>(key: string, responses: MockArweaveTopicResponse<T>[]) {
+    this.queuedTopicResponses[key] = responses.map((response) => JSON.stringify(response));
+  }
+
+  _setAddress(address: string) {
+    this.address = address;
+  }
+
+  _setBalance(balance: BigNumber) {
+    this.balance = balance;
   }
 
   _setCache<T>(key: string, object: T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- retry an empty `getByTopic()` result once before persisting dataworker Arweave artifacts
- skip the write if the retry finds an existing tagged record, reducing duplicate Arweave persists from transient read inconsistencies
- extend the Arweave mock and add focused regression coverage for the retry and persist-after-two-empties paths

## Testing
- `RELAYER_TEST=true yarn hardhat test test/DataworkerUtils.ts`
- `yarn eslint src/dataworker/DataworkerUtils.ts test/mocks/MockArweaveClient.ts test/DataworkerUtils.ts`

## Related
- closes #3243
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://risklabs.slack.com/archives/C03GKNS03C7/p1776234754833979?thread_ts=1776234754.833979&cid=C03GKNS03C7)

<div><a href="https://cursor.com/agents/bc-626c4a4e-b3d7-5bdd-9b56-49f9eabd1ed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-626c4a4e-b3d7-5bdd-9b56-49f9eabd1ed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

