### PR TITLE
feat: Initial messaging support via Redis streams

### DIFF
--- a/src/messaging/MessageStream.ts
+++ b/src/messaging/MessageStream.ts
@@ -1,0 +1,46 @@
+// Transport-agnostic messaging primitives. Callers must not assume any
+// specific transport (Redis Streams, NATS, Kafka, in-memory mock, ...).
+
+export interface PublishOptions {
+  // Retain at most ~this many entries; transports may apply approximately.
+  maxLen?: number;
+}
+
+export interface SubscribeOptions {
+  // Consumer-group identity; stable across calls.
+  group: string;
+  // Consumer-name within the group; unique per concurrent instance.
+  consumer: string;
+  // Block up to this many ms waiting for messages.
+  blockMs?: number;
+  // Max entries returned per fetch.
+  count?: number;
+  // External cancellation; exits `messages()` at the next loop boundary.
+  signal?: AbortSignal;
+}
+
+export interface DeliveredMessage {
+  // Transport-opaque id.
+  id: string;
+  // Opaque payload; caller (de)serialises.
+  payload: string;
+  // Acknowledge successful processing; broker will not redeliver.
+  ack(): Promise<void>;
+  // Optional: request earlier redelivery. Transports without native NACK omit.
+  nack?(): Promise<void>;
+}
+
+export interface Subscription {
+  // Async-iterable of delivered messages. Each yields once; unacked entries
+  // are redelivered after a transport-specific idle period. Single-consumer.
+  messages(): AsyncIterable<DeliveredMessage>;
+  close(): Promise<void>;
+}
+
+export interface MessageStream {
+  // Append a payload; returns the broker-assigned id.
+  publish(topic: string, payload: string, opts?: PublishOptions): Promise<string>;
+  // Begin a durable subscription. Auto-creates the topic and group if absent.
+  subscribe(topic: string, opts: SubscribeOptions): Promise<Subscription>;
+  disconnect(): Promise<void>;
+}

