### PR TITLE
improve(InventoryClient): Prefer origin repayment for Binance routes

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -1837,7 +1837,7 @@ export class InventoryClient {
     return SLOW_WITHDRAWAL_CHAINS.filter((repaymentChainId) => {
       let fastWithdrawal = isUSDC && sdkUtils.chainIsCCTPEnabled(repaymentChainId);
       fastWithdrawal ||= isUSDT && repaymentChainId === CHAIN_IDs.ARBITRUM;
-      fastWithdrawal ||= hasBinanceRoute(repaymentChainId, l1TokenStr);
+      fastWithdrawal ||= hasBinanceRoute(repaymentChainId, l1Token);
       return (
         !fastWithdrawal &&
         this._l1TokenEnabledForChain(l1Token, repaymentChainId) &&

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -45,7 +45,7 @@ import { HubPoolClient, TokenClient, TransactionClient } from ".";
 import { Deposit, TokenInfo } from "../interfaces";
 import { InventoryConfig, isAliasConfig, TokenBalanceConfig } from "../interfaces/InventoryManagement";
 import lodash from "lodash";
-import { SLOW_WITHDRAWAL_CHAINS } from "../common";
+import { hasBinanceRoute, SLOW_WITHDRAWAL_CHAINS } from "../common";
 import { AdapterManager, CrossChainTransferClient } from "./bridges";
 import { TransferTokenParams } from "../adapter/utils";
 import { RebalancerClient } from "../rebalancer/utils/interfaces";
@@ -1837,6 +1837,7 @@ export class InventoryClient {
     return SLOW_WITHDRAWAL_CHAINS.filter((repaymentChainId) => {
       let fastWithdrawal = isUSDC && sdkUtils.chainIsCCTPEnabled(repaymentChainId);
       fastWithdrawal ||= isUSDT && repaymentChainId === CHAIN_IDs.ARBITRUM;
+      fastWithdrawal ||= hasBinanceRoute(repaymentChainId, l1TokenStr);
       return (
         !fastWithdrawal &&
         this._l1TokenEnabledForChain(l1Token, repaymentChainId) &&

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -722,6 +722,25 @@ export const CUSTOM_L2_BRIDGE: Record<number, Record<string, L2BridgeConstructor
   },
 };
 
+/**
+ * @notice Returns true if Binance acecpts deposits for the given chainId and (normalised) token address.
+ * @dev Route existence is derived from the configured L2 bridge for (chainId, l1Token), resolved with
+ * the same precedence as AdapterManager: CUSTOM_L2_BRIDGE first, then falling back to CANONICAL_L2_BRIDGE
+ * for the chain. This naturally covers BSC without a hardcoded special case.
+ * Additionally gated on BINANCE_API_KEY presence: if the operator has not configured Binance
+ * credentials, every route is treated as unavailable — there is no point claiming a route we cannot
+ * use. This is the same env var `getBinanceApiClient()` keys off, keeping the signal coherent with the
+ * rest of the Binance code path. It does NOT check real-time Binance API reachability or per-coin
+ * withdrawal status; a future change may layer a `getAccountCoins()` snapshot over this static check.
+ */
+export function hasBinanceRoute(chainId: number, l1TokenAddress: string): boolean {
+  if (!process.env.BINANCE_API_KEY) {
+    return false;
+  }
+  const bridge = CUSTOM_L2_BRIDGE[chainId]?.[l1TokenAddress] ?? CANONICAL_L2_BRIDGE[chainId];
+  return bridge === L2BinanceCEXBridge || bridge === L2BinanceCEXNativeBridge;
+}
+
 // Path to the external SpokePool indexer. Must be updated if src/libexec/* files are relocated or if the `outputDir` on TSC has been modified.
 export const RELAYER_SPOKEPOOL_LISTENER_EVM = "./dist/src/libexec/RelayerSpokePoolListener.js";
 export const RELAYER_SPOKEPOOL_LISTENER_SVM = "./dist/src/libexec/RelayerSpokePoolListenerSVM.js";

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -11,6 +11,7 @@ import {
   TOKEN_SYMBOLS_MAP,
   Signer,
   ZERO_ADDRESS,
+  Address,
   EvmAddress,
   toWei,
   toGWei,
@@ -733,11 +734,11 @@ export const CUSTOM_L2_BRIDGE: Record<number, Record<string, L2BridgeConstructor
  * rest of the Binance code path. It does NOT check real-time Binance API reachability or per-coin
  * withdrawal status; a future change may layer a `getAccountCoins()` snapshot over this static check.
  */
-export function hasBinanceRoute(chainId: number, l1TokenAddress: string): boolean {
+export function hasBinanceRoute(chainId: number, l1Token: Address): boolean {
   if (!process.env.BINANCE_API_KEY) {
     return false;
   }
-  const bridge = CUSTOM_L2_BRIDGE[chainId]?.[l1TokenAddress] ?? CANONICAL_L2_BRIDGE[chainId];
+  const bridge = CUSTOM_L2_BRIDGE[chainId]?.[l1Token.toNative()] ?? CANONICAL_L2_BRIDGE[chainId];
   return bridge === L2BinanceCEXBridge || bridge === L2BinanceCEXNativeBridge;
 }
 

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -12,6 +12,7 @@ import {
   Signer,
   ZERO_ADDRESS,
   Address,
+  binanceCredentialsConfigured,
   EvmAddress,
   toWei,
   toGWei,
@@ -728,14 +729,15 @@ export const CUSTOM_L2_BRIDGE: Record<number, Record<string, L2BridgeConstructor
  * @dev Route existence is derived from the configured L2 bridge for (chainId, l1Token), resolved with
  * the same precedence as AdapterManager: CUSTOM_L2_BRIDGE first, then falling back to CANONICAL_L2_BRIDGE
  * for the chain. This naturally covers BSC without a hardcoded special case.
- * Additionally gated on BINANCE_API_KEY presence: if the operator has not configured Binance
- * credentials, every route is treated as unavailable — there is no point claiming a route we cannot
- * use. This is the same env var `getBinanceApiClient()` keys off, keeping the signal coherent with the
- * rest of the Binance code path. It does NOT check real-time Binance API reachability or per-coin
- * withdrawal status; a future change may layer a `getAccountCoins()` snapshot over this static check.
+ * Additionally gated on `binanceCredentialsConfigured()`, which mirrors the inputs `getBinanceApiClient()`
+ * requires (API key plus either HMAC secret or GCKMS-backed secret via `--binanceSecretKey`). If the
+ * operator has not configured complete Binance credentials, every route is treated as unavailable —
+ * there is no point claiming a route we cannot use. This does NOT check real-time Binance API
+ * reachability or per-coin withdrawal status; a future change may layer a `getAccountCoins()` snapshot
+ * over this static check.
  */
 export function hasBinanceRoute(chainId: number, l1Token: Address): boolean {
-  if (!process.env.BINANCE_API_KEY) {
+  if (!binanceCredentialsConfigured()) {
     return false;
   }
   const bridge = CUSTOM_L2_BRIDGE[chainId]?.[l1Token.toNative()] ?? CANONICAL_L2_BRIDGE[chainId];

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -101,10 +101,7 @@ type ParsedAccountCoins = Coin[];
  * check async.
  */
 export function binanceCredentialsConfigured(): boolean {
-  const {
-   BINANCE_API_KEY: apiKey,
-   BINANCE_HMAC_KEY: hmacKey
-  } = process.env;
+  const { BINANCE_API_KEY: apiKey, BINANCE_HMAC_KEY: hmacKey } = process.env;
   const gckmsKeyArgPresent = process.argv.some(
     (arg) => arg === "--binanceSecretKey" || arg.startsWith("--binanceSecretKey=")
   );

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -93,6 +93,25 @@ export enum BINANCE_WITHDRAWAL_STATUS {
 type ParsedAccountCoins = Coin[];
 
 /**
+ * @notice Synchronous check that mirrors the inputs `getBinanceApiClient()` requires: a Binance API key
+ * plus either an HMAC secret in the environment or a `--binanceSecretKey` CLI arg indicating GCKMS-backed
+ * secret retrieval. This is best-effort — it cannot confirm that GCKMS retrieval will actually succeed,
+ * nor that Binance is reachable at runtime — but it avoids false positives where only one credential is
+ * present. Used by inventory/repayment logic to gate "Binance route available" claims without making the
+ * check async.
+ */
+export function binanceCredentialsConfigured(): boolean {
+  const {
+   BINANCE_API_KEY: apiKey,
+   BINANCE_HMAC_KEY: hmacKey
+  } = process.env;
+  const gckmsKeyArgPresent = process.argv.some(
+    (arg) => arg === "--binanceSecretKey" || arg.startsWith("--binanceSecretKey=")
+  );
+  return isDefined(apiKey) && (isDefined(hmacKey) || gckmsKeyArgPresent);
+}
+
+/**
  * Returns an API client to interface with Binance
  * @param url The base HTTP url to use to connect to Binance.
  * @returns A Binance client from `binance-api-node`.

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -1,6 +1,8 @@
 import { HubPoolClient, SpokePoolClient } from "../clients";
+import { hasBinanceRoute } from "../common";
 import { FillStatus, FillWithBlock, SpokePoolClientsByChain, DepositWithBlock, RelayData } from "../interfaces";
-import { Address, CHAIN_IDs, compareAddressesSimple, EMPTY_MESSAGE, TOKEN_SYMBOLS_MAP } from "../utils";
+import { Address, compareAddressesSimple, EMPTY_MESSAGE, TOKEN_SYMBOLS_MAP } from "../utils";
+import { getInventoryEquivalentL1TokenAddress } from "./TokenUtils";
 import { utils as sdkUtils } from "@across-protocol/sdk";
 
 export type RelayerUnfilledDeposit = {
@@ -86,19 +88,27 @@ export function repaymentChainCanBeQuicklyRebalanced(
   repaymentToken: Address,
   hubPoolClient: HubPoolClient
 ): boolean {
+  const { chainId: hubChainId } = hubPoolClient;
   const originChainIsCctpEnabled =
     sdkUtils.chainIsCCTPEnabled(repaymentChainId) &&
     compareAddressesSimple(TOKEN_SYMBOLS_MAP.USDC.addresses[repaymentChainId], repaymentToken.toNative());
   const originChainIsOFTEnabled =
     sdkUtils.chainIsOFTEnabled(repaymentChainId) &&
     compareAddressesSimple(TOKEN_SYMBOLS_MAP.USDT.addresses[repaymentChainId], repaymentToken.toNative());
-  return (
-    originChainIsCctpEnabled ||
-    originChainIsOFTEnabled ||
-    // We assume that all repayments sent to Mainnet and BSC can be quickly rebalanced to a different chain using
-    // canonical bridges out of L1 or the Binance API respectively.
-    [hubPoolClient.chainId, CHAIN_IDs.BSC].includes(repaymentChainId)
-  );
+  // Repayments on Mainnet can be quickly rebalanced via canonical bridges out of L1.
+  if (originChainIsCctpEnabled || originChainIsOFTEnabled || repaymentChainId === hubChainId) {
+    return true;
+  }
+  // If Binance offers a withdrawal route for this (chain, token), inventory repaid on this chain can be
+  // moved off via Binance in place of the canonical slow-withdrawal bridge. This naturally covers BSC
+  // (whose canonical L2 bridge is Binance for every token) as well as per-token Binance routes on
+  // slow-withdrawal chains like Arbitrum, Optimism, and Base.
+  try {
+    const l1Token = getInventoryEquivalentL1TokenAddress(repaymentToken, repaymentChainId, hubChainId);
+    return hasBinanceRoute(repaymentChainId, l1Token.toNative());
+  } catch {
+    return false;
+  }
 }
 
 export function getAllUnfilledDeposits(

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -105,7 +105,7 @@ export function repaymentChainCanBeQuicklyRebalanced(
   // slow-withdrawal chains like Arbitrum, Optimism, and Base.
   try {
     const l1Token = getInventoryEquivalentL1TokenAddress(repaymentToken, repaymentChainId, hubChainId);
-    return hasBinanceRoute(repaymentChainId, l1Token.toNative());
+    return hasBinanceRoute(repaymentChainId, l1Token);
   } catch {
     return false;
   }

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -37,6 +37,20 @@ import { MockRebalancerClient } from "./mocks/MockRebalancerClient";
 describe("InventoryClient: Refund chain selection", async function () {
   const { MAINNET, OPTIMISM, POLYGON, ARBITRUM, BSC } = CHAIN_IDs;
   const enabledChainIds = [MAINNET, OPTIMISM, POLYGON, ARBITRUM, BSC];
+
+  // hasBinanceRoute() treats (chain, token) as fast-rebalanceable only when BINANCE_API_KEY is set.
+  // These tests assume the default "no Binance credentials" posture; individual tests that exercise
+  // quick-rebalance semantics set it explicitly and restore it on teardown.
+  let _binanceApiKey: string | undefined;
+  before(() => {
+    _binanceApiKey = process.env.BINANCE_API_KEY;
+    delete process.env.BINANCE_API_KEY;
+  });
+  after(() => {
+    if (_binanceApiKey !== undefined) {
+      process.env.BINANCE_API_KEY = _binanceApiKey;
+    }
+  });
   const mainnetWeth = TOKEN_SYMBOLS_MAP.WETH.addresses[MAINNET];
   const mainnetUsdc = TOKEN_SYMBOLS_MAP.USDC.addresses[MAINNET];
 
@@ -596,14 +610,36 @@ describe("InventoryClient: Refund chain selection", async function () {
       expect(refundChains.length).to.equal(0);
     });
     it("returns origin chain even if it is over allocated if origin chain is a quick rebalance source", async function () {
-      sampleDepositData.originChainId = BSC;
-      sampleDepositData.inputToken = toAddressType(l2TokensForWeth[BSC], BSC);
-      seedMocks({
-        [BSC]: { [mainnetWeth]: toWei(10), [mainnetUsdc]: toMegaWei(1000) },
-      });
-      tokenClient.setTokenData(BSC, toAddressType(l2TokensForWeth[BSC], BSC), toWei(10));
-      const refundChains = await inventoryClient.determineRefundChainId(sampleDepositData);
-      expect(refundChains).to.deep.equal([BSC]);
+      // BSC is only treated as quickly rebalanced when the operator has Binance credentials configured,
+      // since its sole exit path is via the Binance CEX bridge.
+      process.env.BINANCE_API_KEY = "test-key";
+      try {
+        sampleDepositData.originChainId = BSC;
+        sampleDepositData.inputToken = toAddressType(l2TokensForWeth[BSC], BSC);
+        seedMocks({
+          [BSC]: { [mainnetWeth]: toWei(10), [mainnetUsdc]: toMegaWei(1000) },
+        });
+        tokenClient.setTokenData(BSC, toAddressType(l2TokensForWeth[BSC], BSC), toWei(10));
+        const refundChains = await inventoryClient.determineRefundChainId(sampleDepositData);
+        expect(refundChains).to.deep.equal([BSC]);
+      } finally {
+        delete process.env.BINANCE_API_KEY;
+      }
+    });
+    it("treats overallocated origin as quick-rebalance when a per-token Binance route exists", async function () {
+      // Arbitrum WETH has a Binance route via L2BinanceCEXNativeBridge in CUSTOM_L2_BRIDGE. When the
+      // operator has Binance credentials, this makes Arbitrum quickly rebalanced for WETH even though
+      // it would otherwise be a 7-day slow-withdrawal chain.
+      process.env.BINANCE_API_KEY = "test-key";
+      try {
+        sampleDepositData.originChainId = ARBITRUM;
+        sampleDepositData.inputToken = toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM);
+        tokenClient.setTokenData(ARBITRUM, toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM), toWei(100));
+        const refundChains = await inventoryClient.determineRefundChainId(sampleDepositData);
+        expect(refundChains).to.deep.equal([ARBITRUM]);
+      } finally {
+        delete process.env.BINANCE_API_KEY;
+      }
     });
   });
 

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -38,17 +38,24 @@ describe("InventoryClient: Refund chain selection", async function () {
   const { MAINNET, OPTIMISM, POLYGON, ARBITRUM, BSC } = CHAIN_IDs;
   const enabledChainIds = [MAINNET, OPTIMISM, POLYGON, ARBITRUM, BSC];
 
-  // hasBinanceRoute() treats (chain, token) as fast-rebalanceable only when BINANCE_API_KEY is set.
-  // These tests assume the default "no Binance credentials" posture; individual tests that exercise
-  // quick-rebalance semantics set it explicitly and restore it on teardown.
+  // hasBinanceRoute() treats (chain, token) as fast-rebalanceable only when complete Binance credentials
+  // (api key + hmac/gckms secret) are configured. These tests assume the default "no Binance credentials"
+  // posture; individual tests that exercise quick-rebalance semantics set them explicitly and restore on
+  // teardown.
   let _binanceApiKey: string | undefined;
+  let _binanceHmacKey: string | undefined;
   before(() => {
     _binanceApiKey = process.env.BINANCE_API_KEY;
+    _binanceHmacKey = process.env.BINANCE_HMAC_KEY;
     delete process.env.BINANCE_API_KEY;
+    delete process.env.BINANCE_HMAC_KEY;
   });
   after(() => {
     if (_binanceApiKey !== undefined) {
       process.env.BINANCE_API_KEY = _binanceApiKey;
+    }
+    if (_binanceHmacKey !== undefined) {
+      process.env.BINANCE_HMAC_KEY = _binanceHmacKey;
     }
   });
   const mainnetWeth = TOKEN_SYMBOLS_MAP.WETH.addresses[MAINNET];
@@ -610,9 +617,10 @@ describe("InventoryClient: Refund chain selection", async function () {
       expect(refundChains.length).to.equal(0);
     });
     it("returns origin chain even if it is over allocated if origin chain is a quick rebalance source", async function () {
-      // BSC is only treated as quickly rebalanced when the operator has Binance credentials configured,
-      // since its sole exit path is via the Binance CEX bridge.
+      // BSC is only treated as quickly rebalanced when the operator has complete Binance credentials
+      // configured, since its sole exit path is via the Binance CEX bridge.
       process.env.BINANCE_API_KEY = "test-key";
+      process.env.BINANCE_HMAC_KEY = "test-secret";
       try {
         sampleDepositData.originChainId = BSC;
         sampleDepositData.inputToken = toAddressType(l2TokensForWeth[BSC], BSC);
@@ -624,19 +632,36 @@ describe("InventoryClient: Refund chain selection", async function () {
         expect(refundChains).to.deep.equal([BSC]);
       } finally {
         delete process.env.BINANCE_API_KEY;
+        delete process.env.BINANCE_HMAC_KEY;
       }
     });
     it("treats overallocated origin as quick-rebalance when a per-token Binance route exists", async function () {
       // Arbitrum WETH has a Binance route via L2BinanceCEXNativeBridge in CUSTOM_L2_BRIDGE. When the
-      // operator has Binance credentials, this makes Arbitrum quickly rebalanced for WETH even though
-      // it would otherwise be a 7-day slow-withdrawal chain.
+      // operator has complete Binance credentials, this makes Arbitrum quickly rebalanced for WETH even
+      // though it would otherwise be a 7-day slow-withdrawal chain.
       process.env.BINANCE_API_KEY = "test-key";
+      process.env.BINANCE_HMAC_KEY = "test-secret";
       try {
         sampleDepositData.originChainId = ARBITRUM;
         sampleDepositData.inputToken = toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM);
         tokenClient.setTokenData(ARBITRUM, toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM), toWei(100));
         const refundChains = await inventoryClient.determineRefundChainId(sampleDepositData);
         expect(refundChains).to.deep.equal([ARBITRUM]);
+      } finally {
+        delete process.env.BINANCE_API_KEY;
+        delete process.env.BINANCE_HMAC_KEY;
+      }
+    });
+    it("does not treat Arbitrum WETH as quick-rebalance when only api key is set (missing secret)", async function () {
+      // With only BINANCE_API_KEY and no HMAC secret or GCKMS CLI arg, getBinanceApiClient() would fail
+      // at runtime. hasBinanceRoute() must mirror that by refusing to claim a Binance route.
+      process.env.BINANCE_API_KEY = "test-key";
+      try {
+        sampleDepositData.originChainId = ARBITRUM;
+        sampleDepositData.inputToken = toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM);
+        tokenClient.setTokenData(ARBITRUM, toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM), toWei(100));
+        const refundChains = await inventoryClient.determineRefundChainId(sampleDepositData);
+        expect(refundChains.length).to.equal(0);
       } finally {
         delete process.env.BINANCE_API_KEY;
       }


### PR DESCRIPTION
Binance offers routes for a few token/chain pairs. This is currently under-utilised and leads to higher SpokePool balances. Introduce a simple/surgical tweak to repayment chain selection to ease HubPool utilisation.