### PR TITLE
fix: Gasless Initialize function

### DIFF
--- a/src/gasless/GaslessRelayer.ts
+++ b/src/gasless/GaslessRelayer.ts
@@ -47,7 +47,6 @@ import {
   APIGaslessDepositResponse,
   DepositWithBlock,
   FillStatus,
-  FillWithBlock,
   GaslessDepositMessage,
   RelayData,
 } from "../interfaces";
@@ -273,7 +272,7 @@ export class GaslessRelayer {
         );
         for (const filledRelay of destinationFilledRelayEvents) {
           const fill = unpackFillEvent(spreadEventWithBlockNumber(filledRelay), destinationChainId);
-          observedFills.add(this._getFilledRelayKey(fill));
+          observedFills.add(this._getFilledRelayKey(fill.originChainId, fill.depositId.toString()));
         }
       }),
     ]);
@@ -406,7 +405,7 @@ export class GaslessRelayer {
         continue;
       }
 
-      const fillKey = this._getFilledRelayKey({ originChainId, depositId: toBN(depositId) });
+      const fillKey = this._getFilledRelayKey(originChainId, depositId);
       const fillSeen = this.observedFills[destinationChainId]?.has(fillKey) ?? false;
       if (fillSeen) {
         this._setState(depositKey, MessageState.FILLED);
@@ -1007,8 +1006,7 @@ export class GaslessRelayer {
    * @dev We key on the origin chain and depositId only since this is what uniquely identifies a deposit on an origin chain for a specific user (the only way to have a collision here with
    * a valid, unfilled deposit is by finding a collision in keccak).
    */
-  private _getFilledRelayKey(filledRelay: Pick<FillWithBlock, "originChainId" | "depositId">): string {
-    const { originChainId, depositId } = filledRelay;
+  private _getFilledRelayKey(originChainId: number, depositId: string): string {
     return `${originChainId}:${depositId}`;
   }
 }

--- a/src/gasless/GaslessRelayer.ts
+++ b/src/gasless/GaslessRelayer.ts
@@ -68,12 +68,6 @@ import {
   validateDeposit,
 } from "../utils/GaslessUtils";
 
-type GaslessRelayerUpdate = {
-  observedFundsDeposited: {
-    [chainId: number]: Omit<DepositWithBlock, "fromLiteChain" | "toLiteChain" | "quoteBlockNumber">[];
-  };
-  observedFilledRelay: { [chainId: number]: FillWithBlock[] };
-};
 const DEPOSIT_EVENT = "FundsDeposited";
 
 export enum MessageState {
@@ -187,9 +181,6 @@ export class GaslessRelayer {
       this.abortController.abort();
     });
 
-    // For the first runthrough, we want to specifically check the API for nonces which have corresponding deposits but no corresponding fills, and then
-    // submit fills for those deposits. This is because this scenario may happen as an edge case when a prior relayer process is killed in the middle of
-    // a deposit/fill flow.
     this.logger.debug({
       at: "GaslessRelayer#initialize",
       message: "Querying gasless API for initial messages",
@@ -238,78 +229,54 @@ export class GaslessRelayer {
     this.abortController.abort();
   }
 
-  /*
-   * @notice Performs an initial lookback to determine which signatures have been observed/processed onchain.
+  /**
+   * Look back on origin/destination chains and populate {@link observedDeposits} / {@link observedFills} for use by
+   * {@link _markFilledFromInitialObservation} (and any future logic that reads those sets).
    */
-  // Update our observed signatures/fills up until `this.depositLookback`.
-  private async updateObserved(apiMessages: AnyGaslessDepositMessage[]): Promise<GaslessRelayerUpdate> {
-    // If a signature is spent, then the deposit must also have been initiated since the `receiveWithAuthorization` signature
-    // can only be redeemed by the periphery contract.
-    const [observedFundsDeposited, observedFilledRelay] = await Promise.all([
-      // For each origin chain, find all the funds deposited events in lookback and check if they have an associated match with an API message. If they do, then we consider the
-      // deposit "observed" and the API message in the middle of the gasless flow.
-      Object.fromEntries(
-        await mapAsync(this.config.relayerOriginChains, async (originChainId) => {
-          const provider = this.providersByChain[originChainId];
-          const observedDeposits = this.observedDeposits[originChainId];
+  private async updateObserved(apiMessages: AnyGaslessDepositMessage[]): Promise<void> {
+    await Promise.all([
+      mapAsync(this.config.relayerOriginChains, async (originChainId) => {
+        const provider = this.providersByChain[originChainId];
+        const observedDeposits = this.observedDeposits[originChainId];
 
-          const searchConfig = await this._getEventSearchConfig(originChainId);
+        const searchConfig = await this._getEventSearchConfig(originChainId);
 
-          const originSpokePool = getSpokePool(originChainId).connect(provider);
-          const originFundsDepositedEvents = await paginatedEventQuery(
-            originSpokePool,
-            originSpokePool.filters.FundsDeposited(),
-            searchConfig
+        const originSpokePool = getSpokePool(originChainId).connect(provider);
+        const originFundsDepositedEvents = await paginatedEventQuery(
+          originSpokePool,
+          originSpokePool.filters.FundsDeposited(),
+          searchConfig
+        );
+        for (const event of originFundsDepositedEvents) {
+          const deposit = unpackDepositEvent(spreadEventWithBlockNumber(event), originChainId);
+          const apiMessage = apiMessages.find(({ depositId }) => deposit.depositId.toString() === depositId);
+          if (!isDefined(apiMessage)) {
+            continue;
+          }
+          observedDeposits.add(
+            this._getDepositKey(deposit.inputToken.toNative(), originChainId, deposit.depositId.toString())
           );
-          const originEventsWithApiMessages = originFundsDepositedEvents
-            .map((event) => {
-              const deposit = unpackDepositEvent(spreadEventWithBlockNumber(event), originChainId);
-              const apiMessage = apiMessages.find(({ depositId }) => deposit.depositId.toString() === depositId);
-              if (isDefined(apiMessage)) {
-                return { apiMessage, deposit };
-              }
-              return undefined;
-            })
-            .filter(isDefined);
-          originEventsWithApiMessages.forEach(({ deposit }) => {
-            observedDeposits.add(
-              this._getDepositKey(deposit.inputToken.toNative(), originChainId, deposit.depositId.toString())
-            );
-          });
-          return [originChainId, originEventsWithApiMessages.map(({ deposit }) => deposit)];
-        })
-      ),
+        }
+      }),
 
-      // For each destination chain, we need to index all `FilledRelay` events. This will let us know whether a deposit from the API has been filled by this relayer
-      // (or any other relayer).
-      Object.fromEntries(
-        await mapAsync(this.config.relayerDestinationChains, async (destinationChainId) => {
-          const provider = this.providersByChain[destinationChainId];
-          const observedFills = this.observedFills[destinationChainId];
+      mapAsync(this.config.relayerDestinationChains, async (destinationChainId) => {
+        const provider = this.providersByChain[destinationChainId];
+        const observedFills = this.observedFills[destinationChainId];
 
-          const searchConfig = await this._getEventSearchConfig(destinationChainId);
-          const destinationSpokePool = getSpokePool(destinationChainId).connect(provider);
+        const searchConfig = await this._getEventSearchConfig(destinationChainId);
+        const destinationSpokePool = getSpokePool(destinationChainId).connect(provider);
 
-          // Query all filledRelay events in the lookback. The lookback should only be a function of the max TTL of an API-served 3009 deposit.
-          const destinationFilledRelayEvents = await paginatedEventQuery(
-            destinationSpokePool,
-            destinationSpokePool.filters.FilledRelay(),
-            searchConfig
-          );
-          const fillEvents = destinationFilledRelayEvents.map((filledRelay) =>
-            unpackFillEvent(spreadEventWithBlockNumber(filledRelay), destinationChainId)
-          );
-
-          // For each fill we observed, index it in our local set.
-          fillEvents.forEach((fill) => observedFills.add(this._getFilledRelayKey(fill)));
-          return [destinationChainId, fillEvents.flat()];
-        })
-      ),
+        const destinationFilledRelayEvents = await paginatedEventQuery(
+          destinationSpokePool,
+          destinationSpokePool.filters.FilledRelay(),
+          searchConfig
+        );
+        for (const filledRelay of destinationFilledRelayEvents) {
+          const fill = unpackFillEvent(spreadEventWithBlockNumber(filledRelay), destinationChainId);
+          observedFills.add(this._getFilledRelayKey(fill));
+        }
+      }),
     ]);
-    return {
-      observedFundsDeposited,
-      observedFilledRelay,
-    };
   }
 
   /**

--- a/src/gasless/GaslessRelayer.ts
+++ b/src/gasless/GaslessRelayer.ts
@@ -246,16 +246,14 @@ export class GaslessRelayer {
           originSpokePool.filters.FundsDeposited(),
           searchConfig
         );
-        for (const event of originFundsDepositedEvents) {
-          const deposit = unpackDepositEvent(spreadEventWithBlockNumber(event), originChainId);
-          const apiMessage = apiMessages.find(({ depositId }) => deposit.depositId.toString() === depositId);
-          if (!isDefined(apiMessage)) {
-            continue;
-          }
-          observedDeposits.add(
-            this._getDepositKey(deposit.inputToken.toNative(), originChainId, deposit.depositId.toString())
+        originFundsDepositedEvents
+          .map((event) => unpackDepositEvent(spreadEventWithBlockNumber(event), originChainId))
+          .filter((deposit) => apiMessages.some(({ depositId }) => deposit.depositId.eq(depositId)))
+          .forEach((deposit) =>
+            observedDeposits.add(
+              this._getDepositKey(deposit.inputToken.toNative(), originChainId, deposit.depositId.toString())
+            )
           );
-        }
       }),
 
       mapAsync(this.config.relayerDestinationChains, async (destinationChainId) => {
@@ -296,7 +294,7 @@ export class GaslessRelayer {
     }
 
     // If the deposit is a refund test deposit, we do not want to fill it at all.
-    if (this.config.refundFlowTestEnabled && deposit.outputAmount.eq(MAX_UINT_VAL)) {
+    if (this.isRefundFlowTestDeposit(deposit.outputAmount)) {
       return false;
     }
 
@@ -622,7 +620,7 @@ export class GaslessRelayer {
             let fillStatus: FillStatus;
 
             if (deposit) {
-              if (this.config.refundFlowTestEnabled && deposit.outputAmount.eq(MAX_UINT_VAL)) {
+              if (this.isRefundFlowTestDeposit(deposit.outputAmount)) {
                 log("info", `Skipped fill on ${destination} for ${origin} deposit (deposit refund test).`);
                 setState(MessageState.FILLED);
                 break;
@@ -773,7 +771,7 @@ export class GaslessRelayer {
     const outputTokenInfo = getTokenInfo(outputToken, destinationChainId);
     const inputTokenInfo = getTokenInfo(inputToken, originChainId);
     const inputAmountInOutputDecimals = ConvertDecimals(inputTokenInfo.decimals, outputTokenInfo.decimals)(inputAmount);
-    if (this.config.refundFlowTestEnabled && outputAmount.eq(MAX_UINT_VAL)) {
+    if (this.isRefundFlowTestDeposit(outputAmount)) {
       this.logger.info({
         at: "GaslessRelayer#initiateFill",
         message: "Refund flow test: skipping fill (deposit already made).",
@@ -999,6 +997,10 @@ export class GaslessRelayer {
    */
   protected _getState(depositKey: string): MessageState {
     return (this.messageState[depositKey] ??= MessageState.INITIAL);
+  }
+
+  private isRefundFlowTestDeposit(outputAmount: RelayData["outputAmount"]): boolean {
+    return this.config.refundFlowTestEnabled && outputAmount.eq(MAX_UINT_VAL);
   }
 
   /*

--- a/src/gasless/GaslessRelayer.ts
+++ b/src/gasless/GaslessRelayer.ts
@@ -196,58 +196,16 @@ export class GaslessRelayer {
     });
     const initialMessages = await this._queryGaslessApi(this.config.initializationRetryAttempts);
 
-    // Update our observed signatures/fills up until `this.depositLookback`.
-    // Include the list of initial deposit messages so we can map FundsDeposited events back to EIP-3009 deposit nonces.
-    const observedEvents = await this.updateObserved(initialMessages);
+    // Index on-chain deposits/fills for API messages (lookback), then mark FILLED in messageState when already complete.
+    await this.updateObserved(initialMessages);
     await this.updateObservedCctpDeposits(initialMessages);
-
-    const unfilledDeposits = initialMessages.filter((depositMessage) => {
-      const { originChainId, depositId, spokePool } = depositMessage;
-
-      // SwapAndBridge deposits go through a separate flow; exclude from the bridge unfilled check.
-      if (depositMessage.depositFlowType === "swapAndBridge" || this._isCctpDeposit(originChainId, spokePool)) {
-        return false;
-      }
-
-      const { destinationChainId, inputToken } = depositMessage.baseDepositData;
-
-      const depositKey = this._getDepositKey(inputToken, originChainId, depositId);
-      const fillKey = this._getFilledRelayKey({ originChainId, depositId: toBN(depositId) });
-      return (
-        this.observedDeposits[originChainId]?.has(depositKey) &&
-        isDefined(this.observedFills[destinationChainId]) &&
-        !this.observedFills[destinationChainId].has(fillKey)
-      );
-    });
+    const markedFilledCount = this._markFilledFromInitialObservation(initialMessages);
 
     this.logger.debug({
       at: "GaslessRelayer#initialize",
-      message: "Found unfilled deposits",
-      unfilledDeposits: unfilledDeposits.length,
-    });
-
-    await mapAsync(unfilledDeposits, async (depositMessage) => {
-      const { originChainId, depositId, spokePool } = depositMessage;
-
-      // In theory, unfilledDeposits will not have CCTP deposits, but just in case.
-      if (this._isCctpDeposit(originChainId, spokePool)) {
-        this.logger.debug({
-          at: "GaslessRelayer#initialize",
-          message: "Skipping fill for CCTP deposit (relayer does not fill CCTP).",
-          depositId,
-          originChainId,
-        });
-        return;
-      }
-
-      const correspondingDeposit = observedEvents.observedFundsDeposited[originChainId].find(
-        (fundsDeposited) => fundsDeposited.depositId.toString() === depositId
-      );
-      assert(
-        isDefined(correspondingDeposit),
-        "Inconsistent data between this.observedDeposits and return data from gaslessRelayer.updateObserved()"
-      );
-      await this.initiateFill(correspondingDeposit, spokePool);
+      message: "Marked FILLED state from initial chain observation",
+      markedFilledCount,
+      apiMessages: initialMessages.length,
     });
 
     // Establish a new bot instance.
@@ -371,6 +329,11 @@ export class GaslessRelayer {
       return false;
     }
 
+    // If the deposit is a refund test deposit, we do not want to fill it at all.
+    if (this.config.refundFlowTestEnabled && deposit.outputAmount.eq(MAX_UINT_VAL)) {
+      return false;
+    }
+
     // Verify that deposit.exclusivityParameter will produce an absolute exclusivityDeadline,
     // not relative to the deposit block timestamp.
     if (isExclusivityRelative(deposit.exclusivityParameter)) {
@@ -447,6 +410,43 @@ export class GaslessRelayer {
       const depositKey = this._getDepositKey(inputToken.toNative(), originChainId, depositId.toString());
       this.observedDeposits[originChainId].add(depositKey);
     });
+  }
+
+  /**
+   * For each API message, set {@link MessageState.FILLED} when the deposit is already fully handled on-chain so
+   * {@link evaluateApiSignatures} skips it.
+   * - Swap-and-bridge and CCTP (relayer does not fill): deposit observed on origin → FILLED.
+   * - Standard bridge: both origin deposit and destination fill observed → FILLED.
+   * Otherwise leave state unset so the message runs through the normal state machine.
+   */
+  protected _markFilledFromInitialObservation(apiMessages: AnyGaslessDepositMessage[]): number {
+    let markedFilledCount = 0;
+    for (const depositMessage of apiMessages) {
+      const { originChainId, depositId, spokePool, depositFlowType } = depositMessage;
+      const { destinationChainId, inputToken } = extractGaslessDepositFields(depositMessage);
+      const depositKey = this._getDepositKey(inputToken.toNative(), originChainId, depositId);
+
+      const depositSeen = this.observedDeposits[originChainId]?.has(depositKey) ?? false;
+      if (!depositSeen) {
+        continue;
+      }
+
+      const isSwap = depositFlowType === "swapAndBridge";
+      const isCctp = this._isCctpDeposit(originChainId, spokePool);
+      if (isSwap || isCctp) {
+        this._setState(depositKey, MessageState.FILLED);
+        markedFilledCount++;
+        continue;
+      }
+
+      const fillKey = this._getFilledRelayKey({ originChainId, depositId: toBN(depositId) });
+      const fillSeen = this.observedFills[destinationChainId]?.has(fillKey) ?? false;
+      if (fillSeen) {
+        this._setState(depositKey, MessageState.FILLED);
+        markedFilledCount++;
+      }
+    }
+    return markedFilledCount;
   }
 
   /*

--- a/test/GaslessRelayer.ts
+++ b/test/GaslessRelayer.ts
@@ -171,6 +171,10 @@ class TestableGaslessRelayer extends GaslessRelayer {
     this.stateTransitions[depositKey] ??= [];
     this.stateTransitions[depositKey].push({ from: currentState, to: state });
   }
+
+  public runMarkFilledFromInitialObservation(messages: AnyGaslessDepositMessage[]): number {
+    return this._markFilledFromInitialObservation(messages);
+  }
 }
 
 /**
@@ -872,6 +876,45 @@ describe("GaslessRelayer", function () {
       expect(relayer.initiateDepositCalls).to.equal(1);
       expect(relayer.initiateFillCalls).to.equal(0);
       expectCctpTransitions(relayer.stateTransitions[nonce]);
+    });
+  });
+
+  describe("Initial observation (mark FILLED from observed deposits/fills)", function () {
+    it("Bridge: sets FILLED when both origin deposit and destination fill are observed", function () {
+      const msg = makeTestDepositMessage();
+      const nonce = depositNonceFor(relayer, msg);
+      const fillKey = `${ORIGIN_CHAIN_ID}:${toBN(msg.depositId)}`;
+
+      relayer.setObservedDeposits({ [ORIGIN_CHAIN_ID]: new Set([nonce]) });
+      relayer.setObservedFills({ [DESTINATION_CHAIN_ID]: new Set([fillKey]) });
+
+      const n = relayer.runMarkFilledFromInitialObservation([msg]);
+      expect(n).to.equal(1);
+      expect(relayer.getMessageState(nonce)).to.equal(MessageState.FILLED);
+    });
+
+    it("Bridge: does not set state when only deposit is observed", function () {
+      const msg = makeTestDepositMessage();
+      const nonce = depositNonceFor(relayer, msg);
+
+      relayer.setObservedDeposits({ [ORIGIN_CHAIN_ID]: new Set([nonce]) });
+      relayer.setObservedFills({ [DESTINATION_CHAIN_ID]: new Set() });
+
+      const n = relayer.runMarkFilledFromInitialObservation([msg]);
+      expect(n).to.equal(0);
+      expect(relayer.getMessageState(nonce)).to.equal(undefined);
+    });
+
+    it("CCTP: sets FILLED when origin deposit is observed (no fill required)", function () {
+      const msg = makeTestCctpMessage();
+      const nonce = depositNonceFor(relayer, msg);
+
+      relayer.setObservedDeposits({ [ORIGIN_CHAIN_ID]: new Set([nonce]) });
+      relayer.setObservedFills({ [DESTINATION_CHAIN_ID]: new Set() });
+
+      const n = relayer.runMarkFilledFromInitialObservation([msg]);
+      expect(n).to.equal(1);
+      expect(relayer.getMessageState(nonce)).to.equal(MessageState.FILLED);
     });
   });
 


### PR DESCRIPTION
Updating GaslessRelayer initialize function so it starts using messageState that was introduced in refactored handler.
This update will only discard (set the state of the message to FILLED) deposits that were fully processed. Eventually, we want to refactor the gaslessRelayer in a way where we can set the correct state for every deposit (i.e. if deposit message already have on-chain deposit but no fill, we should be able to set deposit state so it doesn't need to pass through all the checks and states from scratch, but go directly to the filling, etc.)