--- a/src/messaging/redis/Stream.ts
+++ b/src/messaging/redis/Stream.ts
@@ -1,0 +1,181 @@
+import winston from "winston";
+import { disconnectRedisClient, RedisClient } from "../../utils/Redis";
+import { DeliveredMessage, MessageStream, PublishOptions, SubscribeOptions, Subscription } from "../MessageStream";
+
+const PAYLOAD_FIELD = "payload";
+
+const RECLAIM_INTERVAL_MS_DEFAULT = 30_000;
+const RECLAIM_MIN_IDLE_MS_DEFAULT = 60_000;
+const BLOCK_MS_DEFAULT = 5_000;
+const RECLAIM_CURSOR_START = "0-0";
+
+export interface RedisStreamOptions {
+  // How often XAUTOCLAIM runs to recover entries from dead consumers. Default 30s.
+  reclaimIntervalMs?: number;
+  // Minimum idle before a pending entry is reclaim-eligible. Default 60s.
+  reclaimMinIdleMs?: number;
+  // Identifier surfaced in logs; disambiguates concurrent connections.
+  label?: string;
+}
+
+// Redis Streams implementation of MessageStream. Stranded entries are recovered
+// internally via a periodic XAUTOCLAIM merged into the message iterator.
+export class RedisStream implements MessageStream {
+  private readonly reclaimIntervalMs: number;
+  private readonly reclaimMinIdleMs: number;
+  private readonly label?: string;
+
+  constructor(
+    private readonly client: RedisClient,
+    private readonly logger?: winston.Logger,
+    opts: RedisStreamOptions = {}
+  ) {
+    this.reclaimIntervalMs = opts.reclaimIntervalMs ?? RECLAIM_INTERVAL_MS_DEFAULT;
+    this.reclaimMinIdleMs = opts.reclaimMinIdleMs ?? RECLAIM_MIN_IDLE_MS_DEFAULT;
+    this.label = opts.label;
+  }
+
+  async publish(topic: string, payload: string, opts: PublishOptions = {}): Promise<string> {
+    if (opts.maxLen !== undefined) {
+      return this.client.xAdd(
+        topic,
+        "*",
+        { [PAYLOAD_FIELD]: payload },
+        { TRIM: { strategy: "MAXLEN", strategyModifier: "~", threshold: opts.maxLen } }
+      );
+    }
+    return this.client.xAdd(topic, "*", { [PAYLOAD_FIELD]: payload });
+  }
+
+  async subscribe(topic: string, opts: SubscribeOptions): Promise<Subscription> {
+    await this.ensureGroup(topic, opts.group);
+    return new RedisSubscription(this.client, topic, opts, {
+      reclaimIntervalMs: this.reclaimIntervalMs,
+      reclaimMinIdleMs: this.reclaimMinIdleMs,
+      logger: this.logger,
+    });
+  }
+
+  async disconnect(): Promise<void> {
+    await disconnectRedisClient(this.client, this.logger);
+  }
+
+  private async ensureGroup(topic: string, group: string): Promise<void> {
+    try {
+      await this.client.xGroupCreate(topic, group, "$", { MKSTREAM: true });
+    } catch (err) {
+      // BUSYGROUP -> group already exists; idempotent.
+      if (err instanceof Error && err.message.startsWith("BUSYGROUP")) {
+        return;
+      }
+      throw err;
+    }
+  }
+}
+
+interface RedisSubscriptionConfig {
+  reclaimIntervalMs: number;
+  reclaimMinIdleMs: number;
+  logger?: winston.Logger;
+}
+
+class RedisSubscription implements Subscription {
+  // Internal abort source; combined with the optional external signal in `aborted`.
+  private readonly closeController = new AbortController();
+  private lastReclaimAt = 0;
+
+  constructor(
+    private readonly client: RedisClient,
+    private readonly topic: string,
+    private readonly opts: SubscribeOptions,
+    private readonly config: RedisSubscriptionConfig
+  ) {}
+
+  private get aborted(): boolean {
+    return this.closeController.signal.aborted || (this.opts.signal?.aborted ?? false);
+  }
+
+  async *messages(): AsyncIterableIterator<DeliveredMessage> {
+    const { group, consumer, blockMs = BLOCK_MS_DEFAULT, count } = this.opts;
+    while (!this.aborted) {
+      // Periodic XAUTOCLAIM to recover entries from dead consumers.
+      if (Date.now() - this.lastReclaimAt >= this.config.reclaimIntervalMs) {
+        for await (const msg of this.reclaim(group, consumer, count)) {
+          if (this.aborted) {
+            return;
+          }
+          yield msg;
+        }
+        this.lastReclaimAt = Date.now();
+      }
+
+      let reply;
+      try {
+        reply = await this.client.xReadGroup(group, consumer, [{ key: this.topic, id: ">" }], {
+          BLOCK: blockMs,
+          COUNT: count,
+        });
+      } catch (err) {
+        // Client teardown during shutdown surfaces here; swallow if aborted.
+        if (this.aborted) {
+          return;
+        }
+        throw err;
+      }
+      if (this.aborted) {
+        return;
+      }
+      if (!reply) {
+        continue;
+      }
+      const streamReply = reply.find((r) => r.name === this.topic);
+      if (!streamReply) {
+        continue;
+      }
+      for (const m of streamReply.messages) {
+        if (this.aborted) {
+          return;
+        }
+        yield this.toDelivered(m.id, m.message[PAYLOAD_FIELD] ?? "", group);
+      }
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closeController.abort();
+  }
+
+  private async *reclaim(group: string, consumer: string, count?: number): AsyncIterableIterator<DeliveredMessage> {
+    let cursor = RECLAIM_CURSOR_START;
+    while (!this.aborted) {
+      const result = await this.client.xAutoClaim(
+        this.topic,
+        group,
+        consumer,
+        this.config.reclaimMinIdleMs,
+        cursor,
+        count !== undefined ? { COUNT: count } : undefined
+      );
+      const messages = result.messages ?? [];
+      for (const m of messages) {
+        // Entries deleted between scan and claim surface as null.
+        if (m === null) {
+          continue;
+        }
+        yield this.toDelivered(m.id, m.message[PAYLOAD_FIELD] ?? "", group);
+      }
+      // nextId === "0-0" signals the scan has completed.
+      if (result.nextId === RECLAIM_CURSOR_START) {
+        return;
+      }
+      cursor = result.nextId;
+    }
+  }
+
+  private toDelivered(id: string, payload: string, group: string): DeliveredMessage {
+    const ack = async (): Promise<void> => {
+      await this.client.xAck(this.topic, group, id);
+    };
+    return { id, payload, ack };
+  }
+}

--- a/test/MessageStream.ts
+++ b/test/MessageStream.ts
@@ -1,0 +1,159 @@
+import { expect } from "./utils";
+import { DeliveredMessage, Subscription } from "../src/messaging/MessageStream";
+import { MemoryStream } from "./mocks/MemoryStream";
+
+async function readN(sub: Subscription, n: number, ack = true): Promise<DeliveredMessage[]> {
+  const out: DeliveredMessage[] = [];
+  for await (const m of sub.messages()) {
+    out.push(m);
+    if (ack) await m.ack();
+    if (out.length >= n) break;
+  }
+  return out;
+}
+
+describe("MessageStream contract", function () {
+  describe("publish/subscribe", function () {
+    it("delivers messages published after subscribe", async function () {
+      const stream = new MemoryStream();
+      const sub = await stream.subscribe("t", { group: "g", consumer: "c", blockMs: 1 });
+      await stream.publish("t", "hello");
+      const msgs = await readN(sub, 1);
+      await sub.close();
+      expect(msgs.map((m) => m.payload)).to.deep.equal(["hello"]);
+    });
+
+    it("skips entries published before the group was created", async function () {
+      const stream = new MemoryStream();
+      await stream.publish("t", "before");
+      const sub = await stream.subscribe("t", { group: "g", consumer: "c", blockMs: 1 });
+      await stream.publish("t", "after");
+      const msgs = await readN(sub, 1);
+      await sub.close();
+      expect(msgs.map((m) => m.payload)).to.deep.equal(["after"]);
+    });
+
+    it("returns the broker-assigned id from publish", async function () {
+      const stream = new MemoryStream();
+      const id1 = await stream.publish("t", "a");
+      const id2 = await stream.publish("t", "b");
+      expect(id1).to.be.a("string");
+      expect(id2).to.be.a("string");
+      expect(id1).to.not.equal(id2);
+    });
+
+    it("delivers each message a stable, unique id", async function () {
+      const stream = new MemoryStream();
+      const sub = await stream.subscribe("t", { group: "g", consumer: "c", blockMs: 1 });
+      await stream.publish("t", "a");
+      await stream.publish("t", "b");
+      const msgs = await readN(sub, 2);
+      await sub.close();
+      expect(msgs[0].id).to.not.equal(msgs[1].id);
+    });
+  });
+
+  describe("ack semantics", function () {
+    it("does not redeliver acked messages on resubscribe", async function () {
+      const stream = new MemoryStream();
+      const sub1 = await stream.subscribe("t", { group: "g", consumer: "c1", blockMs: 1 });
+      await stream.publish("t", "a");
+      const first = await readN(sub1, 1, true);
+      await sub1.close();
+      expect(first.map((m) => m.payload)).to.deep.equal(["a"]);
+
+      const sub2 = await stream.subscribe("t", { group: "g", consumer: "c2", blockMs: 1 });
+      await stream.publish("t", "b");
+      const second = await readN(sub2, 1);
+      await sub2.close();
+      expect(second.map((m) => m.payload)).to.deep.equal(["b"]);
+    });
+
+    it("redelivers unacked messages on resubscribe", async function () {
+      const stream = new MemoryStream();
+      const sub1 = await stream.subscribe("t", { group: "g", consumer: "c1", blockMs: 1 });
+      await stream.publish("t", "a");
+      const first = await readN(sub1, 1, false); // no ack
+      await sub1.close();
+      expect(first.map((m) => m.payload)).to.deep.equal(["a"]);
+
+      const sub2 = await stream.subscribe("t", { group: "g", consumer: "c2", blockMs: 1 });
+      const second = await readN(sub2, 1);
+      await sub2.close();
+      expect(second.map((m) => m.payload)).to.deep.equal(["a"]);
+    });
+
+    it("redelivers preserve id across delivery attempts", async function () {
+      const stream = new MemoryStream();
+      const sub1 = await stream.subscribe("t", { group: "g", consumer: "c1", blockMs: 1 });
+      await stream.publish("t", "a");
+      const [firstMsg] = await readN(sub1, 1, false);
+      await sub1.close();
+
+      const sub2 = await stream.subscribe("t", { group: "g", consumer: "c2", blockMs: 1 });
+      const [secondMsg] = await readN(sub2, 1);
+      await sub2.close();
+      expect(secondMsg.id).to.equal(firstMsg.id);
+    });
+  });
+
+  describe("cancellation", function () {
+    it("exits messages() when close() is called", async function () {
+      const stream = new MemoryStream();
+      const sub = await stream.subscribe("t", { group: "g", consumer: "c", blockMs: 1 });
+      const iter = (async () => {
+        const out: string[] = [];
+        for await (const m of sub.messages()) {
+          out.push(m.payload);
+          await m.ack();
+        }
+        return out;
+      })();
+      await stream.publish("t", "a");
+      // Yield long enough for the iterator to consume the entry.
+      await new Promise((r) => setTimeout(r, 20));
+      await sub.close();
+      const collected = await iter;
+      expect(collected).to.deep.equal(["a"]);
+    });
+
+    it("exits messages() when the external signal aborts", async function () {
+      const stream = new MemoryStream();
+      const controller = new AbortController();
+      const sub = await stream.subscribe("t", {
+        group: "g",
+        consumer: "c",
+        blockMs: 1,
+        signal: controller.signal,
+      });
+      const iter = (async () => {
+        const out: string[] = [];
+        for await (const m of sub.messages()) {
+          out.push(m.payload);
+          await m.ack();
+        }
+        return out;
+      })();
+      await stream.publish("t", "a");
+      await new Promise((r) => setTimeout(r, 20));
+      controller.abort();
+      const collected = await iter;
+      expect(collected).to.deep.equal(["a"]);
+    });
+  });
+
+  describe("groups", function () {
+    it("delivers each message to every group independently", async function () {
+      const stream = new MemoryStream();
+      const subA = await stream.subscribe("t", { group: "gA", consumer: "c", blockMs: 1 });
+      const subB = await stream.subscribe("t", { group: "gB", consumer: "c", blockMs: 1 });
+      await stream.publish("t", "x");
+      const [a] = await readN(subA, 1);
+      const [b] = await readN(subB, 1);
+      await subA.close();
+      await subB.close();
+      expect(a.payload).to.equal("x");
+      expect(b.payload).to.equal("x");
+    });
+  });
+});

--- a/test/MessageStream.ts
+++ b/test/MessageStream.ts
@@ -6,8 +6,12 @@ async function readN(sub: Subscription, n: number, ack = true): Promise<Delivere
   const out: DeliveredMessage[] = [];
   for await (const m of sub.messages()) {
     out.push(m);
-    if (ack) await m.ack();
-    if (out.length >= n) break;
+    if (ack) {
+      await m.ack();
+    }
+    if (out.length >= n) {
+      break;
+    }
   }
   return out;
 }

