### PR TITLE
improve: Run eslint & prettier with cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   "main": "dist/index.js",
   "scripts": {
     "postinstall": "patch-package; npm run update-addresses",
-    "lint": "eslint --cache . && prettier --list-different .",
-    "lint-fix": "eslint --cache --fix . && prettier --write .",
+    "lint": "eslint --cache . && prettier --cache --list-different .",
+    "lint-fix": "eslint --cache --fix . && prettier --cache --write .",
     "test": "RELAYER_TEST=true hardhat test",
     "test:parallel": "RELAYER_TEST=true hardhat test --parallel",
     "build": "tsc --build",

--- a/package.json
+++ b/package.json
@@ -56,10 +56,8 @@
   "main": "dist/index.js",
   "scripts": {
     "postinstall": "patch-package; npm run update-addresses",
-    "lint": "eslint . && prettier --list-different .",
-    "lint-fix": "eslint . --fix && prettier --write .",
-    "prettier": "prettier .",
-    "eslint": "eslint .",
+    "lint": "eslint --cache . && prettier --list-different .",
+    "lint-fix": "eslint --cache --fix . && prettier --write .",
     "test": "RELAYER_TEST=true hardhat test",
     "test:parallel": "RELAYER_TEST=true hardhat test --parallel",
     "build": "tsc --build",


### PR DESCRIPTION
Speeds up subsequent eslint runs by multiples (~22s -> ~2s). No impact
in CI, but a decent UX improvement for dev.