### PR TITLE
improve: do not submit helios finalizations when there is no root to execute

### DIFF
--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -13,7 +13,6 @@ import {
   fetchWithTimeout,
   postWithTimeout,
   isHttpError,
-  CHAIN_IDs,
 } from "../../utils";
 import { spreadEventWithBlockNumber } from "../../utils/EventUtils";
 import { FinalizerPromise, CrossChainMessage } from "../types";
@@ -26,16 +25,6 @@ import { calculateHubPoolStoreStorageSlot, getHubPoolStoreContract } from "../..
 import { stringifyThrownValue } from "../../utils/LogUtils";
 import { getSp1HeliosContractEVM } from "../../utils/HeliosUtils";
 import { getBlockFinder, getBlockForTimestamp } from "../../utils/BlockUtils";
-
-// A configuration parameter for the number of _blocks_ the finalizer should wait before attempting a keep-alive action.
-// @dev Blocks, and not timestamps, are used as the unit here since some chains (TRON) do not support historical eth_* RPC queries.
-// The default refresh interval is 60/3 * 60 * 6 = 6 hrs w/ block times of 3 secs.
-const HELIOS_REFRESH_INTERVAL: { [chainId: number]: number } = {
-  [CHAIN_IDs.TEMPO]: 43200, // 500ms
-  [CHAIN_IDs.HYPEREVM]: 21600, // 1s
-  [CHAIN_IDs.PLASMA]: 21600, // 1s
-  [CHAIN_IDs.MONAD]: 54000, // 400ms
-};
 
 // --- Helios Action Types ---
 type HeliosActionType = "UpdateAndExecute" | "ExecuteOnly" | "UpdateOnly";
@@ -81,16 +70,6 @@ export async function heliosL1toL2Finalizer(
   );
   const l1ChainId = hubPoolClient.chainId;
   const l2ChainId = l2SpokePoolClient.chainId;
-  // Before we do anything, we should check if the last executed root bundle on L1 had a pool rebalance leaf for the destination network.
-  // If it did not, then there is no need to run the helios finalizer.
-  if (!shouldFinalize(hubPoolClient, l2SpokePoolClient, l2ChainId)) {
-    logger.debug({
-      at: `Finalizer#heliosL1toL2Finalizer:${l2ChainId}`,
-      message: `No recently executed pool rebalance root for ${l2ChainId}. Skipping finalization procedure.`,
-    });
-    return { callData: [], crossChainMessages: [] };
-  }
-
   const sp1HeliosL2 = await getSp1HeliosContractEVM(l2SpokePoolClient.spokePool, l2SpokePoolClient.spokePool.signer);
   const { sp1HeliosHead, sp1HeliosHeader } = await getSp1HeliosHeadData(sp1HeliosL2);
   const sp1HeliosVkey: string = await sp1HeliosL2.heliosProgramVkey();
@@ -135,6 +114,17 @@ export async function heliosL1toL2Finalizer(
     return { callData: [], crossChainMessages: [] };
   }
 
+  // Do not submit any transactions if we have no pool rebalance root to execute on the l2 chain ID or if we are not attempting a keep-alive action.
+  if (
+    !shouldFinalize(hubPoolClient, l2SpokePoolClient, l2ChainId) &&
+    actions.every((action) => action.type === "UpdateAndExecute")
+  ) {
+    logger.debug({
+      at: `Finalizer#heliosL1toL2Finalizer:${l2ChainId}`,
+      message: `No recently executed pool rebalance root for ${l2ChainId}. Skipping finalization procedure.`,
+    });
+    return { callData: [], crossChainMessages: [] };
+  }
   // --- Step 3: Generate transactions from ready-to-submit actions ---
   return generateTxnsForHeliosActions(logger, readyActions, l1ChainId, l2ChainId, l2SpokePoolClient, sp1HeliosL2);
 }
@@ -150,18 +140,9 @@ function shouldFinalize(hubPoolClient: HubPoolClient, l2SpokePoolClient: SpokePo
     if (executedLeaves.some((leaf) => leaf.chainId === l2ChainId)) {
       return true;
     }
+    return false;
   }
