### PR TITLE
refactor: Consolidate botIdentifier and runIdentifier

### DIFF
--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import winston from "winston";
 import { DEFAULT_MULTICALL_CHUNK_SIZE } from "../common";
 import { ArweaveGatewayConfigSS, ArweaveGatewayConfig } from "../interfaces";
@@ -22,6 +23,8 @@ export class CommonConfig {
   readonly timeToCache: number;
   readonly arweaveGateways: ArweaveGatewayConfig[] | undefined;
   readonly peggedTokenPrices: { [pegTokenSymbol: string]: Set<string> } = {};
+  readonly botIdentifier: string;
+  readonly runIdentifier: string;
 
   // State we'll load after we update the config store client and fetch all chains we want to support.
   public multiCallChunkSize: { [chainId: number]: number } = {};
@@ -29,7 +32,7 @@ export class CommonConfig {
   public fromBlockOverride: Record<number, number> = {};
   public addressFilter?: Set<string>;
 
-  constructor(env: ProcessEnv) {
+  constructor(env: ProcessEnv, opts: { botIdentifier?: string } = {}) {
     const {
       MAX_RELAYER_DEPOSIT_LOOK_BACK,
       BLOCK_RANGE_END_BLOCK_BUFFER,
@@ -44,6 +47,8 @@ export class CommonConfig {
       HUB_POOL_TIME_TO_CACHE,
       ARWEAVE_GATEWAYS,
       PEGGED_TOKEN_PRICES,
+      BOT_IDENTIFIER,
+      RUN_IDENTIFIER,
     } = env;
 
     const mergeConfig = <T>(config: T, envVar: string | undefined): T => {
@@ -102,6 +107,9 @@ export class CommonConfig {
         new Set(tokenSymbolsToPeg),
       ])
     );
+
+    this.botIdentifier = BOT_IDENTIFIER ?? opts.botIdentifier ?? "across";
+    this.runIdentifier = RUN_IDENTIFIER ?? randomUUID();
   }
 
   /**

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -62,7 +62,7 @@ export class DataworkerConfig extends CommonConfig {
       DISPUTE_COOLDOWN,
       LOAD_ARWEAVE_DATA,
     } = env;
-    super(env);
+    super(env, { botIdentifier: "across-dataworker" });
 
     this.minChallengeLeadTime = Number(MIN_CHALLENGE_LEAD_TIME);
     this.awaitChallengePeriod = AWAIT_CHALLENGE_PERIOD === "true";

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -39,8 +39,6 @@ import { Disputer } from "./Disputer";
 config();
 let logger: winston.Logger;
 
-const { RUN_IDENTIFIER: runIdentifier, BOT_IDENTIFIER: botIdentifier = "across-dataworker" } = process.env;
-
 export async function createDataworker(
   _logger: winston.Logger,
   baseSigner: Signer,
@@ -161,14 +159,12 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
   logger = _logger;
 
   const config = new DataworkerConfig(process.env);
+  const { botIdentifier, runIdentifier } = config;
   const personality = resolvePersonality(config);
   const challengeRemaining = await getChallengeRemaining(config.hubPoolChainId, 0, logger);
 
-  // @dev The check for `runIdentifier` doubles as a check whether this instance is being run in GCP (or mocked as a production instance) and as a unique identifier
-  // which can be cached in redis (that is, for any executor/proposer instance, the run identifier lets any other instance know of its existence via a redis mapping
-  // from botIdentifier -> runIdentifier).
   if (
-    isDefined(runIdentifier) &&
+    !config.forcePropose &&
     challengeRemaining > config.minChallengeLeadTime &&
     (config.proposerEnabled || config.l1ExecutorEnabled)
   ) {
@@ -350,7 +346,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
       // - We need to check whether we have an enqueued transaction in the multiCallerClient. Having no transaction there indicates that the executor/proposer instance
       //   exited early for a valid reason (such as insufficient lookback), so there would be no reason to await submitting a transaction.
       const hasTransactionQueued = clients.multiCallerClient.transactionCount() !== 0;
-      if ((config.l1ExecutorEnabled || config.proposerEnabled) && pubSub && runIdentifier && hasTransactionQueued) {
+      if ((config.l1ExecutorEnabled || config.proposerEnabled) && pubSub && hasTransactionQueued) {
         const challengeBuffer = Number(process.env.L1_EXECUTOR_CHALLENGE_BUFFER ?? 24); // Default to 24 seconds or 2 blocks.
         let updatedChallengeRemaining = await getChallengeRemaining(config.hubPoolChainId, challengeBuffer, logger);
         // If the updated challenge remaining is greater than the challenge remaining we observed at the start, then this indicates that during the runtime of this bot,

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -70,8 +70,6 @@ export class DepositAddressHandler {
       message: "Initializing DepositAddressHandler",
     });
 
-    const { RUN_IDENTIFIER: runIdentifier, BOT_IDENTIFIER: botIdentifier } = process.env;
-
     // Set the signer address.
     this.signerAddress = EvmAddress.from(await this.baseSigner.getAddress());
     this.redisCache = await getRedisCache(this.logger);
@@ -103,8 +101,8 @@ export class DepositAddressHandler {
     this.instanceCoordinator = new InstanceCoordinator(
       this.logger,
       this.redisCache,
-      botIdentifier,
-      runIdentifier,
+      this.config.botIdentifier,
+      this.config.runIdentifier,
       this.abortController
     );
     await this.instanceCoordinator.initiateHandover();
@@ -115,8 +113,7 @@ export class DepositAddressHandler {
   }
 
   private getExecutedDepositsRedisKey(): string {
-    const botId = process.env.BOT_IDENTIFIER ?? "deposit-address-handler";
-    return `deposit-address:executed:${botId}`;
+    return `deposit-address:executed:${this.config.botIdentifier}`;
   }
 
   /** Loads executed deposit tx hashes from Redis (e.g. after handover). */

--- a/src/deposit-address/DepositAddressHandlerConfig.ts
+++ b/src/deposit-address/DepositAddressHandlerConfig.ts
@@ -14,7 +14,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
   swapApiKey: string;
 
   constructor(env: ProcessEnv) {
-    super(env);
+    super(env, { botIdentifier: "across-deposit-address-handler" });
 
     const {
       INDEXER_API_POLLING_INTERVAL,

--- a/src/finalizer/config.ts
+++ b/src/finalizer/config.ts
@@ -23,7 +23,7 @@ export class FinalizerConfig extends CommonConfig {
       FINALIZATION_STRATEGY = "l1<->l2",
       FINALIZER_CHUNK_SIZE = 3,
     } = env;
-    super(env);
+    super(env, { botIdentifier: "across-finalizer" });
 
     const userAddresses = parseJson.stringArrayMap(FINALIZER_WITHDRAWAL_TO_ADDRESSES);
     this.userAddresses = new Map();

--- a/src/gasless/GaslessRelayer.ts
+++ b/src/gasless/GaslessRelayer.ts
@@ -141,8 +141,6 @@ export class GaslessRelayer {
       message: "Initializing GaslessRelayer",
     });
 
-    const { RUN_IDENTIFIER: runIdentifier, BOT_IDENTIFIER: botIdentifier } = process.env;
-
     // Set the signer address.
     this.signerAddress = EvmAddress.from(await this.baseSigner.getAddress());
     this.redisCache = await getRedisCache(this.logger);
@@ -205,8 +203,8 @@ export class GaslessRelayer {
     this.instanceCoordinator = new InstanceCoordinator(
       this.logger,
       this.redisCache,
-      botIdentifier,
-      runIdentifier,
+      this.config.botIdentifier,
+      this.config.runIdentifier,
       this.abortController
     );
     await this.instanceCoordinator.initiateHandover();

--- a/src/gasless/GaslessRelayerConfig.ts
+++ b/src/gasless/GaslessRelayerConfig.ts
@@ -38,7 +38,7 @@ export class GaslessRelayerConfig extends CommonConfig {
   depositUsdPageThreshold: number;
 
   constructor(env: ProcessEnv) {
-    super(env);
+    super(env, { botIdentifier: "across-relayer-gasless" });
 
     const {
       API_POLLING_INTERVAL,

--- a/src/hyperliquid/HyperliquidExecutor.ts
+++ b/src/hyperliquid/HyperliquidExecutor.ts
@@ -184,14 +184,12 @@ export class HyperliquidExecutor {
       });
       this.abortController.abort();
     });
-    const { RUN_IDENTIFIER: runIdentifier, BOT_IDENTIFIER: botIdentifier } = process.env;
-
     // Establish a new bot instance.
     this.instanceCoordinator = new InstanceCoordinator(
       this.logger,
       this.redisClient,
-      botIdentifier,
-      runIdentifier,
+      this.config.botIdentifier,
+      this.config.runIdentifier,
       this.abortController
     );
     await this.instanceCoordinator.initiateHandover();

--- a/src/hyperliquid/HyperliquidExecutorConfig.ts
+++ b/src/hyperliquid/HyperliquidExecutorConfig.ts
@@ -10,7 +10,7 @@ export class HyperliquidExecutorConfig extends CommonConfig {
   public readonly maxSlippageByRoute: { [pairName: string]: BigNumber } = {};
 
   constructor(env: ProcessEnv) {
-    super(env);
+    super(env, { botIdentifier: "across-hyperliquid-executor" });
 
     const {
       HYPERLIQUID_SUPPORTED_TOKENS,

--- a/src/monitor/MonitorConfig.ts
+++ b/src/monitor/MonitorConfig.ts
@@ -51,7 +51,7 @@ export class MonitorConfig extends CommonConfig {
   readonly hyperliquidOrderMaximumLifetime: number;
   readonly hyperliquidTokens: string[];
   constructor(env: ProcessEnv) {
-    super(env);
+    super(env, { botIdentifier: "across-monitor" });
 
     const {
       STARTING_BLOCK_NUMBER,

--- a/src/rebalancer/RebalancerConfig.ts
+++ b/src/rebalancer/RebalancerConfig.ts
@@ -68,7 +68,7 @@ export class RebalancerConfig extends CommonConfig {
   public chainIds: number[];
   constructor(env: ProcessEnv) {
     const { REBALANCER_CONFIG, REBALANCER_EXTERNAL_CONFIG } = env;
-    super(env);
+    super(env, { botIdentifier: "across-rebalancer" });
 
     let rebalancerConfig;
     try {

--- a/src/refiller/RefillerConfig.ts
+++ b/src/refiller/RefillerConfig.ts
@@ -31,7 +31,7 @@ export class RefillerConfig extends CommonConfig {
   readonly minUsdhRebalanceAmount: BigNumber;
 
   constructor(env: ProcessEnv) {
-    super(env);
+    super(env, { botIdentifier: "across-refiller" });
 
     const {
       REFILL_BALANCES,

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -106,7 +106,7 @@ export class RelayerConfig extends CommonConfig {
       RELAYER_USE_INVENTORY_MANAGER = "false",
       RELAYER_EVENT_LISTENER = "false",
     } = env;
-    super(env);
+    super(env, { botIdentifier: "across-relayer" });
 
     // External listeners are dependent on looping mode being configured.
     this.externalListener = this.pollingDelay > 0 && RELAYER_EXTERNAL_LISTENER === "true";

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -23,11 +23,7 @@ config();
 let logger: winston.Logger;
 
 const ACTIVE_RELAYER_EXPIRY = 1200; // 20 minutes.
-const {
-  RUN_IDENTIFIER: runIdentifier,
-  BOT_IDENTIFIER: botIdentifier = "across-relayer",
-  RELAYER_MAX_STARTUP_DELAY = "120",
-} = process.env;
+const { RELAYER_MAX_STARTUP_DELAY = "120" } = process.env;
 
 const maxStartupDelay = Number(RELAYER_MAX_STARTUP_DELAY);
 const abortController = new AbortController();
@@ -53,7 +49,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
   });
 
   const config = new RelayerConfig(process.env);
-  const { eventListener, externalListener, pollingDelay } = config;
+  const { botIdentifier, runIdentifier, eventListener, externalListener, pollingDelay } = config;
 
   const loop = pollingDelay > 0;
 
@@ -160,7 +156,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
 
       // Signal to any existing relayer that a handover is underway, or alternatively
       // check for handover initiated by another (newer) relayer instance.
-      if (loop && runIdentifier && redis) {
+      if (loop && redis) {
         if (activeRelayer !== runIdentifier) {
           if (!activeRelayerUpdated) {
             logger.debug({


### PR DESCRIPTION
Make these two fields common in config and supply sensible defaults
incase no env-defined variant is available.

This config will form the basis of an incoming messaging infrastructure.