### PR TITLE
test: Adapt SpokePool time manipulation to SDK 4.3.150

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.109",
     "@across-protocol/contracts": "5.0.7",
-    "@across-protocol/sdk": "4.3.148",
+    "@across-protocol/sdk": "4.3.150",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/test/Dataworker.executeSlowRelay.ts
+++ b/test/Dataworker.executeSlowRelay.ts
@@ -10,7 +10,16 @@ import {
   originChainId,
 } from "./constants";
 import { setupDataworker } from "./fixtures/Dataworker.Fixture";
-import { Contract, SignerWithAddress, depositV3, ethers, expect, fillV3Relay, requestSlowFill } from "./utils";
+import {
+  Contract,
+  SignerWithAddress,
+  depositV3,
+  ethers,
+  expect,
+  fillV3Relay,
+  requestSlowFill,
+  setSpokePoolTime,
+} from "./utils";
 import { interfaces } from "@across-protocol/sdk";
 
 // Tested
@@ -213,7 +222,9 @@ describe("Dataworker: Execute slow relays", async function () {
     await updateAllClients();
 
     // Check that dataworker skips the slow fill once we're past the deadline.
-    await spokePool_2.setCurrentTime(deposit.fillDeadline + 1);
+    // SpokePoolClient now reads currentTime from the latest block timestamp, so we have to
+    // advance the simulated chain — calling setCurrentTime alone would not move the client forward.
+    await setSpokePoolTime(spokePool_2, deposit.fillDeadline + 1);
     await updateAllClients();
     await dataworkerInstance.executeSlowRelayLeaves(spokePoolClients, new BalanceAllocator(providers));
     expect(multiCallerClient.transactionCount()).to.equal(0);

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -54,6 +54,7 @@ import {
   expect,
   fillV3Relay,
   getLastBlockTime,
+  setSpokePoolTime,
   lastSpyLogIncludes,
   MAX_SAFE_ALLOWANCE,
   spyLogIncludes,
@@ -491,11 +492,15 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       const spokePoolTime = (await spokePool_2.getCurrentTime()).toNumber();
       const fillDeadline = spokePoolTime + 60;
 
-      // Make a deposit and then increment SpokePool time beyond it.
+      // Make a deposit and then advance the destination chain past the fill deadline.
       await depositV3(spokePool_1, destinationChainId, depositor, inputToken, inputAmount, outputToken, outputAmount, {
         fillDeadline,
       });
-      await spokePool_2.setCurrentTime(fillDeadline);
+      // The SpokePoolClient now derives currentTime from the latest block, so we have to
+      // move the underlying block timestamp forward — setting only the contract's _currentTime
+      // would no longer be observed by the client.
+      await setSpokePoolTime(spokePool_2, fillDeadline);
+      await updateAllClients();
       const txnReceipts = await relayerInstance.checkForUnfilledDepositsAndFill();
       for (const receipts of Object.values(txnReceipts)) {
         expect((await receipts).length).to.equal(0);
@@ -541,7 +546,10 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
 
       const exclusiveDeposit = deposits.find(({ exclusiveRelayer }) => exclusiveRelayer.eq(relayerAddress));
       expect(exclusiveDeposit).to.exist;
-      await spokePool_2.setCurrentTime(exclusiveDeposit!.exclusivityDeadline + 1);
+      // Advance both block.timestamp and the SpokePool's _currentTime past the exclusivity
+      // deadline. The block timestamp drives the SpokePoolClient's currentTime, while the
+      // contract's _currentTime is still required for the on-chain exclusivity check at fill time.
+      await setSpokePoolTime(spokePool_2, exclusiveDeposit!.exclusivityDeadline + 1);
       await updateAllClients();
 
       // Relayer can unconditionally fill after the exclusivityDeadline.

--- a/test/utils/BlockchainUtils.ts
+++ b/test/utils/BlockchainUtils.ts
@@ -1,3 +1,4 @@
+import { Contract } from "ethers";
 import hre from "hardhat";
 
 /**
@@ -9,4 +10,26 @@ export async function mineRandomBlocks(amount?: number): Promise<void> {
   for (let i = 0; i < randomBlocksToMine; i++) {
     await hre.network.provider.send("evm_mine");
   }
+}
+
+/**
+ * Mines a single block at the supplied timestamp. The simulated chain enforces strictly
+ * increasing block timestamps, so the supplied value must be greater than the latest block's.
+ */
+export async function setNextBlockTimestamp(timestamp: number): Promise<void> {
+  await hre.network.provider.send("evm_setNextBlockTimestamp", [timestamp]);
+  await hre.network.provider.send("evm_mine", []);
+}
+
+/**
+ * Advances both the simulated chain's block.timestamp and the SpokePool contract's internal
+ * `_currentTime` to the supplied value. SpokePoolClient now derives currentTime from the block
+ * timestamp rather than `SpokePool.getCurrentTime()`, so tests that need the client to observe
+ * a particular time must move the underlying block forward — calling SpokePool.setCurrentTime
+ * alone is no longer sufficient.
+ */
+export async function setSpokePoolTime(spokePool: Contract, timestamp: number): Promise<void> {
+  await hre.network.provider.send("evm_setNextBlockTimestamp", [timestamp]);
+  // The setCurrentTime transaction mines a new block, which adopts the timestamp set above.
+  await spokePool.setCurrentTime(timestamp);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.3.148":
-  version "4.3.148"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.148.tgz#f7556606e9badb752ff0ecd516f47510575b7623"
-  integrity sha512-5T9uLAoQr3GWnhqdX3zJXqs4KzYYLtQAxcY1I6rbAiIKqc+I3qGK+T1LD4RaQs6Sw/nRteHLoUfRj+m5Vlf57Q==
+"@across-protocol/sdk@4.3.150":
+  version "4.3.150"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.150.tgz#86ff8b177307f8c6acef3f22bf1362c50cbfce42"
+  integrity sha512-ObB/WF5F05vCEwuGKsDn9d3Ab6eBM9+x7gtn8qiG8NNIU1qgoysRw+qDCokBY57MX9x6l8vN2lMisLHakmFhog==
   dependencies:
     "@across-protocol/constants" "^3.1.110"
     "@across-protocol/contracts" "5.0.7"


### PR DESCRIPTION
## Summary

- Bump \`@across-protocol/sdk\` to 4.3.150, which switches \`EVMSpokePoolClient\` to derive \`currentTime\` from the latest block's timestamp ([sdk#1422](https://github.com/across-protocol/sdk/pull/1422)) rather than from \`SpokePool.getCurrentTime()\`.
- Add \`setNextBlockTimestamp\` and \`setSpokePoolTime\` helpers in \`test/utils/BlockchainUtils.ts\` that advance the simulated chain's block.timestamp (and, where the contract still needs to agree, the SpokePool's \`_currentTime\`) in lockstep.
- Update the three tests that relied on \`SpokePool.setCurrentTime\` alone to manipulate the client's perception of time: \`Relayer.BasicFill\` "Ignores expired deposits" / "Ignores exclusive deposits" and \`Dataworker.executeSlowRelay\` "Ignores expired deposits". Also adds a missing \`updateAllClients()\` in the first so the client actually observes the deposit and the advanced time.

## Test plan

- [x] \`yarn hardhat test test/Relayer.BasicFill.ts\` — 18 passing
- [x] \`yarn hardhat test test/Dataworker.executeSlowRelay.ts\` — 3 passing
- [x] Smoke-checked adjacent suites (\`Relayer.UnfilledDeposits\`, \`Relayer.SlowFill\`, \`Dataworker.proposeRootBundle\`) — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)