### PR TITLE
chore: Forwards-compatible package.json changes for pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,12 +82,12 @@
     "run-gaslessRelayer": "node ./dist/index.js --gaslessRelayer",
     "run-depositAddressHandler": "node ./dist/index.js --depositAddressHandler",
     "relay": "node ./dist/index.js --relayer",
-    "refill-usdc": "tsx ./scripts/refillUsdcToSpecificChain.ts",
+    "refill-usdc": "node ./dist/scripts/refillUsdcToSpecificChain.js",
+    "update-inventory-config": "node ./dist/scripts/fetchInventoryConfig.js",
     "deposit": "tsx ./scripts/spokepool.ts deposit",
     "dispute": "tsx ./scripts/hubpool.ts dispute",
     "update": "git pull && yarn reinstall && yarn version --non-interactive && git show --quiet",
     "update-addresses": "tsx ./scripts/fetch-addresses.ts",
-    "update-inventory-config": "tsx ./scripts/fetchInventoryConfig.ts",
     "validate-root-bundle": "tsx ./src/scripts/validateRootBundle.ts | tee validateRootBundle-${REQUEST_TIME}.log"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "scripts": {
-    "postinstall": "patch-package; yarn update-addresses",
-    "lint": "yarn eslint && yarn prettier --list-different",
-    "lint-fix": "yarn eslint --fix && yarn prettier --write",
+    "postinstall": "patch-package; npm run update-addresses",
+    "lint": "eslint . && prettier --list-different .",
+    "lint-fix": "eslint . --fix && prettier --write .",
     "prettier": "prettier .",
     "eslint": "eslint .",
     "test": "RELAYER_TEST=true hardhat test",
@@ -81,13 +81,13 @@
     "run-gaslessRelayer": "node ./dist/index.js --gaslessRelayer",
     "run-depositAddressHandler": "node ./dist/index.js --depositAddressHandler",
     "relay": "node ./dist/index.js --relayer",
-    "refill-usdc": "node ./dist/scripts/refillUsdcToSpecificChain.js",
-    "deposit": "yarn node ./dist/scripts/spokepool.js deposit",
+    "refill-usdc": "tsx ./scripts/refillUsdcToSpecificChain.ts",
+    "deposit": "tsx ./scripts/spokepool.ts deposit",
     "dispute": "tsx ./scripts/hubpool.ts dispute",
     "update": "git pull && yarn reinstall && yarn version --non-interactive && git show --quiet",
     "update-addresses": "tsx ./scripts/fetch-addresses.ts",
-    "update-inventory-config": "node ./dist/scripts/fetchInventoryConfig.js",
-    "validate-root-bundle": "yarn node ./dist/src/scripts/validateRootBundle.js | tee validateRootBundle-${REQUEST_TIME}.log"
+    "update-inventory-config": "tsx ./scripts/fetchInventoryConfig.ts",
+    "validate-root-bundle": "tsx ./src/scripts/validateRootBundle.ts | tee validateRootBundle-${REQUEST_TIME}.log"
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.4.0",

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_L2_CONTRACT_ADDRESSES } from "@eth-optimism/sdk";
 import { ChainFamily, PUBLIC_NETWORKS } from "@across-protocol/constants";
+import { constants as ethersConstants } from "ethers";
 import { isDefined, isKeyOf } from "../utils/TypeGuards";
 import {
   assert,
@@ -10,7 +11,6 @@ import {
   CHAIN_IDs,
   TOKEN_SYMBOLS_MAP,
   Signer,
-  ZERO_ADDRESS,
   Address,
   binanceCredentialsConfigured,
   EvmAddress,
@@ -20,6 +20,9 @@ import {
   winston,
   toBN,
 } from "../utils";
+
+// Sourced directly to avoid a tsx/esbuild TDZ on the cyclic re-export from ../utils.
+const { AddressZero: ZERO_ADDRESS } = ethersConstants;
 import {
   BaseBridgeAdapter,
   OpStackDefaultERC20Bridge,


### PR DESCRIPTION
- Avoid redundant yarn prefixes.
- Use tsx for script targets.