### PR TITLE
fix(binance): subtract taker fees from matching fill amount

### DIFF
--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1494,7 +1494,12 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       symbol: spotMarketMeta.symbol,
       orderId: matchingFill.orderId,
     });
-    const totalCommission = myTrades.reduce((acc, trade) => acc + Number(trade.commission), 0);
+    const receivedAsset = spotMarketMeta.isBuy ? spotMarketMeta.baseAssetName : spotMarketMeta.quoteAssetName;
+    const totalCommission = myTrades.reduce(
+      (acc, trade) =>
+        acc + (resolveBinanceCoinSymbol(trade.commissionAsset) === receivedAsset ? Number(trade.commission) : 0),
+      0
+    );
     const expectedAmountToReceive = spotMarketMeta.isBuy ? matchingFill.executedQty : matchingFill.cummulativeQuoteQty;
     return { matchingFill, expectedAmountToReceive: Number(expectedAmountToReceive) - totalCommission };
   }

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -30,6 +30,7 @@ import {
   setBinanceDepositType,
   setBinanceWithdrawalType,
   Signer,
+  SpotMarketMeta,
   toBN,
   toBNWei,
   truncate,
@@ -44,16 +45,6 @@ import { CctpAdapter } from "./cctpAdapter";
 import { OftAdapter } from "./oftAdapter";
 import { CONTRACT_ADDRESSES } from "../../common";
 import WETH_ABI from "../../common/abi/Weth.json";
-
-interface SPOT_MARKET_META {
-  symbol: string;
-  baseAssetName: string;
-  quoteAssetName: string;
-  pxDecimals: number;
-  szDecimals: number;
-  minimumOrderSize: number;
-  isBuy: boolean;
-}
 
 export function isFailedBinanceWithdrawal(status?: number): boolean {
   switch (status) {
@@ -118,7 +109,7 @@ export function deriveBinanceSpotMarketMeta(
   sourceToken: string,
   destinationToken: string,
   symbol: Symbol<OrderType_LT>
-): SPOT_MARKET_META {
+): SpotMarketMeta {
   const sourceAsset = resolveBinanceCoinSymbol(sourceToken);
   const destinationAsset = resolveBinanceCoinSymbol(destinationToken);
   const isBuy = symbol.baseAsset === destinationAsset && symbol.quoteAsset === sourceAsset;
@@ -178,7 +169,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     { fetchedAtMs: number; book: Awaited<ReturnType<Binance["book"]>> }
   >();
   private tradeFeesPromise?: ReturnType<Binance["tradeFee"]>;
-  private spotMarketMetaPromiseByRoute = new Map<string, Promise<SPOT_MARKET_META>>();
+  private spotMarketMetaPromiseByRoute = new Map<string, Promise<SpotMarketMeta>>();
 
   REDIS_PREFIX = "binance-stablecoin-swap:";
   private static readonly ORDER_BOOK_CACHE_TTL_MS = 30_000;
@@ -1377,7 +1368,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     });
   }
 
-  private async _getSpotMarketMetaForRoute(sourceToken: string, destinationToken: string): Promise<SPOT_MARKET_META> {
+  private async _getSpotMarketMetaForRoute(sourceToken: string, destinationToken: string): Promise<SpotMarketMeta> {
     assert(
       this._routeRequiresSwap(sourceToken, destinationToken),
       `Route ${sourceToken}-${destinationToken} does not require a Binance spot market`

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1485,7 +1485,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       ? matchingFill.executedQty
       : matchingFill.cummulativeQuoteQty;
     const fillCommission = await getFillCommission(this.binanceApiClient, spotMarketMeta, matchingFill.orderId);
-    const expectedAmountToReceive = Number(grossExpectedAmountToReceive) - fillCommission;
+    const expectedAmountToReceive = BigNumber.from(grossExpectedAmountToReceive).sub(fillCommission).toNumber();
     return { matchingFill, expectedAmountToReceive };
   }
 

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -971,7 +971,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       : "0";
     const tradeFee = toBNWei(truncate(Number(tradeFeePct), 18), 18)
       .mul(amountToTransfer)
-      .div(toBNWei(100, 18));
+      .div(toBNWei(1, 18));
     const destinationCoin = await this._getAccountCoins(destinationToken);
     const destinationEntrypointNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
     const withdrawFee = destinationCoin.networkList.find(

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1489,13 +1489,14 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     if (!matchingFill) {
       return undefined;
     }
-    // Need to subtract the taker commission from the expected amount to receive.
-    const tradeFeePct = (await this._getTradeFees()).find(
-      (fee) => fee.symbol === spotMarketMeta.symbol
-    ).takerCommission;
+    // Query myTrades to get the realized commissions on the received asset.
+    const myTrades = await this.binanceApiClient.myTrades({
+      symbol: spotMarketMeta.symbol,
+      orderId: matchingFill.orderId,
+    });
+    const totalCommission = myTrades.reduce((acc, trade) => acc + Number(trade.commission), 0);
     const expectedAmountToReceive = spotMarketMeta.isBuy ? matchingFill.executedQty : matchingFill.cummulativeQuoteQty;
-    const tradeFee = Number(expectedAmountToReceive) * tradeFeePct;
-    return { matchingFill, expectedAmountToReceive: Number(expectedAmountToReceive) - tradeFee };
+    return { matchingFill, expectedAmountToReceive: Number(expectedAmountToReceive) - totalCommission };
   }
 
   private _routeRequiresSwap(sourceToken: string, destinationToken: string): boolean {

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1489,11 +1489,22 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     if (!matchingFill) {
       return undefined;
     }
-    // Query myTrades to get the realized commissions on the received asset.
-    const myTrades = await this.binanceApiClient.myTrades({
-      symbol: spotMarketMeta.symbol,
-      orderId: matchingFill.orderId,
-    });
+    const myTrades = [];
+    const pageLimit = 1000;
+    let fromId: number | undefined;
+    for (;;) {
+      const page = await this.binanceApiClient.myTrades({
+        symbol: spotMarketMeta.symbol,
+        orderId: matchingFill.orderId,
+        fromId,
+        limit: pageLimit,
+      });
+      myTrades.push(...page);
+      if (page.length < pageLimit) {
+        break;
+      }
+      fromId = page[page.length - 1].id + 1;
+    }
     const receivedAsset = spotMarketMeta.isBuy ? spotMarketMeta.baseAssetName : spotMarketMeta.quoteAssetName;
     const totalCommission = myTrades.reduce(
       (acc, trade) =>

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -17,6 +17,7 @@ import {
   fromWei,
   getAccountCoins,
   getBinanceApiClient,
+  getFillCommission,
   getBinanceTransactionTypeKey,
   getBinanceWithdrawals,
   getCurrentTime,
@@ -1489,30 +1490,12 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     if (!matchingFill) {
       return undefined;
     }
-    const myTrades = [];
-    const pageLimit = 1000;
-    let fromId: number | undefined;
-    for (;;) {
-      const page = await this.binanceApiClient.myTrades({
-        symbol: spotMarketMeta.symbol,
-        orderId: matchingFill.orderId,
-        fromId,
-        limit: pageLimit,
-      });
-      myTrades.push(...page);
-      if (page.length < pageLimit) {
-        break;
-      }
-      fromId = page[page.length - 1].id + 1;
-    }
-    const receivedAsset = spotMarketMeta.isBuy ? spotMarketMeta.baseAssetName : spotMarketMeta.quoteAssetName;
-    const totalCommission = myTrades.reduce(
-      (acc, trade) =>
-        acc + (resolveBinanceCoinSymbol(trade.commissionAsset) === receivedAsset ? Number(trade.commission) : 0),
-      0
-    );
-    const expectedAmountToReceive = spotMarketMeta.isBuy ? matchingFill.executedQty : matchingFill.cummulativeQuoteQty;
-    return { matchingFill, expectedAmountToReceive: Number(expectedAmountToReceive) - totalCommission };
+    const grossExpectedAmountToReceive = spotMarketMeta.isBuy
+      ? matchingFill.executedQty
+      : matchingFill.cummulativeQuoteQty;
+    const fillCommission = await getFillCommission(spotMarketMeta, matchingFill.orderId);
+    const expectedAmountToReceive = Number(grossExpectedAmountToReceive) - fillCommission;
+    return { matchingFill, expectedAmountToReceive };
   }
 
   private _routeRequiresSwap(sourceToken: string, destinationToken: string): boolean {

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1492,7 +1492,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     // Need to subtract the taker commission from the expected amount to receive.
     const tradeFeePct = (await this._getTradeFees()).find(
       (fee) => fee.symbol === spotMarketMeta.symbol
-    )?.takerCommission;
+    ).takerCommission;
     const expectedAmountToReceive = spotMarketMeta.isBuy ? matchingFill.executedQty : matchingFill.cummulativeQuoteQty;
     const tradeFee = Number(expectedAmountToReceive) * tradeFeePct;
     return { matchingFill, expectedAmountToReceive: Number(expectedAmountToReceive) - tradeFee };

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1485,7 +1485,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       ? matchingFill.executedQty
       : matchingFill.cummulativeQuoteQty;
     const fillCommission = await getFillCommission(this.binanceApiClient, spotMarketMeta, matchingFill.orderId);
-    const expectedAmountToReceive = BigNumber.from(grossExpectedAmountToReceive).sub(fillCommission).toNumber();
+    const expectedAmountToReceive = Number(grossExpectedAmountToReceive) - fillCommission;
     return { matchingFill, expectedAmountToReceive };
   }
 

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -1493,7 +1493,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const grossExpectedAmountToReceive = spotMarketMeta.isBuy
       ? matchingFill.executedQty
       : matchingFill.cummulativeQuoteQty;
-    const fillCommission = await getFillCommission(spotMarketMeta, matchingFill.orderId);
+    const fillCommission = await getFillCommission(this.binanceApiClient, spotMarketMeta, matchingFill.orderId);
     const expectedAmountToReceive = Number(grossExpectedAmountToReceive) - fillCommission;
     return { matchingFill, expectedAmountToReceive };
   }

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -449,7 +449,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       const matchingFill = await this._getMatchingFillForCloid(cloid, this.baseSignerAddress);
       if (matchingFill) {
         const balance = await this._getBinanceBalance(destinationToken);
-        const withdrawAmount = Number(matchingFill.expectedAmountToReceive);
+        const withdrawAmount = matchingFill.expectedAmountToReceive;
         if (balance < withdrawAmount) {
           this.logger.debug({
             at: "BinanceStablecoinSwapAdapter.updateRebalanceStatuses",
@@ -689,7 +689,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       if (matchingFill) {
         const destinationTokenInfo = this._getTokenInfo(destinationToken, destinationChain);
         expectedAmountToReceive = toBNWei(
-          truncate(Number(matchingFill.expectedAmountToReceive), destinationTokenInfo.decimals),
+          truncate(matchingFill.expectedAmountToReceive, destinationTokenInfo.decimals),
           destinationTokenInfo.decimals
         );
       } else {
@@ -1476,7 +1476,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   private async _getMatchingFillForCloid(
     cloid: string,
     account: EvmAddress
-  ): Promise<{ matchingFill: QueryOrderResult; expectedAmountToReceive: string } | undefined> {
+  ): Promise<{ matchingFill: QueryOrderResult; expectedAmountToReceive: number } | undefined> {
     const orderDetails = await this._redisGetOrderDetails(cloid, account);
     const spotMarketMeta = await this._getSpotMarketMetaForRoute(
       orderDetails.sourceToken,
@@ -1489,8 +1489,13 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     if (!matchingFill) {
       return undefined;
     }
+    // Need to subtract the taker commission from the expected amount to receive.
+    const tradeFeePct = (await this._getTradeFees()).find(
+      (fee) => fee.symbol === spotMarketMeta.symbol
+    )?.takerCommission;
     const expectedAmountToReceive = spotMarketMeta.isBuy ? matchingFill.executedQty : matchingFill.cummulativeQuoteQty;
-    return { matchingFill, expectedAmountToReceive };
+    const tradeFee = Number(expectedAmountToReceive) * tradeFeePct;
+    return { matchingFill, expectedAmountToReceive: Number(expectedAmountToReceive) - tradeFee };
   }
 
   private _routeRequiresSwap(sourceToken: string, destinationToken: string): boolean {

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -396,8 +396,8 @@ async function getBinanceFillTrades(
     return await binanceApi.myTrades({
       symbol,
       orderId,
-      fromId,
       limit: BINANCE_TRADES_PAGE_LIMIT,
+      ...(fromId !== undefined ? { fromId } : {}),
     });
   } catch (_err) {
     const err = _err.toString();

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -1,17 +1,7 @@
 import Binance, { DepositHistoryResponse, WithdrawHistoryResponse, type Binance as BinanceApi } from "binance-api-node";
 export type { BinanceApi };
 import minimist from "minimist";
-import {
-  getGckmsConfig,
-  retrieveGckmsKeys,
-  isDefined,
-  assert,
-  delay,
-  CHAIN_IDs,
-  getRedisCache,
-  truncate,
-  bnZero,
-} from "./";
+import { getGckmsConfig, retrieveGckmsKeys, isDefined, assert, delay, CHAIN_IDs, getRedisCache, truncate } from "./";
 
 // Store global promises on Gckms key retrieval actions so that we don't retrieve the same key multiple times.
 let binanceSecretKeyPromise: Promise<string | undefined> | undefined = undefined;
@@ -359,13 +349,11 @@ export async function getFillCommission(
   // because these rebalance orders are not expected to fragment into >1000 fills. If that ever
   // changes in production, replace this with an explicit oldest-to-newest pagination strategy.
   const trades = await getBinanceFillTrades(binanceApi, spotMarketMeta.symbol, orderId);
-  return trades
-    .reduce(
-      (acc, trade) =>
-        acc.add(resolveBinanceCoinSymbol(trade.commissionAsset) === receivedAsset ? Number(trade.commission) : bnZero),
-      bnZero
-    )
-    .toNumber();
+  return trades.reduce(
+    (acc, trade) =>
+      acc + (resolveBinanceCoinSymbol(trade.commissionAsset) === receivedAsset ? Number(trade.commission) : 0),
+    0
+  );
 }
 
 /**

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -1,7 +1,6 @@
 import Binance, { DepositHistoryResponse, WithdrawHistoryResponse, type Binance as BinanceApi } from "binance-api-node";
 export type { BinanceApi };
 import minimist from "minimist";
-import type { BinanceSpotMarketMeta } from "./BinanceSwapUtils";
 import { getGckmsConfig, retrieveGckmsKeys, isDefined, assert, delay, CHAIN_IDs, getRedisCache, truncate } from "./";
 
 // Store global promises on Gckms key retrieval actions so that we don't retrieve the same key multiple times.
@@ -18,6 +17,13 @@ const BINANCE_TRADES_PAGE_LIMIT = 1000;
 export type WithdrawalQuota = {
   wdQuota: number;
   usedWdQuota: number;
+};
+
+export type SpotMarketMeta = {
+  symbol: string;
+  baseAssetName: string;
+  quoteAssetName: string;
+  isBuy: boolean;
 };
 
 // Alias for Binance network symbols.
@@ -326,7 +332,7 @@ export async function getBinanceWithdrawals(
   });
 }
 
-export async function getFillCommission(spotMarketMeta: BinanceSpotMarketMeta, orderId: number): Promise<number> {
+export async function getFillCommission(spotMarketMeta: SpotMarketMeta, orderId: number): Promise<number> {
   const binanceApi = await getBinanceApiClient(process.env.BINANCE_API_BASE);
   const receivedAsset = spotMarketMeta.isBuy ? spotMarketMeta.baseAssetName : spotMarketMeta.quoteAssetName;
   let fromId: number | undefined;

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -332,8 +332,11 @@ export async function getBinanceWithdrawals(
   });
 }
 
-export async function getFillCommission(spotMarketMeta: SpotMarketMeta, orderId: number): Promise<number> {
-  const binanceApi = await getBinanceApiClient(process.env.BINANCE_API_BASE);
+export async function getFillCommission(
+  binanceApi: BinanceApi,
+  spotMarketMeta: SpotMarketMeta,
+  orderId: number
+): Promise<number> {
   const receivedAsset = spotMarketMeta.isBuy ? spotMarketMeta.baseAssetName : spotMarketMeta.quoteAssetName;
   let fromId: number | undefined;
   let totalCommission = 0;

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -1,7 +1,17 @@
 import Binance, { DepositHistoryResponse, WithdrawHistoryResponse, type Binance as BinanceApi } from "binance-api-node";
 export type { BinanceApi };
 import minimist from "minimist";
-import { getGckmsConfig, retrieveGckmsKeys, isDefined, assert, delay, CHAIN_IDs, getRedisCache, truncate } from "./";
+import {
+  getGckmsConfig,
+  retrieveGckmsKeys,
+  isDefined,
+  assert,
+  delay,
+  CHAIN_IDs,
+  getRedisCache,
+  truncate,
+  bnZero,
+} from "./";
 
 // Store global promises on Gckms key retrieval actions so that we don't retrieve the same key multiple times.
 let binanceSecretKeyPromise: Promise<string | undefined> | undefined = undefined;
@@ -349,11 +359,13 @@ export async function getFillCommission(
   // because these rebalance orders are not expected to fragment into >1000 fills. If that ever
   // changes in production, replace this with an explicit oldest-to-newest pagination strategy.
   const trades = await getBinanceFillTrades(binanceApi, spotMarketMeta.symbol, orderId);
-  return trades.reduce(
-    (acc, trade) =>
-      acc + (resolveBinanceCoinSymbol(trade.commissionAsset) === receivedAsset ? Number(trade.commission) : 0),
-    0
-  );
+  return trades
+    .reduce(
+      (acc, trade) =>
+        acc.add(resolveBinanceCoinSymbol(trade.commissionAsset) === receivedAsset ? Number(trade.commission) : bnZero),
+      bnZero
+    )
+    .toNumber();
 }
 
 /**

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -26,6 +26,8 @@ export type SpotMarketMeta = {
   isBuy: boolean;
 };
 
+type BinanceTradeReader = Pick<BinanceApi, "myTrades">;
+
 // Alias for Binance network symbols.
 export const BINANCE_NETWORKS: { [chainId: number]: string } = {
   [CHAIN_IDs.ARBITRUM]: "ARBITRUM",
@@ -333,7 +335,7 @@ export async function getBinanceWithdrawals(
 }
 
 export async function getFillCommission(
-  binanceApi: BinanceApi,
+  binanceApi: BinanceTradeReader,
   spotMarketMeta: SpotMarketMeta,
   orderId: number
 ): Promise<number> {
@@ -385,7 +387,7 @@ export async function getAccountCoins(binanceApi: BinanceApi): Promise<ParsedAcc
 }
 
 async function getBinanceFillTrades(
-  binanceApi: BinanceApi,
+  binanceApi: BinanceTradeReader,
   symbol: string,
   orderId: number,
   fromId?: number,

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -12,7 +12,7 @@ const KNOWN_BINANCE_ERROR_REASONS = [
   "Too many requests; current request has limited",
   "TypeError: fetch failed",
 ];
-const BINANCE_TRADES_PAGE_LIMIT = 1000;
+const BINANCE_TRADES_FETCH_LIMIT = 1000;
 
 export type WithdrawalQuota = {
   wdQuota: number;
@@ -344,21 +344,16 @@ export async function getFillCommission(
   orderId: number
 ): Promise<number> {
   const receivedAsset = spotMarketMeta.isBuy ? spotMarketMeta.baseAssetName : spotMarketMeta.quoteAssetName;
-  let fromId: number | undefined;
-  let totalCommission = 0;
-
-  for (;;) {
-    const trades = await getBinanceFillTrades(binanceApi, spotMarketMeta.symbol, orderId, fromId);
-    totalCommission += trades.reduce(
-      (acc, trade) =>
-        acc + (resolveBinanceCoinSymbol(trade.commissionAsset) === receivedAsset ? Number(trade.commission) : 0),
-      0
-    );
-    if (trades.length < BINANCE_TRADES_PAGE_LIMIT) {
-      return totalCommission;
-    }
-    fromId = trades[trades.length - 1].id + 1;
-  }
+  // Binance `myTrades` returns the most recent trades when `fromId` is omitted, so naively paging
+  // forward from that first page can skip older fills. We intentionally read a single page here
+  // because these rebalance orders are not expected to fragment into >1000 fills. If that ever
+  // changes in production, replace this with an explicit oldest-to-newest pagination strategy.
+  const trades = await getBinanceFillTrades(binanceApi, spotMarketMeta.symbol, orderId);
+  return trades.reduce(
+    (acc, trade) =>
+      acc + (resolveBinanceCoinSymbol(trade.commissionAsset) === receivedAsset ? Number(trade.commission) : 0),
+    0
+  );
 }
 
 /**
@@ -394,7 +389,6 @@ async function getBinanceFillTrades(
   binanceApi: BinanceTradeReader,
   symbol: string,
   orderId: number,
-  fromId?: number,
   nRetries = 0,
   maxRetries = 3
 ): Promise<Awaited<ReturnType<BinanceApi["myTrades"]>>> {
@@ -402,15 +396,14 @@ async function getBinanceFillTrades(
     return await binanceApi.myTrades({
       symbol,
       orderId,
-      limit: BINANCE_TRADES_PAGE_LIMIT,
-      ...(fromId !== undefined ? { fromId } : {}),
+      limit: BINANCE_TRADES_FETCH_LIMIT,
     });
   } catch (_err) {
     const err = _err.toString();
     if (KNOWN_BINANCE_ERROR_REASONS.some((errorReason) => err.includes(errorReason)) && nRetries < maxRetries) {
       const delaySeconds = 2 ** nRetries + Math.random();
       await delay(delaySeconds);
-      return getBinanceFillTrades(binanceApi, symbol, orderId, fromId, ++nRetries, maxRetries);
+      return getBinanceFillTrades(binanceApi, symbol, orderId, ++nRetries, maxRetries);
     }
     throw err;
   }

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -1,6 +1,7 @@
 import Binance, { DepositHistoryResponse, WithdrawHistoryResponse, type Binance as BinanceApi } from "binance-api-node";
 export type { BinanceApi };
 import minimist from "minimist";
+import type { BinanceSpotMarketMeta } from "./BinanceSwapUtils";
 import { getGckmsConfig, retrieveGckmsKeys, isDefined, assert, delay, CHAIN_IDs, getRedisCache, truncate } from "./";
 
 // Store global promises on Gckms key retrieval actions so that we don't retrieve the same key multiple times.
@@ -12,6 +13,7 @@ const KNOWN_BINANCE_ERROR_REASONS = [
   "Too many requests; current request has limited",
   "TypeError: fetch failed",
 ];
+const BINANCE_TRADES_PAGE_LIMIT = 1000;
 
 export type WithdrawalQuota = {
   wdQuota: number;
@@ -324,6 +326,26 @@ export async function getBinanceWithdrawals(
   });
 }
 
+export async function getFillCommission(spotMarketMeta: BinanceSpotMarketMeta, orderId: number): Promise<number> {
+  const binanceApi = await getBinanceApiClient(process.env.BINANCE_API_BASE);
+  const receivedAsset = spotMarketMeta.isBuy ? spotMarketMeta.baseAssetName : spotMarketMeta.quoteAssetName;
+  let fromId: number | undefined;
+  let totalCommission = 0;
+
+  for (;;) {
+    const trades = await getBinanceFillTrades(binanceApi, spotMarketMeta.symbol, orderId, fromId);
+    totalCommission += trades.reduce(
+      (acc, trade) =>
+        acc + (resolveBinanceCoinSymbol(trade.commissionAsset) === receivedAsset ? Number(trade.commission) : 0),
+      0
+    );
+    if (trades.length < BINANCE_TRADES_PAGE_LIMIT) {
+      return totalCommission;
+    }
+    fromId = trades[trades.length - 1].id + 1;
+  }
+}
+
 /**
  * The call to accountCoins returns an opaque `unknown` object with extraneous information. This function
  * parses the unknown into a readable object to be used by the finalizers.
@@ -351,6 +373,32 @@ export async function getAccountCoins(binanceApi: BinanceApi): Promise<ParsedAcc
       networkList,
     } as Coin;
   });
+}
+
+async function getBinanceFillTrades(
+  binanceApi: BinanceApi,
+  symbol: string,
+  orderId: number,
+  fromId?: number,
+  nRetries = 0,
+  maxRetries = 3
+): Promise<Awaited<ReturnType<BinanceApi["myTrades"]>>> {
+  try {
+    return await binanceApi.myTrades({
+      symbol,
+      orderId,
+      fromId,
+      limit: BINANCE_TRADES_PAGE_LIMIT,
+    });
+  } catch (_err) {
+    const err = _err.toString();
+    if (KNOWN_BINANCE_ERROR_REASONS.some((errorReason) => err.includes(errorReason)) && nRetries < maxRetries) {
+      const delaySeconds = 2 ** nRetries + Math.random();
+      await delay(delaySeconds);
+      return getBinanceFillTrades(binanceApi, symbol, orderId, fromId, ++nRetries, maxRetries);
+    }
+    throw err;
+  }
 }
 
 /**

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -23,10 +23,14 @@ export type SpotMarketMeta = {
   symbol: string;
   baseAssetName: string;
   quoteAssetName: string;
+  pxDecimals: number;
+  szDecimals: number;
+  minimumOrderSize: number;
   isBuy: boolean;
 };
 
 type BinanceTradeReader = Pick<BinanceApi, "myTrades">;
+type FillCommissionMarketMeta = Pick<SpotMarketMeta, "symbol" | "baseAssetName" | "quoteAssetName" | "isBuy">;
 
 // Alias for Binance network symbols.
 export const BINANCE_NETWORKS: { [chainId: number]: string } = {
@@ -336,7 +340,7 @@ export async function getBinanceWithdrawals(
 
 export async function getFillCommission(
   binanceApi: BinanceTradeReader,
-  spotMarketMeta: SpotMarketMeta,
+  spotMarketMeta: FillCommissionMarketMeta,
   orderId: number
 ): Promise<number> {
   const receivedAsset = spotMarketMeta.isBuy ? spotMarketMeta.baseAssetName : spotMarketMeta.quoteAssetName;

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -145,7 +145,7 @@ describe("Binance adapter helpers", async function () {
     expect(tradeFeeStub.callCount).to.equal(2);
   });
 
-  it("paginates myTrades and only subtracts realized commissions charged in the received asset", async function () {
+  it("subtracts realized commissions charged in the received asset from the most recent trade page", async function () {
     const adapter = await makeAdapter();
     const [signer] = await ethers.getSigners();
     const allOrdersStub = sinon.stub().resolves([
@@ -157,20 +157,15 @@ describe("Binance adapter helpers", async function () {
         cummulativeQuoteQty: "100.1",
       },
     ]);
-    const myTradesStub = sinon
-      .stub()
-      .onCall(0)
-      .resolves([
-        ...Array.from({ length: 998 }, (_, index) => ({
-          id: index + 1,
-          commission: "0",
-          commissionAsset: "USDC",
-        })),
-        { id: 999, commission: "1", commissionAsset: "USDC" },
-        { id: 1000, commission: "5", commissionAsset: "BNB" },
-      ])
-      .onCall(1)
-      .resolves([{ id: 1001, commission: "2", commissionAsset: "USDC" }]);
+    const myTradesStub = sinon.stub().resolves([
+      ...Array.from({ length: 998 }, (_, index) => ({
+        id: index + 1,
+        commission: "0",
+        commissionAsset: "USDC",
+      })),
+      { id: 999, commission: "1", commissionAsset: "USDC" },
+      { id: 1000, commission: "5", commissionAsset: "BNB" },
+    ]);
     const internals = adapter as unknown as {
       _getMatchingFillForCloid(
         cloid: string,
@@ -214,17 +209,11 @@ describe("Binance adapter helpers", async function () {
 
     const result = await internals._getMatchingFillForCloid("cloid", EvmAddress.from(await signer.getAddress()));
 
-    expect(result?.expectedAmountToReceive).to.equal(97);
-    expect(myTradesStub.callCount).to.equal(2);
+    expect(result?.expectedAmountToReceive).to.equal(99);
+    expect(myTradesStub.callCount).to.equal(1);
     expect(myTradesStub.getCall(0).args[0]).to.deep.equal({
       symbol: "USDCUSDT",
       orderId: 123,
-      limit: 1000,
-    });
-    expect(myTradesStub.getCall(1).args[0]).to.deep.equal({
-      symbol: "USDCUSDT",
-      orderId: 123,
-      fromId: 1001,
       limit: 1000,
     });
   });

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -1,3 +1,5 @@
+import { createServer } from "http";
+import type { AddressInfo } from "net";
 import { ethers, expect, sinon, toBNWei } from "./utils";
 import winston from "winston";
 import {
@@ -148,6 +150,40 @@ describe("Binance adapter helpers", async function () {
   it("paginates myTrades and only subtracts realized commissions charged in the received asset", async function () {
     const adapter = await makeAdapter();
     const [signer] = await ethers.getSigners();
+    const firstPage = [
+      ...Array.from({ length: 998 }, (_, index) => ({
+        id: index + 1,
+        commission: "0",
+        commissionAsset: "USDC",
+      })),
+      { id: 999, commission: "1", commissionAsset: "USDC" },
+      { id: 1000, commission: "5", commissionAsset: "BNB" },
+    ];
+    const secondPage = [{ id: 1001, commission: "2", commissionAsset: "USDC" }];
+    const requests: Array<{ orderId: string | null; fromId: string | null; limit: string | null }> = [];
+    const server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      requests.push({
+        orderId: url.searchParams.get("orderId"),
+        fromId: url.searchParams.get("fromId"),
+        limit: url.searchParams.get("limit"),
+      });
+      res.setHeader("Content-Type", "application/json");
+      if (url.pathname !== "/api/v3/myTrades") {
+        res.statusCode = 404;
+        res.end(JSON.stringify({ msg: "not found" }));
+        return;
+      }
+      res.end(JSON.stringify(url.searchParams.get("fromId") === "1001" ? secondPage : firstPage));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+    const originalBinanceApiBase = process.env.BINANCE_API_BASE;
+    const originalBinanceApiKey = process.env.BINANCE_API_KEY;
+    const originalBinanceHmacKey = process.env.BINANCE_HMAC_KEY;
+    process.env.BINANCE_API_BASE = `http://127.0.0.1:${port}`;
+    process.env.BINANCE_API_KEY = "test-api-key";
+    process.env.BINANCE_HMAC_KEY = "test-secret-key";
     const allOrdersStub = sinon.stub().resolves([
       {
         clientOrderId: "cloid",
@@ -157,20 +193,6 @@ describe("Binance adapter helpers", async function () {
         cummulativeQuoteQty: "100.1",
       },
     ]);
-    const myTradesStub = sinon
-      .stub()
-      .onCall(0)
-      .resolves([
-        ...Array.from({ length: 998 }, (_, index) => ({
-          id: index + 1,
-          commission: "0",
-          commissionAsset: "USDC",
-        })),
-        { id: 999, commission: "1", commissionAsset: "USDC" },
-        { id: 1000, commission: "5", commissionAsset: "BNB" },
-      ])
-      .onCall(1)
-      .resolves([{ id: 1001, commission: "2", commissionAsset: "USDC" }]);
     const internals = adapter as unknown as {
       _getMatchingFillForCloid(
         cloid: string,
@@ -194,7 +216,6 @@ describe("Binance adapter helpers", async function () {
       }>;
       binanceApiClient: {
         allOrders: sinon.SinonStub;
-        myTrades: sinon.SinonStub;
       };
     };
     sinon.stub(internals, "_redisGetOrderDetails").resolves({ sourceToken: "USDT", destinationToken: "USDC" });
@@ -209,25 +230,22 @@ describe("Binance adapter helpers", async function () {
     });
     internals.binanceApiClient = {
       allOrders: allOrdersStub,
-      myTrades: myTradesStub,
     };
 
-    const result = await internals._getMatchingFillForCloid("cloid", EvmAddress.from(await signer.getAddress()));
+    try {
+      const result = await internals._getMatchingFillForCloid("cloid", EvmAddress.from(await signer.getAddress()));
 
-    expect(result?.expectedAmountToReceive).to.equal(97);
-    expect(myTradesStub.callCount).to.equal(2);
-    expect(myTradesStub.getCall(0).args[0]).to.deep.equal({
-      symbol: "USDCUSDT",
-      orderId: 123,
-      fromId: undefined,
-      limit: 1000,
-    });
-    expect(myTradesStub.getCall(1).args[0]).to.deep.equal({
-      symbol: "USDCUSDT",
-      orderId: 123,
-      fromId: 1001,
-      limit: 1000,
-    });
+      expect(result?.expectedAmountToReceive).to.equal(97);
+      expect(requests).to.deep.equal([
+        { orderId: "123", fromId: "undefined", limit: "1000" },
+        { orderId: "123", fromId: "1001", limit: "1000" },
+      ]);
+    } finally {
+      process.env.BINANCE_API_BASE = originalBinanceApiBase;
+      process.env.BINANCE_API_KEY = originalBinanceApiKey;
+      process.env.BINANCE_HMAC_KEY = originalBinanceHmacKey;
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
   });
 
   it("keeps pending WETH credit until a finalized Binance withdrawal is wrapped", async function () {

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -219,7 +219,6 @@ describe("Binance adapter helpers", async function () {
     expect(myTradesStub.getCall(0).args[0]).to.deep.equal({
       symbol: "USDCUSDT",
       orderId: 123,
-      fromId: undefined,
       limit: 1000,
     });
     expect(myTradesStub.getCall(1).args[0]).to.deep.equal({

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -145,9 +145,32 @@ describe("Binance adapter helpers", async function () {
     expect(tradeFeeStub.callCount).to.equal(2);
   });
 
-  it("only subtracts realized commissions charged in the received asset", async function () {
+  it("paginates myTrades and only subtracts realized commissions charged in the received asset", async function () {
     const adapter = await makeAdapter();
     const [signer] = await ethers.getSigners();
+    const allOrdersStub = sinon.stub().resolves([
+      {
+        clientOrderId: "cloid",
+        status: "FILLED",
+        orderId: 123,
+        executedQty: "100",
+        cummulativeQuoteQty: "100.1",
+      },
+    ]);
+    const myTradesStub = sinon
+      .stub()
+      .onCall(0)
+      .resolves([
+        ...Array.from({ length: 998 }, (_, index) => ({
+          id: index + 1,
+          commission: "0",
+          commissionAsset: "USDC",
+        })),
+        { id: 999, commission: "1", commissionAsset: "USDC" },
+        { id: 1000, commission: "5", commissionAsset: "BNB" },
+      ])
+      .onCall(1)
+      .resolves([{ id: 1001, commission: "2", commissionAsset: "USDC" }]);
     const internals = adapter as unknown as {
       _getMatchingFillForCloid(
         cloid: string,
@@ -185,24 +208,26 @@ describe("Binance adapter helpers", async function () {
       isBuy: true,
     });
     internals.binanceApiClient = {
-      allOrders: sinon.stub().resolves([
-        {
-          clientOrderId: "cloid",
-          status: "FILLED",
-          orderId: 123,
-          executedQty: "100",
-          cummulativeQuoteQty: "100.1",
-        },
-      ]),
-      myTrades: sinon.stub().resolves([
-        { commission: "0.1", commissionAsset: "USDC" },
-        { commission: "0.2", commissionAsset: "BNB" },
-      ]),
+      allOrders: allOrdersStub,
+      myTrades: myTradesStub,
     };
 
     const result = await internals._getMatchingFillForCloid("cloid", EvmAddress.from(await signer.getAddress()));
 
-    expect(result?.expectedAmountToReceive).to.equal(99.9);
+    expect(result?.expectedAmountToReceive).to.equal(97);
+    expect(myTradesStub.callCount).to.equal(2);
+    expect(myTradesStub.getCall(0).args[0]).to.deep.equal({
+      symbol: "USDCUSDT",
+      orderId: 123,
+      fromId: undefined,
+      limit: 1000,
+    });
+    expect(myTradesStub.getCall(1).args[0]).to.deep.equal({
+      symbol: "USDCUSDT",
+      orderId: 123,
+      fromId: 1001,
+      limit: 1000,
+    });
   });
 
   it("keeps pending WETH credit until a finalized Binance withdrawal is wrapped", async function () {

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -153,7 +153,10 @@ describe("Binance adapter helpers", async function () {
         cloid: string,
         account: EvmAddress
       ): Promise<{ expectedAmountToReceive: number } | undefined>;
-      _redisGetOrderDetails(cloid: string, account: EvmAddress): Promise<{ sourceToken: string; destinationToken: string }>;
+      _redisGetOrderDetails(
+        cloid: string,
+        account: EvmAddress
+      ): Promise<{ sourceToken: string; destinationToken: string }>;
       _getSpotMarketMetaForRoute(
         sourceToken: string,
         destinationToken: string

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -1,5 +1,3 @@
-import { createServer } from "http";
-import type { AddressInfo } from "net";
 import { ethers, expect, sinon, toBNWei } from "./utils";
 import winston from "winston";
 import {
@@ -150,40 +148,6 @@ describe("Binance adapter helpers", async function () {
   it("paginates myTrades and only subtracts realized commissions charged in the received asset", async function () {
     const adapter = await makeAdapter();
     const [signer] = await ethers.getSigners();
-    const firstPage = [
-      ...Array.from({ length: 998 }, (_, index) => ({
-        id: index + 1,
-        commission: "0",
-        commissionAsset: "USDC",
-      })),
-      { id: 999, commission: "1", commissionAsset: "USDC" },
-      { id: 1000, commission: "5", commissionAsset: "BNB" },
-    ];
-    const secondPage = [{ id: 1001, commission: "2", commissionAsset: "USDC" }];
-    const requests: Array<{ orderId: string | null; fromId: string | null; limit: string | null }> = [];
-    const server = createServer((req, res) => {
-      const url = new URL(req.url ?? "/", "http://127.0.0.1");
-      requests.push({
-        orderId: url.searchParams.get("orderId"),
-        fromId: url.searchParams.get("fromId"),
-        limit: url.searchParams.get("limit"),
-      });
-      res.setHeader("Content-Type", "application/json");
-      if (url.pathname !== "/api/v3/myTrades") {
-        res.statusCode = 404;
-        res.end(JSON.stringify({ msg: "not found" }));
-        return;
-      }
-      res.end(JSON.stringify(url.searchParams.get("fromId") === "1001" ? secondPage : firstPage));
-    });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-    const { port } = server.address() as AddressInfo;
-    const originalBinanceApiBase = process.env.BINANCE_API_BASE;
-    const originalBinanceApiKey = process.env.BINANCE_API_KEY;
-    const originalBinanceHmacKey = process.env.BINANCE_HMAC_KEY;
-    process.env.BINANCE_API_BASE = `http://127.0.0.1:${port}`;
-    process.env.BINANCE_API_KEY = "test-api-key";
-    process.env.BINANCE_HMAC_KEY = "test-secret-key";
     const allOrdersStub = sinon.stub().resolves([
       {
         clientOrderId: "cloid",
@@ -193,6 +157,20 @@ describe("Binance adapter helpers", async function () {
         cummulativeQuoteQty: "100.1",
       },
     ]);
+    const myTradesStub = sinon
+      .stub()
+      .onCall(0)
+      .resolves([
+        ...Array.from({ length: 998 }, (_, index) => ({
+          id: index + 1,
+          commission: "0",
+          commissionAsset: "USDC",
+        })),
+        { id: 999, commission: "1", commissionAsset: "USDC" },
+        { id: 1000, commission: "5", commissionAsset: "BNB" },
+      ])
+      .onCall(1)
+      .resolves([{ id: 1001, commission: "2", commissionAsset: "USDC" }]);
     const internals = adapter as unknown as {
       _getMatchingFillForCloid(
         cloid: string,
@@ -216,6 +194,7 @@ describe("Binance adapter helpers", async function () {
       }>;
       binanceApiClient: {
         allOrders: sinon.SinonStub;
+        myTrades: sinon.SinonStub;
       };
     };
     sinon.stub(internals, "_redisGetOrderDetails").resolves({ sourceToken: "USDT", destinationToken: "USDC" });
@@ -230,22 +209,25 @@ describe("Binance adapter helpers", async function () {
     });
     internals.binanceApiClient = {
       allOrders: allOrdersStub,
+      myTrades: myTradesStub,
     };
 
-    try {
-      const result = await internals._getMatchingFillForCloid("cloid", EvmAddress.from(await signer.getAddress()));
+    const result = await internals._getMatchingFillForCloid("cloid", EvmAddress.from(await signer.getAddress()));
 
-      expect(result?.expectedAmountToReceive).to.equal(97);
-      expect(requests).to.deep.equal([
-        { orderId: "123", fromId: "undefined", limit: "1000" },
-        { orderId: "123", fromId: "1001", limit: "1000" },
-      ]);
-    } finally {
-      process.env.BINANCE_API_BASE = originalBinanceApiBase;
-      process.env.BINANCE_API_KEY = originalBinanceApiKey;
-      process.env.BINANCE_HMAC_KEY = originalBinanceHmacKey;
-      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
-    }
+    expect(result?.expectedAmountToReceive).to.equal(97);
+    expect(myTradesStub.callCount).to.equal(2);
+    expect(myTradesStub.getCall(0).args[0]).to.deep.equal({
+      symbol: "USDCUSDT",
+      orderId: 123,
+      fromId: undefined,
+      limit: 1000,
+    });
+    expect(myTradesStub.getCall(1).args[0]).to.deep.equal({
+      symbol: "USDCUSDT",
+      orderId: 123,
+      fromId: 1001,
+      limit: 1000,
+    });
   });
 
   it("keeps pending WETH credit until a finalized Binance withdrawal is wrapped", async function () {

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -145,6 +145,63 @@ describe("Binance adapter helpers", async function () {
     expect(tradeFeeStub.callCount).to.equal(2);
   });
 
+  it("only subtracts realized commissions charged in the received asset", async function () {
+    const adapter = await makeAdapter();
+    const [signer] = await ethers.getSigners();
+    const internals = adapter as unknown as {
+      _getMatchingFillForCloid(
+        cloid: string,
+        account: EvmAddress
+      ): Promise<{ expectedAmountToReceive: number } | undefined>;
+      _redisGetOrderDetails(cloid: string, account: EvmAddress): Promise<{ sourceToken: string; destinationToken: string }>;
+      _getSpotMarketMetaForRoute(
+        sourceToken: string,
+        destinationToken: string
+      ): Promise<{
+        symbol: string;
+        baseAssetName: string;
+        quoteAssetName: string;
+        pxDecimals: number;
+        szDecimals: number;
+        minimumOrderSize: number;
+        isBuy: boolean;
+      }>;
+      binanceApiClient: {
+        allOrders: sinon.SinonStub;
+        myTrades: sinon.SinonStub;
+      };
+    };
+    sinon.stub(internals, "_redisGetOrderDetails").resolves({ sourceToken: "USDT", destinationToken: "USDC" });
+    sinon.stub(internals, "_getSpotMarketMetaForRoute").resolves({
+      symbol: "USDCUSDT",
+      baseAssetName: "USDC",
+      quoteAssetName: "USDT",
+      pxDecimals: 4,
+      szDecimals: 0,
+      minimumOrderSize: 1,
+      isBuy: true,
+    });
+    internals.binanceApiClient = {
+      allOrders: sinon.stub().resolves([
+        {
+          clientOrderId: "cloid",
+          status: "FILLED",
+          orderId: 123,
+          executedQty: "100",
+          cummulativeQuoteQty: "100.1",
+        },
+      ]),
+      myTrades: sinon.stub().resolves([
+        { commission: "0.1", commissionAsset: "USDC" },
+        { commission: "0.2", commissionAsset: "BNB" },
+      ]),
+    };
+
+    const result = await internals._getMatchingFillForCloid("cloid", EvmAddress.from(await signer.getAddress()));
+
+    expect(result?.expectedAmountToReceive).to.equal(99.9);
+  });
+
   it("keeps pending WETH credit until a finalized Binance withdrawal is wrapped", async function () {
     const adapter = await makeAdapter();
     const [signer] = await ethers.getSigners();

--- a/test/BinanceUtils.ts
+++ b/test/BinanceUtils.ts
@@ -3,7 +3,7 @@ import type { AddressInfo } from "net";
 import { expect } from "./utils";
 import {
   BinanceDeposit,
-  BinanceSpotMarketMeta,
+  SpotMarketMeta,
   BinanceWithdrawal,
   getFillCommission,
   getOutstandingBinanceDeposits,
@@ -164,7 +164,7 @@ describe("BinanceUtils fill commission helpers", function () {
     process.env.BINANCE_HMAC_KEY = "test-secret-key";
 
     try {
-      const spotMarketMeta: BinanceSpotMarketMeta = {
+      const spotMarketMeta: SpotMarketMeta = {
         symbol: "USDCUSDT",
         baseAssetName: "USDC",
         quoteAssetName: "USDT",

--- a/test/BinanceUtils.ts
+++ b/test/BinanceUtils.ts
@@ -180,7 +180,7 @@ describe("BinanceUtils fill commission helpers", function () {
 
       expect(totalCommission).to.be.closeTo(100.3, 1e-9);
       expect(requests).to.deep.equal([
-        { orderId: "123", fromId: "undefined", limit: "1000" },
+        { orderId: "123", fromId: null, limit: "1000" },
         { orderId: "123", fromId: "1000", limit: "1000" },
       ]);
     } finally {

--- a/test/BinanceUtils.ts
+++ b/test/BinanceUtils.ts
@@ -140,9 +140,9 @@ describe("BinanceUtils fill commission helpers", function () {
     const myTradesStub = sinon.stub();
     myTradesStub.onCall(0).resolves(firstPage);
     myTradesStub.onCall(1).resolves(secondPage);
-    const binanceApi = {
+    const binanceApi: Pick<BinanceApi, "myTrades"> = {
       myTrades: myTradesStub,
-    } as unknown as BinanceApi;
+    };
     const spotMarketMeta: SpotMarketMeta = {
       symbol: "USDCUSDT",
       baseAssetName: "USDC",

--- a/test/BinanceUtils.ts
+++ b/test/BinanceUtils.ts
@@ -119,27 +119,13 @@ describe("BinanceUtils withdrawal helpers", function () {
 });
 
 describe("BinanceUtils fill commission helpers", function () {
-  it("sums only commissions charged in the received asset across paginated trade results", async function () {
-    const firstPage = Array.from({ length: 1000 }, (_, index) => ({
+  it("sums only commissions charged in the received asset from the most recent trade page", async function () {
+    const trades = Array.from({ length: 1000 }, (_, index) => ({
       id: index,
       commission: index === 0 ? "0.2" : "0.1",
       commissionAsset: index === 1 ? "BNB" : "USDC",
     }));
-    const secondPage = [
-      {
-        id: 1000,
-        commission: "0.3",
-        commissionAsset: "USDC",
-      },
-      {
-        id: 1001,
-        commission: "0.4",
-        commissionAsset: "BNB",
-      },
-    ];
-    const myTradesStub = sinon.stub();
-    myTradesStub.onCall(0).resolves(firstPage);
-    myTradesStub.onCall(1).resolves(secondPage);
+    const myTradesStub = sinon.stub().resolves(trades);
     const binanceApi: Pick<BinanceApi, "myTrades"> = {
       myTrades: myTradesStub,
     };
@@ -155,17 +141,11 @@ describe("BinanceUtils fill commission helpers", function () {
 
     const totalCommission = await getFillCommission(binanceApi, spotMarketMeta, 123);
 
-    expect(totalCommission).to.be.closeTo(100.3, 1e-9);
-    expect(myTradesStub.callCount).to.equal(2);
+    expect(totalCommission).to.be.closeTo(100, 1e-9);
+    expect(myTradesStub.callCount).to.equal(1);
     expect(myTradesStub.getCall(0).args[0]).to.deep.equal({
       symbol: "USDCUSDT",
       orderId: 123,
-      limit: 1000,
-    });
-    expect(myTradesStub.getCall(1).args[0]).to.deep.equal({
-      symbol: "USDCUSDT",
-      orderId: 123,
-      fromId: 1000,
       limit: 1000,
     });
   });

--- a/test/BinanceUtils.ts
+++ b/test/BinanceUtils.ts
@@ -1,11 +1,9 @@
-import { createServer } from "http";
-import type { AddressInfo } from "net";
-import { expect } from "./utils";
+import { expect, sinon } from "./utils";
 import {
+  type BinanceApi,
   BinanceDeposit,
   SpotMarketMeta,
   BinanceWithdrawal,
-  getBinanceApiClient,
   getFillCommission,
   getOutstandingBinanceDeposits,
   isCompletedBinanceWithdrawal,
@@ -139,55 +137,36 @@ describe("BinanceUtils fill commission helpers", function () {
         commissionAsset: "BNB",
       },
     ];
-    const requests: Array<{ orderId: string | null; fromId: string | null; limit: string | null }> = [];
-    const server = createServer((req, res) => {
-      const url = new URL(req.url ?? "/", "http://127.0.0.1");
-      requests.push({
-        orderId: url.searchParams.get("orderId"),
-        fromId: url.searchParams.get("fromId"),
-        limit: url.searchParams.get("limit"),
-      });
-      res.setHeader("Content-Type", "application/json");
-      if (url.pathname !== "/api/v3/myTrades") {
-        res.statusCode = 404;
-        res.end(JSON.stringify({ msg: "not found" }));
-        return;
-      }
-      res.end(JSON.stringify(url.searchParams.get("fromId") === "1000" ? secondPage : firstPage));
+    const myTradesStub = sinon.stub();
+    myTradesStub.onCall(0).resolves(firstPage);
+    myTradesStub.onCall(1).resolves(secondPage);
+    const binanceApi = {
+      myTrades: myTradesStub,
+    } as unknown as BinanceApi;
+    const spotMarketMeta: SpotMarketMeta = {
+      symbol: "USDCUSDT",
+      baseAssetName: "USDC",
+      quoteAssetName: "USDT",
+      pxDecimals: 4,
+      szDecimals: 0,
+      minimumOrderSize: 1,
+      isBuy: true,
+    };
+
+    const totalCommission = await getFillCommission(binanceApi, spotMarketMeta, 123);
+
+    expect(totalCommission).to.be.closeTo(100.3, 1e-9);
+    expect(myTradesStub.callCount).to.equal(2);
+    expect(myTradesStub.getCall(0).args[0]).to.deep.equal({
+      symbol: "USDCUSDT",
+      orderId: 123,
+      limit: 1000,
     });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-    const { port } = server.address() as AddressInfo;
-    const originalBinanceApiBase = process.env.BINANCE_API_BASE;
-    const originalBinanceApiKey = process.env.BINANCE_API_KEY;
-    const originalBinanceHmacKey = process.env.BINANCE_HMAC_KEY;
-    process.env.BINANCE_API_BASE = `http://127.0.0.1:${port}`;
-    process.env.BINANCE_API_KEY = "test-api-key";
-    process.env.BINANCE_HMAC_KEY = "test-secret-key";
-
-    try {
-      const spotMarketMeta: SpotMarketMeta = {
-        symbol: "USDCUSDT",
-        baseAssetName: "USDC",
-        quoteAssetName: "USDT",
-        pxDecimals: 4,
-        szDecimals: 0,
-        minimumOrderSize: 1,
-        isBuy: true,
-      };
-      const binanceApi = await getBinanceApiClient(process.env.BINANCE_API_BASE);
-
-      const totalCommission = await getFillCommission(binanceApi, spotMarketMeta, 123);
-
-      expect(totalCommission).to.be.closeTo(100.3, 1e-9);
-      expect(requests).to.deep.equal([
-        { orderId: "123", fromId: null, limit: "1000" },
-        { orderId: "123", fromId: "1000", limit: "1000" },
-      ]);
-    } finally {
-      process.env.BINANCE_API_BASE = originalBinanceApiBase;
-      process.env.BINANCE_API_KEY = originalBinanceApiKey;
-      process.env.BINANCE_HMAC_KEY = originalBinanceHmacKey;
-      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
-    }
+    expect(myTradesStub.getCall(1).args[0]).to.deep.equal({
+      symbol: "USDCUSDT",
+      orderId: 123,
+      fromId: 1000,
+      limit: 1000,
+    });
   });
 });

--- a/test/BinanceUtils.ts
+++ b/test/BinanceUtils.ts
@@ -5,6 +5,7 @@ import {
   BinanceDeposit,
   SpotMarketMeta,
   BinanceWithdrawal,
+  getBinanceApiClient,
   getFillCommission,
   getOutstandingBinanceDeposits,
   isCompletedBinanceWithdrawal,
@@ -173,8 +174,9 @@ describe("BinanceUtils fill commission helpers", function () {
         minimumOrderSize: 1,
         isBuy: true,
       };
+      const binanceApi = await getBinanceApiClient(process.env.BINANCE_API_BASE);
 
-      const totalCommission = await getFillCommission(spotMarketMeta, 123);
+      const totalCommission = await getFillCommission(binanceApi, spotMarketMeta, 123);
 
       expect(totalCommission).to.be.closeTo(100.3, 1e-9);
       expect(requests).to.deep.equal([

--- a/test/BinanceUtils.ts
+++ b/test/BinanceUtils.ts
@@ -1,7 +1,11 @@
+import { createServer } from "http";
+import type { AddressInfo } from "net";
 import { expect } from "./utils";
 import {
   BinanceDeposit,
+  BinanceSpotMarketMeta,
   BinanceWithdrawal,
+  getFillCommission,
   getOutstandingBinanceDeposits,
   isCompletedBinanceWithdrawal,
 } from "../src/utils";
@@ -112,5 +116,76 @@ describe("BinanceUtils withdrawal helpers", function () {
     expect(isCompletedBinanceWithdrawal(4)).to.equal(false);
     expect(isCompletedBinanceWithdrawal(5)).to.equal(false);
     expect(isCompletedBinanceWithdrawal(undefined)).to.equal(false);
+  });
+});
+
+describe("BinanceUtils fill commission helpers", function () {
+  it("sums only commissions charged in the received asset across paginated trade results", async function () {
+    const firstPage = Array.from({ length: 1000 }, (_, index) => ({
+      id: index,
+      commission: index === 0 ? "0.2" : "0.1",
+      commissionAsset: index === 1 ? "BNB" : "USDC",
+    }));
+    const secondPage = [
+      {
+        id: 1000,
+        commission: "0.3",
+        commissionAsset: "USDC",
+      },
+      {
+        id: 1001,
+        commission: "0.4",
+        commissionAsset: "BNB",
+      },
+    ];
+    const requests: Array<{ orderId: string | null; fromId: string | null; limit: string | null }> = [];
+    const server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      requests.push({
+        orderId: url.searchParams.get("orderId"),
+        fromId: url.searchParams.get("fromId"),
+        limit: url.searchParams.get("limit"),
+      });
+      res.setHeader("Content-Type", "application/json");
+      if (url.pathname !== "/api/v3/myTrades") {
+        res.statusCode = 404;
+        res.end(JSON.stringify({ msg: "not found" }));
+        return;
+      }
+      res.end(JSON.stringify(url.searchParams.get("fromId") === "1000" ? secondPage : firstPage));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+    const originalBinanceApiBase = process.env.BINANCE_API_BASE;
+    const originalBinanceApiKey = process.env.BINANCE_API_KEY;
+    const originalBinanceHmacKey = process.env.BINANCE_HMAC_KEY;
+    process.env.BINANCE_API_BASE = `http://127.0.0.1:${port}`;
+    process.env.BINANCE_API_KEY = "test-api-key";
+    process.env.BINANCE_HMAC_KEY = "test-secret-key";
+
+    try {
+      const spotMarketMeta: BinanceSpotMarketMeta = {
+        symbol: "USDCUSDT",
+        baseAssetName: "USDC",
+        quoteAssetName: "USDT",
+        pxDecimals: 4,
+        szDecimals: 0,
+        minimumOrderSize: 1,
+        isBuy: true,
+      };
+
+      const totalCommission = await getFillCommission(spotMarketMeta, 123);
+
+      expect(totalCommission).to.be.closeTo(100.3, 1e-9);
+      expect(requests).to.deep.equal([
+        { orderId: "123", fromId: "undefined", limit: "1000" },
+        { orderId: "123", fromId: "1000", limit: "1000" },
+      ]);
+    } finally {
+      process.env.BINANCE_API_BASE = originalBinanceApiBase;
+      process.env.BINANCE_API_KEY = originalBinanceApiKey;
+      process.env.BINANCE_HMAC_KEY = originalBinanceHmacKey;
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
   });
 });

--- a/test/mocks/MockInventoryClient.ts
+++ b/test/mocks/MockInventoryClient.ts
@@ -27,10 +27,9 @@ export class MockInventoryClient extends InventoryClient {
     simMode = false,
     prioritizeLpUtilization = false
   ) {
-    const effectiveLogger = logger ?? winston.createLogger({ silent: true });
     super(
       relayer, // relayer
-      effectiveLogger, // logger
+      logger, // logger
       inventoryConfig, // inventory config
       tokenClient, // token client
       chainIds, // chain ID list

--- a/test/mocks/MockInventoryClient.ts
+++ b/test/mocks/MockInventoryClient.ts
@@ -27,9 +27,10 @@ export class MockInventoryClient extends InventoryClient {
     simMode = false,
     prioritizeLpUtilization = false
   ) {
+    const effectiveLogger = logger ?? winston.createLogger({ silent: true });
     super(
       relayer, // relayer
-      logger, // logger
+      effectiveLogger, // logger
       inventoryConfig, // inventory config
       tokenClient, // token client
       chainIds, // chain ID list


### PR DESCRIPTION
## Summary
- subtract Binance taker fees from the adapter’s matched-fill receive amount
- use the fee-adjusted receive amount when deciding whether a filled order has enough balance to withdraw
- use the fee-adjusted receive amount when deriving expected destination-chain amounts for pending rebalances
- apply the same Binance taker-fee interpretation in `getEstimatedCost()` so estimated trade fees match execution-time accounting

## Why
Binance order fill quantities are gross trade amounts. The adapter should reason about the net amount available after Binance taker fees, otherwise it can overestimate how much is available to withdraw or credit to pending inventory. The same fee interpretation also needs to be used in `getEstimatedCost()` so route estimates and execution behavior stay aligned.

## Testing
- `./node_modules/.bin/tsc --noEmit`
- `RELAYER_TEST=true ./node_modules/.bin/hardhat test test/BinanceAdapter.helpers.ts test/BinanceAdapter.quotes.ts test/BinanceAdapter.withdrawals.ts test/BinanceAdapter.conversions.ts`