### PR TITLE
feat(deposit-address): implement refund-withdraw path (OPS-353)

### DIFF
--- a/src/clients/AcrossApiBaseClient.ts
+++ b/src/clients/AcrossApiBaseClient.ts
@@ -1,4 +1,4 @@
-import { fetchWithTimeout } from "../utils/SDKUtils";
+import { fetchWithTimeout, postWithTimeout } from "../utils/SDKUtils";
 import winston from "winston";
 
 /**
@@ -57,6 +57,41 @@ export abstract class BaseAcrossApiClient {
         message: `Failed to get from ${this.urlBase}`,
         endpoint,
         params,
+        error: (err as Error).message,
+      });
+      return;
+    }
+  }
+
+  protected async _post<T>(endpoint: string, body: unknown): Promise<T | undefined> {
+    try {
+      const headers: Record<string, string> = { "Content-Type": "application/json", Accept: "application/json" };
+      if (this.apiKey) {
+        headers.Authorization = `Bearer ${this.apiKey}`;
+      }
+
+      const result = await postWithTimeout<T>(
+        `${this.urlBase}/${endpoint}`,
+        body,
+        {},
+        headers,
+        this.apiResponseTimeout
+      );
+
+      if (!result) {
+        this.logger.warn({
+          at: this.logContext,
+          message: `Invalid response from ${this.urlBase}`,
+          endpoint,
+        });
+        return;
+      }
+      return result;
+    } catch (err) {
+      this.logger.warn({
+        at: this.logContext,
+        message: `Failed to post to ${this.urlBase}`,
+        endpoint,
         error: (err as Error).message,
       });
       return;

--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -17,6 +17,30 @@ export interface SwapApiResponse {
   };
 }
 
+export interface SignedWithdrawRequest {
+  chainId: number;
+  depositAddress: string;
+  token: string;
+  amount: string;
+  user: string;
+  withdrawImplementation: string;
+  proof: string[];
+  salt: string;
+  merkleRoot: string;
+}
+
+export interface SignedWithdrawResponse {
+  signedWithdrawTx: {
+    chainId: number;
+    to: string;
+    data: string;
+    value: string;
+  };
+  bundledDeploy: boolean;
+  signer: string;
+  deadline: number;
+}
+
 interface SwapData {
   approval?: {
     target: EvmAddress;
@@ -120,6 +144,10 @@ export class AcrossSwapApiClient extends BaseAcrossApiClient {
       recipient: recipient.toNative(),
     };
     return this._get<SwapApiResponse>("/swap/approval", params);
+  }
+
+  async signedWithdraw(req: SignedWithdrawRequest): Promise<SignedWithdrawResponse | undefined> {
+    return this._post<SignedWithdrawResponse>("swap/counterfactual/sign-withdraw", req);
   }
 
   private _isRouteSupported(route: SwapRoute): boolean {

--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -147,7 +147,7 @@ export class AcrossSwapApiClient extends BaseAcrossApiClient {
   }
 
   async signedWithdraw(req: SignedWithdrawRequest): Promise<SignedWithdrawResponse | undefined> {
-    return this._post<SignedWithdrawResponse>("swap/counterfactual/sign-withdraw", req);
+    return this._post<SignedWithdrawResponse>("/swap/counterfactual/sign-withdraw", req);
   }
 
   private _isRouteSupported(route: SwapRoute): boolean {

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -430,8 +430,9 @@ export class DepositAddressHandler {
     const { erc20Transfer, routeParams, depositAddress, paramsHash, salt, counterfactualMaterials } = depositMessage;
     const { contractAddress: token, amount, chainId } = erc20Transfer;
     const { withdrawLeaf } = counterfactualMaterials;
+    // `_post` swallows errors and returns undefined, so retry on both throw and falsy return.
     try {
-      return await this.api.signedWithdraw({
+      const result = await this.api.signedWithdraw({
         chainId: Number(chainId),
         depositAddress,
         token,
@@ -442,10 +443,13 @@ export class DepositAddressHandler {
         salt,
         merkleRoot: paramsHash,
       });
+      if (result) {
+        return result;
+      }
     } catch {
-      // Logging is handled in AcrossSwapApiClient (matches `_getSwapApiQuote`).
-      return retriesRemaining > 0 ? this._getSignedWithdraw(depositMessage, --retriesRemaining) : undefined;
+      // Logging is handled in AcrossSwapApiClient.
     }
+    return retriesRemaining > 0 ? this._getSignedWithdraw(depositMessage, --retriesRemaining) : undefined;
   }
 
   /**

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -336,91 +336,110 @@ export class DepositAddressHandler {
     }
 
     this.observedExecutedWithdraws[chainId].add(depositKey);
-
-    // Defensive on-chain balance check — guards against reorged indexer messages and against
-    // acting on a deposit-address that has already been withdrawn through another path.
-    const provider = this.providersByChain[chainId];
-    const tokenContract = new Contract(token, ERC20_ABI, provider);
-
-    let onchainBalance: BigNumber;
+    // Release the in-flight lock on every exit path except a confirmed on-chain withdraw; an
+    // unexpected throw must not strand the depositKey, since the next poll would silently skip it.
+    let withdrawCommitted = false;
     try {
-      onchainBalance = await tokenContract.balanceOf(depositAddress);
-    } catch (err) {
-      this.logger.warn({
-        at: "DepositAddressHandler#initiateWithdraw",
-        message: "Skipping withdraw: failed to fetch deposit address balance",
-        depositAddress,
-        token,
-        depositKey,
-        refTxHash,
+      // Defensive on-chain balance check — guards against reorged indexer messages and against
+      // acting on a deposit-address that has already been withdrawn through another path.
+      const provider = this.providersByChain[chainId];
+      const tokenContract = new Contract(token, ERC20_ABI, provider);
+
+      let onchainBalance: BigNumber;
+      try {
+        onchainBalance = await tokenContract.balanceOf(depositAddress);
+      } catch (err) {
+        this.logger.warn({
+          at: "DepositAddressHandler#initiateWithdraw",
+          message: "Skipping withdraw: failed to fetch deposit address balance",
+          depositAddress,
+          token,
+          depositKey,
+          refTxHash,
+          chainId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+
+      if (onchainBalance.lt(toBN(amount))) {
+        this.logger.debug({
+          at: "DepositAddressHandler#initiateWithdraw",
+          message: "Skipping withdraw: deposit address balance below transfer amount",
+          depositAddress,
+          token,
+          amount,
+          onchainBalance: onchainBalance.toString(),
+          depositKey,
+          refTxHash,
+          chainId,
+        });
+        return;
+      }
+
+      const signed = await this._getSignedWithdraw(depositMessage);
+      if (!isDefined(signed)) {
+        this.logger.warn({
+          at: "DepositAddressHandler#initiateWithdraw",
+          message: "Failed to fetch signed withdraw from quote-api",
+          depositKey,
+          refTxHash,
+          depositAddress,
+          chainId,
+        });
+        return;
+      }
+
+      if (signed.signedWithdrawTx.chainId !== chainId) {
+        this.logger.warn({
+          at: "DepositAddressHandler#initiateWithdraw",
+          message: "Skipping withdraw: signed payload chainId does not match refund chainId",
+          signedChainId: signed.signedWithdrawTx.chainId,
+          chainId,
+          depositKey,
+          refTxHash,
+          depositAddress,
+        });
+        return;
+      }
+
+      const useDispatcher = this.depositAddressSigners.length > 0;
+      const withdrawTx = {
+        contract: this.getExecuteContract(signed.signedWithdrawTx.to, chainId, useDispatcher),
+        method: "",
+        args: [signed.signedWithdrawTx.data],
+        value: toBN(signed.signedWithdrawTx.value),
         chainId,
-        err: err instanceof Error ? err.message : String(err),
-      });
-      this.observedExecutedWithdraws[chainId].delete(depositKey);
-      return;
+        message: "Completed Refund Withdraw 💸",
+        mrkdwn: `Refund withdraw on ${getNetworkName(chainId)} for deposit address ${blockExplorerLink(
+          depositAddress,
+          chainId
+        )} (classification: ${erc20Transfer.transferClassification}, bundledDeploy: ${signed.bundledDeploy})`,
+      };
+
+      const receipt = await sendAndConfirmTransaction(withdrawTx, this.transactionClient, useDispatcher);
+      if (!isDefined(receipt)) {
+        this.logger.warn({
+          at: "DepositAddressHandler#initiateWithdraw",
+          message: "Failed to submit withdraw tx",
+          depositKey,
+          refTxHash,
+          depositAddress,
+          chainId,
+        });
+        return;
+      }
+
+      // The withdraw is on-chain; keep the in-flight lock and never re-attempt this depositKey,
+      // even if the Redis persist below throws (handover may miss it, but a double-send is worse).
+      this.executedWithdrawKeys.add(depositKey);
+      withdrawCommitted = true;
+      await this._persistWithdrawnKeysRedis();
+    } finally {
+      if (!withdrawCommitted) {
+        this.observedExecutedWithdraws[chainId].delete(depositKey);
+      }
     }
-
-    if (onchainBalance.lt(toBN(amount))) {
-      this.logger.debug({
-        at: "DepositAddressHandler#initiateWithdraw",
-        message: "Skipping withdraw: deposit address balance below transfer amount",
-        depositAddress,
-        token,
-        amount,
-        onchainBalance: onchainBalance.toString(),
-        depositKey,
-        refTxHash,
-        chainId,
-      });
-      this.observedExecutedWithdraws[chainId].delete(depositKey);
-      return;
-    }
-
-    const signed = await this._getSignedWithdraw(depositMessage);
-    if (!isDefined(signed)) {
-      this.logger.warn({
-        at: "DepositAddressHandler#initiateWithdraw",
-        message: "Failed to fetch signed withdraw from quote-api",
-        depositKey,
-        refTxHash,
-        depositAddress,
-        chainId,
-      });
-      this.observedExecutedWithdraws[chainId].delete(depositKey);
-      return;
-    }
-
-    const useDispatcher = this.depositAddressSigners.length > 0;
-    const withdrawTx = {
-      contract: this.getExecuteContract(signed.signedWithdrawTx.to, chainId, useDispatcher),
-      method: "",
-      args: [signed.signedWithdrawTx.data],
-      value: toBN(signed.signedWithdrawTx.value),
-      chainId,
-      message: "Completed Refund Withdraw 💸",
-      mrkdwn: `Refund withdraw on ${getNetworkName(chainId)} for deposit address ${blockExplorerLink(
-        depositAddress,
-        chainId
-      )} (classification: ${erc20Transfer.transferClassification}, bundledDeploy: ${signed.bundledDeploy})`,
-    };
-
-    const receipt = await sendAndConfirmTransaction(withdrawTx, this.transactionClient, useDispatcher);
-    if (!isDefined(receipt)) {
-      this.logger.warn({
-        at: "DepositAddressHandler#initiateWithdraw",
-        message: "Failed to submit withdraw tx",
-        depositKey,
-        refTxHash,
-        depositAddress,
-        chainId,
-      });
-      this.observedExecutedWithdraws[chainId].delete(depositKey);
-      return;
-    }
-
-    // Persist full set to Redis immediately so handover cannot miss this withdraw.
-    this.executedWithdrawKeys.add(depositKey);
-    await this._persistWithdrawnKeysRedis();
   }
 
   private async _getSignedWithdraw(
@@ -429,7 +448,22 @@ export class DepositAddressHandler {
   ): Promise<SignedWithdrawResponse | undefined> {
     const { erc20Transfer, routeParams, depositAddress, paramsHash, salt, counterfactualMaterials } = depositMessage;
     const { contractAddress: token, amount, chainId } = erc20Transfer;
-    const { withdrawLeaf } = counterfactualMaterials;
+    const withdrawLeaf = counterfactualMaterials?.withdrawLeaf;
+    if (
+      !isDefined(withdrawLeaf) ||
+      !isDefined(withdrawLeaf.implementationAddress) ||
+      !isDefined(withdrawLeaf.merkleProof)
+    ) {
+      this.logger.warn({
+        at: "DepositAddressHandler#_getSignedWithdraw",
+        message: "Skipping withdraw: indexer message missing counterfactual withdraw materials",
+        depositAddress,
+        paramsHash,
+        txHash: erc20Transfer.transactionHash,
+        chainId,
+      });
+      return undefined;
+    }
     // `_post` swallows errors and returns undefined, so retry on both throw and falsy return.
     try {
       const result = await this.api.signedWithdraw({

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -260,10 +260,8 @@ export class DepositAddressHandler {
   /**
    * Dispatches an indexer message to the deposit or refund-withdraw path based on its classification:
    *   - correct_transfer: forward deposit/execute path.
-   *   - mis_route / intent_refund: refund-withdraw path (OPS-353).
+   *   - mis_route / intent_refund: refund-withdraw path.
    *   - anything else: dropped (forward-compat) until explicitly supported.
-   * Per-path gating (chain membership, withdraw-enabled flag, executed-set checks) lives inside
-   * `initiateDeposit` / `initiateWithdraw`.
    */
   private async processExecution(depositMessage: DepositAddressMessage): Promise<void> {
     const classification = depositMessage.erc20Transfer.transferClassification;
@@ -285,7 +283,7 @@ export class DepositAddressHandler {
   }
 
   /**
-   * @notice Refund-withdraw path entry point (OPS-353). Gated behind config.withdrawEnabled.
+   * @notice Refund-withdraw path entry point. Gated behind config.withdrawEnabled.
    * Refunds the full transfer amount via the quote-api signed-withdraw flow; gas-reserve / fee
    * deduction is deferred to a follow-up task. The quote-api response bundles the
    * counterfactual-deposit deploy + signedWithdrawToUser into a single Multicall3 call when the
@@ -297,11 +295,10 @@ export class DepositAddressHandler {
       transactionHash: refTxHash,
       contractAddress: token,
       amount,
-      chainId: _chainId,
       transferClassification: classification,
     } = erc20Transfer;
     // Refund chain is where funds landed (NOT routeParams.originChainId — for mis_routes those differ).
-    const chainId = Number(_chainId);
+    const chainId = Number(erc20Transfer.chainId);
     const depositKey = getDepositKey(depositMessage);
 
     // Drop refund-withdraws while the gate is closed. intent_refund in particular would re-loop the
@@ -314,7 +311,7 @@ export class DepositAddressHandler {
         depositAddress,
         paramsHash,
         txHash: refTxHash,
-        chainId: _chainId,
+        chainId,
       });
       return;
     }

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -19,6 +19,7 @@ import {
   assert,
   getNetworkName,
   blockExplorerLink,
+  BigNumber,
 } from "../utils";
 import { getRedisCache, RedisCacheInterface } from "../cache/Redis";
 import { DepositAddressMessage } from "../interfaces";
@@ -53,6 +54,16 @@ export class DepositAddressHandler {
 
   /** Set of erc20Transfer.transactionHash for deposits successfully executed (persisted in Redis for handover). */
   private executedDepositTxHashes: Set<string> = new Set();
+
+  /** Set of erc20Transfer.transactionHash for refund withdraws successfully executed (persisted in Redis for handover). */
+  private executedWithdrawTxHashes: Set<string> = new Set();
+
+  /**
+   * In-memory set of refTxHashes for withdraws currently being processed in this run. Prevents the
+   * next poll (which can fire on a 1s interval, faster than a withdraw confirms) from racing against
+   * an in-flight broadcast. Mirrors `observedExecutedDeposits` on the deposit path.
+   */
+  private observedExecutedWithdraws: Set<string> = new Set();
 
   private api: AcrossSwapApiClient;
   private indexerApi: AcrossIndexerApiClient;
@@ -129,12 +140,17 @@ export class DepositAddressHandler {
     await this.instanceCoordinator.initiateHandover();
 
     await this._loadExecutedDepositsFromRedis();
+    await this._loadWithdrawnDepositsFromRedis();
 
     this.initialized = true;
   }
 
   private getExecutedDepositsRedisKey(): string {
     return `deposit-address:executed:${this.config.botIdentifier}`;
+  }
+
+  private getWithdrawnDepositsRedisKey(): string {
+    return `deposit-address:withdrawn:${this.config.botIdentifier}`;
   }
 
   /** Loads executed deposit tx hashes from Redis (e.g. after handover). */
@@ -163,6 +179,35 @@ export class DepositAddressHandler {
       at: "DepositAddressHandler#_loadExecutedDepositsFromRedis",
       message: "Loaded executed deposit tx hashes from Redis",
       count: this.executedDepositTxHashes.size,
+    });
+  }
+
+  /** Loads executed refund-withdraw tx hashes from Redis (e.g. after handover). */
+  private async _loadWithdrawnDepositsFromRedis(): Promise<void> {
+    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    const { redisCache } = this;
+    const redisKey = this.getWithdrawnDepositsRedisKey();
+    const raw = await redisCache.get<string>(redisKey);
+    let arr: string[] = [];
+    try {
+      if (raw) {
+        arr = parseJson.stringArray(raw);
+      }
+    } catch (err) {
+      this.logger.error({
+        at: "DepositAddressHandler#_loadWithdrawnDepositsFromRedis",
+        message: "Failed to parse withdrawn deposits from Redis, using empty set",
+        redisKey,
+        err: err instanceof Error ? err.message : String(err),
+      });
+
+      throw err;
+    }
+    this.executedWithdrawTxHashes = new Set(arr);
+    this.logger.debug({
+      at: "DepositAddressHandler#_loadWithdrawnDepositsFromRedis",
+      message: "Loaded executed withdraw tx hashes from Redis",
+      count: this.executedWithdrawTxHashes.size,
     });
   }
 
