### PR TITLE
feat(cctp-finalizer): enable Ink

### DIFF
--- a/src/cctp-finalizer/services/cctpService.ts
+++ b/src/cctp-finalizer/services/cctpService.ts
@@ -329,6 +329,7 @@ export class CCTPService {
       999: process.env.HYPEREVM_RPC_URL!,
       56: process.env.BSC_RPC_URL!,
       143: process.env.MONAD_RPC_URL!,
+      57073: process.env.INK_RPC_URL!,
       34268394551451: process.env.SOLANA_RPC_URL!,
       // Test networks
       11155111: process.env.SEPOLIA_RPC_URL!,


### PR DESCRIPTION
Value is already configured in Zion ([here](https://github.com/UMAprotocol/zion/blob/master/projects/bots/across/terraform/locals.tf#L125)).