### PR TITLE
improve(build): Update dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
-.github
+.*
+
 node_modules
 package-lock.json
 env
 dist
-.DS_Store
+
+test
+docs


### PR DESCRIPTION
Blanket ignore dotfiles. Notably excludes .git, cutting out ~80MB.