### PR TITLE
improve: wrap nm api calls in retries

### DIFF
--- a/src/refiller/Refiller.ts
+++ b/src/refiller/Refiller.ts
@@ -498,10 +498,7 @@ export class Refiller {
           message: `Address ${this.baseSignerAddress.toNative()} is not registered in the native markets API. Creating new address ID.`,
           address: this.baseSignerAddress,
         });
-        const _addressId = await retryAsync(
-          postWithTimeout<{ id: string }>,
-          3,
-          1,
+        const _addressId = await postWithTimeout<{ id: string }>(
           `${nativeMarketsApiUrl}/addresses`,
           newAddressIdData,
           {},

--- a/src/refiller/Refiller.ts
+++ b/src/refiller/Refiller.ts
@@ -23,6 +23,7 @@ import {
   mapAsync,
   parseUnits,
   postWithTimeout,
+  retryAsync,
   submitTransaction,
   Signer,
   toAddressType,
@@ -469,9 +470,16 @@ export class Refiller {
     if (isDefined(addressIdCache)) {
       addressId = addressIdCache;
     } else {
-      const registeredAddresses = await fetchWithTimeout<{
-        items: { chain: string; token: string; address_hex: string; id: string }[];
-      }>(`${nativeMarketsApiUrl}/addresses`, {}, headers);
+      const registeredAddresses = await retryAsync(
+        fetchWithTimeout<{
+          items: { chain: string; token: string; address_hex: string; id: string }[];
+        }>,
+        3,
+        1,
+        `${nativeMarketsApiUrl}/addresses`,
+        {},
+        headers
+      );
       addressId = registeredAddresses.items.find(
         ({ chain, token, address_hex }) =>
           chain === "hyper_evm" && token === "usdh" && address_hex === this.baseSignerAddress.toNative()
@@ -490,7 +498,10 @@ export class Refiller {
           message: `Address ${this.baseSignerAddress.toNative()} is not registered in the native markets API. Creating new address ID.`,
           address: this.baseSignerAddress,
         });
-        const _addressId = await postWithTimeout<{ id: string }>(
+        const _addressId = await retryAsync(
+          postWithTimeout<{ id: string }>,
+          3,
+          1,
           `${nativeMarketsApiUrl}/addresses`,
           newAddressIdData,
           {},
@@ -511,7 +522,10 @@ export class Refiller {
       source_address?: TransferRouteAddress;
       destination_address: TransferRouteAddress;
     }
-    const transferRoutes = await fetchWithTimeout<{ items: TransferRoute[] }>(
+    const transferRoutes = await retryAsync(
+      fetchWithTimeout<{ items: TransferRoute[] }>,
+      3,
+      1,
       `${nativeMarketsApiUrl}/transfer_routes`,
       {},
       headers
@@ -539,7 +553,10 @@ export class Refiller {
         address: this.baseSignerAddress,
         addressId,
       });
-      availableTransferRoute = await postWithTimeout(
+      availableTransferRoute = await retryAsync(
+        postWithTimeout<TransferRoute>,
+        3,
+        1,
         `${nativeMarketsApiUrl}/transfer_routes`,
         newTransferRouteData,
         {},

--- a/src/refiller/Refiller.ts
+++ b/src/refiller/Refiller.ts
@@ -550,10 +550,7 @@ export class Refiller {
         address: this.baseSignerAddress,
         addressId,
       });
-      availableTransferRoute = await retryAsync(
-        postWithTimeout<TransferRoute>,
-        3,
-        1,
+      availableTransferRoute = await postWithTimeout<TransferRoute>(
         `${nativeMarketsApiUrl}/transfer_routes`,
         newTransferRouteData,
         {},


### PR DESCRIPTION
This is to avoid crashing the refiller when transient api errors occur. 