### PR TITLE
fix(BinanceCEXBridge): filter pending deposits by L2 tx.from

### DIFF
--- a/src/adapter/l2Bridges/BinanceCEXBridge.ts
+++ b/src/adapter/l2Bridges/BinanceCEXBridge.ts
@@ -24,6 +24,7 @@ import {
   getBinanceWithdrawalType,
   isCompletedBinanceWithdrawal,
   getOutstandingBinanceDeposits,
+  isDefined,
 } from "../../utils";
 import { L1Token } from "../../interfaces";
 import { BaseL2BridgeAdapter } from "./BaseL2BridgeAdapter";
@@ -105,9 +106,26 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
       getBinanceWithdrawals(binanceApiClient, this.l1TokenInfo.symbol, fromTimestamp),
     ]);
     // Remove any deposits and withdrawals that are marked as related to a swap.
+    // Also filter deposits by sender address — the Binance deposit API doesn't expose
+    // the sender, so we read tx.from directly. Without this, operators with a shared
+    // Binance account across multiple relayers see every relayer's outstanding deposits
+    // attributed to each relayer individually. Only deposits on this adapter's L2
+    // network can be filtered (we lack providers for other networks), so we drop
+    // cross-network deposits here — getOutstandingBinanceDeposits() then computes
+    // per-(relayer, network) net outstanding.
     const depositHistory = await filterAsync(_depositHistory, async (deposit) => {
+      if (deposit.coin !== this.l1TokenInfo.symbol) {
+        return false;
+      }
+      if (deposit.network !== this.depositNetwork) {
+        return false;
+      }
       const depositType = await getBinanceDepositType(deposit);
-      return deposit.coin === this.l1TokenInfo.symbol && depositType !== BinanceTransactionType.SWAP;
+      if (depositType === BinanceTransactionType.SWAP) {
+        return false;
+      }
+      const tx = await this.l2Bridge.provider.getTransaction(deposit.txId);
+      return isDefined(tx) && compareAddressesSimple(tx.from, fromAddress.toNative());
     });
     const withdrawHistory = await filterAsync(_withdrawHistory, async (withdrawal) => {
       const withdrawalType = await getBinanceWithdrawalType(withdrawal);


### PR DESCRIPTION
## Summary

- \`BinanceCEXBridge.getL2PendingWithdrawalAmount\` filtered withdrawals by the relayer's L1 recipient address but not deposits. The Binance deposit API doesn't expose a sender field, so operators with a Binance account shared across multiple relayers saw the full pending deposit pool attributed to each relayer individually.
- Read \`tx.from\` from each deposit's L2 transaction to filter deposits by sender. Drop deposits on other networks (we don't have providers for them here) — the per-(relayer, network) net outstanding calculation in \`getOutstandingBinanceDeposits()\` stays correct because it operates on this network's deposits only.

## How this was observed

Monitoring 3 relayers that share a single Binance account, all three reported the **exact same** 122.40133176 WETH pending on Optimism (where WETH withdrawals go via \`L2BinanceCEXNativeBridge\`). Direct query of OP Stack \`ETHBridgeInitiated\` events for each relayer returned 0 events — confirming the Binance CEX path was the source.

Root cause in \`src/adapter/l2Bridges/BinanceCEXBridge.ts:108-120\` (pre-fix):
- \`depositHistory\` = all operator Binance deposits, filtered only by coin + non-swap
- \`withdrawHistory\` = filtered by \`recipient === fromAddress\` (per-relayer)
- \`getOutstandingBinanceDeposits(deposits, withdrawals)\` then computed \"deposits that haven't been covered by THIS relayer's withdrawals\" — so every relayer saw the shared deposit pool minus only their own withdrawals.

After the fix: per-relayer attribution is correct. For our three relayers, one shows a real pending amount on the chain where they actually deposited, the other two show empty pending as expected.

## Test plan

- [x] \`yarn build\` compiles
- [x] \`yarn test test/BinanceUtils.ts test/BinanceAdapter.withdrawals.ts\` — 10 tests pass
- [x] Live run on dev VM with 3 monitored relayers sharing one Binance account — per-relayer pending amounts now distinct; previously all three reported identical shared totals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)