### PR TITLE
improve(build): Drop yarn cache from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ WORKDIR /across-relayer
 COPY . ./
 
 RUN apk add --no-cache --virtual .build-deps python3 make g++ \
- && yarn \
+ && yarn install \
+ && yarn cache clean \
  && apk del .build-deps
 
 RUN yarn build


### PR DESCRIPTION
Saves almost 50% of the unpacked image size.