### PR TITLE
improve: Migrate Docker base image from Debian to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /across-relayer
 COPY . ./
 
 RUN apt-get update
-RUN apt-get install -y jq yarn rsync
+RUN apt-get install -y yarn
 RUN yarn
 
 RUN yarn build

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /across-relayer
 COPY . ./
 
 RUN apt-get update
-RUN apt-get install -y libudev-dev libusb-1.0-0-dev jq yarn rsync
+RUN apt-get install -y jq yarn rsync
 RUN yarn
 
 RUN yarn build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.18
+FROM node:22.18-alpine3.22
 
 ARG CONFIGURAMA_FOLDER_PATH
 ARG CONFIGURAMA_FOLDER_ENVIRONMENT
@@ -12,10 +12,10 @@ WORKDIR /across-relayer
 
 COPY . ./
 
-RUN apt-get update
-RUN apt-get install -y yarn
-RUN yarn
+RUN apk add --no-cache --virtual .build-deps python3 make g++ \
+ && yarn \
+ && apk del .build-deps
 
 RUN yarn build
 
-ENTRYPOINT ["/bin/bash", "scripts/runCommand.sh"]
+ENTRYPOINT ["/bin/sh", "scripts/runCommand.sh"]


### PR DESCRIPTION
In my testing this gives a ~25% reduction in the resulting image size for only a marginal increase in the build time.