### PR TITLE
improve(test): Build concurrently with lint & test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,6 @@ jobs:
           paths:
             - node_modules
       - run:
-          name: Build
-          command: yarn build
-      - run:
           name: Extract Solana version
           command: |
             set -euo pipefail
@@ -61,10 +58,18 @@ jobs:
           root: .
           paths:
             - node_modules
-            - dist
             - artifacts
             - cache
             - .solana-version
+  typecheck:
+    executor: node
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Typecheck
+          command: yarn typecheck
   test:
     executor: node
     parallelism: 20
@@ -140,6 +145,9 @@ workflows:
   build_and_test:
     jobs:
       - install
+      - typecheck:
+          requires:
+            - install
       - test:
           requires:
             - install

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "test": "RELAYER_TEST=true hardhat test",
     "test:parallel": "RELAYER_TEST=true hardhat test --parallel",
     "build": "tsc --build",
+    "typecheck": "tsc --noEmit",
     "watch": "tsc --build --incremental --watch",
     "build:test": "tsc --project tsconfig.test.json",
     "clean": "dir=\"./node_modules\"; mv \"${dir}\" \"${dir}_\" 2>/dev/null && rm -r \"${dir}_\" & rm -f dist/tsconfig.tsbuildinfo",


### PR DESCRIPTION
Build is only used to detect typing issues - it's not actually used by test or lint. Identify it specifically as a type-checking mechanism (i.e. drop dist output) and run it concurrently with lint and test.