-
-  // If the L2 has not had a leaf execution in 6 hours, then we should also finalize.
-  assert(isEVMSpokePoolClient(l2SpokePoolClient), "shouldFinalize requires an EVM spoke pool client");
-  const l2Executions = l2SpokePoolClient.getRelayerRefundExecutions();
-  const latestL2Execution = l2Executions[l2Executions.length - 1];
-  if (!latestL2Execution) {
-    return true;
-  }
-  const currentBlock = l2SpokePoolClient.latestHeightSearched;
-  const blocksSinceLastExecution = currentBlock - latestL2Execution.blockNumber;
-  return blocksSinceLastExecution > (HELIOS_REFRESH_INTERVAL[l2ChainId] ?? 7200); // Default to lowest case @ 3s/block (6hrs).
+  return true;
 }
 
 // ==================================

--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -13,6 +13,7 @@ import {
   fetchWithTimeout,
   postWithTimeout,
   isHttpError,
+  isDefined,
 } from "../../utils";
 import { spreadEventWithBlockNumber } from "../../utils/EventUtils";
 import { FinalizerPromise, CrossChainMessage } from "../types";
@@ -75,7 +76,7 @@ export async function heliosL1toL2Finalizer(
   const sp1HeliosVkey: string = await sp1HeliosL2.heliosProgramVkey();
 
   // --- Step 1: Identify all actions needed (pending L1 -> L2 messages to finalize & keep-alive) ---
-  const actions = await identifyRequiredActions(
+  const _actions = await identifyRequiredActions(
     logger,
     hubPoolClient,
     l1SpokePoolClient,
@@ -84,6 +85,7 @@ export async function heliosL1toL2Finalizer(
     l1ChainId,
     l2ChainId
   );
+  const actions = filterRequiredActions(hubPoolClient, l2SpokePoolClient, l2ChainId, _actions);
 
   logger.debug({
     at: `Finalizer#heliosL1toL2Finalizer:${l2ChainId}`,
@@ -114,35 +116,8 @@ export async function heliosL1toL2Finalizer(
     return { callData: [], crossChainMessages: [] };
   }
 
-  // Do not submit any transactions if we have no pool rebalance root to execute on the l2 chain ID or if we are not attempting a keep-alive action.
-  if (
-    !shouldFinalize(hubPoolClient, l2SpokePoolClient, l2ChainId) &&
-    actions.every((action) => action.type === "UpdateAndExecute")
-  ) {
-    logger.debug({
-      at: `Finalizer#heliosL1toL2Finalizer:${l2ChainId}`,
-      message: `No recently executed pool rebalance root for ${l2ChainId}. Skipping finalization procedure.`,
-    });
-    return { callData: [], crossChainMessages: [] };
-  }
   // --- Step 3: Generate transactions from ready-to-submit actions ---
   return generateTxnsForHeliosActions(logger, readyActions, l1ChainId, l2ChainId, l2SpokePoolClient, sp1HeliosL2);
-}
-
-function shouldFinalize(hubPoolClient: HubPoolClient, l2SpokePoolClient: SpokePoolClient, l2ChainId: number): boolean {
-  // If the most recent executed root bundle contained a pool rebalance leaf for `l2ChainId`, then we should finalize.
-  const latestExecutedBundle = hubPoolClient.getLatestFullyExecutedRootBundle(hubPoolClient.latestHeightSearched);
-  if (latestExecutedBundle) {
-    const executedLeaves = hubPoolClient.getExecutedLeavesForRootBundle(
-      latestExecutedBundle,
-      hubPoolClient.latestHeightSearched
-    );
-    if (executedLeaves.some((leaf) => leaf.chainId === l2ChainId)) {
-      return true;
-    }
-    return false;
-  }
-  return true;
 }
 
 // ==================================
@@ -481,6 +456,28 @@ async function getRelevantL1Events(
   );
 
   return relevantStoredCallDataEvents;
+}
+
+function filterRequiredActions(
+  hubPoolClient: HubPoolClient,
+  l2SpokePoolClient: SpokePoolClient,
+  l2ChainId: number,
+  actions: HeliosAction[]
+): HeliosAction[] {
+  return actions.filter((action) => {
+    if (action.type !== "UpdateAndExecute") {
+      return true;
+    }
+    // If a root bundle in our lookback has an unexecuted L2 leaf and that leaf has a corresponding pool rebalance leaf for the l2 network, then we want to execute.
+    const matchingExecutedRootBundle = hubPoolClient.getExecutedRootBundles().find((leaf) => {
+      if (leaf.chainId !== l2ChainId) {
+        return false;
+      }
+      // The action's `StoredCalldataEvent` will be in the same transaction as the HubPool's `ExecutedRootBundle` event since the execution of any pool rebalance leaf is atomic.
+      return leaf.txnRef === action.l1Event.txnRef;
+    });
+    return isDefined(matchingExecutedRootBundle) ? true : false;
+  });
 }
 
 /** Query L2 Verification Events and return verified slots map */

--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -13,6 +13,7 @@ import {
   fetchWithTimeout,
   postWithTimeout,
   isHttpError,
+  CHAIN_IDs,
 } from "../../utils";
 import { spreadEventWithBlockNumber } from "../../utils/EventUtils";
 import { FinalizerPromise, CrossChainMessage } from "../types";
@@ -25,6 +26,16 @@ import { calculateHubPoolStoreStorageSlot, getHubPoolStoreContract } from "../..
 import { stringifyThrownValue } from "../../utils/LogUtils";
 import { getSp1HeliosContractEVM } from "../../utils/HeliosUtils";
 import { getBlockFinder, getBlockForTimestamp } from "../../utils/BlockUtils";
+
+// A configuration parameter for the number of _blocks_ the finalizer should wait before attempting a keep-alive action.
+// @dev Blocks, and not timestamps, are used as the unit here since some chains (TRON) do not support historical eth_* RPC queries.
+// The default refresh interval is 60/3 * 60 * 6 = 6 hrs w/ block times of 3 secs.
+const HELIOS_REFRESH_INTERVAL: { [chainId: number]: number } = {
+  [CHAIN_IDs.TEMPO]: 43200, // 500ms
+  [CHAIN_IDs.HYPEREVM]: 21600, // 1s
+  [CHAIN_IDs.PLASMA]: 21600, // 1s
+  [CHAIN_IDs.MONAD]: 54000, // 400ms
+};
 
 // --- Helios Action Types ---
 type HeliosActionType = "UpdateAndExecute" | "ExecuteOnly" | "UpdateOnly";
@@ -74,12 +85,12 @@ export async function heliosL1toL2Finalizer(
   // If it did not, then there is no need to run the helios finalizer.
   if (!shouldFinalize(hubPoolClient, l2SpokePoolClient, l2ChainId)) {
     logger.debug({
-    at: `Finalizer#heliosL1toL2Finalizer:${l2ChainId}`,
-    message: `No recently executed pool rebalance root for ${l2ChainId}. Skipping finalization procedure.`,
+      at: `Finalizer#heliosL1toL2Finalizer:${l2ChainId}`,
+      message: `No recently executed pool rebalance root for ${l2ChainId}. Skipping finalization procedure.`,
     });
     return { callData: [], crossChainMessages: [] };
   }
-  
+
   const sp1HeliosL2 = await getSp1HeliosContractEVM(l2SpokePoolClient.spokePool, l2SpokePoolClient.spokePool.signer);
   const { sp1HeliosHead, sp1HeliosHeader } = await getSp1HeliosHeadData(sp1HeliosL2);
   const sp1HeliosVkey: string = await sp1HeliosL2.heliosProgramVkey();
@@ -120,7 +131,7 @@ export async function heliosL1toL2Finalizer(
     logger.debug({
       at: `Finalizer#heliosL1toL2Finalizer:${l2ChainId}`,
       message: "No Helios actions are ready for submission after enrichment phase.",
-    })
+    });
     return { callData: [], crossChainMessages: [] };
   }
 
@@ -128,11 +139,7 @@ export async function heliosL1toL2Finalizer(
   return generateTxnsForHeliosActions(logger, readyActions, l1ChainId, l2ChainId, l2SpokePoolClient, sp1HeliosL2);
 }
 
-function shouldFinalize(
-  hubPoolClient: HubPoolClient,
-  l2SpokePoolClient: SpokePoolClient,
-  l2ChainId: number
-): Promise<boolean> {
+function shouldFinalize(hubPoolClient: HubPoolClient, l2SpokePoolClient: SpokePoolClient, l2ChainId: number): boolean {
   // If the most recent executed root bundle contained a pool rebalance leaf for `l2ChainId`, then we should finalize.
   const latestExecutedBundle = hubPoolClient.getLatestFullyExecutedRootBundle(hubPoolClient.latestHeightSearched);
   if (latestExecutedBundle) {
@@ -154,7 +161,7 @@ function shouldFinalize(
   }
   const currentBlock = l2SpokePoolClient.latestHeightSearched;
   const blocksSinceLastExecution = currentBlock - latestL2Execution.blockNumber;
-  return blocksSinceLastExecution > HELIOS_REFRESH_INTERVAL[l2ChainId] ?? 7200; // Default to lowest case @ 3s/block (6hrs).
+  return blocksSinceLastExecution > (HELIOS_REFRESH_INTERVAL[l2ChainId] ?? 7200); // Default to lowest case @ 3s/block (6hrs).
 }
 
 // ==================================

--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -70,6 +70,16 @@ export async function heliosL1toL2Finalizer(
   );
   const l1ChainId = hubPoolClient.chainId;
   const l2ChainId = l2SpokePoolClient.chainId;
+  // Before we do anything, we should check if the last executed root bundle on L1 had a pool rebalance leaf for the destination network.
+  // If it did not, then there is no need to run the helios finalizer.
+  if (!shouldFinalize(hubPoolClient, l2SpokePoolClient, l2ChainId)) {
+    logger.debug({
+    at: `Finalizer#heliosL1toL2Finalizer:${l2ChainId}`,
+    message: `No recently executed pool rebalance root for ${l2ChainId}. Skipping finalization procedure.`,
+    });
+    return { callData: [], crossChainMessages: [] };
+  }
+  
   const sp1HeliosL2 = await getSp1HeliosContractEVM(l2SpokePoolClient.spokePool, l2SpokePoolClient.spokePool.signer);
   const { sp1HeliosHead, sp1HeliosHeader } = await getSp1HeliosHeadData(sp1HeliosL2);
   const sp1HeliosVkey: string = await sp1HeliosL2.heliosProgramVkey();
@@ -110,12 +120,41 @@ export async function heliosL1toL2Finalizer(
     logger.debug({
       at: `Finalizer#heliosL1toL2Finalizer:${l2ChainId}`,
       message: "No Helios actions are ready for submission after enrichment phase.",
-    });
+    })
     return { callData: [], crossChainMessages: [] };
   }
 
   // --- Step 3: Generate transactions from ready-to-submit actions ---
   return generateTxnsForHeliosActions(logger, readyActions, l1ChainId, l2ChainId, l2SpokePoolClient, sp1HeliosL2);
+}
+
+function shouldFinalize(
+  hubPoolClient: HubPoolClient,
+  l2SpokePoolClient: SpokePoolClient,
+  l2ChainId: number
+): Promise<boolean> {
+  // If the most recent executed root bundle contained a pool rebalance leaf for `l2ChainId`, then we should finalize.
+  const latestExecutedBundle = hubPoolClient.getLatestFullyExecutedRootBundle(hubPoolClient.latestHeightSearched);
+  if (latestExecutedBundle) {
+    const executedLeaves = hubPoolClient.getExecutedLeavesForRootBundle(
+      latestExecutedBundle,
+      hubPoolClient.latestHeightSearched
+    );
+    if (executedLeaves.some((leaf) => leaf.chainId === l2ChainId)) {
+      return true;
+    }
+  }
+
+  // If the L2 has not had a leaf execution in 6 hours, then we should also finalize.
+  assert(isEVMSpokePoolClient(l2SpokePoolClient), "shouldFinalize requires an EVM spoke pool client");
+  const l2Executions = l2SpokePoolClient.getRelayerRefundExecutions();
+  const latestL2Execution = l2Executions[l2Executions.length - 1];
+  if (!latestL2Execution) {
+    return true;
+  }
+  const currentBlock = l2SpokePoolClient.latestHeightSearched;
+  const blocksSinceLastExecution = currentBlock - latestL2Execution.blockNumber;
+  return blocksSinceLastExecution > HELIOS_REFRESH_INTERVAL[l2ChainId] ?? 7200; // Default to lowest case @ 3s/block (6hrs).
 }
 
 // ==================================

--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -476,7 +476,7 @@ function filterRequiredActions(
       // The action's `StoredCalldataEvent` will be in the same transaction as the HubPool's `ExecutedRootBundle` event since the execution of any pool rebalance leaf is atomic.
       return leaf.txnRef === action.l1Event.txnRef;
     });
-    return isDefined(matchingExecutedRootBundle) ? true : false;
+    return isDefined(matchingExecutedRootBundle);
   });
 }
 


### PR DESCRIPTION
This adds a function which will make the helios finalizer exit early if the root bundle we want to relay to a universal L2 has no pool rebalance root. We will still complete any KeepAlive action or partially executed root bundle, and will only not begin any new relay (i.e. via `UpdateAndExecute`). 