### PR TITLE
chore: Drop redundant dependencies from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /across-relayer
 COPY . ./
 
 RUN apt-get update
-RUN apt-get install -y jq yarn rsync
+RUN apt-get install -y yarn
 RUN yarn
 
 RUN yarn build

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /across-relayer
 COPY . ./
 
 RUN apt-get update
-RUN apt-get install -y libudev-dev libusb-1.0-0-dev jq yarn rsync
+RUN apt-get install -y jq yarn rsync
 RUN yarn
 
 RUN yarn build


### PR DESCRIPTION
These were required for long-gone legacy dependencies.