### PR TITLE
improve(binanceUtils): Remove binanceCredentialsConfigured()

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -3,7 +3,6 @@ import WETH_ABI from "../common/abi/Weth.json";
 import {
   bnZero,
   BigNumber,
-  CHAIN_IDs,
   winston,
   toBN,
   getNetworkName,
@@ -45,7 +44,7 @@ import { HubPoolClient, TokenClient, TransactionClient } from ".";
 import { Deposit, TokenInfo } from "../interfaces";
 import { InventoryConfig, isAliasConfig, TokenBalanceConfig } from "../interfaces/InventoryManagement";
 import lodash from "lodash";
-import { hasBinanceRoute, SLOW_WITHDRAWAL_CHAINS } from "../common";
+import { SLOW_WITHDRAWAL_CHAINS } from "../common";
 import { AdapterManager, CrossChainTransferClient } from "./bridges";
 import { TransferTokenParams } from "../adapter/utils";
 import { RebalancerClient } from "../rebalancer/utils/interfaces";
@@ -1829,20 +1828,15 @@ export class InventoryClient {
    */
   getSlowWithdrawalRepaymentChains(l1Token: EvmAddress): number[] {
     const { hubPoolClient } = this;
-    const { USDC, USDT } = TOKEN_SYMBOLS_MAP;
-    const l1TokenStr = l1Token.toNative();
-    const isUSDC = USDC.addresses[hubPoolClient.chainId] === l1TokenStr;
-    const isUSDT = !isUSDC && USDT.addresses[hubPoolClient.chainId] === l1TokenStr;
-
     return SLOW_WITHDRAWAL_CHAINS.filter((repaymentChainId) => {
-      let fastWithdrawal = isUSDC && sdkUtils.chainIsCCTPEnabled(repaymentChainId);
-      fastWithdrawal ||= isUSDT && repaymentChainId === CHAIN_IDs.ARBITRUM;
-      fastWithdrawal ||= hasBinanceRoute(repaymentChainId, l1Token);
-      return (
-        !fastWithdrawal &&
-        this._l1TokenEnabledForChain(l1Token, repaymentChainId) &&
-        this.hubPoolClient.l2TokenEnabledForL1Token(l1Token, repaymentChainId)
-      );
+      if (
+        !this._l1TokenEnabledForChain(l1Token, repaymentChainId) ||
+        !this.hubPoolClient.l2TokenEnabledForL1Token(l1Token, repaymentChainId)
+      ) {
+        return false;
+      }
+      const repaymentToken = this.hubPoolClient.getL2TokenForL1TokenAtBlock(l1Token, repaymentChainId);
+      return !repaymentChainCanBeQuicklyRebalanced(repaymentChainId, repaymentToken, hubPoolClient);
     });
   }
 

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -509,7 +509,7 @@ export class InventoryClient {
     return perChainRepaymentOverride ?? globalRepaymentOverride;
   }
 
-  getPossibleRepaymentChainIds(deposit: Deposit): number[] {
+  async getPossibleRepaymentChainIds(deposit: Deposit): Promise<number[]> {
     // Origin chain is always included in the repayment chain list.
     const { originChainId, destinationChainId, inputToken } = deposit;
     const chainIds = new Set<number>();
@@ -534,7 +534,7 @@ export class InventoryClient {
         isDefined(l1Token),
         `InventoryClient#getPossibleRepaymentChainIds: No L1 token found for input token ${inputToken.toNative()} on origin chain ${originChainId}`
       );
-      this.getSlowWithdrawalRepaymentChains(l1Token).forEach((chainId) => {
+      (await this.getSlowWithdrawalRepaymentChains(l1Token)).forEach((chainId) => {
         if (this.hubPoolClient.l2TokenEnabledForL1Token(l1Token, chainId)) {
           chainIds.add(chainId);
         }
@@ -673,7 +673,10 @@ export class InventoryClient {
     // If the deposit forces origin chain repayment but the origin chain is one we can easily rebalance inventory from,
     // then don't ignore this deposit based on perceived over-allocation. For example, the hub chain and chains connected
     // to the user's Binance API are easy to move inventory from so we should never skip filling these deposits.
-    if (forceOriginRepayment && repaymentChainCanBeQuicklyRebalanced(originChainId, inputToken, this.hubPoolClient)) {
+    if (
+      forceOriginRepayment &&
+      (await repaymentChainCanBeQuicklyRebalanced(originChainId, inputToken, this.hubPoolClient))
+    ) {
       return [originChainId];
     }
 
@@ -721,7 +724,7 @@ export class InventoryClient {
       const excessRunningBalancePcts = await this.getExcessRunningBalancePcts(
         l1Token,
         inputAmountInL1TokenDecimals,
-        this.getSlowWithdrawalRepaymentChains(l1Token)
+        await this.getSlowWithdrawalRepaymentChains(l1Token)
       );
       // Sort chains by highest excess percentage over the spoke target, so we can prioritize
       // taking repayment on chains with the most excess balance.
@@ -737,7 +740,8 @@ export class InventoryClient {
     // we should take repayment away from the lite chain where possible.
     // We also want to prioritize taking repayment on the origin chain if it is a quick rebalance source.
     if (
-      (deposit.toLiteChain || repaymentChainCanBeQuicklyRebalanced(originChainId, inputToken, this.hubPoolClient)) &&
+      (deposit.toLiteChain ||
+        (await repaymentChainCanBeQuicklyRebalanced(originChainId, inputToken, this.hubPoolClient))) &&
       !chainsToEvaluate.includes(originChainId) &&
       this._l1TokenEnabledForChain(l1Token, Number(originChainId))
     ) {
@@ -765,7 +769,7 @@ export class InventoryClient {
 
     // Sanity check that the possible chains used to pre-compute LP fees by the relayer are a subset of the
     // chains that are actually eligible for repayment.
-    const possibleRepaymentChainIds = this.getPossibleRepaymentChainIds(deposit);
+    const possibleRepaymentChainIds = await this.getPossibleRepaymentChainIds(deposit);
     if (chainsToEvaluate.some((_chain) => !possibleRepaymentChainIds.includes(_chain))) {
       throw new Error(
         `InventoryClient.getPossibleRepaymentChainIds (${possibleRepaymentChainIds})and determineRefundChainId (${chainsToEvaluate}) disagree on eligible repayment chains`
@@ -882,7 +886,7 @@ export class InventoryClient {
     // Conditionally add the origin chain as a fallback option if the relayer has a fast rebalance route.
     if (
       !eligibleRefundChains.includes(originChainId) &&
-      repaymentChainCanBeQuicklyRebalanced(originChainId, inputToken, this.hubPoolClient)
+      (await repaymentChainCanBeQuicklyRebalanced(originChainId, inputToken, this.hubPoolClient))
     ) {
       eligibleRefundChains.push(originChainId);
     }
@@ -1826,9 +1830,9 @@ export class InventoryClient {
    * @param l1Token
    * @returns list of chains for l1Token that have a token config enabled and have pool rebalance routes set.
    */
-  getSlowWithdrawalRepaymentChains(l1Token: EvmAddress): number[] {
+  async getSlowWithdrawalRepaymentChains(l1Token: EvmAddress): Promise<number[]> {
     const { hubPoolClient } = this;
-    return SLOW_WITHDRAWAL_CHAINS.filter((repaymentChainId) => {
+    return await sdkUtils.filterAsync(SLOW_WITHDRAWAL_CHAINS, async (repaymentChainId) => {
       if (
         !this._l1TokenEnabledForChain(l1Token, repaymentChainId) ||
         !this.hubPoolClient.l2TokenEnabledForL1Token(l1Token, repaymentChainId)
@@ -1836,7 +1840,7 @@ export class InventoryClient {
         return false;
       }
       const repaymentToken = this.hubPoolClient.getL2TokenForL1TokenAtBlock(l1Token, repaymentChainId);
-      return !repaymentChainCanBeQuicklyRebalanced(repaymentChainId, repaymentToken, hubPoolClient);
+      return !(await repaymentChainCanBeQuicklyRebalanced(repaymentChainId, repaymentToken, hubPoolClient));
     });
   }
 

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -12,13 +12,13 @@ import {
   Signer,
   ZERO_ADDRESS,
   Address,
-  binanceCredentialsConfigured,
   EvmAddress,
   toWei,
   toGWei,
   BigNumber,
   winston,
   toBN,
+  getBinanceApiClient,
 } from "../utils";
 import {
   BaseBridgeAdapter,
@@ -729,15 +729,16 @@ export const CUSTOM_L2_BRIDGE: Record<number, Record<string, L2BridgeConstructor
  * @dev Route existence is derived from the configured L2 bridge for (chainId, l1Token), resolved with
  * the same precedence as AdapterManager: CUSTOM_L2_BRIDGE first, then falling back to CANONICAL_L2_BRIDGE
  * for the chain. This naturally covers BSC without a hardcoded special case.
- * Additionally gated on `binanceCredentialsConfigured()`, which mirrors the inputs `getBinanceApiClient()`
- * requires (API key plus either HMAC secret or GCKMS-backed secret via `--binanceSecretKey`). If the
- * operator has not configured complete Binance credentials, every route is treated as unavailable —
- * there is no point claiming a route we cannot use. This does NOT check real-time Binance API
- * reachability or per-coin withdrawal status; a future change may layer a `getAccountCoins()` snapshot
- * over this static check.
+ * Additionally gated on whether `getBinanceApiClient()` can be constructed. If the operator has not
+ * configured a complete Binance credential set (API key plus either HMAC secret or GCKMS-backed secret
+ * via `--binanceSecretKey`), every route is treated as unavailable because the relayer could not use it.
+ * This does NOT check real-time Binance API reachability or per-coin withdrawal status; a future change
+ * may layer a `getAccountCoins()` snapshot over this static check.
  */
-export function hasBinanceRoute(chainId: number, l1Token: Address): boolean {
-  if (!binanceCredentialsConfigured()) {
+export async function hasBinanceRoute(chainId: number, l1Token: Address): Promise<boolean> {
+  try {
+    await getBinanceApiClient();
+  } catch {
     return false;
   }
   const bridge = CUSTOM_L2_BRIDGE[chainId]?.[l1Token.toNative()] ?? CANONICAL_L2_BRIDGE[chainId];

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -855,14 +855,14 @@ export class Relayer {
 
     // We need to compute LP fees for any possible repayment chain the inventory client could select
     // for each deposit filled.
-    const lpFeeRequests = deposits
-      .map((deposit) => {
-        const possibleRepaymentChainIds = inventoryClient.getPossibleRepaymentChainIds(deposit);
+    const lpFeeRequests = (
+      await sdkUtils.mapAsync(deposits, async (deposit) => {
+        const possibleRepaymentChainIds = await inventoryClient.getPossibleRepaymentChainIds(deposit);
         return possibleRepaymentChainIds.map((paymentChainId) => {
           return { ...deposit, paymentChainId };
         });
       })
-      .flat();
+    ).flat();
 
     const _lpFees = await hubPoolClient.batchComputeRealizedLpFeePct(lpFeeRequests);
 

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -93,22 +93,6 @@ export enum BINANCE_WITHDRAWAL_STATUS {
 type ParsedAccountCoins = Coin[];
 
 /**
- * @notice Synchronous check that mirrors the inputs `getBinanceApiClient()` requires: a Binance API key
- * plus either an HMAC secret in the environment or a `--binanceSecretKey` CLI arg indicating GCKMS-backed
- * secret retrieval. This is best-effort — it cannot confirm that GCKMS retrieval will actually succeed,
- * nor that Binance is reachable at runtime — but it avoids false positives where only one credential is
- * present. Used by inventory/repayment logic to gate "Binance route available" claims without making the
- * check async.
- */
-export function binanceCredentialsConfigured(): boolean {
-  const { BINANCE_API_KEY: apiKey, BINANCE_HMAC_KEY: hmacKey } = process.env;
-  const gckmsKeyArgPresent = process.argv.some(
-    (arg) => arg === "--binanceSecretKey" || arg.startsWith("--binanceSecretKey=")
-  );
-  return isDefined(apiKey) && (isDefined(hmacKey) || gckmsKeyArgPresent);
-}
-
-/**
  * Returns an API client to interface with Binance
  * @param url The base HTTP url to use to connect to Binance.
  * @returns A Binance client from `binance-api-node`.

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -83,11 +83,11 @@ export function depositForcesOriginChainRepayment(
  * @dev This function can be used by the InventoryClient and Relayer to help determine whether a deposit should
  * be filled or ignored given current inventory allocation levels.
  */
-export function repaymentChainCanBeQuicklyRebalanced(
+export async function repaymentChainCanBeQuicklyRebalanced(
   repaymentChainId: number,
   repaymentToken: Address,
   hubPoolClient: HubPoolClient
-): boolean {
+): Promise<boolean> {
   const { chainId: hubChainId } = hubPoolClient;
   const originChainIsCctpEnabled =
     sdkUtils.chainIsCCTPEnabled(repaymentChainId) &&
@@ -106,7 +106,7 @@ export function repaymentChainCanBeQuicklyRebalanced(
   // slow-withdrawal chains like Arbitrum, Optimism, and Base.
   try {
     const l1Token = getInventoryEquivalentL1TokenAddress(repaymentToken, repaymentChainId, hubChainId);
-    return hasBinanceRoute(repaymentChainId, l1Token);
+    return await hasBinanceRoute(repaymentChainId, l1Token);
   } catch {
     return false;
   }

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -1,7 +1,7 @@
 import { HubPoolClient, SpokePoolClient } from "../clients";
 import { hasBinanceRoute } from "../common";
 import { FillStatus, FillWithBlock, SpokePoolClientsByChain, DepositWithBlock, RelayData } from "../interfaces";
-import { Address, compareAddressesSimple, EMPTY_MESSAGE, TOKEN_SYMBOLS_MAP } from "../utils";
+import { Address, CHAIN_IDs, compareAddressesSimple, EMPTY_MESSAGE, TOKEN_SYMBOLS_MAP } from "../utils";
 import { getInventoryEquivalentL1TokenAddress } from "./TokenUtils";
 import { utils as sdkUtils } from "@across-protocol/sdk";
 
@@ -94,7 +94,8 @@ export function repaymentChainCanBeQuicklyRebalanced(
     compareAddressesSimple(TOKEN_SYMBOLS_MAP.USDC.addresses[repaymentChainId], repaymentToken.toNative());
   const originChainIsOFTEnabled =
     sdkUtils.chainIsOFTEnabled(repaymentChainId) &&
-    compareAddressesSimple(TOKEN_SYMBOLS_MAP.USDT.addresses[repaymentChainId], repaymentToken.toNative());
+    compareAddressesSimple(TOKEN_SYMBOLS_MAP.USDT.addresses[repaymentChainId], repaymentToken.toNative()) &&
+    repaymentChainId !== CHAIN_IDs.HYPEREVM; // OFT withdrawals from HyperEVM take ~12 hours.
   // Repayments on Mainnet can be quickly rebalanced via canonical bridges out of L1.
   if (originChainIsCctpEnabled || originChainIsOFTEnabled || repaymentChainId === hubChainId) {
     return true;

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -429,7 +429,7 @@ describe("InventoryClient: Refund chain selection", async function () {
     it("includes origin, destination, and hub chain in repayment chain list", async function () {
       // In the case of a deposit that doesn't force origin chain repayment, the possible repayment chain
       // list should include the origin, destination, and hub chain.
-      const possibleRepaymentChains = inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
+      const possibleRepaymentChains = await inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
       [sampleDepositData.originChainId, sampleDepositData.destinationChainId, hubPoolClient.chainId].forEach(
         (chainId) => {
           expect(possibleRepaymentChains).to.include(chainId);
@@ -576,7 +576,7 @@ describe("InventoryClient: Refund chain selection", async function () {
       expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"74074074074074074"')).to.be.true;
     });
     it("includes origin, destination and hub chain in repayment chain list", async function () {
-      const possibleRepaymentChains = inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
+      const possibleRepaymentChains = await inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
       [sampleDepositData.originChainId, sampleDepositData.destinationChainId, MAINNET].forEach((chainId) => {
         expect(possibleRepaymentChains).to.include(chainId);
       });
@@ -717,7 +717,7 @@ describe("InventoryClient: Refund chain selection", async function () {
       expect(refundChains.length).to.equal(0);
     });
     it("includes only origin chain repayment chain list", async function () {
-      const possibleRepaymentChains = inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
+      const possibleRepaymentChains = await inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
       [sampleDepositData.originChainId].forEach((chainId) => {
         expect(possibleRepaymentChains).to.include(chainId);
       });
@@ -777,7 +777,7 @@ describe("InventoryClient: Refund chain selection", async function () {
       expect(refundChains.length).to.equal(0);
     });
     it("includes only origin chain repayment chain list", async function () {
-      const possibleRepaymentChains = inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
+      const possibleRepaymentChains = await inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
       [sampleDepositData.originChainId].forEach((chainId) => {
         expect(possibleRepaymentChains).to.include(chainId);
       });
@@ -836,7 +836,7 @@ describe("InventoryClient: Refund chain selection", async function () {
       expect(refundChains).to.deep.equal([MAINNET]);
     });
     it("includes hub chain and origin chain on repayment chain list, does not include destination chain", async function () {
-      const possibleRepaymentChains = inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
+      const possibleRepaymentChains = await inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
       expect(possibleRepaymentChains).to.not.include(sampleDepositData.destinationChainId);
       expect(possibleRepaymentChains).to.include(sampleDepositData.originChainId);
       expect(possibleRepaymentChains).to.include(hubPoolClient.chainId);
@@ -854,11 +854,13 @@ describe("InventoryClient: Refund chain selection", async function () {
         [ARBITRUM]: toWei("0.2"),
       };
       // Fill in rest of slow withdrawal chains with 0 excess since we won't test them.
-      inventoryClient.getSlowWithdrawalRepaymentChains(toAddressType(mainnetWeth, MAINNET)).forEach((chainId) => {
-        if (!excessRunningBalances[chainId]) {
-          excessRunningBalances[chainId] = toWei("0");
+      (await inventoryClient.getSlowWithdrawalRepaymentChains(toAddressType(mainnetWeth, MAINNET))).forEach(
+        (chainId) => {
+          if (!excessRunningBalances[chainId]) {
+            excessRunningBalances[chainId] = toWei("0");
+          }
         }
-      });
+      );
       inventoryClient = new MockInventoryClient(
         toAddressType(owner.address, MAINNET),
         spyLogger,
@@ -919,10 +921,12 @@ describe("InventoryClient: Refund chain selection", async function () {
       ]);
     });
     it("includes slow withdrawal chains in possible repayment chain list", async function () {
-      const possibleRepaymentChains = inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
-      inventoryClient.getSlowWithdrawalRepaymentChains(toAddressType(mainnetWeth, MAINNET)).forEach((chainId) => {
-        expect(possibleRepaymentChains).to.include(chainId);
-      });
+      const possibleRepaymentChains = await inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
+      (await inventoryClient.getSlowWithdrawalRepaymentChains(toAddressType(mainnetWeth, MAINNET))).forEach(
+        (chainId) => {
+          expect(possibleRepaymentChains).to.include(chainId);
+        }
+      );
       [sampleDepositData.originChainId, sampleDepositData.destinationChainId].forEach((chainId) => {
         expect(possibleRepaymentChains).to.include(chainId);
       });
@@ -1123,7 +1127,7 @@ describe("InventoryClient: Refund chain selection", async function () {
       sampleDepositData.outputAmount = toBNWei(1);
       // Should not force origin chain repayment (uses global false, and Arbitrum with WETH is not a quick rebalance source)
       // Check getPossibleRepaymentChainIds to verify it includes multiple chains
-      const possibleChains2 = _inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
+      const possibleChains2 = await _inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
       // When forceOriginRepayment is false, possible chains should include more than just origin
       expect(possibleChains2.length).to.be.greaterThan(1);
       expect(possibleChains2).to.include(ARBITRUM); // Origin chain should be in the list
@@ -1172,7 +1176,7 @@ describe("InventoryClient: Refund chain selection", async function () {
       // Should NOT force origin chain repayment because per-chain config overrides global
       // Since forceOriginRepaymentPerChain[MAINNET] = false, shouldForceOriginRepayment returns false
       // Verify that forceOriginRepayment is actually false by checking getPossibleRepaymentChainIds
-      const possibleChains = _inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
+      const possibleChains = await _inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
       // When forceOriginRepayment is false, possible chains should include more than just origin
       // This is the key test - it should not be forced to only Polygon
       expect(possibleChains.length).to.be.greaterThan(1);
@@ -1264,7 +1268,7 @@ describe("InventoryClient: Refund chain selection", async function () {
       });
       (_inventoryClient as MockInventoryClient).setUpcomingRefunds(mainnetUsdc, {});
 
-      const possibleRepaymentChains = _inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
+      const possibleRepaymentChains = await _inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
       // When forceOriginRepayment is true and origin is a quick rebalance source (Polygon with native USDC/CCTP),
       // getPossibleRepaymentChainIds should return only origin chain
       expect(possibleRepaymentChains).to.deep.equal([POLYGON]);
@@ -1422,7 +1426,7 @@ describe("InventoryClient: Refund chain selection", async function () {
       });
       (_inventoryClient as MockInventoryClient).setUpcomingRefunds(mainnetWeth, {});
 
-      const possibleRepaymentChains = _inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
+      const possibleRepaymentChains = await _inventoryClient.getPossibleRepaymentChainIds(sampleDepositData);
       expect(possibleRepaymentChains).to.include(ARBITRUM);
     });
 


### PR DESCRIPTION
binanceConfigured() is redundant with existing functionality in getBinanceApiClient but the reason (probably) why we didn't use this before is that getBinanceApiClient is async. However, I think this change is more correct, for just checking whether the CLI flags are set doesn't mean that the binance API client is configured correctly, for example the CLI value might be invalid.
