### PR TITLE
improve(EventUtils): Harden against chain quirks

### DIFF
--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -184,32 +184,16 @@ export class EventManager {
   }
 
   /**
-   * Produce a SHA256 hash representing an Ethers event, based on select input fields.
+   * Produce a SHA256 hash representing an Ethers event, based on its on-chain identity.
+   * `(blockHash, transactionHash, logIndex)` uniquely identifies a log on the canonical chain;
+   * blockNumber/transactionIndex are derivable, and args is omitted to avoid hash drift between
+   * ingestion paths that parse logs differently (e.g. viem vs ethers).
    * @param event An Ethers event to be hashed.
    * @returns A SHA256 string derived from the event.
    */
   hashEvent(event: Log): string {
-    const { event: eventName, blockNumber, blockHash, transactionHash, transactionIndex, logIndex, args } = event;
-    const _args = this.flattenObject(args);
-    const key = `${eventName}-${blockNumber}-${blockHash}-${transactionHash}-${transactionIndex}-${logIndex}-${_args}`;
+    const { event: eventName, blockHash, transactionHash, logIndex } = event;
+    const key = `${eventName}-${blockHash}-${transactionHash}-${logIndex}`;
     return ethersUtils.id(key);
-  }
-
-  /**
-   * Recurse through an object and sort its keys in order to produce an ordered string of values.
-   * @param obj Object to iterate through.
-   * @returns string A hyphenated string containing all arguments of the object, sorted by key.
-   */
-  private flattenObject(obj: Record<string, unknown>): string {
-    const args = Object.keys(obj)
-      .sort()
-      .map((k) => {
-        const val = obj[k];
-        // When val is a nested object, recursively flatten and stringify it.
-        return typeof val === "object" ? this.flattenObject(val as Record<string, unknown>) : val;
-      })
-      .join("-");
-
-    return args;
   }
 }

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -1,6 +1,5 @@
 import assert from "assert";
 import winston from "winston";
-import { utils as ethersUtils } from "ethers";
 import { Log as viemLog } from "viem";
 import { utils as sdkUtils } from "@across-protocol/sdk";
 import { Log } from "../interfaces";
