### PR TITLE
fix(test): Fix test:parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "lint": "eslint --cache . && prettier --cache --list-different .",
     "lint-fix": "eslint --cache --fix . && prettier --cache --write .",
     "test": "RELAYER_TEST=true hardhat test",
-    "test:parallel": "RELAYER_TEST=true hardhat test --parallel",
+    "test:parallel": "RELAYER_TEST=true NODE_OPTIONS='--import tsx/esm --no-warnings' hardhat test --parallel",
     "build": "tsc --build",
     "typecheck": "tsc --noEmit",
     "strict-null-budget": "./scripts/strict-null-budget.sh",

--- a/test/Solana.setup.ts
+++ b/test/Solana.setup.ts
@@ -4,36 +4,28 @@ import path from "node:path";
 import { createDefaultSolanaClient, generateKeyPairSignerWithSol, initializeSvmSpoke } from "./utils/svm/utils";
 import { validatorSetup, validatorTeardown } from "./utils/svm/validator.setup";
 
-// Create the signer
-let signer: Awaited<ReturnType<typeof generateKeyPairSignerWithSol>>;
+export type SolanaSigner = Awaited<ReturnType<typeof generateKeyPairSignerWithSol>>;
 
-before(async function () {
-  /* Get test signer */
+// Invoke from a scoped `before` hook; root hooks don't fire in parallel workers.
+export async function setupSolana(): Promise<SolanaSigner> {
   const keyFilePath = path.resolve(__dirname, "utils", "svm", "keys", "localnet-wallet.json");
   const fileContents = await fs.readFile(keyFilePath, "utf-8");
   const secretKey = new Uint8Array(JSON.parse(fileContents));
-  signer = await createKeyPairSignerFromBytes(secretKey);
+  const signer = await createKeyPairSignerFromBytes(secretKey);
 
-  /* Local validator spin‑up can take a few seconds */
-  this.timeout(60_000);
   await validatorSetup(signer.address);
 
   const solanaClient = createDefaultSolanaClient();
-
-  // Airdrop SOL to the signer
   await airdropFactory(solanaClient)({
     recipientAddress: signer.address,
     lamports: lamports(1_000_000_000n),
     commitment: "confirmed",
   });
-
-  // Initialize the program and get the state
   await initializeSvmSpoke(signer, solanaClient, signer.address);
-});
 
-after(() => {
+  return signer;
+}
+
+export function teardownSolana(): void {
   validatorTeardown();
-});
-
-// Export signer for use in tests
-export { signer };
+}

--- a/test/finalizeCCTPV1Messages.test.ts
+++ b/test/finalizeCCTPV1Messages.test.ts
@@ -5,7 +5,7 @@ import { PublicKey } from "@solana/web3.js";
 import { expect } from "chai";
 import { arch, clients } from "@across-protocol/sdk";
 import { createDefaultSolanaClient, encodePauseDepositsMessageBody } from "./utils/svm/utils";
-import { signer } from "./Solana.setup";
+import { setupSolana, SolanaSigner, teardownSolana } from "./Solana.setup";
 import { finalizeCCTPV1MessagesSVM } from "../src/finalizer/utils/cctp/svmUtils";
 import { cctpV1L1toSvmL2Finalizer } from "../src/finalizer/utils/cctp/l1ToSvmL2";
 import { AttestedCCTPMessage, ZERO_ADDRESS, EvmAddress } from "../src/utils";
@@ -81,6 +81,17 @@ describe("finalizeCCTPV1Messages", () => {
   const solanaClient = createDefaultSolanaClient() as ExtendedSolanaClient;
   const { spyLogger } = createSpyLogger();
   let hubPoolClient: clients.HubPoolClient;
+  let signer: SolanaSigner;
+
+  before(async function () {
+    // Local validator spin-up can take a few seconds.
+    this.timeout(60_000);
+    signer = await setupSolana();
+  });
+
+  after(() => {
+    teardownSolana();
+  });
 
   beforeEach(async function () {
     ({ hubPoolClient } = await setupDataworker(ethers, 25, 25, 0));


### PR DESCRIPTION
Two fixes to enable Mocha parallel workers locally (~6× wall-time vs serial). CI is unaffected  it uses `yarn test` with CircleCI-level file splitting.

- `test:parallel` now sets `NODE_OPTIONS='--import tsx/esm --no-warnings'`. Mocha parallel workers load test files via ESM `import()`, bypassing the existing CJS `ts-node/register` hook; they fall back to Node 22's strip-only TS loader and reject parameter properties (e.g. on `MultiCallerClient.ts`). tsx handles them.
- `test/Solana.setup.ts` exposes `setupSolana()` / `teardownSolana()` instead of registering Mocha root-level `before/after`. Root hooks don't fire in parallel workers without the Root Hook Plugin pattern. `finalizeCCTPV1Messages.test.ts` invokes them from a scoped `before`/`after`, so the validator only spins up in the worker drawing that file.

Identified and fixed by Claude.