--- a/test/mocks/MemoryStream.ts
+++ b/test/mocks/MemoryStream.ts
@@ -61,10 +61,14 @@ export class MemoryStream implements MessageStream {
 
   _ack(groupKey: string, id: string): void {
     const state = this.groups.get(groupKey);
-    if (state === undefined) return;
+    if (state === undefined) {
+      return;
+    }
     const entries = this.topics.get(state.topic) ?? [];
     const idx = entries.findIndex((e) => e.id === id);
-    if (idx >= 0) state.pending.delete(idx);
+    if (idx >= 0) {
+      state.pending.delete(idx);
+    }
   }
 }
 
@@ -80,14 +84,20 @@ class MemorySubscription implements Subscription {
 
   async *messages(): AsyncIterableIterator<DeliveredMessage> {
     const state = this.stream._group(this.groupKey);
-    if (state === undefined) return;
+    if (state === undefined) {
+      return;
+    }
 
     // Redelivery: yield entries pending from prior subscriptions, in id order.
     const pendingSnapshot = [...state.pending].sort((a, b) => a - b);
     for (const idx of pendingSnapshot) {
-      if (this.aborted) return;
+      if (this.aborted) {
+        return;
+      }
       const entry = this.stream._entries(this.topic)[idx];
-      if (entry !== undefined) yield this.toDelivered(entry);
+      if (entry !== undefined) {
+        yield this.toDelivered(entry);
+      }
     }
 
     // Live: yield new entries as they're published.
@@ -99,7 +109,9 @@ class MemorySubscription implements Subscription {
         state.pending.add(idx);
         yield this.toDelivered(entries[idx]);
       }
-      if (this.aborted) return;
+      if (this.aborted) {
+        return;
+      }
       await new Promise((r) => setTimeout(r, blockMs));
     }
   }