@@ -238,8 +283,10 @@ export class DepositAddressHandler {
 
     // For mis_route the funds land on a chain different from routeParams.originChainId, so the
     // bot must act on whichever chain the ERC20 actually arrived on (erc20Transfer.chainId).
-    const filteredWithdraws = withdrawMessages.filter((m) =>
-      this.config.relayerOriginChains.includes(Number(m.erc20Transfer.chainId))
+    const filteredWithdraws = withdrawMessages.filter(
+      (m) =>
+        this.config.relayerOriginChains.includes(Number(m.erc20Transfer.chainId)) &&
+        !this.executedWithdrawTxHashes.has(m.erc20Transfer.transactionHash)
     );
 
     // We want to remove all executed deposits from the in-memory set if they are not returned by the indexer.
@@ -249,6 +296,11 @@ export class DepositAddressHandler {
     for (const tx of [...this.executedDepositTxHashes]) {
       if (!refTxHashesFromIndexer.has(tx)) {
         this.executedDepositTxHashes.delete(tx);
+      }
+    }
+    for (const tx of [...this.executedWithdrawTxHashes]) {
+      if (!refTxHashesFromIndexer.has(tx)) {
+        this.executedWithdrawTxHashes.delete(tx);
       }
     }
 
@@ -263,19 +315,100 @@ export class DepositAddressHandler {
 
   /**
    * @notice Refund-withdraw path entry point (OPS-353). Gated behind config.withdrawEnabled.
-   * Implementation pending: gas-reserve computation, dispatcher deploy-on-first-touch, and
-   * refund-action submission with the backend-signed authorization (ACB-407).
+   * Refunds the full transfer amount via the quote-api signed-withdraw flow; gas-reserve / fee
+   * deduction is deferred to a follow-up task. The quote-api response bundles the
+   * counterfactual-deposit deploy + signedWithdrawToUser into a single Multicall3 call when the
+   * deposit clone is not yet on-chain, so the bot does not need its own deploy step.
    */
   private async initiateWithdraw(depositMessage: DepositAddressMessage): Promise<void> {
-    this.logger.debug({
-      at: "DepositAddressHandler#initiateWithdraw",
-      message: "Withdraw flow not implemented yet; skipping",
-      classification: depositMessage.erc20Transfer.transferClassification,
-      depositAddress: depositMessage.depositAddress,
-      paramsHash: depositMessage.paramsHash,
-      txHash: depositMessage.erc20Transfer.transactionHash,
-      chainId: depositMessage.erc20Transfer.chainId,
+    const { erc20Transfer, routeParams, depositAddress, paramsHash, salt, counterfactualMaterials } = depositMessage;
+    const { transactionHash: refTxHash, contractAddress: token, amount, chainId: _chainId } = erc20Transfer;
+    // Refund chain is where funds landed (NOT routeParams.originChainId — for mis_routes those differ).
+    const chainId = Number(_chainId);
+
+    if (this.executedWithdrawTxHashes.has(refTxHash) || this.observedExecutedWithdraws.has(refTxHash)) {
+      return;
+    }
+
+    // Reserve the slot before any async work so an overlapping poll cannot double-broadcast.
+    this.observedExecutedWithdraws.add(refTxHash);
+
+    const { withdrawLeaf } = counterfactualMaterials;
+
+    // Defensive on-chain balance check — guards against reorged indexer messages and against
+    // acting on a deposit-address that has already been withdrawn through another path.
+    const provider = this.providersByChain[chainId];
+    const tokenContract = new Contract(token, ERC20_ABI, provider);
+    const onchainBalance: BigNumber = await tokenContract.balanceOf(depositAddress);
+    if (onchainBalance.lt(toBN(amount))) {
+      this.logger.debug({
+        at: "DepositAddressHandler#initiateWithdraw",
+        message: "Skipping withdraw: deposit address balance below transfer amount",
+        depositAddress,
+        token,
+        amount,
+        onchainBalance: onchainBalance.toString(),
+        refTxHash,
+        chainId,
+      });
+      this.observedExecutedWithdraws.delete(refTxHash);
+      return;
+    }
+
+    const signed = await this.api.signedWithdraw({
+      chainId,
+      depositAddress,
+      token,
+      amount,
+      user: routeParams.refundAddress,
+      withdrawImplementation: withdrawLeaf.implementationAddress,
+      proof: withdrawLeaf.merkleProof,
+      salt,
+      merkleRoot: paramsHash,
     });
+    if (!isDefined(signed)) {
+      this.logger.warn({
+        at: "DepositAddressHandler#initiateWithdraw",
+        message: "Failed to fetch signed withdraw from quote-api",
+        refTxHash,
+        depositAddress,
+        chainId,
+      });
+      this.observedExecutedWithdraws.delete(refTxHash);
+      return;
+    }
+
+    const useDispatcher = this.depositAddressSigners.length > 0;
+    const withdrawTx = {
+      contract: this.getExecuteContract(signed.signedWithdrawTx.to, chainId, useDispatcher),
+      method: "",
+      args: [signed.signedWithdrawTx.data],
+      value: toBN(signed.signedWithdrawTx.value),
+      chainId,
+      message: "Completed Refund Withdraw 💸",
+      mrkdwn: `Refund withdraw on ${getNetworkName(chainId)} for deposit address ${blockExplorerLink(
+        depositAddress,
+        chainId
+      )} (classification: ${erc20Transfer.transferClassification}, bundledDeploy: ${signed.bundledDeploy})`,
+    };
+
+    const receipt = await sendAndConfirmTransaction(withdrawTx, this.transactionClient, useDispatcher);
+    if (!isDefined(receipt)) {
+      this.logger.warn({
+        at: "DepositAddressHandler#initiateWithdraw",
+        message: "Failed to submit withdraw tx",
+        refTxHash,
+        depositAddress,
+        chainId,
+      });
+      this.observedExecutedWithdraws.delete(refTxHash);
+      return;
+    }
+
+    // Promote from in-flight set to the persisted set. Keep the in-flight entry until Redis
+    // is updated so a racing poll doesn't slip through the gap.
+    this.executedWithdrawTxHashes.add(refTxHash);
+    await this._persistWithdrawnDepositsRedis();
   }
 
   /**
@@ -287,6 +420,14 @@ export class DepositAddressHandler {
     const { redisCache } = this;
     const redisKey = this.getExecutedDepositsRedisKey();
     await redisCache.set(redisKey, JSON.stringify([...this.executedDepositTxHashes]));
+  }
+
+  /** Same pattern as `_persistExecutedDepositsRedis` but for refund-withdraw tx hashes. */
+  private async _persistWithdrawnDepositsRedis(): Promise<void> {
+    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    const { redisCache } = this;
+    const redisKey = this.getWithdrawnDepositsRedisKey();
+    await redisCache.set(redisKey, JSON.stringify([...this.executedWithdrawTxHashes]));
   }
 
   private async initiateDeposit(depositMessage: DepositAddressMessage): Promise<void> {

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -23,7 +23,7 @@ import {
 } from "../utils";
 import { getRedisCache, RedisCacheInterface } from "../cache/Redis";
 import { DepositAddressMessage } from "../interfaces";
-import { AcrossSwapApiClient, TransactionClient, SwapApiResponse } from "../clients";
+import { AcrossSwapApiClient, TransactionClient, SwapApiResponse, SignedWithdrawResponse } from "../clients";
 import { AcrossIndexerApiClient } from "../clients/AcrossIndexerApiClient";
 import ERC20_ABI from "../common/abi/MinimalERC20.json";
 
@@ -55,15 +55,16 @@ export class DepositAddressHandler {
   /** Set of erc20Transfer.transactionHash for deposits successfully executed (persisted in Redis for handover). */
   private executedDepositTxHashes: Set<string> = new Set();
 
-  /** Set of erc20Transfer.transactionHash for refund withdraws successfully executed (persisted in Redis for handover). */
-  private executedWithdrawTxHashes: Set<string> = new Set();
+  /** Set of depositKeys for refund withdraws successfully executed (persisted in Redis for handover). */
+  private executedWithdrawDepositKeys: Set<string> = new Set();
 
   /**
-   * In-memory set of refTxHashes for withdraws currently being processed in this run. Prevents the
-   * next poll (which can fire on a 1s interval, faster than a withdraw confirms) from racing against
-   * an in-flight broadcast. Mirrors `observedExecutedDeposits` on the deposit path.
+   * Per chainId (refund chain = erc20Transfer.chainId): set of depositKeys for withdraws currently
+   * being processed in this run. Prevents the next poll (which can fire on a 1s interval, faster
+   * than a withdraw confirms) from racing against an in-flight broadcast. Mirrors
+   * `observedExecutedDeposits` on the deposit path.
    */
-  private observedExecutedWithdraws: Set<string> = new Set();
+  private observedExecutedWithdraws: { [chainId: number]: Set<string> } = {};
 
   private api: AcrossSwapApiClient;
   private indexerApi: AcrossIndexerApiClient;
@@ -127,6 +128,7 @@ export class DepositAddressHandler {
       const provider = await getProvider(chainId);
       this.providersByChain[chainId] = provider;
       this.observedExecutedDeposits[chainId] = new Set<string>();
+      this.observedExecutedWithdraws[chainId] = new Set<string>();
     });
 
     // Establish bot instance and take over. First thing after handover: load persisted executed deposits from Redis.
@@ -140,7 +142,7 @@ export class DepositAddressHandler {
     await this.instanceCoordinator.initiateHandover();
 
     await this._loadExecutedDepositsFromRedis();
-    await this._loadWithdrawnDepositsFromRedis();
+    await this._loadWithdrawnDepositKeysFromRedis();
 
     this.initialized = true;
   }
@@ -149,8 +151,8 @@ export class DepositAddressHandler {
     return `deposit-address:executed:${this.config.botIdentifier}`;
   }
 
-  private getWithdrawnDepositsRedisKey(): string {
-    return `deposit-address:withdrawn:${this.config.botIdentifier}`;
+  private getWithdrawnDepositKeysRedisKey(): string {
+    return `deposit-address:withdrawn-deposit-keys:${this.config.botIdentifier}`;
   }
 
   /** Loads executed deposit tx hashes from Redis (e.g. after handover). */
@@ -182,11 +184,11 @@ export class DepositAddressHandler {
     });
   }
 
-  /** Loads executed refund-withdraw tx hashes from Redis (e.g. after handover). */
-  private async _loadWithdrawnDepositsFromRedis(): Promise<void> {
+  /** Loads executed refund-withdraw depositKeys from Redis (e.g. after handover). */
+  private async _loadWithdrawnDepositKeysFromRedis(): Promise<void> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
     const { redisCache } = this;
-    const redisKey = this.getWithdrawnDepositsRedisKey();
+    const redisKey = this.getWithdrawnDepositKeysRedisKey();
     const raw = await redisCache.get<string>(redisKey);
     let arr: string[] = [];
     try {
@@ -195,19 +197,19 @@ export class DepositAddressHandler {
       }
     } catch (err) {
       this.logger.error({
-        at: "DepositAddressHandler#_loadWithdrawnDepositsFromRedis",
-        message: "Failed to parse withdrawn deposits from Redis, using empty set",
+        at: "DepositAddressHandler#_loadWithdrawnDepositKeysFromRedis",
+        message: "Failed to parse withdrawn deposit keys from Redis, using empty set",
         redisKey,
         err: err instanceof Error ? err.message : String(err),
       });
 
       throw err;
     }
-    this.executedWithdrawTxHashes = new Set(arr);
+    this.executedWithdrawDepositKeys = new Set(arr);
     this.logger.debug({
-      at: "DepositAddressHandler#_loadWithdrawnDepositsFromRedis",
-      message: "Loaded executed withdraw tx hashes from Redis",
-      count: this.executedWithdrawTxHashes.size,
+      at: "DepositAddressHandler#_loadWithdrawnDepositKeysFromRedis",
+      message: "Loaded executed withdraw deposit keys from Redis",
+      count: this.executedWithdrawDepositKeys.size,
     });
   }
 
@@ -286,21 +288,22 @@ export class DepositAddressHandler {
     const filteredWithdraws = withdrawMessages.filter(
       (m) =>
         this.config.relayerOriginChains.includes(Number(m.erc20Transfer.chainId)) &&
-        !this.executedWithdrawTxHashes.has(m.erc20Transfer.transactionHash)
+        !this.executedWithdrawDepositKeys.has(getDepositKey(m))
     );
 
     // We want to remove all executed deposits from the in-memory set if they are not returned by the indexer.
     // This is because the indexer will stop sending the deposit once it has been "expired" (internal TTL).
     // So there is no point of keeping them in Redis after Indexer API stops returning them.
     const refTxHashesFromIndexer = new Set(depositMessages.map((m) => m.erc20Transfer.transactionHash));
+    const depositKeysFromIndexer = new Set(depositMessages.map((m) => getDepositKey(m)));
     for (const tx of [...this.executedDepositTxHashes]) {
       if (!refTxHashesFromIndexer.has(tx)) {
         this.executedDepositTxHashes.delete(tx);
       }
     }
-    for (const tx of [...this.executedWithdrawTxHashes]) {
-      if (!refTxHashesFromIndexer.has(tx)) {
-        this.executedWithdrawTxHashes.delete(tx);
+    for (const key of [...this.executedWithdrawDepositKeys]) {
+      if (!depositKeysFromIndexer.has(key)) {
+        this.executedWithdrawDepositKeys.delete(key);
       }
     }
 
@@ -321,25 +324,52 @@ export class DepositAddressHandler {
    * deposit clone is not yet on-chain, so the bot does not need its own deploy step.
    */
   private async initiateWithdraw(depositMessage: DepositAddressMessage): Promise<void> {
-    const { erc20Transfer, routeParams, depositAddress, paramsHash, salt, counterfactualMaterials } = depositMessage;
+    const { erc20Transfer, depositAddress } = depositMessage;
     const { transactionHash: refTxHash, contractAddress: token, amount, chainId: _chainId } = erc20Transfer;
     // Refund chain is where funds landed (NOT routeParams.originChainId — for mis_routes those differ).
     const chainId = Number(_chainId);
+    const depositKey = getDepositKey(depositMessage);
 
-    if (this.executedWithdrawTxHashes.has(refTxHash) || this.observedExecutedWithdraws.has(refTxHash)) {
+    // Skip if a previous instance (or this one) already executed this withdraw (persisted in Redis).
+    if (this.executedWithdrawDepositKeys.has(depositKey)) {
+      this.logger.debug({
+        at: "DepositAddressHandler#initiateWithdraw",
+        message: "Skipping already executed withdraw (found in Redis)",
+        refTxHash,
+        depositKey,
+      });
       return;
     }
 
-    // Reserve the slot before any async work so an overlapping poll cannot double-broadcast.
-    this.observedExecutedWithdraws.add(refTxHash);
+    if (this.observedExecutedWithdraws[chainId]?.has(depositKey)) {
+      return;
+    }
 
-    const { withdrawLeaf } = counterfactualMaterials;
+    this.observedExecutedWithdraws[chainId].add(depositKey);
 
     // Defensive on-chain balance check — guards against reorged indexer messages and against
     // acting on a deposit-address that has already been withdrawn through another path.
     const provider = this.providersByChain[chainId];
     const tokenContract = new Contract(token, ERC20_ABI, provider);
-    const onchainBalance: BigNumber = await tokenContract.balanceOf(depositAddress);
+
+    let onchainBalance: BigNumber;
+    try {
+      onchainBalance = await tokenContract.balanceOf(depositAddress);
+    } catch (err) {
+      this.logger.warn({
+        at: "DepositAddressHandler#initiateWithdraw",
+        message: "Skipping withdraw: failed to fetch deposit address balance",
+        depositAddress,
+        token,
+        depositKey,
+        refTxHash,
+        chainId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      this.observedExecutedWithdraws[chainId].delete(depositKey);
+      return;
+    }
+
     if (onchainBalance.lt(toBN(amount))) {
       this.logger.debug({
         at: "DepositAddressHandler#initiateWithdraw",
@@ -348,33 +378,25 @@ export class DepositAddressHandler {
         token,
         amount,
         onchainBalance: onchainBalance.toString(),
+        depositKey,
         refTxHash,
         chainId,
       });
-      this.observedExecutedWithdraws.delete(refTxHash);
+      this.observedExecutedWithdraws[chainId].delete(depositKey);
       return;
     }
 
-    const signed = await this.api.signedWithdraw({
-      chainId,
-      depositAddress,
-      token,
-      amount,
-      user: routeParams.refundAddress,
-      withdrawImplementation: withdrawLeaf.implementationAddress,
-      proof: withdrawLeaf.merkleProof,
-      salt,
-      merkleRoot: paramsHash,
-    });
+    const signed = await this._getSignedWithdraw(depositMessage);
     if (!isDefined(signed)) {
       this.logger.warn({
         at: "DepositAddressHandler#initiateWithdraw",
         message: "Failed to fetch signed withdraw from quote-api",
+        depositKey,
         refTxHash,
         depositAddress,
         chainId,
       });
-      this.observedExecutedWithdraws.delete(refTxHash);
+      this.observedExecutedWithdraws[chainId].delete(depositKey);
       return;
     }
 
@@ -397,18 +419,43 @@ export class DepositAddressHandler {
       this.logger.warn({
         at: "DepositAddressHandler#initiateWithdraw",
         message: "Failed to submit withdraw tx",
+        depositKey,
         refTxHash,
         depositAddress,
         chainId,
       });
-      this.observedExecutedWithdraws.delete(refTxHash);
+      this.observedExecutedWithdraws[chainId].delete(depositKey);
       return;
     }
 
-    // Promote from in-flight set to the persisted set. Keep the in-flight entry until Redis
-    // is updated so a racing poll doesn't slip through the gap.
-    this.executedWithdrawTxHashes.add(refTxHash);
-    await this._persistWithdrawnDepositsRedis();
+    // Persist full set to Redis immediately so handover cannot miss this withdraw.
+    this.executedWithdrawDepositKeys.add(depositKey);
+    await this._persistWithdrawnDepositKeysRedis();
+  }
+
+  private async _getSignedWithdraw(
+    depositMessage: DepositAddressMessage,
+    retriesRemaining = 3
+  ): Promise<SignedWithdrawResponse | undefined> {
+    const { erc20Transfer, routeParams, depositAddress, paramsHash, salt, counterfactualMaterials } = depositMessage;
+    const { contractAddress: token, amount, chainId } = erc20Transfer;
+    const { withdrawLeaf } = counterfactualMaterials;
+    try {
+      return await this.api.signedWithdraw({
+        chainId: Number(chainId),
+        depositAddress,
+        token,
+        amount,
+        user: routeParams.refundAddress,
+        withdrawImplementation: withdrawLeaf.implementationAddress,
+        proof: withdrawLeaf.merkleProof,
+        salt,
+        merkleRoot: paramsHash,
+      });
+    } catch {
+      // Logging is handled in AcrossSwapApiClient (matches `_getSwapApiQuote`).
+      return retriesRemaining > 0 ? this._getSignedWithdraw(depositMessage, --retriesRemaining) : undefined;
+    }
   }
 
   /**
@@ -422,12 +469,12 @@ export class DepositAddressHandler {
     await redisCache.set(redisKey, JSON.stringify([...this.executedDepositTxHashes]));
   }
 
-  /** Same pattern as `_persistExecutedDepositsRedis` but for refund-withdraw tx hashes. */
-  private async _persistWithdrawnDepositsRedis(): Promise<void> {
+  /** Same pattern as `_persistExecutedDepositsRedis` but for refund-withdraw deposit keys. */
+  private async _persistWithdrawnDepositKeysRedis(): Promise<void> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
     const { redisCache } = this;
-    const redisKey = this.getWithdrawnDepositsRedisKey();
-    await redisCache.set(redisKey, JSON.stringify([...this.executedWithdrawTxHashes]));
+    const redisKey = this.getWithdrawnDepositKeysRedisKey();
+    await redisCache.set(redisKey, JSON.stringify([...this.executedWithdrawDepositKeys]));
   }
 
   private async initiateDeposit(depositMessage: DepositAddressMessage): Promise<void> {

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -56,7 +56,7 @@ export class DepositAddressHandler {
   private executedDepositTxHashes: Set<string> = new Set();
 
   /** Set of depositKeys for refund withdraws successfully executed (persisted in Redis for handover). */
-  private executedWithdrawDepositKeys: Set<string> = new Set();
+  private executedWithdrawKeys: Set<string> = new Set();
 
   /**
    * Per chainId (refund chain = erc20Transfer.chainId): set of depositKeys for withdraws currently
@@ -142,7 +142,7 @@ export class DepositAddressHandler {
     await this.instanceCoordinator.initiateHandover();
 
     await this._loadExecutedDepositsFromRedis();
-    await this._loadWithdrawnDepositKeysFromRedis();
+    await this._loadWithdrawnKeysFromRedis();
 
     this.initialized = true;
   }
@@ -151,7 +151,7 @@ export class DepositAddressHandler {
     return `deposit-address:executed:${this.config.botIdentifier}`;
   }
 
-  private getWithdrawnDepositKeysRedisKey(): string {
+  private getWithdrawnKeysRedisKey(): string {
     return `deposit-address:withdrawn-deposit-keys:${this.config.botIdentifier}`;
   }
 
@@ -185,10 +185,10 @@ export class DepositAddressHandler {
   }
 
   /** Loads executed refund-withdraw depositKeys from Redis (e.g. after handover). */
-  private async _loadWithdrawnDepositKeysFromRedis(): Promise<void> {
+  private async _loadWithdrawnKeysFromRedis(): Promise<void> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
     const { redisCache } = this;
-    const redisKey = this.getWithdrawnDepositKeysRedisKey();
+    const redisKey = this.getWithdrawnKeysRedisKey();
     const raw = await redisCache.get<string>(redisKey);
     let arr: string[] = [];
     try {
@@ -197,7 +197,7 @@ export class DepositAddressHandler {
       }
     } catch (err) {
       this.logger.error({
-        at: "DepositAddressHandler#_loadWithdrawnDepositKeysFromRedis",
+        at: "DepositAddressHandler#_loadWithdrawnKeysFromRedis",
         message: "Failed to parse withdrawn deposit keys from Redis, using empty set",
         redisKey,
         err: err instanceof Error ? err.message : String(err),
@@ -205,11 +205,11 @@ export class DepositAddressHandler {
 
       throw err;
     }
-    this.executedWithdrawDepositKeys = new Set(arr);
+    this.executedWithdrawKeys = new Set(arr);
     this.logger.debug({
-      at: "DepositAddressHandler#_loadWithdrawnDepositKeysFromRedis",
+      at: "DepositAddressHandler#_loadWithdrawnKeysFromRedis",
       message: "Loaded executed withdraw deposit keys from Redis",
-      count: this.executedWithdrawDepositKeys.size,
+      count: this.executedWithdrawKeys.size,
     });
   }
 
@@ -236,61 +236,6 @@ export class DepositAddressHandler {
   private async evaluateDepositAddresses(): Promise<void> {
     const depositMessages = await this._queryIndexerApi();
 
-    // Partition by classification:
-    //   - correct_transfer: forward deposit/execute path.
-    //   - mis_route / intent_refund: refund-withdraw path (OPS-353). Gated behind WITHDRAW_ENABLED.
-    //     While the gate is closed, drop them so the bot doesn't try to bridge them
-    //     (intent_refund in particular would re-loop the same intent).
-    //   - unknown: drop (forward-compat) until explicitly supported.
-    const correctTransferMessages: DepositAddressMessage[] = [];
-    const withdrawMessages: DepositAddressMessage[] = [];
-    for (const m of depositMessages) {
-      const classification = m.erc20Transfer.transferClassification;
-      if (classification === "correct_transfer") {
-        correctTransferMessages.push(m);
-        continue;
-      }
-      if (classification === "mis_route" || classification === "intent_refund") {
-        if (this.config.withdrawEnabled) {
-          withdrawMessages.push(m);
-        } else {
-          this.logger.debug({
-            at: "DepositAddressHandler#evaluateDepositAddresses",
-            message: "deposit-address transfer skipped: withdraw flow disabled",
-            classification,
-            depositAddress: m.depositAddress,
-            paramsHash: m.paramsHash,
-            txHash: m.erc20Transfer.transactionHash,
-            chainId: m.erc20Transfer.chainId,
-          });
-        }
-        continue;
-      }
-      this.logger.debug({
-        at: "DepositAddressHandler#evaluateDepositAddresses",
-        message: "deposit-address transfer skipped: unknown classification",
-        classification,
-        depositAddress: m.depositAddress,
-        paramsHash: m.paramsHash,
-        txHash: m.erc20Transfer.transactionHash,
-        chainId: m.erc20Transfer.chainId,
-      });
-    }
-
-    const filtered = correctTransferMessages.filter(
-      (m) =>
-        this.config.relayerOriginChains.includes(Number(m.routeParams.originChainId)) &&
-        !this.executedDepositTxHashes.has(m.erc20Transfer.transactionHash)
-    );
-
-    // For mis_route the funds land on a chain different from routeParams.originChainId, so the
-    // bot must act on whichever chain the ERC20 actually arrived on (erc20Transfer.chainId).
-    const filteredWithdraws = withdrawMessages.filter(
-      (m) =>
-        this.config.relayerOriginChains.includes(Number(m.erc20Transfer.chainId)) &&
-        !this.executedWithdrawDepositKeys.has(getDepositKey(m))
-    );
-
     // We want to remove all executed deposits from the in-memory set if they are not returned by the indexer.
     // This is because the indexer will stop sending the deposit once it has been "expired" (internal TTL).
     // So there is no point of keeping them in Redis after Indexer API stops returning them.
@@ -301,18 +246,41 @@ export class DepositAddressHandler {
         this.executedDepositTxHashes.delete(tx);
       }
     }
-    for (const key of [...this.executedWithdrawDepositKeys]) {
+    for (const key of [...this.executedWithdrawKeys]) {
       if (!depositKeysFromIndexer.has(key)) {
-        this.executedWithdrawDepositKeys.delete(key);
+        this.executedWithdrawKeys.delete(key);
       }
     }
 
-    await forEachAsync(filtered, async (depositMessage) => {
-      await this.initiateDeposit(depositMessage);
+    await forEachAsync(depositMessages, async (depositMessage) => {
+      await this.processExecution(depositMessage);
     });
+  }
 
-    await forEachAsync(filteredWithdraws, async (depositMessage) => {
-      await this.initiateWithdraw(depositMessage);
+  /**
+   * Dispatches an indexer message to the deposit or refund-withdraw path based on its classification:
+   *   - correct_transfer: forward deposit/execute path.
+   *   - mis_route / intent_refund: refund-withdraw path (OPS-353).
+   *   - anything else: dropped (forward-compat) until explicitly supported.
+   * Per-path gating (chain membership, withdraw-enabled flag, executed-set checks) lives inside
+   * `initiateDeposit` / `initiateWithdraw`.
+   */
+  private async processExecution(depositMessage: DepositAddressMessage): Promise<void> {
+    const classification = depositMessage.erc20Transfer.transferClassification;
+    if (classification === "correct_transfer") {
+      return this.initiateDeposit(depositMessage);
+    }
+    if (classification === "mis_route" || classification === "intent_refund") {
+      return this.initiateWithdraw(depositMessage);
+    }
+    this.logger.debug({
+      at: "DepositAddressHandler#processExecution",
+      message: "deposit-address transfer skipped: unknown classification",
+      classification,
+      depositAddress: depositMessage.depositAddress,
+      paramsHash: depositMessage.paramsHash,
+      txHash: depositMessage.erc20Transfer.transactionHash,
+      chainId: depositMessage.erc20Transfer.chainId,
     });
   }
 
@@ -324,14 +292,39 @@ export class DepositAddressHandler {
    * deposit clone is not yet on-chain, so the bot does not need its own deploy step.
    */
   private async initiateWithdraw(depositMessage: DepositAddressMessage): Promise<void> {
-    const { erc20Transfer, depositAddress } = depositMessage;
-    const { transactionHash: refTxHash, contractAddress: token, amount, chainId: _chainId } = erc20Transfer;
+    const { erc20Transfer, depositAddress, paramsHash } = depositMessage;
+    const {
+      transactionHash: refTxHash,
+      contractAddress: token,
+      amount,
+      chainId: _chainId,
+      transferClassification: classification,
+    } = erc20Transfer;
     // Refund chain is where funds landed (NOT routeParams.originChainId — for mis_routes those differ).
     const chainId = Number(_chainId);
     const depositKey = getDepositKey(depositMessage);
 
+    // Drop refund-withdraws while the gate is closed. intent_refund in particular would re-loop the
+    // same intent if forwarded down the deposit path, so we cannot fall back to initiateDeposit.
+    if (!this.config.withdrawEnabled) {
+      this.logger.debug({
+        at: "DepositAddressHandler#initiateWithdraw",
+        message: "deposit-address transfer skipped: withdraw flow disabled",
+        classification,
+        depositAddress,
+        paramsHash,
+        txHash: refTxHash,
+        chainId: _chainId,
+      });
+      return;
+    }
+
+    if (!this.config.relayerOriginChains.includes(chainId)) {
+      return;
+    }
+
     // Skip if a previous instance (or this one) already executed this withdraw (persisted in Redis).
-    if (this.executedWithdrawDepositKeys.has(depositKey)) {
+    if (this.executedWithdrawKeys.has(depositKey)) {
       this.logger.debug({
         at: "DepositAddressHandler#initiateWithdraw",
         message: "Skipping already executed withdraw (found in Redis)",
@@ -429,8 +422,8 @@ export class DepositAddressHandler {
     }
 
     // Persist full set to Redis immediately so handover cannot miss this withdraw.
-    this.executedWithdrawDepositKeys.add(depositKey);
-    await this._persistWithdrawnDepositKeysRedis();
+    this.executedWithdrawKeys.add(depositKey);
+    await this._persistWithdrawnKeysRedis();
   }
 
   private async _getSignedWithdraw(
@@ -470,11 +463,11 @@ export class DepositAddressHandler {
   }
 
   /** Same pattern as `_persistExecutedDepositsRedis` but for refund-withdraw deposit keys. */
-  private async _persistWithdrawnDepositKeysRedis(): Promise<void> {
+  private async _persistWithdrawnKeysRedis(): Promise<void> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
     const { redisCache } = this;
-    const redisKey = this.getWithdrawnDepositKeysRedisKey();
-    await redisCache.set(redisKey, JSON.stringify([...this.executedWithdrawDepositKeys]));
+    const redisKey = this.getWithdrawnKeysRedisKey();
+    await redisCache.set(redisKey, JSON.stringify([...this.executedWithdrawKeys]));
   }
 
   private async initiateDeposit(depositMessage: DepositAddressMessage): Promise<void> {
@@ -488,6 +481,10 @@ export class DepositAddressHandler {
     const destinationChainId = Number(_destinationChainId);
     const inputAmount = toBN(_inputAmount);
     const depositKey = getDepositKey(depositMessage);
+
+    if (!this.config.relayerOriginChains.includes(originChainId)) {
+      return;
+    }
 
     // Skip if a previous instance (or this one) already executed this deposit (persisted in Redis).
     if (this.executedDepositTxHashes.has(refTxHash)) {

--- a/src/interfaces/DepositAddress.ts
+++ b/src/interfaces/DepositAddress.ts
@@ -18,6 +18,18 @@ export interface Erc20Transfer {
   transactionHash: string;
   transferClassification: DepositAddressTransferClassification;
 }
+
+export interface CounterfactualLeaf {
+  implementationAddress: string;
+  encodedParams: string;
+  leafHash: string;
+  merkleProof: string[];
+}
+
+export interface CounterfactualMaterials {
+  withdrawLeaf: CounterfactualLeaf;
+}
+
 export interface DepositAddressMessage {
   depositAddress: string;
   paramsHash: string;
@@ -26,6 +38,8 @@ export interface DepositAddressMessage {
   salt: string;
   counterfactualDepositContractAddress: string;
   counterfactualFactoryContractAddress: string;
+  adminWithdrawManagerContractAddress: string;
+  counterfactualMaterials: CounterfactualMaterials;
   shouldSponsorAccountCreation: boolean;
 }
 


### PR DESCRIPTION
1. Wires the bot's `mis_route` and `intent_refund` classifications to the new quote-api `/swap/counterfactual/sign-withdraw` endpoint. Refunds the full ERC-20 transfer amount to the leaf-pinned `refundAddress`; 
⚠️ gas-reserve / fee deduction is deferred to a follow-up, but should be added to this PR

- Extend DepositAddressMessage with adminWithdrawManagerContractAddress and counterfactualMaterials.withdrawLeaf
- Add _post to BaseAcrossApiClient and signedWithdraw to AcrossSwapApiClient.
- Replace initiateWithdraw stub: balance guard, in-flight + Redis dedup (mirrors initiateDeposit), and raw-tx broadcast of the quote-api response.