@@ -84,7 +83,7 @@ type QuorumEvent = Log & { providers: string[] };
  */
 export class EventManager {
   public readonly chain: string;
-  public readonly events: { [eventHash: string]: QuorumEvent } = {};
+  public readonly events: { [eventKey: string]: QuorumEvent } = {};
   public readonly blockHashes: { [blockHash: string]: string[] } = {};
 
   constructor(
@@ -103,8 +102,8 @@ export class EventManager {
    * @param event Event to search for.
    * @returns The matching event, or undefined.
    */
-  findEvent(eventHash: string): QuorumEvent | undefined {
-    return this.events[eventHash];
+  findEvent(eventKey: string): QuorumEvent | undefined {
+    return this.events[eventKey];
   }
 
   /**
@@ -112,8 +111,8 @@ export class EventManager {
    * @param event A Log instance with appended provider information.
    * @returns The number of unique providers that reported this event.
    */
-  getEventQuorum(eventHash: string): number {
-    const storedEvent = this.findEvent(eventHash);
+  getEventQuorum(eventKey: string): number {
+    const storedEvent = this.findEvent(eventKey);
     return isDefined(storedEvent) ? dedupArray(storedEvent.providers).length : 0;
   }
 
@@ -122,10 +121,10 @@ export class EventManager {
    * @param event A Log instance with appended provider information.
    * @returns The number of unique providers that reported this event.
    */
-  protected _addEvent(eventHash: string, event: QuorumEvent): void {
-    this.events[eventHash] = event;
+  protected _addEvent(eventKey: string, event: QuorumEvent): void {
+    this.events[eventKey] = event;
     this.blockHashes[event.blockHash] ??= [];
-    this.blockHashes[event.blockHash].push(eventHash);
+    this.blockHashes[event.blockHash].push(eventKey);
   }
 
   /**
@@ -138,16 +137,16 @@ export class EventManager {
   add(event: Log, provider: string): boolean {
     assert(!event.removed);
 
-    const eventHash = this.hashEvent(event);
+    const eventKey = this.getEventKey(event);
 
-    // If `eventHash` is not recorded in `eventHashes` then it's presumed to be a new event. If it is
-    // already found in the `eventHashes` array, then at least one provider has already supplied it.
-    const storedEvent = this.findEvent(eventHash);
+    // If `eventKey` is not recorded then it's presumed to be a new event. If it is already found,
+    // then at least one provider has already supplied it.
+    const storedEvent = this.findEvent(eventKey);
 
     // Store or update the set of events for this block number.
     if (!isDefined(storedEvent)) {
       // Event hasn't been seen before, so store it.
-      this._addEvent(eventHash, { ...event, providers: [provider] });
+      this._addEvent(eventKey, { ...event, providers: [provider] });
       return this.quorum === 1;
     }
 
@@ -171,10 +170,10 @@ export class EventManager {
   remove(event: Log, provider: string): void {
     assert(event.removed);
 
-    const eventHashes = this.blockHashes[event.blockHash];
-    const nEvents = eventHashes.length;
+    const eventKeys = this.blockHashes[event.blockHash];
+    const nEvents = eventKeys.length;
     if (nEvents > 0) {
-      eventHashes.forEach((eventHash) => delete this.events[eventHash]);
+      eventKeys.forEach((eventKey) => delete this.events[eventKey]);
       this.logger.warn({
         at: "EventManager::remove",
         message: `Dropped ${nEvents} event(s) at ${this.chain} block ${event.blockNumber}.`,
@@ -183,17 +182,9 @@ export class EventManager {
     }
   }
 
-  /**
-   * Produce a SHA256 hash representing an Ethers event, based on its on-chain identity.
-   * `(blockHash, transactionHash, logIndex)` uniquely identifies a log on the canonical chain;
-   * blockNumber/transactionIndex are derivable, and args is omitted to avoid hash drift between
-   * ingestion paths that parse logs differently (e.g. viem vs ethers).
-   * @param event An Ethers event to be hashed.
-   * @returns A SHA256 string derived from the event.
-   */
-  hashEvent(event: Log): string {
+  // Key on canonical on-chain identity; avoids drift between viem/ethers parsings of the same log.
+  getEventKey(event: Log): string {
     const { event: eventName, blockHash, transactionHash, logIndex } = event;
-    const key = `${eventName}-${blockHash}-${transactionHash}-${logIndex}`;
-    return ethersUtils.id(key);
+    return `${eventName}-${blockHash}-${transactionHash}-${logIndex}`;
   }
 }

--- a/test/EventManager.ts
+++ b/test/EventManager.ts
@@ -27,7 +27,7 @@ describe("EventManager: Event Handling ", function () {
     blockHash: makeHash(),
     event: "randomEvent",
   };
-  let eventHash: string;
+  let eventKey: string;
 
   let logger: winston.Logger;
   let eventMgr: EventManager;
@@ -37,23 +37,23 @@ describe("EventManager: Event Handling ", function () {
     ({ spyLogger: logger } = createSpyLogger());
     quorum = 2;
     eventMgr = new EventManager(logger, chainId, quorum);
-    eventHash = eventMgr.hashEvent(eventTemplate);
+    eventKey = eventMgr.getEventKey(eventTemplate);
   });
 
   it("Correctly applies quorum on added events", async function () {
     providers.forEach((provider, idx) => {
       // Verify initial quorum.
-      let eventQuorum = eventMgr.getEventQuorum(eventHash);
+      let eventQuorum = eventMgr.getEventQuorum(eventKey);
       expect(eventQuorum).to.equal(idx);
 
       // Add the event from the current provider and verify that quorum updates.
       eventMgr.add(eventTemplate, provider);
-      eventQuorum = eventMgr.getEventQuorum(eventHash);
+      eventQuorum = eventMgr.getEventQuorum(eventKey);
       expect(eventQuorum).to.equal(idx + 1);
 
       // Try re-adding the same event from the same provider => shouldn't affect quorum.
       eventMgr.add(eventTemplate, provider);
-      eventQuorum = eventMgr.getEventQuorum(eventHash);
+      eventQuorum = eventMgr.getEventQuorum(eventKey);
       expect(eventQuorum).to.equal(idx + 1);
     });
   });
@@ -84,23 +84,23 @@ describe("EventManager: Event Handling ", function () {
     let metQuorum = eventMgr.add(eventTemplate, provider1);
     expect(metQuorum).to.be.false;
 
-    let eventQuorum = eventMgr.getEventQuorum(eventHash);
+    let eventQuorum = eventMgr.getEventQuorum(eventKey);
     expect(eventQuorum).to.equal(1);
 
     // Remove the event after notification by the same provider.
     eventMgr.remove({ ...eventTemplate, removed }, provider1);
-    eventQuorum = eventMgr.getEventQuorum(eventHash);
+    eventQuorum = eventMgr.getEventQuorum(eventKey);
     expect(eventQuorum).to.equal(0);
 
     // Re-add the same event.
     metQuorum = eventMgr.add(eventTemplate, provider1);
     expect(metQuorum).to.be.false;
-    eventQuorum = eventMgr.getEventQuorum(eventHash);
+    eventQuorum = eventMgr.getEventQuorum(eventKey);
     expect(eventQuorum).to.equal(1);
 
     // Remove the event after notification by a different provider.
     eventMgr.remove({ ...eventTemplate, removed }, "randomProvider");
-    eventQuorum = eventMgr.getEventQuorum(eventHash);
+    eventQuorum = eventMgr.getEventQuorum(eventKey);
     expect(eventQuorum).to.equal(0);
 
     // Add the same event from provider2. There should be no quorum.
@@ -108,57 +108,18 @@ describe("EventManager: Event Handling ", function () {
     expect(eventQuorum).to.equal(0);
   });
 
-  it("Hashes events correctly: uniqueness", async function () {
+  it("Keys events correctly: uniqueness", async function () {
     const log1 = eventTemplate;
-    const hash1 = eventMgr.hashEvent(log1);
-    expect(hash1).to.exist;
+    const key1 = eventMgr.getEventKey(log1);
+    expect(key1).to.exist;
 
     const log2 = { ...log1, logIndex: log1.logIndex + 1 };
-    const hash2 = eventMgr.hashEvent(log2);
-    expect(hash2).to.not.equal(hash1);
+    const key2 = eventMgr.getEventKey(log2);
+    expect(key2).to.not.equal(key1);
 
     const log3 = { ...log2, logIndex: log2.logIndex - 1 };
-    const hash3 = eventMgr.hashEvent(log3);
-    expect(hash3).to.equal(hash1);
-  });
-
-  it("Hashes events correctly: sorting", async function () {
-    const log = {
-      ...eventTemplate,
-      args: {
-        c: 3,
-        b: 2,
-        f: {
-          h: 7,
-          i: 8,
-          g: 6,
-        },
-        a: 1,
-        d: 4,
-        e: 5,
-      },
-    };
-    const sortedLog = {
-      ...log,
-      args: {
-        a: 1,
-        b: 2,
-        c: 3,
-        d: 4,
-        e: 5,
-        f: {
-          g: 6,
-          h: 7,
-          i: 8,
-        },
-      },
-    };
-
-    const hash1 = eventMgr.hashEvent(log);
-    expect(hash1).to.exist;
-
-    const hash2 = eventMgr.hashEvent(sortedLog);
-    expect(hash2).to.equal(hash1);
+    const key3 = eventMgr.getEventKey(log3);
+    expect(key3).to.equal(key1);
   });
 
   it("Does not submit duplicate events", async function () {

--- a/test/RelayerSpokePoolListenerTVM.ts
+++ b/test/RelayerSpokePoolListenerTVM.ts
@@ -81,7 +81,7 @@ describe("RelayerSpokePoolListenerTVM: processBlock re-org detection", function 
     const { orphans } = processBlock(makeBlock(102, makeHash(), makeHash()), blocks, eventMgr, chain, provider, logger);
 
     expect(orphans).to.be.empty;
-    expect(eventMgr.findEvent(eventMgr.hashEvent(event100))).to.exist;
+    expect(eventMgr.findEvent(eventMgr.getEventKey(event100))).to.exist;
   });
 
   it("Parent-hash mismatch ejects orphaned events", function () {
@@ -99,7 +99,7 @@ describe("RelayerSpokePoolListenerTVM: processBlock re-org detection", function 
 
     expect(orphans).to.have.lengthOf(1);
     expect(orphans[0].blockNumber).to.equal(101);
-    expect(eventMgr.findEvent(eventMgr.hashEvent(event101))).to.not.exist;
+    expect(eventMgr.findEvent(eventMgr.getEventKey(event101))).to.not.exist;
     expect(blocks.has(101n)).to.be.false;
     expect(blocks.has(102n)).to.be.true;
   });


### PR DESCRIPTION
HyperEVM often throws up "duplicate" events because different RPCs disagree about transactionIndex due to the inclusion (or not) of system transactions.

Consolidate on the minimal set of unique constraints that are required to detect uniqueness. This should reduce the noise from duplicate events.

While here, drop the hashing of the eventKey - it's redundant.