### PR TITLE
fix: do not use hardcoded hub lookback in the finalizer

### DIFF
--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -30,7 +30,6 @@ import {
   EvmAddress,
   getProvider,
   chunk,
-  getCurrentTime,
 } from "../utils";
 import { ChainFinalizer, CrossChainMessage, Finalizer, isAugmentedTransaction } from "./types";
 import {
@@ -394,7 +393,7 @@ export async function constructFinalizerClients(
   // withdrawn to L1, so assuming these L1 tokens do not change in the future, then we can reduce the hub pool
   // client lookback. Note, this should not be impacted by L2 tokens changing, for example when changing
   // USDC.e --> USDC because the l1 token matching both L2 version stays the same.
-  const hubPoolLookBack = getCurrentTime() - config.maxFinalizerLookback + 8 * 3600;
+  const hubPoolLookBack = config.maxFinalizerLookback + 8 * 3600;
   const commonClients = await constructClients(_logger, config, baseSigner, hubPoolLookBack);
   await updateFinalizerClients(commonClients);
 

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -30,6 +30,7 @@ import {
   EvmAddress,
   getProvider,
   chunk,
+  getCurrentTime,
 } from "../utils";
 import { ChainFinalizer, CrossChainMessage, Finalizer, isAugmentedTransaction } from "./types";
 import {
@@ -393,7 +394,7 @@ export async function constructFinalizerClients(
   // withdrawn to L1, so assuming these L1 tokens do not change in the future, then we can reduce the hub pool
   // client lookback. Note, this should not be impacted by L2 tokens changing, for example when changing
   // USDC.e --> USDC because the l1 token matching both L2 version stays the same.
-  const hubPoolLookBack = 3600 * 8;
+  const hubPoolLookBack = getCurrentTime() - config.maxFinalizerLookback;
   const commonClients = await constructClients(_logger, config, baseSigner, hubPoolLookBack);
   await updateFinalizerClients(commonClients);
 

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -394,7 +394,7 @@ export async function constructFinalizerClients(
   // withdrawn to L1, so assuming these L1 tokens do not change in the future, then we can reduce the hub pool
   // client lookback. Note, this should not be impacted by L2 tokens changing, for example when changing
   // USDC.e --> USDC because the l1 token matching both L2 version stays the same.
-  const hubPoolLookBack = getCurrentTime() - config.maxFinalizerLookback;
+  const hubPoolLookBack = getCurrentTime() - config.maxFinalizerLookback + 8 * 3600;
   const commonClients = await constructClients(_logger, config, baseSigner, hubPoolLookBack);
   await updateFinalizerClients(commonClients);
 


### PR DESCRIPTION
The hardcoded lookback makes it difficult for finalizer to reliably use the hub pool client in conjunction with finalizer data since there will almost always be a discrepancy between the number of events received in the finalizer (configured via max tokenbridge lookback) and the events stored in the hub pool client (hardcoded to 8 hours). This makes the hub pool lookback a function of the max finalizer lookback.