### PR TITLE
improve: optionally disable arweave

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1236,7 +1236,7 @@ export class Dataworker {
             blockNumberRanges,
             spokePoolClients,
             matchingRootBundle.blockNumber,
-            true // Load data from arweave when executing for speed.
+            this.config.loadArweaveData ?? true // Load data from arweave when executing for speed.
           );
 
           const { slowFillLeaves: leaves, slowFillTree: tree } = rootBundleData;
@@ -1566,7 +1566,7 @@ export class Dataworker {
       pendingRootBundle,
       spokePoolClients,
       earliestBlocksInSpokePoolClients,
-      true // Load data from arweave when executing leaves for speed.
+      this.config.loadArweaveData ?? true // Load data from arweave when executing leaves for speed.
     );
 
     if (!valid) {
@@ -2327,7 +2327,7 @@ export class Dataworker {
           blockNumberRanges,
           spokePoolClients,
           matchingRootBundle.blockNumber,
-          true // Load data from arweave when executing leaves for speed.
+          this.config.loadArweaveData ?? true // Load data from arweave when executing leaves for speed.
         );
 
         if (tree.getHexRoot() !== rootBundleRelay.relayerRefundRoot) {

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -1,5 +1,5 @@
 import { CommonConfig, ProcessEnv } from "../common";
-import { assert, getArweaveJWKSigner, parseJson } from "../utils";
+import { assert, getArweaveJWKSigner, parseJson, isDefined } from "../utils";
 
 export class DataworkerConfig extends CommonConfig {
   readonly minChallengeLeadTime: number;
@@ -38,6 +38,9 @@ export class DataworkerConfig extends CommonConfig {
   // A list of chains to ignore slow fill/relayer refund execution. Primarily used for debugging purposes.
   readonly executorIgnoreChains: number[];
 
+  // Used to instruct the dataworker to load data from arweave in times when doing so is optional (i.e. execution).
+  readonly loadArweaveData: boolean | undefined;
+
   constructor(env: ProcessEnv) {
     const {
       MAX_POOL_REBALANCE_LEAF_SIZE_OVERRIDE,
@@ -57,12 +60,14 @@ export class DataworkerConfig extends CommonConfig {
       MIN_CHALLENGE_LEAD_TIME = "600",
       AWAIT_CHALLENGE_PERIOD = "false",
       DISPUTE_COOLDOWN,
+      LOAD_ARWEAVE_DATA,
     } = env;
     super(env);
 
     this.minChallengeLeadTime = Number(MIN_CHALLENGE_LEAD_TIME);
     this.awaitChallengePeriod = AWAIT_CHALLENGE_PERIOD === "true";
     this.disputeCooldown = Number(DISPUTE_COOLDOWN ?? 120);
+    this.loadArweaveData = isDefined(LOAD_ARWEAVE_DATA) ? LOAD_ARWEAVE_DATA === "true" : undefined;
 
     this.bufferToPropose = BUFFER_TO_PROPOSE ? Number(BUFFER_TO_PROPOSE) : (20 * 60) / 15; // 20 mins of blocks;
     // Should we assert that the leaf count caps are > 0?


### PR DESCRIPTION
This is useful when we do not want to use arweave and fallback to RPCs as the source of truth for executions.