### PR TITLE
fix: use legacy bridge interface for Lens

### DIFF
--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -21,6 +21,7 @@ import {
   EvmAddress,
   Address,
   Provider,
+  CHAIN_IDs,
 } from "../../utils";
 import { FinalizerPromise, CrossChainMessage } from "../types";
 
@@ -225,18 +226,22 @@ async function prepareFinalization(
   l2ChainId: number,
   l1SharedBridge: Contract
 ): Promise<Multicall2Call> {
+  const isLegacyBridge = [CHAIN_IDs.LENS].includes(l2ChainId);
   const args = [
     l2ChainId,
     withdrawal.l1BatchNumber,
     withdrawal.l2MessageIndex,
-    withdrawal.sender,
+    isLegacyBridge ? undefined : withdrawal.sender,
     withdrawal.l2TxNumberInBlock,
     withdrawal.message,
     withdrawal.proof,
   ];
+  const calldata = await (isLegacyBridge
+    ? l1SharedBridge.populateTransaction.finalizeWithdrawal(...args.filter(isDefined))
+    : l1SharedBridge.populateTransaction.finalizeDeposit(args));
 
   // @todo Support withdrawing directly as WETH here.
-  const [target, txn] = [l1SharedBridge.address, await l1SharedBridge.populateTransaction.finalizeDeposit(args)];
+  const [target, txn] = [l1SharedBridge.address, calldata];
   assert(isDefined(txn.data), "zkSync: finalizeDeposit populateTransaction missing data");
   return { target, callData: txn.data };
 }

--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -236,9 +236,9 @@ async function prepareFinalization(
     withdrawal.message,
     withdrawal.proof,
   ];
-  const calldata = await (isLegacyBridge
-    ? l1SharedBridge.populateTransaction.finalizeWithdrawal(...args.filter(isDefined))
-    : l1SharedBridge.populateTransaction.finalizeDeposit(args));
+  const calldata = isLegacyBridge
+    ? await l1SharedBridge.populateTransaction.finalizeWithdrawal(...args.filter(isDefined))
+    : await l1SharedBridge.populateTransaction.finalizeDeposit(args);
 
   // @todo Support withdrawing directly as WETH here.
   const [target, txn] = [l1SharedBridge.address, calldata];


### PR DESCRIPTION
The Lens USDC bridge does not support `finalizeDeposit` so we need to still use `finalizeWithdrawal` there. 