### PR TITLE
Revert "chore: [codex] Remove unused zkSync Binance USDC bridge constant (#3158)"

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -719,6 +719,9 @@ export const CUSTOM_L2_BRIDGE: Record<number, Record<string, L2BridgeConstructor
     [TOKEN_SYMBOLS_MAP.ezETH.addresses[CHAIN_IDs.MAINNET]]: HyperlaneXERC20BridgeL2,
     [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: L2UsdcCCTPBridge,
   },
+  [CHAIN_IDs.ZK_SYNC]: {
+    [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: L2BinanceCEXBridge,
+  },
 };
 
 /**


### PR DESCRIPTION
I've tested locally that we can deposit USDC.e into Binance on Zksync so this is safe to revert and also update in the bot configs
This reverts commit e42f9aef40ff2946fcffd4dc742ccf1d2da15afc.