--- a/test/mocks/MemoryStream.ts
+++ b/test/mocks/MemoryStream.ts
@@ -1,0 +1,124 @@
+// In-memory MessageStream impl for unit tests. Single-consumer per (topic, group).
+// Resubscribe redelivers unacked entries — stands in for the transport-specific
+// "idle period" redelivery in the contract.
+
+import {
+  DeliveredMessage,
+  MessageStream,
+  PublishOptions,
+  SubscribeOptions,
+  Subscription,
+} from "../../src/messaging/MessageStream";
+
+interface Entry {
+  id: string;
+  payload: string;
+}
+
+interface GroupState {
+  topic: string;
+  // Position in entries array; entries[0..cursor) have been delivered to this group.
+  cursor: number;
+  // Indices into entries that are delivered but not yet acked.
+  pending: Set<number>;
+}
+
+export class MemoryStream implements MessageStream {
+  private readonly topics = new Map<string, Entry[]>();
+  private readonly groups = new Map<string, GroupState>();
+  private nextSeq = 1;
+
+  async publish(topic: string, payload: string, _opts: PublishOptions = {}): Promise<string> {
+    const id = `${this.nextSeq++}-0`;
+    const entries = this.topics.get(topic) ?? [];
+    entries.push({ id, payload });
+    this.topics.set(topic, entries);
+    return id;
+  }
+
+  async subscribe(topic: string, opts: SubscribeOptions): Promise<Subscription> {
+    const groupKey = `${topic}::${opts.group}`;
+    if (!this.groups.has(groupKey)) {
+      // Mirrors XGROUP CREATE ... "$" — new groups skip existing entries.
+      const entries = this.topics.get(topic) ?? [];
+      this.groups.set(groupKey, { topic, cursor: entries.length, pending: new Set() });
+    }
+    return new MemorySubscription(this, topic, opts, groupKey);
+  }
+
+  async disconnect(): Promise<void> {
+    this.topics.clear();
+    this.groups.clear();
+  }
+
+  _entries(topic: string): Entry[] {
+    return this.topics.get(topic) ?? [];
+  }
+
+  _group(key: string): GroupState | undefined {
+    return this.groups.get(key);
+  }
+
+  _ack(groupKey: string, id: string): void {
+    const state = this.groups.get(groupKey);
+    if (state === undefined) return;
+    const entries = this.topics.get(state.topic) ?? [];
+    const idx = entries.findIndex((e) => e.id === id);
+    if (idx >= 0) state.pending.delete(idx);
+  }
+}
+
+class MemorySubscription implements Subscription {
+  private readonly closeController = new AbortController();
+
+  constructor(
+    private readonly stream: MemoryStream,
+    private readonly topic: string,
+    private readonly opts: SubscribeOptions,
+    private readonly groupKey: string
+  ) {}
+
+  async *messages(): AsyncIterableIterator<DeliveredMessage> {
+    const state = this.stream._group(this.groupKey);
+    if (state === undefined) return;
+
+    // Redelivery: yield entries pending from prior subscriptions, in id order.
+    const pendingSnapshot = [...state.pending].sort((a, b) => a - b);
+    for (const idx of pendingSnapshot) {
+      if (this.aborted) return;
+      const entry = this.stream._entries(this.topic)[idx];
+      if (entry !== undefined) yield this.toDelivered(entry);
+    }
+
+    // Live: yield new entries as they're published.
+    const blockMs = this.opts.blockMs ?? 5;
+    while (!this.aborted) {
+      const entries = this.stream._entries(this.topic);
+      while (!this.aborted && state.cursor < entries.length) {
+        const idx = state.cursor++;
+        state.pending.add(idx);
+        yield this.toDelivered(entries[idx]);
+      }
+      if (this.aborted) return;
+      await new Promise((r) => setTimeout(r, blockMs));
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closeController.abort();
+  }
+
+  private get aborted(): boolean {
+    return this.closeController.signal.aborted || (this.opts.signal?.aborted ?? false);
+  }
+
+  private toDelivered(entry: Entry): DeliveredMessage {
+    return {
+      id: entry.id,
+      payload: entry.payload,
+      ack: async () => {
+        this.stream._ack(this.groupKey, entry.id);
+      },
+    };
+  }
+}


### PR DESCRIPTION
Introduce support for Redis streams, which offer reliable message
transport. This implementation is payload-agnostic, but it will be
subsequently used for cross-instance transaction management & tracking.

The use of Redis here is experimental; an interface layer is built to 
permit subsequent migration to another transport if Redis proves 
unsuitable.