### PR TITLE
feat(arweave): set Arweave data in Redis in addition to trying to set to Arweave

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.109",
     "@across-protocol/contracts": "5.0.7",
-    "@across-protocol/sdk": "4.3.144",
+    "@across-protocol/sdk": "4.3.145",
     "@arbitrum/sdk": "^4.0.2",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -762,7 +762,8 @@ export class Dataworker {
             bundleBlockRanges: bundleBlockRangeMap,
           },
           this.logger,
-          `bundles-${partialArweaveDataKey}`
+          `bundles-${partialArweaveDataKey}`,
+          this.clients.arweaveTopicCache
         ),
         persistDataToArweave(
           this.clients.arweaveClient,
@@ -795,7 +796,8 @@ export class Dataworker {
             slowRelayRoot: expectedTrees.slowRelayTree.tree.getHexRoot(),
           },
           this.logger,
-          `merkletree-${partialArweaveDataKey}`
+          `merkletree-${partialArweaveDataKey}`,
+          this.clients.arweaveTopicCache
         ),
       ]);
     }

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -20,15 +20,6 @@ export interface DataworkerClients extends Clients {
   arweaveTopicCache?: interfaces.CachingMechanismInterface;
 }
 
-type BundleDataClientWithTopicCacheConstructor = new (
-  logger: winston.Logger,
-  clients: Clients,
-  spokePoolClients: Record<number, never>,
-  chainIdListForBundleEvaluationBlockNumbers: number[],
-  blockRangeEndBlockBuffer?: { [chainId: number]: number },
-  arweaveTopicCache?: interfaces.CachingMechanismInterface
-) => BundleDataClient;
-
 export async function constructDataworkerClients(
   logger: winston.Logger,
   config: DataworkerConfig,
@@ -59,10 +50,7 @@ export async function constructDataworkerClients(
 
   // TODO: Remove need to pass in spokePoolClients into BundleDataClient since we pass in empty {} here and pass in
   // clients for each class level call we make. Its more of a static class.
-  // The published SDK type still exposes the older 5-arg constructor. The runtime ignores extra args today,
-  // and the paired SDK topic-cache PR consumes the 6th arg once released.
-  const BundleDataClientCtor = BundleDataClient as unknown as BundleDataClientWithTopicCacheConstructor;
-  const bundleDataClient = new BundleDataClientCtor(
+  const bundleDataClient = new BundleDataClient(
     logger,
     commonClients,
     {},

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -20,6 +20,15 @@ export interface DataworkerClients extends Clients {
   arweaveTopicCache?: interfaces.CachingMechanismInterface;
 }
 
+type BundleDataClientWithTopicCacheConstructor = new (
+  logger: winston.Logger,
+  clients: Clients,
+  spokePoolClients: Record<number, never>,
+  chainIdListForBundleEvaluationBlockNumbers: number[],
+  blockRangeEndBlockBuffer?: { [chainId: number]: number },
+  arweaveTopicCache?: interfaces.CachingMechanismInterface
+) => BundleDataClient;
+
 export async function constructDataworkerClients(
   logger: winston.Logger,
   config: DataworkerConfig,
@@ -50,7 +59,10 @@ export async function constructDataworkerClients(
 
   // TODO: Remove need to pass in spokePoolClients into BundleDataClient since we pass in empty {} here and pass in
   // clients for each class level call we make. Its more of a static class.
-  const bundleDataClient = new BundleDataClient(
+  // The published SDK type still exposes the older 5-arg constructor. The runtime ignores extra args today,
+  // and the paired SDK topic-cache PR consumes the 6th arg once released.
+  const BundleDataClientCtor = BundleDataClient as unknown as BundleDataClientWithTopicCacheConstructor;
+  const bundleDataClient = new BundleDataClientCtor(
     logger,
     commonClients,
     {},

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -8,15 +8,16 @@ import {
   updateClients,
   updateSpokePoolClients,
 } from "../common";
-import { Signer, getArweaveJWKSigner } from "../utils";
+import { Signer, getArweaveJWKSigner, getRedisCache } from "../utils";
 import { BundleDataClient, HubPoolClient } from "../clients";
 import { getBlockForChain } from "./DataworkerUtils";
 import { Dataworker } from "./Dataworker";
 import { ProposedRootBundle, SpokePoolClientsByChain } from "../interfaces";
-import { caching } from "@across-protocol/sdk";
+import { caching, interfaces } from "@across-protocol/sdk";
 
 export interface DataworkerClients extends Clients {
   bundleDataClient: BundleDataClient;
+  arweaveTopicCache?: interfaces.CachingMechanismInterface;
 }
 
 export async function constructDataworkerClients(
@@ -36,6 +37,17 @@ export async function constructDataworkerClients(
   await updateClients(commonClients, config, logger);
   await hubPoolClient.update();
 
+  let arweaveTopicCache: interfaces.CachingMechanismInterface | undefined;
+  try {
+    arweaveTopicCache = await getRedisCache(logger);
+  } catch (error) {
+    logger.debug({
+      at: "DataworkerClientHelper#constructDataworkerClients",
+      message: "Failed to initialize Arweave topic cache, continuing without Redis topic caching",
+      error: String(error),
+    });
+  }
+
   // TODO: Remove need to pass in spokePoolClients into BundleDataClient since we pass in empty {} here and pass in
   // clients for each class level call we make. Its more of a static class.
   const bundleDataClient = new BundleDataClient(
@@ -43,7 +55,8 @@ export async function constructDataworkerClients(
     commonClients,
     {},
     configStoreClient.getChainIdIndicesForBlock(),
-    config.blockRangeEndBlockBuffer
+    config.blockRangeEndBlockBuffer,
+    arweaveTopicCache
   );
 
   // Define the Arweave client. We need to use a read-write signer for the
@@ -59,6 +72,7 @@ export async function constructDataworkerClients(
     ...commonClients,
     bundleDataClient,
     arweaveClient,
+    arweaveTopicCache,
   };
 }
 

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -456,7 +456,12 @@ export function l2TokensToCountTowardsSpokePoolLeafExecutionCapital(
 
 /**
  * Persists data to Arweave with a given tag, given that the data doesn't
- * already exist on Arweave with the tag.
+ * already exist on Arweave with the tag. Also persists the data to the cache (e.g. a Redis cache) if provided.
+ * Contract:
+ * - `tag` is a deterministic identifier for the bundle payload.
+ * - Repeated calls with the same `tag` must provide semantically identical `data`.
+ * - Because of that invariant, it is safe to seed Redis from `data` even if Arweave is unavailable.
+ * - When Arweave already has data for `tag`, that persisted payload is assumed to must match `data`.
  * @param client The Arweave client to use for persistence.
  * @param data The data to persist to Arweave.
  * @param logger A winston logger
@@ -475,63 +480,66 @@ export async function persistDataToArweave(
     `Arweave tag cannot exceed ${ARWEAVE_TAG_BYTE_LIMIT} bytes`
   );
 
-  const profiler = new Profiler({
-    logger,
-    at: "DataworkerUtils#persistDataToArweave",
-  });
-  const mark = profiler.start("persistDataToArweave");
-
-  // Check if data already exists on Arweave with the given tag.
-  // If so, we don't need to persist it again.
-  const [matchingTxns, address, balance] = await Promise.all([
-    client.getByTopic(tag, any()),
-    client.getAddress(),
-    client.getBalance(),
-  ]);
-
-  // Check balance. Maybe move this to Monitor function.
-  const MINIMUM_AR_BALANCE = parseWinston("1");
-  if (balance.lte(MINIMUM_AR_BALANCE)) {
-    logger.error({
+  // Wrap all Arweave operations in a try-catch block to ensure that we always persist to the cache if provided.
+  try {
+    const profiler = new Profiler({
+      logger,
       at: "DataworkerUtils#persistDataToArweave",
-      message: "Arweave balance is below minimum target balance",
-      address,
-      balance: formatWinston(balance),
-      minimumBalance: formatWinston(MINIMUM_AR_BALANCE),
     });
-  } else {
-    logger.debug({
-      at: "DataworkerUtils#persistDataToArweave",
-      message: "Arweave balance is above minimum target balance",
-      address,
-      balance: formatWinston(balance),
-      minimumBalance: formatWinston(MINIMUM_AR_BALANCE),
-    });
-  }
+    const mark = profiler.start("persistDataToArweave");
 
-  if (matchingTxns.length > 0) {
-    logger.debug({
-      at: "DataworkerUtils#persistDataToArweave",
-      message: `Data already exists on Arweave with tag: ${tag}`,
-      hash: matchingTxns.map((txn) => txn.hash),
-    });
+    // Check if data already exists on Arweave with the given tag.
+    // If so, we don't need to persist it again.
+    const [matchingTxns, address, balance] = await Promise.all([
+      client.getByTopic(tag, any()),
+      client.getAddress(),
+      client.getBalance(),
+    ]);
+
+    // Check balance. Maybe move this to Monitor function.
+    const MINIMUM_AR_BALANCE = parseWinston("1");
+    if (balance.lte(MINIMUM_AR_BALANCE)) {
+      logger.warn({
+        at: "DataworkerUtils#persistDataToArweave",
+        message: "Arweave balance is below minimum target balance",
+        address,
+        balance: formatWinston(balance),
+        minimumBalance: formatWinston(MINIMUM_AR_BALANCE),
+      });
+    } else {
+      logger.debug({
+        at: "DataworkerUtils#persistDataToArweave",
+        message: "Arweave balance is above minimum target balance",
+        address,
+        balance: formatWinston(balance),
+        minimumBalance: formatWinston(MINIMUM_AR_BALANCE),
+      });
+    }
+
+    if (matchingTxns.length > 0) {
+      logger.debug({
+        at: "DataworkerUtils#persistDataToArweave",
+        message: `Data already exists on Arweave with tag: ${tag}`,
+        hash: matchingTxns.map((txn) => txn.hash),
+      });
+    } else {
+      const hashTxn = await client.set(data, tag);
+      logger.info({
+        at: "DataworkerUtils#persistDataToArweave",
+        message: "Persisted data to Arweave! 💾",
+        tag,
+        receipt: `https://arweave.app/tx/${hashTxn}`,
+        rawData: `https://arweave.net/${hashTxn}`,
+        address,
+        balance: formatWinston(balance),
+        notificationPath: "across-arweave",
+      });
+      mark.stop({
+        message: "Time to persist to Arweave",
+      });
+    }
+  } finally {
     await persistArweaveTopicToCache(topicCache, tag, data, logger);
-  } else {
-    const hashTxn = await client.set(data, tag);
-    logger.info({
-      at: "DataworkerUtils#persistDataToArweave",
-      message: "Persisted data to Arweave! 💾",
-      tag,
-      receipt: `https://arweave.app/tx/${hashTxn}`,
-      rawData: `https://arweave.net/${hashTxn}`,
-      address,
-      balance: formatWinston(balance),
-      notificationPath: "across-arweave",
-    });
-    await persistArweaveTopicToCache(topicCache, tag, data, logger);
-    mark.stop({
-      message: "Time to persist to Arweave",
-    });
   }
 }
 
@@ -546,11 +554,22 @@ async function persistArweaveTopicToCache(
   }
 
   try {
-    await topicCache.set(
-      getArweaveTopicCacheKey(tag),
-      JSON.stringify(data, utils.jsonReplacerWithBigNumbers),
-      sdkConstants.DEFAULT_CACHING_TTL
-    );
+    const cacheKey = getArweaveTopicCacheKey(tag);
+    const cachedData = await topicCache.get<string>(cacheKey);
+    if (isDefined(cachedData)) {
+      // We can return here and not update because we assume that the input data is the same for any given tag.
+      return;
+    }
+    const serializedPayload = serializeArweaveTopicPayload(data);
+    await topicCache.set(cacheKey, serializedPayload, sdkConstants.DEFAULT_CACHING_TTL);
+    logger.debug({
+      at: "DataworkerUtils#persistArweaveTopicToCache",
+      message: isDefined(cachedData)
+        ? "Updated Arweave topic payload in Redis cache"
+        : "Persisted Arweave topic payload into Redis cache",
+      tag,
+      cacheKey,
+    });
   } catch (error) {
     logger.debug({
       at: "DataworkerUtils#persistArweaveTopicToCache",
@@ -563,4 +582,8 @@ async function persistArweaveTopicToCache(
 
 function getArweaveTopicCacheKey(tag: string): string {
   return `arweave-topic:${tag}`;
+}
+
+function serializeArweaveTopicPayload(data: Record<string, unknown>): string {
+  return JSON.stringify(data, utils.jsonReplacerWithBigNumbers);
 }

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -480,49 +480,63 @@ export async function persistDataToArweave(
     `Arweave tag cannot exceed ${ARWEAVE_TAG_BYTE_LIMIT} bytes`
   );
 
-  // Wrap all Arweave operations in a try-catch block to ensure that we always persist to the cache if provided.
-  try {
-    const profiler = new Profiler({
-      logger,
-      at: "DataworkerUtils#persistDataToArweave",
-    });
-    const mark = profiler.start("persistDataToArweave");
+  const profiler = new Profiler({
+    logger,
+    at: "DataworkerUtils#persistDataToArweave",
+  });
+  const mark = profiler.start("persistDataToArweave");
 
+  // Wrap all Arweave operations in a try-catch block to ensure that we always persist to the cache if provided.
+  let matchingTxns: { hash: string }[];
+  let address: string;
+  let balance: BigNumber;
+  try {
     // Check if data already exists on Arweave with the given tag.
     // If so, we don't need to persist it again.
-    const [matchingTxns, address, balance] = await Promise.all([
+    [matchingTxns, address, balance] = await Promise.all([
       client.getByTopic(tag, any()),
       client.getAddress(),
       client.getBalance(),
     ]);
+  } catch (error) {
+    logger.debug({
+      at: "DataworkerUtils#persistDataToArweave",
+      message: "getByTopic, getAddress, or getBalance failed; cannot persist to Arweave",
+      tag,
+      error: String(error),
+    });
+    await persistArweaveTopicToCache(topicCache, tag, data, logger);
+    return;
+  }
 
-    // Check balance. Maybe move this to Monitor function.
-    const MINIMUM_AR_BALANCE = parseWinston("1");
-    if (balance.lte(MINIMUM_AR_BALANCE)) {
-      logger.warn({
-        at: "DataworkerUtils#persistDataToArweave",
-        message: "Arweave balance is below minimum target balance",
-        address,
-        balance: formatWinston(balance),
-        minimumBalance: formatWinston(MINIMUM_AR_BALANCE),
-      });
-    } else {
-      logger.debug({
-        at: "DataworkerUtils#persistDataToArweave",
-        message: "Arweave balance is above minimum target balance",
-        address,
-        balance: formatWinston(balance),
-        minimumBalance: formatWinston(MINIMUM_AR_BALANCE),
-      });
-    }
+  // Check balance. Maybe move this to Monitor function.
+  const MINIMUM_AR_BALANCE = parseWinston("1");
+  if (balance.lte(MINIMUM_AR_BALANCE)) {
+    logger.warn({
+      at: "DataworkerUtils#persistDataToArweave",
+      message: "Arweave balance is below minimum target balance",
+      address,
+      balance: formatWinston(balance),
+      minimumBalance: formatWinston(MINIMUM_AR_BALANCE),
+    });
+  } else {
+    logger.debug({
+      at: "DataworkerUtils#persistDataToArweave",
+      message: "Arweave balance is above minimum target balance",
+      address,
+      balance: formatWinston(balance),
+      minimumBalance: formatWinston(MINIMUM_AR_BALANCE),
+    });
+  }
 
-    if (matchingTxns.length > 0) {
-      logger.debug({
-        at: "DataworkerUtils#persistDataToArweave",
-        message: `Data already exists on Arweave with tag: ${tag}`,
-        hash: matchingTxns.map((txn) => txn.hash),
-      });
-    } else {
+  if (matchingTxns.length > 0) {
+    logger.debug({
+      at: "DataworkerUtils#persistDataToArweave",
+      message: `Data already exists on Arweave with tag: ${tag}`,
+      hash: matchingTxns.map((txn) => txn.hash),
+    });
+  } else {
+    try {
       const hashTxn = await client.set(data, tag);
       logger.info({
         at: "DataworkerUtils#persistDataToArweave",
@@ -537,10 +551,18 @@ export async function persistDataToArweave(
       mark.stop({
         message: "Time to persist to Arweave",
       });
+    } catch (error) {
+      logger.debug({
+        at: "DataworkerUtils#persistDataToArweave",
+        message: "Failed to persist data to Arweave",
+        tag,
+        error: String(error),
+      });
     }
-  } finally {
-    await persistArweaveTopicToCache(topicCache, tag, data, logger);
   }
+
+  // Regardless of whether the data was persisted to Arweave, we should persist to the cache.
+  await persistArweaveTopicToCache(topicCache, tag, data, logger);
 }
 
 async function persistArweaveTopicToCache(

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { utils, interfaces, caching } from "@across-protocol/sdk";
+import { utils, interfaces, caching, constants as sdkConstants } from "@across-protocol/sdk";
 import { SpokePoolClient } from "../clients";
 import {
   ARWEAVE_TAG_BYTE_LIMIT,
@@ -466,10 +466,12 @@ export async function persistDataToArweave(
   client: caching.ArweaveClient,
   data: Record<string, unknown>,
   logger: winston.Logger,
-  tag?: string
+  tag?: string,
+  topicCache?: interfaces.CachingMechanismInterface
 ): Promise<void> {
+  const normalizedTag = tag ?? "";
   assert(
-    Buffer.from(tag).length <= ARWEAVE_TAG_BYTE_LIMIT,
+    Buffer.from(normalizedTag).length <= ARWEAVE_TAG_BYTE_LIMIT,
     `Arweave tag cannot exceed ${ARWEAVE_TAG_BYTE_LIMIT} bytes`
   );
 
@@ -482,7 +484,7 @@ export async function persistDataToArweave(
   // Check if data already exists on Arweave with the given tag.
   // If so, we don't need to persist it again.
   const [matchingTxns, address, balance] = await Promise.all([
-    client.getByTopic(tag, any()),
+    client.getByTopic(normalizedTag, any()),
     client.getAddress(),
     client.getBalance(),
   ]);
@@ -510,23 +512,55 @@ export async function persistDataToArweave(
   if (matchingTxns.length > 0) {
     logger.debug({
       at: "DataworkerUtils#persistDataToArweave",
-      message: `Data already exists on Arweave with tag: ${tag}`,
+      message: `Data already exists on Arweave with tag: ${normalizedTag}`,
       hash: matchingTxns.map((txn) => txn.hash),
     });
+    await persistArweaveTopicToCache(topicCache, normalizedTag, data, logger);
   } else {
-    const hashTxn = await client.set(data, tag);
+    const hashTxn = await client.set(data, normalizedTag);
     logger.info({
       at: "DataworkerUtils#persistDataToArweave",
       message: "Persisted data to Arweave! 💾",
-      tag,
+      tag: normalizedTag,
       receipt: `https://arweave.app/tx/${hashTxn}`,
       rawData: `https://arweave.net/${hashTxn}`,
       address,
       balance: formatWinston(balance),
       notificationPath: "across-arweave",
     });
+    await persistArweaveTopicToCache(topicCache, normalizedTag, data, logger);
     mark.stop({
       message: "Time to persist to Arweave",
     });
   }
+}
+
+async function persistArweaveTopicToCache(
+  topicCache: interfaces.CachingMechanismInterface | undefined,
+  tag: string,
+  data: Record<string, unknown>,
+  logger: winston.Logger
+): Promise<void> {
+  if (!isDefined(topicCache) || tag.length === 0) {
+    return;
+  }
+
+  try {
+    await topicCache.set(
+      getArweaveTopicCacheKey(tag),
+      JSON.stringify(data, utils.jsonReplacerWithBigNumbers),
+      sdkConstants.DEFAULT_CACHING_TTL
+    );
+  } catch (error) {
+    logger.debug({
+      at: "DataworkerUtils#persistArweaveTopicToCache",
+      message: "Failed to persist Arweave topic payload into Redis cache",
+      tag,
+      error: String(error),
+    });
+  }
+}
+
+function getArweaveTopicCacheKey(tag: string): string {
+  return `arweave-topic:${tag}`;
 }

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -469,7 +469,8 @@ export async function persistDataToArweave(
   tag?: string,
   topicCache?: interfaces.CachingMechanismInterface
 ): Promise<void> {
-  const normalizedTag = tag ?? "";
+  assert(isDefined(tag) && tag.length > 0, "Arweave tag is required");
+  const normalizedTag = tag;
   assert(
     Buffer.from(normalizedTag).length <= ARWEAVE_TAG_BYTE_LIMIT,
     `Arweave tag cannot exceed ${ARWEAVE_TAG_BYTE_LIMIT} bytes`

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -470,9 +470,8 @@ export async function persistDataToArweave(
   topicCache?: interfaces.CachingMechanismInterface
 ): Promise<void> {
   assert(isDefined(tag) && tag.length > 0, "Arweave tag is required");
-  const normalizedTag = tag;
   assert(
-    Buffer.from(normalizedTag).length <= ARWEAVE_TAG_BYTE_LIMIT,
+    Buffer.from(tag).length <= ARWEAVE_TAG_BYTE_LIMIT,
     `Arweave tag cannot exceed ${ARWEAVE_TAG_BYTE_LIMIT} bytes`
   );
 
@@ -485,7 +484,7 @@ export async function persistDataToArweave(
   // Check if data already exists on Arweave with the given tag.
   // If so, we don't need to persist it again.
   const [matchingTxns, address, balance] = await Promise.all([
-    client.getByTopic(normalizedTag, any()),
+    client.getByTopic(tag, any()),
     client.getAddress(),
     client.getBalance(),
   ]);
@@ -513,23 +512,23 @@ export async function persistDataToArweave(
   if (matchingTxns.length > 0) {
     logger.debug({
       at: "DataworkerUtils#persistDataToArweave",
-      message: `Data already exists on Arweave with tag: ${normalizedTag}`,
+      message: `Data already exists on Arweave with tag: ${tag}`,
       hash: matchingTxns.map((txn) => txn.hash),
     });
-    await persistArweaveTopicToCache(topicCache, normalizedTag, data, logger);
+    await persistArweaveTopicToCache(topicCache, tag, data, logger);
   } else {
-    const hashTxn = await client.set(data, normalizedTag);
+    const hashTxn = await client.set(data, tag);
     logger.info({
       at: "DataworkerUtils#persistDataToArweave",
       message: "Persisted data to Arweave! 💾",
-      tag: normalizedTag,
+      tag,
       receipt: `https://arweave.app/tx/${hashTxn}`,
       rawData: `https://arweave.net/${hashTxn}`,
       address,
       balance: formatWinston(balance),
       notificationPath: "across-arweave",
     });
-    await persistArweaveTopicToCache(topicCache, normalizedTag, data, logger);
+    await persistArweaveTopicToCache(topicCache, tag, data, logger);
     mark.stop({
       message: "Time to persist to Arweave",
     });

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -466,10 +466,10 @@ export async function persistDataToArweave(
   client: caching.ArweaveClient,
   data: Record<string, unknown>,
   logger: winston.Logger,
-  tag?: string,
+  tag: string,
   topicCache?: interfaces.CachingMechanismInterface
 ): Promise<void> {
-  assert(isDefined(tag) && tag.length > 0, "Arweave tag is required");
+  assert(tag.length > 0, "Arweave tag is required");
   assert(
     Buffer.from(tag).length <= ARWEAVE_TAG_BYTE_LIMIT,
     `Arweave tag cannot exceed ${ARWEAVE_TAG_BYTE_LIMIT} bytes`

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -554,7 +554,7 @@ async function persistArweaveTopicToCache(
   }
 
   try {
-    const cacheKey = getArweaveTopicCacheKey(tag);
+    const cacheKey = utils.getArweaveTopicCacheKey(tag);
     const cachedData = await topicCache.get<string>(cacheKey);
     if (isDefined(cachedData)) {
       // We can return here and not update because we assume that the input data is the same for any given tag.
@@ -578,10 +578,6 @@ async function persistArweaveTopicToCache(
       error: String(error),
     });
   }
-}
-
-function getArweaveTopicCacheKey(tag: string): string {
-  return `arweave-topic:${tag}`;
 }
 
 function serializeArweaveTopicPayload(data: Record<string, unknown>): string {

--- a/test/DataworkerUtils.Arweave.ts
+++ b/test/DataworkerUtils.Arweave.ts
@@ -74,7 +74,7 @@ describe("persistDataToArweave topic cache seeding", () => {
       set: sinon.stub().rejects(new Error("gateway write failed")),
     } as unknown as caching.ArweaveClient;
 
-    await assertPromiseError(persistDataToArweave(client, payload, spyLogger, tag, topicCache), "gateway write failed");
+    await persistDataToArweave(client, payload, spyLogger, tag, topicCache);
 
     const cachedPayload = await topicCache.get<string>(`arweave-topic:${tag}`);
     expect(JSON.parse(cachedPayload!)).to.deep.equal(payload);

--- a/test/DataworkerUtils.Arweave.ts
+++ b/test/DataworkerUtils.Arweave.ts
@@ -59,4 +59,23 @@ describe("persistDataToArweave topic cache seeding", () => {
     const cachedPayload = await topicCache.get<string>(`arweave-topic:${tag}`);
     expect(cachedPayload).to.equal(null);
   });
+
+  it("should fail fast when the Arweave tag is omitted", async () => {
+    const { spyLogger } = createSpyLogger();
+    const topicCache = new caching.MemoryCacheClient();
+    const getByTopic = sinon.stub().resolves([]);
+    const client = {
+      getByTopic,
+      getAddress: sinon.stub().resolves("arweave-address"),
+      getBalance: sinon.stub().resolves(parseWinston("2")),
+      set: sinon.stub().resolves("tx-1"),
+    } as unknown as caching.ArweaveClient;
+
+    await assertPromiseError(
+      persistDataToArweave(client, payload, spyLogger, undefined, topicCache),
+      "Arweave tag is required"
+    );
+
+    expect(getByTopic.called).to.be.false;
+  });
 });

--- a/test/DataworkerUtils.Arweave.ts
+++ b/test/DataworkerUtils.Arweave.ts
@@ -29,18 +29,19 @@ describe("persistDataToArweave topic cache seeding", () => {
   it("should seed the topic cache even when the topic already exists on Arweave", async () => {
     const { spyLogger } = createSpyLogger();
     const topicCache = new caching.MemoryCacheClient();
+    const set = sinon.stub().resolves("tx-2");
     const client = {
       getByTopic: sinon.stub().resolves([{ data: { existing: true }, hash: "tx-existing" }]),
       getAddress: sinon.stub().resolves("arweave-address"),
       getBalance: sinon.stub().resolves(parseWinston("2")),
-      set: sinon.stub().resolves("tx-2"),
+      set,
     } as unknown as caching.ArweaveClient;
 
     await persistDataToArweave(client, payload, spyLogger, tag, topicCache);
 
     const cachedPayload = await topicCache.get<string>(`arweave-topic:${tag}`);
     expect(JSON.parse(cachedPayload!)).to.deep.equal(payload);
-    expect((client as any).set.called).to.be.false;
+    expect(set.called).to.be.false;
   });
 
   it("should not seed the topic cache when the Arweave write fails", async () => {

--- a/test/DataworkerUtils.Arweave.ts
+++ b/test/DataworkerUtils.Arweave.ts
@@ -1,0 +1,61 @@
+import { caching } from "@across-protocol/sdk";
+import { persistDataToArweave, parseWinston } from "../src/dataworker/DataworkerUtils";
+import { assertPromiseError, createSpyLogger, expect, sinon } from "./utils";
+
+describe("persistDataToArweave topic cache seeding", () => {
+  const tag = "bundles-123";
+  const payload = { test: "value" };
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should seed the topic cache after a successful Arweave write", async () => {
+    const { spyLogger } = createSpyLogger();
+    const topicCache = new caching.MemoryCacheClient();
+    const client = {
+      getByTopic: sinon.stub().resolves([]),
+      getAddress: sinon.stub().resolves("arweave-address"),
+      getBalance: sinon.stub().resolves(parseWinston("2")),
+      set: sinon.stub().resolves("tx-1"),
+    } as unknown as caching.ArweaveClient;
+
+    await persistDataToArweave(client, payload, spyLogger, tag, topicCache);
+
+    const cachedPayload = await topicCache.get<string>(`arweave-topic:${tag}`);
+    expect(JSON.parse(cachedPayload!)).to.deep.equal(payload);
+  });
+
+  it("should seed the topic cache even when the topic already exists on Arweave", async () => {
+    const { spyLogger } = createSpyLogger();
+    const topicCache = new caching.MemoryCacheClient();
+    const client = {
+      getByTopic: sinon.stub().resolves([{ data: { existing: true }, hash: "tx-existing" }]),
+      getAddress: sinon.stub().resolves("arweave-address"),
+      getBalance: sinon.stub().resolves(parseWinston("2")),
+      set: sinon.stub().resolves("tx-2"),
+    } as unknown as caching.ArweaveClient;
+
+    await persistDataToArweave(client, payload, spyLogger, tag, topicCache);
+
+    const cachedPayload = await topicCache.get<string>(`arweave-topic:${tag}`);
+    expect(JSON.parse(cachedPayload!)).to.deep.equal(payload);
+    expect((client as any).set.called).to.be.false;
+  });
+
+  it("should not seed the topic cache when the Arweave write fails", async () => {
+    const { spyLogger } = createSpyLogger();
+    const topicCache = new caching.MemoryCacheClient();
+    const client = {
+      getByTopic: sinon.stub().resolves([]),
+      getAddress: sinon.stub().resolves("arweave-address"),
+      getBalance: sinon.stub().resolves(parseWinston("2")),
+      set: sinon.stub().rejects(new Error("gateway write failed")),
+    } as unknown as caching.ArweaveClient;
+
+    await assertPromiseError(persistDataToArweave(client, payload, spyLogger, tag, topicCache), "gateway write failed");
+
+    const cachedPayload = await topicCache.get<string>(`arweave-topic:${tag}`);
+    expect(cachedPayload).to.equal(null);
+  });
+});

--- a/test/DataworkerUtils.Arweave.ts
+++ b/test/DataworkerUtils.Arweave.ts
@@ -30,8 +30,9 @@ describe("persistDataToArweave topic cache seeding", () => {
     const { spyLogger } = createSpyLogger();
     const topicCache = new caching.MemoryCacheClient();
     const set = sinon.stub().resolves("tx-2");
+    const existingPayload = { ...payload };
     const client = {
-      getByTopic: sinon.stub().resolves([{ data: { existing: true }, hash: "tx-existing" }]),
+      getByTopic: sinon.stub().resolves([{ data: existingPayload, hash: "tx-existing" }]),
       getAddress: sinon.stub().resolves("arweave-address"),
       getBalance: sinon.stub().resolves(parseWinston("2")),
       set,
@@ -40,11 +41,30 @@ describe("persistDataToArweave topic cache seeding", () => {
     await persistDataToArweave(client, payload, spyLogger, tag, topicCache);
 
     const cachedPayload = await topicCache.get<string>(`arweave-topic:${tag}`);
-    expect(JSON.parse(cachedPayload!)).to.deep.equal(payload);
+    expect(JSON.parse(cachedPayload!)).to.deep.equal(existingPayload);
     expect(set.called).to.be.false;
   });
 
-  it("should not seed the topic cache when the Arweave write fails", async () => {
+  it("should not overwrite an existing topic cache entry", async () => {
+    const { spyLogger } = createSpyLogger();
+    const topicCache = new caching.MemoryCacheClient();
+    const set = sinon.stub().resolves("tx-2");
+    await topicCache.set(`arweave-topic:${tag}`, JSON.stringify({ stale: true }), 60);
+    const client = {
+      getByTopic: sinon.stub().resolves([{ data: { ...payload }, hash: "tx-existing" }]),
+      getAddress: sinon.stub().resolves("arweave-address"),
+      getBalance: sinon.stub().resolves(parseWinston("2")),
+      set,
+    } as unknown as caching.ArweaveClient;
+
+    await persistDataToArweave(client, payload, spyLogger, tag, topicCache);
+
+    const cachedPayload = await topicCache.get<string>(`arweave-topic:${tag}`);
+    expect(JSON.parse(cachedPayload!)).to.deep.equal({ stale: true });
+    expect(set.called).to.be.false;
+  });
+
+  it("should seed the topic cache when the Arweave write fails", async () => {
     const { spyLogger } = createSpyLogger();
     const topicCache = new caching.MemoryCacheClient();
     const client = {
@@ -57,7 +77,7 @@ describe("persistDataToArweave topic cache seeding", () => {
     await assertPromiseError(persistDataToArweave(client, payload, spyLogger, tag, topicCache), "gateway write failed");
 
     const cachedPayload = await topicCache.get<string>(`arweave-topic:${tag}`);
-    expect(cachedPayload).to.equal(null);
+    expect(JSON.parse(cachedPayload!)).to.deep.equal(payload);
   });
 
   it("should fail fast when the Arweave tag is empty", async () => {

--- a/test/DataworkerUtils.Arweave.ts
+++ b/test/DataworkerUtils.Arweave.ts
@@ -60,7 +60,7 @@ describe("persistDataToArweave topic cache seeding", () => {
     expect(cachedPayload).to.equal(null);
   });
 
-  it("should fail fast when the Arweave tag is omitted", async () => {
+  it("should fail fast when the Arweave tag is empty", async () => {
     const { spyLogger } = createSpyLogger();
     const topicCache = new caching.MemoryCacheClient();
     const getByTopic = sinon.stub().resolves([]);
@@ -72,7 +72,7 @@ describe("persistDataToArweave topic cache seeding", () => {
     } as unknown as caching.ArweaveClient;
 
     await assertPromiseError(
-      persistDataToArweave(client, payload, spyLogger, undefined, topicCache),
+      persistDataToArweave(client, payload, spyLogger, "", topicCache),
       "Arweave tag is required"
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,10 +34,10 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.3.144":
-  version "4.3.144"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.144.tgz#0052bf3c156c9bb42ec075aaa229f132a368694a"
-  integrity sha512-ml6tR6QcxfGjEPfEAYzhSYMalK0M4tSBKOkRHU5BmXQKyS/5EdDDBa2K0pyNnK6p+pwmuz/2fUKufA5NqxTqTw==
+"@across-protocol/sdk@4.3.145":
+  version "4.3.145"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.145.tgz#649a205a492825fe269e0a6273cb38aa2294626c"
+  integrity sha512-j9bk4m73HpXHn7GbBfimX5r7c4FwwHFVQsZslA1cdxY4zQdKQePedPQxEbvlLN1Ayv9YlS0G8KelSXi/ykFPBw==
   dependencies:
     "@across-protocol/constants" "^3.1.109"
     "@across-protocol/contracts" "5.0.7"


### PR DESCRIPTION
## Problem
The dataworker write hot path already computes the exact bundle and merkle-tree payloads that downstream readers need, but after persisting to Arweave those payloads still have to be rediscovered through external Arweave gateway reads. That keeps later read paths dependent on external gateway availability and propagation even when the writer has already materialized the payload locally.

There was also no relayer-side wiring to share a Redis-backed topic cache between the writer path and the `BundleDataClient` read path.

## Solution
- initialize a shared Redis-backed Arweave topic cache during dataworker client construction
- pass that cache into `BundleDataClient` so Arweave-assisted bundle reads can consult Redis first
- pass the same cache into both `bundles-*` and `merkletree-*` calls to `persistDataToArweave()`
- regardless of whetehr `persistDataToArweave()` successfully writes a topic, seed Redis with the payload under `arweave-topic:{tag}`
- when `persistDataToArweave()` detects that the topic already exists on Arweave, still seed Redis with the current payload so later readers do not need to hit Arweave first
- Only set data in Redis if its not already set

## Integration
This PR is designed to pair with the SDK-side Arweave topic-cache reader, so `BundleDataClient` can read these `arweave-topic:{tag}` entries from Redis before falling back to external Arweave gateways.

## Verification
- `eslint src/dataworker/DataworkerUtils.ts src/dataworker/DataworkerClientHelper.ts src/dataworker/Dataworker.ts test/DataworkerUtils.Arweave.ts`
- `prettier --check src/dataworker/DataworkerUtils.ts src/dataworker/DataworkerClientHelper.ts src/dataworker/Dataworker.ts test/DataworkerUtils.Arweave.ts`
- `hardhat test test/DataworkerUtils.Arweave.ts`