### PR TITLE
feat: Transaction manager for centralised txn submission

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,7 @@ import { runHyperliquidExecutor, runHyperliquidFinalizer } from "./src/hyperliqu
 import { runCumulativeBalanceRebalancer as swapRebalancer } from "./src/rebalancer";
 import { runGaslessRelayer } from "./src/gasless";
 import { runDepositAddressHandler } from "./src/deposit-address";
+import { runTransactionManager } from "./src/transactionManager";
 
 let logger: typeof Logger;
 let cmd: string | undefined;
@@ -40,6 +41,7 @@ const CMDS = {
   swapRebalancer: swapRebalancer,
   gaslessRelayer: runGaslessRelayer,
   depositAddressHandler: runDepositAddressHandler,
+  transactionManager: runTransactionManager,
 };
 
 export async function run(args: { [k: string]: boolean | string }): Promise<void> {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "run-inventoryManager-swapper": "node ./dist/index.js --swapRebalancer",
     "run-gaslessRelayer": "node ./dist/index.js --gaslessRelayer",
     "run-depositAddressHandler": "node ./dist/index.js --depositAddressHandler",
+    "run-transactionManager": "node ./dist/index.js --transactionManager",
     "relay": "node ./dist/index.js --relayer",
     "refill-usdc": "node ./dist/scripts/refillUsdcToSpecificChain.js",
     "update-inventory-config": "node ./dist/scripts/fetchInventoryConfig.js",

--- a/scripts/inspectTxnPubsub.ts
+++ b/scripts/inspectTxnPubsub.ts
@@ -1,0 +1,105 @@
+/*
+Live tail of TransactionManager request/response Pub/Sub traffic.
+
+Usage:
+  yarn ts-node ./scripts/inspectTxnPubsub.ts --chain 11155111
+  yarn ts-node ./scripts/inspectTxnPubsub.ts --chain 11155111 --id req-abc
+  yarn ts-node ./scripts/inspectTxnPubsub.ts --chain 11155111 --failures-only
+
+Args:
+  --chain <id>          required
+  --id <reqId>          filter to a specific correlation id
+  --failures-only       filter to ok:false messages (responses only)
+  --url <url>           redis URL (default REDIS_URL)
+*/
+
+import minimist from "minimist";
+import winston from "winston";
+import { connectRedisClient, disconnectRedisClient } from "../src/utils/Redis";
+import { decodeRequest, decodeResponse } from "../src/transactionManager/wire";
+
+interface CliArgs {
+  chain: number;
+  id?: string;
+  failuresOnly: boolean;
+  url: string | undefined;
+}
+
+const logger = winston.createLogger({
+  level: "info",
+  transports: [new winston.transports.Console({ format: winston.format.simple() })],
+});
+
+function parseArgs(): CliArgs {
+  const argv = minimist(process.argv.slice(2), {
+    string: ["url", "id"],
+    boolean: ["failures-only"],
+  });
+  if (!argv.chain) {
+    throw new Error("--chain is required");
+  }
+  return {
+    chain: Number(argv.chain),
+    id: typeof argv.id === "string" ? argv.id : undefined,
+    failuresOnly: Boolean(argv["failures-only"]),
+    url: typeof argv.url === "string" ? argv.url : undefined,
+  };
+}
+
+function isRequestChannel(channel: string): boolean {
+  return channel.startsWith("txn:requests:");
+}
+
+function render(channel: string, raw: string, args: CliArgs): void {
+  try {
+    const payload = isRequestChannel(channel) ? decodeRequest(raw) : decodeResponse(raw);
+    if (args.id !== undefined && payload.id !== args.id) {
+      return;
+    }
+    if (args.failuresOnly && (payload as { ok?: boolean }).ok !== false) {
+      return;
+    }
+    process.stdout.write(`\n[${channel}]\n${JSON.stringify(payload, null, 2)}\n`);
+  } catch (err) {
+    logger.warn({
+      at: "inspect",
+      message: "decode failed",
+      channel,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  const client = await connectRedisClient(logger, args.url);
+
+  const reqPattern = `txn:requests:${args.chain}:*`;
+  const respPattern = `txn:responses:${args.chain}:*`;
+  logger.info({ at: "inspect", message: "subscribing", patterns: [reqPattern, respPattern] });
+
+  const listener = (msg: string, channel: string): void => render(channel, msg, args);
+  await client.pSubscribe(reqPattern, listener);
+  await client.pSubscribe(respPattern, listener);
+
+  let stop = false;
+  const onSignal = (): void => {
+    stop = true;
+  };
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+
+  while (!stop) {
+    await new Promise((r) => setTimeout(r, 250));
+  }
+
+  await client.pUnsubscribe(reqPattern, listener);
+  await client.pUnsubscribe(respPattern, listener);
+  await disconnectRedisClient(client, logger);
+  logger.info({ at: "inspect", message: "stopped" });
+}
+
+void main().catch((err) => {
+  logger.error({ at: "inspect", message: "fatal", error: err instanceof Error ? err.stack : String(err) });
+  process.exit(1);
+});

--- a/scripts/testTxnManager.sh
+++ b/scripts/testTxnManager.sh
@@ -1,0 +1,189 @@
+#!/bin/sh
+# Helper for running TransactionManager broker tests.
+# Run each subcommand in its own terminal.
+#
+# Usage:
+#   scripts/testTxnManager.sh manager          # start the TransactionManager
+#   scripts/testTxnManager.sh parallel [N]     # fire N parallel submits (default 5)
+#   scripts/testTxnManager.sh multi [W] [C]    # spawn W concurrent caller processes,
+#                                              # each firing C parallel submits (default 3 3)
+#   scripts/testTxnManager.sh single           # one submit + await receipt
+#   scripts/testTxnManager.sh inspect          # tail request/response Pub/Sub traffic
+#   scripts/testTxnManager.sh handover         # start manager A, then B; observe A's
+#                                              # renewal detect displacement and drain
+#   scripts/testTxnManager.sh handover-load [N] # same, but with N parallel submits
+#                                              # running across the handover (default 10)
+#
+# Override defaults via env if needed:
+#   CHAIN_ID, TOKEN, RECIPIENT, WALLET
+
+set -e
+
+CHAIN_ID="${CHAIN_ID:-11155111}"
+TOKEN="${TOKEN:-0x49fCaC04AE71dbD074304Fb12071bD771e0E927A}"
+RECIPIENT="${RECIPIENT:-0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D}"
+WALLET="${WALLET:-secret}"
+
+cmd="${1:-}"
+
+case "$cmd" in
+  manager)
+    TXN_MANAGER_CHAIN_ID="$CHAIN_ID" \
+      yarn ts-node ./index.ts --transactionManager --wallet="$WALLET"
+    ;;
+  parallel)
+    count="${2:-5}"
+    TRANSACTION_CLIENT_BROADCAST=redis \
+      yarn ts-node ./scripts/testTxnManagerParallel.ts \
+        --chainId "$CHAIN_ID" \
+        --token "$TOKEN" \
+        --to "$RECIPIENT" \
+        --count "$count" \
+        --wallet="$WALLET"
+    ;;
+  multi)
+    workers="${2:-3}"
+    count="${3:-3}"
+    echo "Spawning $workers concurrent callers, each firing $count submits ($((workers * count)) total)" >&2
+    start=$(date +%s)
+    i=1
+    while [ "$i" -le "$workers" ]; do
+      (
+        TRANSACTION_CLIENT_BROADCAST=redis \
+          yarn ts-node ./scripts/testTxnManagerParallel.ts \
+            --chainId "$CHAIN_ID" \
+            --token "$TOKEN" \
+            --to "$RECIPIENT" \
+            --count "$count" \
+            --wallet="$WALLET" 2>&1 | sed "s/^/[w$i] /"
+      ) &
+      i=$((i + 1))
+    done
+    wait
+    echo "All $workers workers settled in $(( $(date +%s) - start ))s" >&2
+    ;;
+  single)
+    TRANSACTION_CLIENT_BROADCAST=redis \
+      yarn ts-node ./scripts/testTxnManagerErc20.ts \
+        --chainId "$CHAIN_ID" \
+        --token "$TOKEN" \
+        --amount 0 \
+        --to "$RECIPIENT" \
+        --wait \
+        --wallet="$WALLET"
+    ;;
+  inspect)
+    yarn ts-node ./scripts/inspectTxnPubsub.ts --chain "$CHAIN_ID"
+    ;;
+  handover)
+    # Demonstrate the InstanceCoordinator-driven handover: A claims the lease,
+    # B starts later and overwrites it, A's next renewal observes the change
+    # and aborts (drain + exit). Bounded by leaseRenewIntervalSec (~20s).
+    echo "Starting manager A in background..."
+    TXN_MANAGER_CHAIN_ID="$CHAIN_ID" \
+      yarn ts-node ./index.ts --transactionManager --wallet="$WALLET" 2>&1 | sed "s/^/[A] /" &
+    a_pid=$!
+
+    sleep 5
+
+    echo "Starting manager B in background; A should detect and drain within ~20s..."
+    TXN_MANAGER_CHAIN_ID="$CHAIN_ID" \
+      yarn ts-node ./index.ts --transactionManager --wallet="$WALLET" 2>&1 | sed "s/^/[B] /" &
+    b_pid=$!
+
+    # A is expected to exit on its own when displaced. Wait for it with a cap.
+    echo "Waiting up to 60s for A to exit..."
+    waited=0
+    while kill -0 "$a_pid" 2>/dev/null && [ "$waited" -lt 60 ]; do
+      sleep 1
+      waited=$((waited + 1))
+    done
+    if kill -0 "$a_pid" 2>/dev/null; then
+      echo "A did not exit within 60s; killing." >&2
+      kill "$a_pid" 2>/dev/null
+      wait "$a_pid" 2>/dev/null
+      echo "Handover did NOT complete as expected." >&2
+      kill "$b_pid" 2>/dev/null
+      wait "$b_pid" 2>/dev/null
+      exit 1
+    fi
+    echo "A exited after ${waited}s. Stopping B." >&2
+    kill "$b_pid" 2>/dev/null
+    wait "$b_pid" 2>/dev/null
+    ;;
+  handover-load)
+    # Handover while a caller is submitting concurrently. Sequence:
+    #   t=0:  start manager A; A claims lease.
+    #   t=5:  start parallel caller (N submits).
+    #   t=7:  start manager B; B overwrites the lease.
+    #   A's renewal task detects displacement within ~20s and drains.
+    #   Caller may see brief overlap (both A and B receiving requests) —
+    #   TransactionClient's REPLACEMENT_UNDERPRICED retry resolves nonce races.
+    count="${2:-10}"
+
+    echo "Starting manager A..."
+    TXN_MANAGER_CHAIN_ID="$CHAIN_ID" \
+      yarn ts-node ./index.ts --transactionManager --wallet="$WALLET" 2>&1 | sed "s/^/[A] /" &
+    a_pid=$!
+    sleep 5
+
+    echo "Starting parallel caller ($count submits)..."
+    TRANSACTION_CLIENT_BROADCAST=redis \
+      yarn ts-node ./scripts/testTxnManagerParallel.ts \
+        --chainId "$CHAIN_ID" \
+        --token "$TOKEN" \
+        --to "$RECIPIENT" \
+        --count "$count" \
+        --wallet="$WALLET" 2>&1 | sed "s/^/[caller] /" &
+    caller_pid=$!
+    sleep 2
+
+    echo "Starting manager B (handover trigger)..."
+    TXN_MANAGER_CHAIN_ID="$CHAIN_ID" \
+      yarn ts-node ./index.ts --transactionManager --wallet="$WALLET" 2>&1 | sed "s/^/[B] /" &
+    b_pid=$!
+
+    echo "Waiting up to 90s for A to exit..."
+    waited=0
+    while kill -0 "$a_pid" 2>/dev/null && [ "$waited" -lt 90 ]; do
+      sleep 1
+      waited=$((waited + 1))
+    done
+    if kill -0 "$a_pid" 2>/dev/null; then
+      echo "A did not exit within 90s; killing." >&2
+      kill "$a_pid" 2>/dev/null
+      wait "$a_pid" 2>/dev/null
+    else
+      echo "A exited after ${waited}s." >&2
+    fi
+
+    echo "Waiting up to 90s for caller to settle..."
+    caller_waited=0
+    while kill -0 "$caller_pid" 2>/dev/null && [ "$caller_waited" -lt 90 ]; do
+      sleep 1
+      caller_waited=$((caller_waited + 1))
+    done
+    if kill -0 "$caller_pid" 2>/dev/null; then
+      echo "Caller did not settle within 90s; killing." >&2
+      kill "$caller_pid" 2>/dev/null
+      wait "$caller_pid" 2>/dev/null
+      caller_exit=124
+    else
+      wait "$caller_pid"
+      caller_exit=$?
+      echo "Caller exited after ${caller_waited}s (status=$caller_exit)." >&2
+    fi
+    echo "Stopping B." >&2
+    # Kill the pipeline's sed AND the underlying manager process. $b_pid is sed
+    # in a piped background job; the yarn/ts-node process keeps running unless
+    # signalled directly. Match by chain + flag to avoid touching other bots.
+    kill "$b_pid" 2>/dev/null
+    pkill -TERM -f "ts-node ./index.ts --transactionManager" 2>/dev/null || true
+    wait "$b_pid" 2>/dev/null
+    exit "$caller_exit"
+    ;;
+  *)
+    echo "Usage: $0 {manager|parallel [N]|multi [W] [C]|single|inspect|handover|handover-load [N]}" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/testTxnManagerErc20.ts
+++ b/scripts/testTxnManagerErc20.ts
@@ -1,0 +1,150 @@
+/*
+End-to-end test of the TransactionManager broker loop with an ERC20.transfer.
+Acts as a minimal caller bot that submits via redis instead of direct RPC.
+
+Setup (two terminals + redis):
+
+  # 1. Redis (e.g. docker run -p 6379:6379 redis)
+
+  # 2. Manager — owns the wallet, listens on txn:requests:<chainId>:<eoa>
+  TXN_MANAGER_CHAIN_ID=11155111 \
+    yarn ts-node ./index.ts --transactionManager --wallet=secret
+
+  # 3. This script — same wallet (so the EOA matches), submits via redis
+  TRANSACTION_CLIENT_BROADCAST=redis \
+    yarn ts-node ./scripts/testTxnManagerErc20.ts \
+      --chainId 11155111 \
+      --token 0x... \
+      --to 0x... \
+      --amount 1000000 \
+      --wait \
+      --wallet=secret
+
+  # Optional: tail traffic in a 4th terminal
+  yarn ts-node ./scripts/inspectTxnStream.ts --chain 11155111 --requests --responses
+
+Notes:
+- The shim and manager must use the SAME wallet (same EOA), since the
+  request stream is keyed by the caller's `txn.contract.signer` EOA and the
+  manager only listens on its own EOA's stream.
+- The caller-side broadcast mode is forced via TRANSACTION_CLIENT_BROADCAST=redis;
+  the script doesn't read CommonConfig.
+*/
+
+import minimist from "minimist";
+import winston from "winston";
+import { ERC20, ethers, getProvider, retrieveSignerFromCLIArgs, toBN } from "../src/utils";
+import {
+  AugmentedTransaction,
+  TransactionClient,
+  initTransactionBackend,
+  disposeTransactionBackend,
+} from "../src/clients/TransactionClient";
+
+const logger = winston.createLogger({
+  level: "debug",
+  transports: [new winston.transports.Console({ format: winston.format.simple() })],
+});
+
+interface CliArgs {
+  chainId: number;
+  token: string;
+  to: string;
+  amount: string;
+  wait: boolean;
+}
+
+function parseArgs(): CliArgs {
+  const argv = minimist(process.argv.slice(2), {
+    string: ["chainId", "token", "to", "amount"],
+    boolean: ["wait"],
+  });
+  for (const k of ["chainId", "token", "to", "amount"]) {
+    if (!argv[k]) {
+      throw new Error(`--${k} is required`);
+    }
+  }
+  if (!ethers.utils.isAddress(argv.token)) {
+    throw new Error(`Invalid --token: ${argv.token}`);
+  }
+  if (!ethers.utils.isAddress(argv.to)) {
+    throw new Error(`Invalid --to: ${argv.to}`);
+  }
+  return {
+    chainId: Number(argv.chainId),
+    token: argv.token,
+    to: argv.to,
+    amount: argv.amount,
+    wait: Boolean(argv.wait),
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+
+  const baseSigner = await retrieveSignerFromCLIArgs();
+  const eoa = await baseSigner.getAddress();
+  const provider = await getProvider(args.chainId);
+  const signer = baseSigner.connect(provider);
+  logger.info({ at: "test", message: "wallet connected", eoa, chainId: args.chainId });
+
+  const callerId = `test-caller-${Date.now()}`;
+  await initTransactionBackend(logger, "redis", callerId);
+  const txnClient = new TransactionClient(logger);
+
+  const erc20 = new ethers.Contract(args.token, ERC20.abi, signer);
+  const [decimals, symbol] = await Promise.all([erc20.decimals(), erc20.symbol()]);
+  const human = ethers.utils.formatUnits(args.amount, decimals);
+  logger.info({
+    at: "test",
+    message: `Submitting transfer of ${human} ${symbol} → ${args.to}`,
+    token: args.token,
+    callerId,
+  });
+
+  const augTxn: AugmentedTransaction = {
+    contract: erc20,
+    chainId: args.chainId,
+    method: "transfer",
+    args: [args.to, toBN(args.amount)],
+    message: `test-erc20-transfer ${human} ${symbol}`,
+    mrkdwn: `transfer ${human} ${symbol} → ${args.to}`,
+  };
+
+  const t0 = Date.now();
+  const responses = await txnClient.submit(args.chainId, [augTxn]);
+  if (responses.length === 0) {
+    throw new Error("submit() returned no responses — see preceding log for the underlying failure.");
+  }
+  const [response] = responses;
+  logger.info({
+    at: "test",
+    message: "ACK received",
+    hash: response.hash,
+    nonce: response.nonce,
+    elapsedMs: Date.now() - t0,
+  });
+
+  if (args.wait) {
+    const tWait = Date.now();
+    const receipt = await response.wait();
+    logger.info({
+      at: "test",
+      message: "final received",
+      hash: receipt.transactionHash,
+      blockNumber: receipt.blockNumber,
+      status: receipt.status,
+      gasUsed: receipt.gasUsed.toString(),
+      confirmationMs: Date.now() - tWait,
+    });
+  }
+
+  await disposeTransactionBackend();
+}
+
+void main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    logger.error({ at: "test", message: "fatal", error: err instanceof Error ? err.stack : String(err) });
+    process.exit(1);
+  });

--- a/scripts/testTxnManagerParallel.ts
+++ b/scripts/testTxnManagerParallel.ts
@@ -1,0 +1,197 @@
+/*
+Parallel-broadcast test of the TransactionManager loop. Fires N submits via
+Promise.all and validates that the manager processes them in stream order with
+consecutive nonces.
+
+Setup mirrors testTxnManagerErc20:
+
+  TXN_MANAGER_CHAIN_ID=11155111 yarn ts-node ./index.ts --transactionManager --wallet=secret
+
+  TRANSACTION_CLIENT_BROADCAST=redis \
+    yarn ts-node ./scripts/testTxnManagerParallel.ts \
+      --chainId 11155111 \
+      --token 0x... \
+      --to 0x... \
+      --count 5 \
+      --wallet=secret
+
+The script intentionally uses amount=0 so balance isn't a constraint.
+
+What it asserts:
+- All N submits resolve (no failures).
+- Hashes are unique.
+- Nonces are consecutive (manager's _runTransaction nonceBySigner state).
+- Optionally `--wait` to also confirm each receipt.
+*/
+
+import minimist from "minimist";
+import winston from "winston";
+import { ERC20, ethers, getProvider, retrieveSignerFromCLIArgs } from "../src/utils";
+import {
+  AugmentedTransaction,
+  TransactionClient,
+  initTransactionBackend,
+  disposeTransactionBackend,
+} from "../src/clients/TransactionClient";
+
+const logger = winston.createLogger({
+  level: "info",
+  transports: [new winston.transports.Console({ format: winston.format.simple() })],
+});
+
+interface CliArgs {
+  chainId: number;
+  token: string;
+  to: string;
+  count: number;
+  wait: boolean;
+}
+
+function parseArgs(): CliArgs {
+  const argv = minimist(process.argv.slice(2), {
+    string: ["chainId", "token", "to", "count"],
+    boolean: ["wait"],
+    default: { count: "3" },
+  });
+  for (const k of ["chainId", "token", "to"]) {
+    if (!argv[k]) {
+      throw new Error(`--${k} is required`);
+    }
+  }
+  if (!ethers.utils.isAddress(argv.token)) {
+    throw new Error(`Invalid --token: ${argv.token}`);
+  }
+  if (!ethers.utils.isAddress(argv.to)) {
+    throw new Error(`Invalid --to: ${argv.to}`);
+  }
+  const count = Number(argv.count);
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new Error(`Invalid --count: ${argv.count}`);
+  }
+  return {
+    chainId: Number(argv.chainId),
+    token: argv.token,
+    to: argv.to,
+    count,
+    wait: Boolean(argv.wait),
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+
+  const baseSigner = await retrieveSignerFromCLIArgs();
+  const eoa = await baseSigner.getAddress();
+  const provider = await getProvider(args.chainId);
+  const signer = baseSigner.connect(provider);
+  logger.info({ at: "test", message: "wallet connected", eoa, chainId: args.chainId, count: args.count });
+
+  const callerId = `test-parallel-${Date.now()}`;
+  await initTransactionBackend(logger, "redis", callerId);
+  const txnClient = new TransactionClient(logger);
+
+  const erc20 = new ethers.Contract(args.token, ERC20.abi, signer);
+  const symbol = await erc20.symbol();
+
+  // Build N independent AugmentedTransactions. Each transfers 0 tokens, so
+  // balance isn't a constraint — only nonce ordering.
+  const augTxns: AugmentedTransaction[] = Array.from({ length: args.count }, (_, idx) => ({
+    contract: erc20,
+    chainId: args.chainId,
+    method: "transfer",
+    args: [args.to, ethers.BigNumber.from(0)],
+    message: `parallel-test-${idx + 1}`,
+  }));
+
+  logger.info({ at: "test", message: `Firing ${args.count} parallel submits…`, symbol });
+
+  // Track per-submit completion so a hang shows which ones are still pending.
+  const pending = new Set<number>(augTxns.map((_, idx) => idx + 1));
+  const watchdog = setInterval(() => {
+    if (pending.size > 0) {
+      logger.warn({ at: "test", message: "Still awaiting ACK", pending: [...pending] });
+    }
+  }, 10_000);
+
+  const t0 = Date.now();
+  const results = await Promise.all(
+    augTxns.map(async (txn, idx) => {
+      const tStart = Date.now();
+      try {
+        const [response] = await txnClient.submit(args.chainId, [txn]);
+        pending.delete(idx + 1);
+        return { idx: idx + 1, hash: response.hash, nonce: response.nonce, ackMs: Date.now() - tStart, response };
+      } catch (err) {
+        pending.delete(idx + 1);
+        logger.error({
+          at: "test",
+          message: "submit() rejected",
+          idx: idx + 1,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
+      }
+    })
+  );
+  clearInterval(watchdog);
+
+  const totalMs = Date.now() - t0;
+  for (const r of results) {
+    logger.info({ at: "test", message: "ACK", idx: r.idx, nonce: r.nonce, hash: r.hash, ackMs: r.ackMs });
+  }
+
+  // ---- assertions ----
+  const sorted = [...results].sort((a, b) => a.nonce - b.nonce);
+  const baseNonce = sorted[0].nonce;
+  const expectedNonces = sorted.map((_, i) => baseNonce + i);
+  const actualNonces = sorted.map((r) => r.nonce);
+  const consecutive = expectedNonces.every((n, i) => n === actualNonces[i]);
+  const hashes = new Set(results.map((r) => r.hash));
+  const uniqueHashes = hashes.size === results.length;
+
+  logger.info({
+    at: "test",
+    message: "results",
+    totalMs,
+    baseNonce,
+    nonces: actualNonces,
+    consecutive,
+    uniqueHashes,
+  });
+
+  if (!consecutive) {
+    throw new Error(`Non-consecutive nonces: ${JSON.stringify(actualNonces)}`);
+  }
+  if (!uniqueHashes) {
+    throw new Error(`Duplicate hashes among ${results.length} results`);
+  }
+
+  if (args.wait) {
+    const tWait = Date.now();
+    const receipts = await Promise.all(
+      results.map(async (r) => {
+        const receipt = await r.response.wait();
+        return {
+          idx: r.idx,
+          nonce: r.nonce,
+          hash: receipt.transactionHash,
+          blockNumber: receipt.blockNumber,
+          status: receipt.status,
+        };
+      })
+    );
+    for (const r of receipts) {
+      logger.info({ at: "test", message: "final", ...r });
+    }
+    logger.info({ at: "test", message: "all confirmed", confirmationMs: Date.now() - tWait });
+  }
+
+  await disposeTransactionBackend();
+}
+
+void main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    logger.error({ at: "test", message: "fatal", error: err instanceof Error ? err.stack : String(err) });
+    process.exit(1);
+  });

--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -30,6 +30,17 @@ import {
 } from "../utils";
 import { DEFAULT_GAS_FEE_SCALERS } from "../common";
 import { FeeData } from "@ethersproject/abstract-provider";
+import { Backend, broadcastMode, sharedBackend } from "./transactionBackend";
+
+export {
+  Backend,
+  BackendOptions,
+  BackendPubSub,
+  initTransactionBackend,
+  disposeTransactionBackend,
+  requestTopic,
+  responseTopic,
+} from "./transactionBackend";
 
 // Empirically, a max fee scaler of ~5% can result in successful transaction replacement.
 // Stuck transactions are very disruptive, so go for 10% to avoid the hassle.
@@ -88,11 +99,19 @@ export class TransactionClient {
 
   protected readonly DEFAULT_GAS_LIMIT_MULTIPLIER = 1.0;
 
-  // eslint-disable-next-line no-useless-constructor
+  // Per-instance backend override; falls back to the process-level
+  // module-level shared backend if not set. Useful for tests.
+  private backend?: Backend;
+
   constructor(
     readonly logger: winston.Logger,
-    readonly signers: Signer[] = []
+    readonly signers: Signer[] = [],
+    private readonly broadcast: "rpc" | "redis" = broadcastMode()
   ) {}
+
+  setBackend(backend: Backend): void {
+    this.backend = backend;
+  }
 
   protected _simulate(txn: AugmentedTransaction): Promise<TransactionSimulationResult> {
     return willSucceed(txn);
@@ -184,6 +203,10 @@ export class TransactionClient {
   }
 
   async submit(chainId: number, txns: AugmentedTransaction[]): Promise<TransactionResponse[]> {
+    if (this.broadcast === "redis") {
+      return this._submitViaRedis(chainId, txns);
+    }
+
     const networkName = getNetworkName(chainId);
     const txnResponses: TransactionResponse[] = [];
 
@@ -251,6 +274,75 @@ export class TransactionClient {
     this.logger.info({
       at: "TransactionClient#submit",
       message: `Completed ${networkName} transaction submission! 🧙`,
+      mrkdwn,
+    });
+
+    return txnResponses;
+  }
+
+  // Submit via the configured Backend. Mirrors the per-txn loop and
+  // partial-return-on-failure semantics of the direct-RPC path above, but
+  // delegates the actual submission to the backend (which handles wire
+  // serialisation, ACK/final correlation, and synthesised TransactionResponse
+  // construction). Nonce tracking lives in the manager and is therefore
+  // absent here.
+  private async _submitViaRedis(chainId: number, txns: AugmentedTransaction[]): Promise<TransactionResponse[]> {
+    const backend = this.backend ?? sharedBackend();
+    if (!isDefined(backend)) {
+      throw new Error(
+        "TransactionClient is in redis broadcast mode but no Backend has been configured. " +
+          "Call initTransactionBackend() at bot startup, or setBackend() per-instance."
+      );
+    }
+    const networkName = getNetworkName(chainId);
+    const txnResponses: TransactionResponse[] = [];
+
+    this.logger.debug({
+      at: "TransactionClient#submit",
+      message: `Processing ${txns.length} transactions via redis.`,
+    });
+
+    let mrkdwn = "";
+    for (let idx = 0; idx < txns.length; ++idx) {
+      let txn = txns[idx];
+      if (txn.chainId !== chainId) {
+        throw new Error(`chainId mismatch for method ${txn.method} (${txn.chainId} !== ${chainId})`);
+      }
+
+      // Apply gasLimit multiplier client-side, matching direct-mode behaviour.
+      // The wire's `gasLimitMultiplier` field is informational; the manager
+      // applies it only if it estimates gas itself.
+      const gasLimitMultiplier = txn.gasLimitMultiplier ?? this.DEFAULT_GAS_LIMIT_MULTIPLIER;
+      if (gasLimitMultiplier > this.DEFAULT_GAS_LIMIT_MULTIPLIER) {
+        txn = {
+          ...txn,
+          gasLimit: txn.gasLimit?.mul(toBNWei(gasLimitMultiplier)).div(fixedPoint),
+        };
+      }
+
+      let response: TransactionResponse;
+      try {
+        response = await backend.submit(txn);
+      } catch (error) {
+        this.logger.info({
+          at: "TransactionClient#submitViaRedis",
+          message: `Transaction ${idx + 1} submission on ${networkName} failed.`,
+          mrkdwn,
+          errorMessage: isError(error) ? error.message : undefined,
+          error: stringifyThrownValue(error),
+          notificationPath: "across-error",
+        });
+        return txnResponses;
+      }
+
+      const blockExplorer = blockExplorerLink(response.hash, txn.chainId);
+      mrkdwn += `  ${idx + 1}. ${txn.message || "No message"} (${blockExplorer}): ${txn.mrkdwn || "No markdown"}\n`;
+      txnResponses.push(response);
+    }
+
+    this.logger.info({
+      at: "TransactionClient#submitViaRedis",
+      message: `Completed ${networkName} transaction submission via redis! 🧙`,
       mrkdwn,
     });
 

--- a/src/clients/transactionBackend.ts
+++ b/src/clients/transactionBackend.ts
@@ -1,0 +1,383 @@
+// Broker submission backend. Active when TRANSACTION_CLIENT_BROADCAST=redis.
+// Publishes SubmissionRequests to the per-EOA request topic, listens on the
+// per-EOA response topic for ack + final messages, dispatches them to pending
+// entries by request id, and synthesises an ethers TransactionResponse for
+// callers. Direct-RPC submission paths in TransactionClient are untouched.
+
+import { BigNumber, ethers } from "ethers";
+import { Log, TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
+import { randomUUID } from "crypto";
+import winston from "winston";
+import { isDefined } from "../utils";
+import { getRedisPubSub, RedisPubSub } from "../messaging/redis/PubSub";
+import {
+  AckMessage,
+  decodeResponse,
+  encodeRequest,
+  FinalMessage,
+  ResponseMessage,
+  SubmissionRequest,
+  TransactionReceiptLite,
+} from "../transactionManager/wire";
+import type { AugmentedTransaction } from "./TransactionClient";
+
+// Module-level state. Bot startup calls `initTransactionBackend` to populate.
+// `new TransactionClient(logger)` picks these up via accessors below.
+// Redis forbids PUBLISH on a connection in SUBSCRIBE state, so producer and
+// subscriber must own distinct sockets.
+let _broadcastMode: "rpc" | "redis" = "rpc";
+let _sharedBackend: Backend | undefined;
+let _sharedPublisher: RedisPubSub | undefined;
+let _sharedSubscriber: RedisPubSub | undefined;
+
+export function broadcastMode(): "rpc" | "redis" {
+  return _broadcastMode;
+}
+export function sharedBackend(): Backend | undefined {
+  return _sharedBackend;
+}
+
+export async function initTransactionBackend(
+  logger: winston.Logger,
+  broadcast: "rpc" | "redis",
+  callerId: string
+): Promise<void> {
+  _broadcastMode = broadcast;
+  if (broadcast !== "redis" || isDefined(_sharedBackend)) {
+    return;
+  }
+
+  const publisher = await getRedisPubSub(logger);
+  const subscriber = await getRedisPubSub(logger);
+  if (!isDefined(publisher) || !isDefined(subscriber)) {
+    return;
+  } // RELAYER_TEST or other opt-out
+  _sharedPublisher = publisher;
+  _sharedSubscriber = subscriber;
+  _sharedBackend = new Backend(publisher, subscriber, logger, { callerId });
+}
+
+export async function disposeTransactionBackend(): Promise<void> {
+  if (isDefined(_sharedBackend)) {
+    await _sharedBackend.disconnect();
+  }
+  await Promise.allSettled([_sharedPublisher?.disconnect(), _sharedSubscriber?.disconnect()]);
+  _sharedBackend = undefined;
+  _sharedPublisher = undefined;
+  _sharedSubscriber = undefined;
+  _broadcastMode = "rpc";
+}
+
+// Topic naming.
+const REQUEST_TOPIC_PREFIX = "txn:requests";
+const RESPONSE_TOPIC_PREFIX = "txn:responses";
+
+export function requestTopic(chainId: number, eoa: string): string {
+  return `${REQUEST_TOPIC_PREFIX}:${chainId}:${eoa.toLowerCase()}`;
+}
+
+export function responseTopic(chainId: number, eoa: string): string {
+  return `${RESPONSE_TOPIC_PREFIX}:${chainId}:${eoa.toLowerCase()}`;
+}
+
+function subscriptionKey(chainId: number, eoa: string): string {
+  return `${chainId}:${eoa.toLowerCase()}`;
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  // Default no-op assignments; the Promise executor runs synchronously and
+  // overwrites both before the constructor returns.
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (error: Error) => void = () => undefined;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+interface PendingEntry {
+  ack: Deferred<AckMessage>;
+  final: Deferred<FinalMessage>;
+  eoa: string;
+  to: string;
+  chainId: number;
+}
+
+type Listener = (payload: string, topic: string) => void;
+
+interface SubscriptionRecord {
+  topic: string;
+  listener: Listener;
+}
+
+export interface BackendOptions {
+  // Identifier surfaced in logs; helps disambiguate concurrent caller processes.
+  callerId: string;
+}
+
+// Minimum pubsub surface the Backend uses; satisfied by RedisPubSub and by
+// test in-memory stand-ins. Avoids coupling tests to the concrete Redis class.
+export interface BackendPubSub {
+  pub(topic: string, message: string): Promise<number>;
+  sub(topic: string, listener: (message: string, topic: string) => void): Promise<void>;
+  unsub(topic: string, listener: (message: string, topic: string) => void): Promise<void>;
+}
+
+/**
+ * Broker submission backend. Caller-facing return is a synthesised ethers
+ * `TransactionResponse` whose `.wait()` awaits the manager's final message —
+ * callers don't see the wire envelope, only the same handle shape as the
+ * direct-RPC path.
+ */
+export class Backend {
+  // Keyed by `<chainId>:<eoa>` — each pair subscribes once to its response topic.
+  private readonly subscribed = new Map<string, SubscriptionRecord>();
+  // Race-dedup for concurrent first submits on a new (chain, eoa).
+  private readonly subscribingPromises = new Map<string, Promise<void>>();
+  private readonly pending = new Map<string, PendingEntry>();
+  private readonly abortController = new AbortController();
+
+  constructor(
+    private readonly publisher: BackendPubSub,
+    private readonly subscriber: BackendPubSub,
+    private readonly logger: winston.Logger,
+    private readonly opts: BackendOptions
+  ) {}
+
+  async submit(txn: AugmentedTransaction): Promise<TransactionResponse> {
+    if (this.abortController.signal.aborted) {
+      throw new Error("Backend is closed");
+    }
+    const eoa = await txn.contract.signer.getAddress();
+    await this.ensureSubscription(txn.chainId, eoa);
+
+    const id = randomUUID();
+    const request = this.buildRequest(id, txn);
+
+    const ackD = deferred<AckMessage>();
+    const finalD = deferred<FinalMessage>();
+    this.pending.set(id, {
+      ack: ackD,
+      final: finalD,
+      eoa,
+      to: txn.contract.address,
+      chainId: txn.chainId,
+    });
+
+    try {
+      await this.publisher.pub(requestTopic(txn.chainId, eoa), encodeRequest(request));
+    } catch (err) {
+      this.pending.delete(id);
+      throw err;
+    }
+
+    const ack = await ackD.promise;
+    if (ack.ok === false) {
+      this.pending.delete(id);
+      throw new Error(`TransactionManager rejected request (${ack.reason}): ${ack.error}`);
+    }
+
+    return this.toResponse(ack, txn, eoa, finalD.promise);
+  }
+
+  async disconnect(): Promise<void> {
+    this.abortController.abort();
+    for (const { topic, listener } of this.subscribed.values()) {
+      await this.subscriber.unsub(topic, listener);
+    }
+    this.subscribed.clear();
+    this.subscribingPromises.clear();
+    const reason = new Error("Backend closed");
+    for (const entry of this.pending.values()) {
+      entry.ack.reject(reason);
+      entry.final.reject(reason);
+    }
+    this.pending.clear();
+  }
+
+  private async ensureSubscription(chainId: number, eoa: string): Promise<void> {
+    const key = subscriptionKey(chainId, eoa);
+    if (this.subscribed.has(key)) {
+      return;
+    }
+    let pending = this.subscribingPromises.get(key);
+    if (!pending) {
+      pending = (async () => {
+        const topic = responseTopic(chainId, eoa);
+        const listener: Listener = (payload) => {
+          if (this.abortController.signal.aborted) {
+            return;
+          }
+          try {
+            this.handleResponse(decodeResponse(payload));
+          } catch (err) {
+            this.logger.warn({
+              at: "Backend#listener",
+              message: "Decode failed",
+              chainId,
+              eoa,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        };
+        await this.subscriber.sub(topic, listener);
+        this.subscribed.set(key, { topic, listener });
+      })();
+      this.subscribingPromises.set(key, pending);
+    }
+    await pending;
+  }
+
+  private handleResponse(msg: ResponseMessage): void {
+    const entry = this.pending.get(msg.id);
+    if (!entry) {
+      // Either not ours, or already resolved and removed.
+      return;
+    }
+    if (msg.phase === "ack") {
+      entry.ack.resolve(msg);
+      // ACK failures are terminal — no `final` will follow. Reject the final
+      // promise to unblock any caller that already called .wait().
+      if (msg.ok === false) {
+        entry.final.reject(new Error(`TransactionManager rejected request (${msg.reason}): ${msg.error}`));
+        this.pending.delete(msg.id);
+      }
+      return;
+    }
+    // phase === "final"
+    entry.final.resolve(msg);
+    this.pending.delete(msg.id);
+  }
+
+  private buildRequest(id: string, txn: AugmentedTransaction): SubmissionRequest {
+    // superstruct 1.x's `optional()` doesn't lift fields to TS-optional in
+    // Infer; provide every field explicitly with `undefined` for unset ones.
+    return {
+      id,
+      chainId: txn.chainId,
+      to: txn.contract.address,
+      abi: extractMethodAbi(txn),
+      method: txn.method,
+      args: normaliseArgs(txn.args),
+      value: txn.value !== undefined ? txn.value.toHexString() : undefined,
+      gasLimit: txn.gasLimit !== undefined ? txn.gasLimit.toHexString() : undefined,
+      gasLimitMultiplier: txn.gasLimitMultiplier,
+      confirmations: undefined,
+      message: txn.message,
+      mrkdwn: txn.mrkdwn,
+    };
+  }
+
+  private toResponse(
+    ack: AckMessage & { ok: true },
+    txn: AugmentedTransaction,
+    eoa: string,
+    finalPromise: Promise<FinalMessage>
+  ): TransactionResponse {
+    const wait = async (_confirmations?: number): Promise<TransactionReceipt> => {
+      const final = await finalPromise;
+      if (final.ok === false) {
+        throw new Error(`TransactionManager confirmation failed (${final.reason}): ${final.error}`);
+      }
+      return synthesiseReceipt(final.hash, eoa, txn.contract.address, final.receipt);
+    };
+
+    // Synthesised; only `.hash` and `.wait()` are load-bearing for callers
+    // today (see MultiCallerClient, Refiller). Other fields are filled with
+    // honest placeholders.
+    const response = {
+      hash: ack.hash,
+      nonce: ack.nonce,
+      from: eoa,
+      to: txn.contract.address,
+      chainId: txn.chainId,
+      data: "0x",
+      value: txn.value ?? BigNumber.from(0),
+      gasLimit: txn.gasLimit ?? BigNumber.from(0),
+      gasPrice: BigNumber.from(0),
+      confirmations: 0,
+      r: "0x",
+      s: "0x",
+      v: 0,
+      type: 0,
+      wait,
+    };
+    return response as unknown as TransactionResponse;
+  }
+}
+
+function extractMethodAbi(txn: AugmentedTransaction): unknown[] {
+  if (txn.method === "") {
+    return [];
+  }
+  try {
+    const fragment = txn.contract.interface.getFunction(txn.method);
+    // fragment.format("json") yields a bare object; wrap so the manager's `new Contract(to, abi, ...)` accepts it.
+    return [JSON.parse(fragment.format(ethers.utils.FormatTypes.json))];
+  } catch {
+    return [];
+  }
+}
+
+// Recurse before JSON.stringify: BigNumber.prototype.toJSON runs before any
+// replacer would, so we'd otherwise ship `{type:"BigNumber",hex:...}` blobs
+// that the manager can't coerce back into uint256 args.
+function normaliseArgs(args: unknown[]): unknown[] {
+  return args.map(normaliseArg);
+}
+
+function normaliseArg(value: unknown): unknown {
+  if (BigNumber.isBigNumber(value)) {
+    return value.toHexString();
+  }
+  if (typeof value === "bigint") {
+    return "0x" + value.toString(16);
+  }
+  if (Array.isArray(value)) {
+    return value.map(normaliseArg);
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, normaliseArg(v)]));
+  }
+  return value;
+}
+
+function synthesiseReceipt(hash: string, from: string, to: string, lite: TransactionReceiptLite): TransactionReceipt {
+  const logs: Log[] = lite.logs.map((l, idx) => ({
+    transactionHash: hash,
+    blockHash: lite.blockHash,
+    blockNumber: lite.blockNumber,
+    logIndex: idx,
+    transactionIndex: 0,
+    removed: false,
+    address: l.address,
+    topics: l.topics,
+    data: l.data,
+  }));
+  const receipt = {
+    transactionHash: hash,
+    blockHash: lite.blockHash,
+    blockNumber: lite.blockNumber,
+    status: lite.status,
+    gasUsed: BigNumber.from(lite.gasUsed),
+    effectiveGasPrice: BigNumber.from(lite.effectiveGasPrice),
+    logs,
+    from,
+    to,
+    contractAddress: "",
+    transactionIndex: 0,
+    logsBloom: "0x",
+    cumulativeGasUsed: BigNumber.from(0),
+    confirmations: 1,
+    byzantium: true,
+    type: 0,
+  };
+  return receipt as unknown as TransactionReceipt;
+}

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -29,6 +29,7 @@ import {
   SVMSpokePoolClient,
   SpokePoolClient,
 } from "../clients";
+import { initTransactionBackend } from "../clients/TransactionClient";
 import { CommonConfig } from "./Config";
 import { SpokePoolClientsByChain } from "../interfaces";
 import { caching, clients, arch } from "@across-protocol/sdk";
@@ -397,6 +398,14 @@ export async function constructClients(
     config.timeToCache
   );
 
+  // Set process-level submission defaults. After this, every
+  // `new TransactionClient(...)` in the process picks up the configured
+  // broadcast mode and (in redis mode) the shared Backend automatically.
+  await initTransactionBackend(
+    logger,
+    config.transactionClientBroadcast,
+    `${config.botIdentifier}-${config.runIdentifier}`
+  );
   const multiCallerClient = new MultiCallerClient(logger, config.multiCallChunkSize, hubSigner);
 
   // Define the Arweave client as "read-only" to prevent any accidental writes to the Arweave network.

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -23,6 +23,7 @@ export class CommonConfig {
   readonly timeToCache: number;
   readonly arweaveGateways: ArweaveGatewayConfig[] | undefined;
   readonly peggedTokenPrices: { [pegTokenSymbol: string]: Set<string> } = {};
+  readonly transactionClientBroadcast: "rpc" | "redis";
   readonly botIdentifier: string;
   readonly runIdentifier: string;
 
@@ -47,6 +48,7 @@ export class CommonConfig {
       HUB_POOL_TIME_TO_CACHE,
       ARWEAVE_GATEWAYS,
       PEGGED_TOKEN_PRICES,
+      TRANSACTION_CLIENT_BROADCAST,
       BOT_IDENTIFIER,
       RUN_IDENTIFIER,
     } = env;
@@ -107,6 +109,12 @@ export class CommonConfig {
         new Set(tokenSymbolsToPeg),
       ])
     );
+
+    const broadcast = TRANSACTION_CLIENT_BROADCAST ?? "rpc";
+    if (broadcast !== "rpc" && broadcast !== "redis") {
+      throw new Error(`Invalid TRANSACTION_CLIENT_BROADCAST: ${broadcast} (expected "rpc" or "redis")`);
+    }
+    this.transactionClientBroadcast = broadcast;
 
     this.botIdentifier = BOT_IDENTIFIER ?? opts.botIdentifier ?? "across";
     this.runIdentifier = RUN_IDENTIFIER ?? randomUUID();

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -17,6 +17,7 @@ import { getRedisCache, RedisCacheInterface } from "../cache/Redis";
 import { Relayer } from "./Relayer";
 import { RelayerConfig } from "./RelayerConfig";
 import { constructRelayerClients } from "./RelayerClientHelper";
+import { disposeTransactionBackend } from "../clients/TransactionClient";
 import { InventoryClientState, isSpokePoolClientWithListener } from "../clients";
 import { updateSpokePoolClients } from "../common";
 config();
@@ -211,6 +212,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
       }
     }
   } finally {
+    await disposeTransactionBackend();
     await disconnectRedisClients(logger);
 
     if (externalListener) {
@@ -259,6 +261,7 @@ export async function runRebalancer(_logger: winston.Logger, baseSigner: Signer)
     await inventoryClient.withdrawExcessBalances();
   } finally {
     abortController.abort();
+    await disposeTransactionBackend();
     await disconnectRedisClients(logger);
     logger.debug({ at, message: `${personality} instance completed.` });
   }
@@ -290,6 +293,7 @@ export async function runInventoryManager(_logger: winston.Logger, baseSigner: S
     assert(isDefined(redis), "Inventory state export requires a Redis cache");
     await setInventoryState(redis, inventoryClient.getInventoryCacheKey(config.inventoryTopic), inventory);
   } finally {
+    await disposeTransactionBackend();
     await disconnectRedisClients(logger);
     logger.debug({ at, message: `${personality} instance completed.` });
   }

--- a/src/transactionManager/TransactionManager.ts
+++ b/src/transactionManager/TransactionManager.ts
@@ -1,0 +1,390 @@
+import assert from "assert";
+import { typeguards } from "@across-protocol/sdk";
+import { BigNumber, ethers } from "ethers";
+import { Log, TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
+import { InstanceCoordinator, isDefined, scheduleSequentialTask, Signer, winston } from "../utils";
+import { RedisPubSub } from "../messaging/redis/PubSub";
+import { RedisCacheInterface } from "../cache/Redis";
+import { AugmentedTransaction, TransactionClient } from "../clients/TransactionClient";
+import {
+  AckFailure,
+  AckMessage,
+  decodeRequest,
+  encodeAck,
+  encodeFinal,
+  FinalMessage,
+  SubmissionRequest,
+  TransactionReceiptLite,
+} from "./wire";
+
+const CONFIRMATION_TIMEOUT_MS_DEFAULT = 180_000;
+const LEASE_TTL_SEC_DEFAULT = 60;
+const LEASE_RENEW_INTERVAL_SEC_DEFAULT = 20;
+
+export interface TransactionManagerOptions {
+  chainId: number;
+  // EOA owned by this manager. Must be connected to a Provider for the chain.
+  signer: Signer;
+  // Per-process identifier; used as the InstanceCoordinator lease value.
+  runIdentifier: string;
+  // Redis forbids PUBLISH on a connection in SUBSCRIBE state; publisher and
+  // subscriber must own distinct sockets.
+  publisher: RedisPubSub;
+  subscriber: RedisPubSub;
+  // Backs the InstanceCoordinator that enforces one-active-manager-per-EOA.
+  cache: RedisCacheInterface;
+  logger: winston.Logger;
+  // External cancellation; manager also aborts on lease loss.
+  abortController: AbortController;
+  // Total wall-clock budget per request for confirmation, in ms.
+  confirmationTimeoutMs?: number;
+  // Lease TTL and renewal cadence. TTL > renewal interval, with safety margin.
+  leaseTtlSec?: number;
+  leaseRenewIntervalSec?: number;
+  // Optional dependency injection; defaults to a fresh direct-RPC client.
+  txnClient?: TransactionClient;
+}
+
+// Topic construction.
+export function requestTopic(chainId: number, eoa: string): string {
+  return `txn:requests:${chainId}:${eoa.toLowerCase()}`;
+}
+export function responseTopic(chainId: number, eoa: string): string {
+  return `txn:responses:${chainId}:${eoa.toLowerCase()}`;
+}
+
+// Standalone TransactionManager process. One instance owns one (chainId, EOA).
+// Receives submission requests via Redis Pub/Sub, broadcasts to chain, emits
+// ack + final responses on the per-EOA response topic. Phase 1 (broadcast)
+// is serialised via a promise chain to preserve nonce ordering; phase 2
+// (confirmation tracking) detaches so the next phase 1 can start.
+export class TransactionManager {
+  private responseTopic?: string;
+  private readonly txnClient: TransactionClient;
+  private readonly confirmationTimeoutMs: number;
+  private readonly leaseTtlSec: number;
+  private readonly leaseRenewIntervalSec: number;
+  // Detached phase-2 tasks (confirmation tracking). Drained on shutdown.
+  private readonly inFlight = new Set<Promise<void>>();
+
+  constructor(private readonly opts: TransactionManagerOptions) {
+    this.txnClient = opts.txnClient ?? new TransactionClient(opts.logger, [], "rpc");
+    this.confirmationTimeoutMs = opts.confirmationTimeoutMs ?? CONFIRMATION_TIMEOUT_MS_DEFAULT;
+    this.leaseTtlSec = opts.leaseTtlSec ?? LEASE_TTL_SEC_DEFAULT;
+    this.leaseRenewIntervalSec = opts.leaseRenewIntervalSec ?? LEASE_RENEW_INTERVAL_SEC_DEFAULT;
+  }
+
+  async start(): Promise<void> {
+    const eoa = (await this.opts.signer.getAddress()).toLowerCase();
+    const reqTopic = requestTopic(this.opts.chainId, eoa);
+    const respTopic = responseTopic(this.opts.chainId, eoa);
+    this.responseTopic = respTopic;
+    const { abortController } = this.opts;
+    const { signal } = abortController;
+
+    // Enforce one-active-manager-per-EOA. Aggressive handover: writing our
+    // runIdentifier displaces any prior holder; the prior holder's next
+    // renewal observes the change and aborts.
+    const coord = new InstanceCoordinator(
+      this.opts.logger,
+      this.opts.cache,
+      `across-transaction-manager-${eoa}`,
+      this.opts.runIdentifier,
+      abortController,
+      this.leaseTtlSec
+    );
+    await coord.initiateHandover();
+    scheduleSequentialTask(
+      "TransactionManager lease renewal",
+      this.opts.logger,
+      () => this.renewLease(coord),
+      this.leaseRenewIntervalSec,
+      signal
+    );
+
+    this.opts.logger.info({
+      at: "TransactionManager#start",
+      message: "Starting transaction manager",
+      chainId: this.opts.chainId,
+      eoa,
+      runIdentifier: this.opts.runIdentifier,
+      requestTopic: reqTopic,
+      responseTopic: respTopic,
+    });
+
+    // Phase 1 serialisation. Each incoming request appends itself onto the
+    // chain so broadcasts run in arrival order and never compete for a nonce.
+    let chain: Promise<unknown> = Promise.resolve();
+    const listener = (payload: string, topic: string): void => {
+      if (topic !== reqTopic) {
+        return;
+      }
+      let req: SubmissionRequest;
+      try {
+        req = decodeRequest(payload);
+      } catch (err) {
+        this.opts.logger.warn({
+          at: "TransactionManager#listener",
+          message: "Decode failed; dropping",
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+      // Always process: once the request is in the chain, the caller is
+      // waiting for an ACK. Skipping on abort would leave the caller hanging.
+      // After abort, listener is unsubbed so no new requests can enqueue.
+      chain = chain
+        .then(() => this.processRequest(req))
+        .catch((err) =>
+          this.opts.logger.error({
+            at: "TransactionManager#processRequest",
+            message: "Unhandled error",
+            id: req.id,
+            error: err instanceof Error ? err.stack : String(err),
+          })
+        );
+    };
+
+    await this.opts.subscriber.sub(reqTopic, listener);
+
+    try {
+      // Block until external signal aborts.
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) {
+          resolve();
+          return;
+        }
+        signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    } finally {
+      await this.opts.subscriber.unsub(reqTopic, listener);
+      await chain; // drain pending phase 1
+      await Promise.allSettled(this.inFlight); // drain pending phase 2
+    }
+  }
+
+  private async renewLease(coord: InstanceCoordinator): Promise<void> {
+    const active = await coord.getActiveInstance();
+    if (active !== this.opts.runIdentifier) {
+      this.opts.logger.warn({
+        at: "TransactionManager#renewLease",
+        message: `Lost lease for ${coord.identifier}; ${active ?? "<none>"} is now active. Draining.`,
+      });
+      this.opts.abortController.abort();
+      return;
+    }
+    await coord.setActiveInstance();
+  }
+
+  private async processRequest(req: SubmissionRequest): Promise<void> {
+    let response: TransactionResponse | undefined;
+    try {
+      response = await this.broadcastRequest(req);
+    } catch (err) {
+      this.opts.logger.error({
+        at: "TransactionManager#processRequest",
+        message: "Unhandled error in broadcast phase",
+        id: req.id,
+        error: err instanceof Error ? err.stack : String(err),
+      });
+      await this.emitAckFailure(req.id, "unknown", err instanceof Error ? err.message : String(err));
+      return;
+    }
+
+    if (!isDefined(response)) {
+      // Pre-broadcast failure; broadcastRequest already emitted an ack failure.
+      return;
+    }
+
+    await this.emitAckSuccess(req.id, response.hash, response.nonce);
+
+    // Detach phase 2 so the worker can pull the next request.
+    const task = this.handleConfirmation(req, response);
+    this.inFlight.add(task);
+    void task.finally(() => this.inFlight.delete(task));
+  }
+
+  // Phase 1: simulate + broadcast. Returns the response on success, undefined
+  // on pre-broadcast failure (in which case an ack failure has been emitted).
+  private async broadcastRequest(req: SubmissionRequest): Promise<TransactionResponse | undefined> {
+    const augTxn = this.buildAugmentedTransaction(req);
+
+    const [simResult] = await this.txnClient.simulate([augTxn]);
+    if (!simResult.succeed) {
+      this.opts.logger.warn({
+        at: "TransactionManager#broadcastRequest",
+        message: "Simulation failed",
+        id: req.id,
+        reason: simResult.reason,
+      });
+      await this.emitAckFailure(req.id, "simulation", simResult.reason ?? "simulation reverted");
+      return undefined;
+    }
+
+    let response: TransactionResponse;
+    try {
+      const [r] = await this.txnClient.submit(req.chainId, [augTxn]);
+      response = r;
+    } catch (err) {
+      const failure = classifyAckFailure(err);
+      await this.emitAckFailure(req.id, failure.reason, failure.message);
+      return undefined;
+    }
+    return response;
+  }
+
+  // Phase 2: await confirmation, emit final.
+  private async handleConfirmation(req: SubmissionRequest, response: TransactionResponse): Promise<void> {
+    try {
+      await this.waitAndEmitFinal(req, response);
+    } catch (err) {
+      this.opts.logger.error({
+        at: "TransactionManager#handleConfirmation",
+        message: "Unhandled error in confirmation phase",
+        id: req.id,
+        error: err instanceof Error ? err.stack : String(err),
+      });
+    }
+  }
+
+  private async waitAndEmitFinal(req: SubmissionRequest, response: TransactionResponse): Promise<void> {
+    const confirmations = req.confirmations ?? 1;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    let receipt: TransactionReceipt;
+    try {
+      const timeout = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(
+          () => reject(new Error(`Confirmation timeout after ${this.confirmationTimeoutMs}ms`)),
+          this.confirmationTimeoutMs
+        );
+      });
+      receipt = await Promise.race([response.wait(confirmations), timeout]);
+    } catch (err) {
+      await this.emitFinalFailure(
+        req.id,
+        "confirmation",
+        err instanceof Error ? err.message : String(err),
+        response.hash
+      );
+      return;
+    } finally {
+      if (isDefined(timeoutHandle)) {
+        clearTimeout(timeoutHandle);
+      }
+    }
+
+    if (receipt.status !== 1) {
+      await this.emitFinalFailure(req.id, "reverted", "transaction status = 0", receipt.transactionHash);
+      return;
+    }
+    await this.emitFinalSuccess(req.id, receipt);
+  }
+
+  private buildAugmentedTransaction(req: SubmissionRequest): AugmentedTransaction {
+    const abi = parseAbi(req.abi);
+    const contract = new ethers.Contract(req.to, abi, this.opts.signer);
+    return {
+      contract,
+      chainId: req.chainId,
+      method: req.method,
+      args: req.args,
+      gasLimit: isDefined(req.gasLimit) ? BigNumber.from(req.gasLimit) : undefined,
+      gasLimitMultiplier: req.gasLimitMultiplier,
+      value: isDefined(req.value) ? BigNumber.from(req.value) : undefined,
+      message: req.message,
+      mrkdwn: req.mrkdwn,
+    };
+  }
+
+  private async emitAckSuccess(id: string, hash: string, nonce: number): Promise<void> {
+    const msg: AckMessage = { id, phase: "ack", ok: true, hash, nonce };
+    await this.publishResponse(encodeAck(msg));
+  }
+
+  private async emitAckFailure(id: string, reason: AckFailure, error: string): Promise<void> {
+    const msg: AckMessage = { id, phase: "ack", ok: false, reason, error };
+    await this.publishResponse(encodeAck(msg));
+  }
+
+  private async emitFinalSuccess(id: string, receipt: TransactionReceipt): Promise<void> {
+    const msg: FinalMessage = {
+      id,
+      phase: "final",
+      ok: true,
+      hash: receipt.transactionHash,
+      receipt: toReceiptLite(receipt),
+    };
+    await this.publishResponse(encodeFinal(msg));
+  }
+
+  private async emitFinalFailure(
+    id: string,
+    reason: "confirmation" | "reverted",
+    error: string,
+    hash?: string
+  ): Promise<void> {
+    const msg: FinalMessage = { id, phase: "final", ok: false, reason, error, hash };
+    await this.publishResponse(encodeFinal(msg));
+  }
+
+  private async publishResponse(payload: string): Promise<void> {
+    assert(isDefined(this.responseTopic), "TransactionManager.publishResponse called before start()");
+    try {
+      await this.opts.publisher.pub(this.responseTopic, payload);
+    } catch (err) {
+      this.opts.logger.warn({
+        at: "TransactionManager#publishResponse",
+        message: "Failed to publish response",
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+function parseAbi(abi: SubmissionRequest["abi"]): ethers.ContractInterface {
+  if (typeof abi === "string") {
+    return abi === "" ? [] : abi;
+  }
+  // ethers accepts a JSON-encoded ABI string. Stringifying avoids structural
+  // assertions on the fragment shape — ethers parses + validates at construction.
+  return JSON.stringify(abi);
+}
+
+function toReceiptLite(receipt: TransactionReceipt): TransactionReceiptLite {
+  return {
+    blockNumber: receipt.blockNumber,
+    blockHash: receipt.blockHash,
+    status: receipt.status === 1 ? 1 : 0,
+    gasUsed: receipt.gasUsed.toHexString(),
+    effectiveGasPrice: receipt.effectiveGasPrice?.toHexString() ?? "0x0",
+    logs: receipt.logs.map((l: Log) => ({
+      address: l.address,
+      topics: l.topics,
+      data: l.data,
+    })),
+  };
+}
+
+export function classifyAckFailure(err: unknown): { reason: AckFailure; message: string } {
+  if (typeguards.isEthersError(err)) {
+    const { code, reason: errReason } = err;
+    if (code === ethers.errors.INSUFFICIENT_FUNDS) {
+      return { reason: "insufficient_funds", message: err.message };
+    }
+    if (
+      code === ethers.errors.INVALID_ARGUMENT ||
+      code === ethers.errors.MISSING_ARGUMENT ||
+      code === ethers.errors.UNEXPECTED_ARGUMENT
+    ) {
+      return { reason: "validation", message: err.message };
+    }
+    if (code === ethers.errors.UNPREDICTABLE_GAS_LIMIT) {
+      if ((errReason ?? "").includes("revert")) {
+        return { reason: "simulation", message: err.message };
+      }
+    }
+    // REPLACEMENT_UNDERPRICED is retried inside TransactionClient with scaled
+    // gas; if it surfaces here, retries were exhausted — falls through to "unknown".
+  }
+  return { reason: "unknown", message: err instanceof Error ? err.message : String(err) };
+}

--- a/src/transactionManager/TransactionManagerConfig.ts
+++ b/src/transactionManager/TransactionManagerConfig.ts
@@ -1,0 +1,28 @@
+import { CommonConfig, ProcessEnv } from "../common";
+
+export class TransactionManagerConfig extends CommonConfig {
+  readonly chainId: number;
+  readonly confirmationTimeoutMs?: number;
+
+  constructor(env: ProcessEnv, eoa: string) {
+    super(env, { botIdentifier: `across-transaction-manager-${eoa.toLowerCase()}` });
+
+    const { TXN_MANAGER_CHAIN_ID, TXN_MANAGER_CONFIRMATION_TIMEOUT_MS } = env;
+    if (!TXN_MANAGER_CHAIN_ID) {
+      throw new Error("TXN_MANAGER_CHAIN_ID env var must be set");
+    }
+    const chainId = Number(TXN_MANAGER_CHAIN_ID);
+    if (!Number.isInteger(chainId) || chainId <= 0) {
+      throw new Error(`Invalid TXN_MANAGER_CHAIN_ID: ${TXN_MANAGER_CHAIN_ID}`);
+    }
+    this.chainId = chainId;
+
+    if (TXN_MANAGER_CONFIRMATION_TIMEOUT_MS) {
+      const ms = Number(TXN_MANAGER_CONFIRMATION_TIMEOUT_MS);
+      if (!Number.isInteger(ms) || ms <= 0) {
+        throw new Error(`Invalid TXN_MANAGER_CONFIRMATION_TIMEOUT_MS: ${TXN_MANAGER_CONFIRMATION_TIMEOUT_MS}`);
+      }
+      this.confirmationTimeoutMs = ms;
+    }
+  }
+}

--- a/src/transactionManager/index.ts
+++ b/src/transactionManager/index.ts
@@ -1,0 +1,59 @@
+import assert from "assert";
+import { config, getProvider, Signer, startupLogLevel, winston } from "../utils";
+import { getRedisCache } from "../cache/Redis";
+import { getRedisPubSub } from "../messaging/redis/PubSub";
+import { TransactionManager } from "./TransactionManager";
+import { TransactionManagerConfig } from "./TransactionManagerConfig";
+
+config();
+
+export { TransactionManager, TransactionManagerConfig };
+
+export async function runTransactionManager(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
+  const logger = _logger;
+  const eoa = await baseSigner.getAddress();
+  const cfg = new TransactionManagerConfig(process.env, eoa);
+
+  const provider = await getProvider(cfg.chainId, logger);
+  const signer = baseSigner.connect(provider);
+
+  const cache = await getRedisCache(logger);
+  assert(cache !== undefined, "TransactionManager requires a Redis cache for lease coordination");
+  // Redis forbids PUBLISH on a SUBSCRIBE'd connection, so we need distinct sockets.
+  const publisher = await getRedisPubSub(logger);
+  const subscriber = await getRedisPubSub(logger);
+  assert(publisher !== undefined && subscriber !== undefined, "TransactionManager requires Redis Pub/Sub");
+
+  const abortController = new AbortController();
+  const manager = new TransactionManager({
+    chainId: cfg.chainId,
+    signer,
+    runIdentifier: cfg.runIdentifier,
+    publisher,
+    subscriber,
+    cache,
+    logger,
+    abortController,
+    confirmationTimeoutMs: cfg.confirmationTimeoutMs,
+  });
+
+  const abort = (): void => abortController.abort();
+  process.on("SIGHUP", abort);
+  process.on("SIGINT", abort);
+  process.on("SIGTERM", abort);
+
+  logger[startupLogLevel(cfg)]({
+    at: "TransactionManager#index",
+    message: "TransactionManager started 🚦",
+    chainId: cfg.chainId,
+    eoa,
+    botIdentifier: cfg.botIdentifier,
+    runIdentifier: cfg.runIdentifier,
+  });
+
+  try {
+    await manager.start();
+  } finally {
+    await Promise.allSettled([publisher.disconnect(), subscriber.disconnect()]);
+  }
+}

--- a/src/transactionManager/wire.ts
+++ b/src/transactionManager/wire.ts
@@ -1,0 +1,119 @@
+// Wire shapes for the TransactionManager protocol. Library-neutral: numeric
+// fields cross the wire as hex strings, failure reasons use module enums (no
+// ethers/viem error codes), and receipt fields use a primitive subset.
+
+import { any, array, create, enums, Infer, literal, number, object, optional, string, union } from "superstruct";
+
+const HexString = string();
+const Address = string();
+
+const AckFailureS = enums(["validation", "simulation", "insufficient_funds", "unknown"] as const);
+
+const FinalFailureS = enums(["confirmation", "reverted"] as const);
+
+const TransactionReceiptLiteS = object({
+  blockNumber: number(),
+  blockHash: string(),
+  status: union([literal(0), literal(1)]),
+  gasUsed: HexString,
+  effectiveGasPrice: HexString,
+  logs: array(
+    object({
+      address: Address,
+      topics: array(string()),
+      data: HexString,
+    })
+  ),
+});
+
+const SubmissionRequestS = object({
+  id: string(),
+  chainId: number(),
+  to: Address,
+  // Method-scoped fragment array or JSON-encoded ABI string; inner shape not validated here.
+  abi: union([array(any()), string()]),
+  method: string(),
+  args: array(any()),
+  value: optional(HexString),
+  gasLimit: optional(HexString),
+  gasLimitMultiplier: optional(number()),
+  confirmations: optional(number()),
+  message: optional(string()),
+  mrkdwn: optional(string()),
+});
+
+const AckSuccessS = object({
+  id: string(),
+  phase: literal("ack"),
+  ok: literal(true),
+  hash: HexString,
+  nonce: number(),
+});
+
+const AckFailureMessageS = object({
+  id: string(),
+  phase: literal("ack"),
+  ok: literal(false),
+  reason: AckFailureS,
+  error: string(),
+});
+
+const AckMessageS = union([AckSuccessS, AckFailureMessageS]);
+
+const FinalSuccessS = object({
+  id: string(),
+  phase: literal("final"),
+  ok: literal(true),
+  hash: HexString,
+  receipt: TransactionReceiptLiteS,
+});
+
+const FinalFailureMessageS = object({
+  id: string(),
+  phase: literal("final"),
+  ok: literal(false),
+  hash: optional(HexString),
+  reason: FinalFailureS,
+  error: string(),
+});
+
+const FinalMessageS = union([FinalSuccessS, FinalFailureMessageS]);
+
+const ResponseMessageS = union([AckSuccessS, AckFailureMessageS, FinalSuccessS, FinalFailureMessageS]);
+
+export type AckFailure = Infer<typeof AckFailureS>;
+export type FinalFailure = Infer<typeof FinalFailureS>;
+export type TransactionReceiptLite = Infer<typeof TransactionReceiptLiteS>;
+export type SubmissionRequest = Infer<typeof SubmissionRequestS>;
+export type AckMessage = Infer<typeof AckMessageS>;
+export type FinalMessage = Infer<typeof FinalMessageS>;
+export type ResponseMessage = Infer<typeof ResponseMessageS>;
+
+export function encodeRequest(req: SubmissionRequest): string {
+  return JSON.stringify(req);
+}
+
+export function decodeRequest(payload: string): SubmissionRequest {
+  return create(JSON.parse(payload), SubmissionRequestS);
+}
+
+export function encodeAck(msg: AckMessage): string {
+  return JSON.stringify(msg);
+}
+
+export function decodeAck(payload: string): AckMessage {
+  return create(JSON.parse(payload), AckMessageS);
+}
+
+export function encodeFinal(msg: FinalMessage): string {
+  return JSON.stringify(msg);
+}
+
+export function decodeFinal(payload: string): FinalMessage {
+  return create(JSON.parse(payload), FinalMessageS);
+}
+
+// Decodes either ACK or final; use when phase is unknown in advance.
+export function decodeResponse(payload: string): ResponseMessage {
+  return create(JSON.parse(payload), ResponseMessageS);
+}

--- a/test/TransactionBackend.ts
+++ b/test/TransactionBackend.ts
@@ -1,0 +1,240 @@
+import { ethers } from "ethers";
+import sinon from "sinon";
+import { expect, createSpyLogger, randomAddress, winston } from "./utils";
+import { MemoryPubSub } from "./mocks/MemoryPubSub";
+import { Backend, requestTopic, responseTopic, type AugmentedTransaction } from "../src/clients/TransactionClient";
+import { encodeAck, encodeFinal, decodeRequest } from "../src/transactionManager/wire";
+
+const eoa = "0xAbC0000000000000000000000000000000000001";
+const contractAddress = "0x0000000000000000000000000000000000000002";
+const chainId = 1;
+
+function fakeContract(): { contract: ethers.Contract; eoa: string } {
+  // Minimal stub: only signer.getAddress, address, interface.getFunction, method are used.
+  const iface = new ethers.utils.Interface(["function transfer(address to, uint256 amount) returns (bool)"]);
+  const signer = { getAddress: async () => eoa } as unknown as ethers.Signer;
+  const contract = {
+    address: contractAddress,
+    signer,
+    interface: iface,
+  } as unknown as ethers.Contract;
+  return { contract, eoa };
+}
+
+function fakeTxn(): AugmentedTransaction {
+  const { contract } = fakeContract();
+  return {
+    contract,
+    chainId,
+    method: "transfer",
+    args: [randomAddress(), 1],
+    message: "test",
+    mrkdwn: "test",
+  } as AugmentedTransaction;
+}
+
+describe("TransactionBackend", function () {
+  let pubsub: MemoryPubSub;
+  let backend: Backend;
+  let logger: winston.Logger;
+
+  beforeEach(function () {
+    ({ spyLogger: logger } = createSpyLogger());
+    // For tests we use a single MemoryPubSub for both publisher and subscriber:
+    // there's no SUBSCRIBE-state restriction in the mock, so one instance is fine.
+    pubsub = new MemoryPubSub();
+    backend = new Backend(pubsub, pubsub, logger, { callerId: "test-caller" });
+  });
+
+  afterEach(async function () {
+    await backend.disconnect();
+  });
+
+  describe("submit + ack/final flow", function () {
+    it("resolves submit on ack success and wait() on final success", async function () {
+      const txn = fakeTxn();
+      const reqChannel = requestTopic(chainId, eoa);
+      const respChannel = responseTopic(chainId, eoa);
+
+      // Capture the request the backend publishes so we can build a matching response.
+      const published: string[] = [];
+      await pubsub.sub(reqChannel, (msg) => {
+        published.push(msg);
+      });
+
+      const submitPromise = backend.submit(txn);
+
+      // Wait a tick for backend to subscribe + publish.
+      await new Promise((r) => setTimeout(r, 5));
+      expect(published.length).to.equal(1);
+      const req = decodeRequest(published[0]);
+      expect(req.chainId).to.equal(chainId);
+      expect(req.method).to.equal("transfer");
+
+      // Publish ack success on the response channel.
+      const hash = "0x" + "ab".repeat(32);
+      await pubsub.pub(respChannel, encodeAck({ id: req.id, phase: "ack", ok: true, hash, nonce: 42 }));
+
+      const response = await submitPromise;
+      expect(response.hash).to.equal(hash);
+      expect(response.nonce).to.equal(42);
+
+      // Publish final success and verify wait() resolves with the receipt.
+      const blockHash = "0x" + "bb".repeat(32);
+      await pubsub.pub(
+        respChannel,
+        encodeFinal({
+          id: req.id,
+          phase: "final",
+          ok: true,
+          hash,
+          receipt: {
+            blockNumber: 100,
+            blockHash,
+            status: 1,
+            gasUsed: "0x5208",
+            effectiveGasPrice: "0x3b9aca00",
+            logs: [],
+          },
+        })
+      );
+
+      const receipt = await response.wait();
+      expect(receipt.transactionHash).to.equal(hash);
+      expect(receipt.blockNumber).to.equal(100);
+      expect(receipt.status).to.equal(1);
+    });
+
+    it("rejects submit when ack reports failure", async function () {
+      const txn = fakeTxn();
+      const reqChannel = requestTopic(chainId, eoa);
+      const respChannel = responseTopic(chainId, eoa);
+
+      const published: string[] = [];
+      await pubsub.sub(reqChannel, (msg) => {
+        published.push(msg);
+      });
+
+      const submitPromise = backend.submit(txn);
+      await new Promise((r) => setTimeout(r, 5));
+      const req = decodeRequest(published[0]);
+
+      await pubsub.pub(
+        respChannel,
+        encodeAck({ id: req.id, phase: "ack", ok: false, reason: "simulation", error: "revert: foo" })
+      );
+
+      let err: Error | undefined;
+      try {
+        await submitPromise;
+      } catch (e) {
+        err = e as Error;
+      }
+      expect(err).to.exist;
+      expect(err?.message).to.match(/simulation.*revert: foo/);
+    });
+
+    it("rejects wait() when final reports failure", async function () {
+      const txn = fakeTxn();
+      const reqChannel = requestTopic(chainId, eoa);
+      const respChannel = responseTopic(chainId, eoa);
+
+      const published: string[] = [];
+      await pubsub.sub(reqChannel, (msg) => {
+        published.push(msg);
+      });
+
+      const submitPromise = backend.submit(txn);
+      await new Promise((r) => setTimeout(r, 5));
+      const req = decodeRequest(published[0]);
+
+      const hash = "0x" + "ab".repeat(32);
+      await pubsub.pub(respChannel, encodeAck({ id: req.id, phase: "ack", ok: true, hash, nonce: 7 }));
+      const response = await submitPromise;
+
+      await pubsub.pub(
+        respChannel,
+        encodeFinal({ id: req.id, phase: "final", ok: false, reason: "reverted", error: "status=0", hash })
+      );
+
+      let err: Error | undefined;
+      try {
+        await response.wait();
+      } catch (e) {
+        err = e as Error;
+      }
+      expect(err).to.exist;
+      expect(err?.message).to.match(/reverted.*status=0/);
+    });
+  });
+
+  describe("subscription lifecycle", function () {
+    it("subscribes to each (chain, eoa) response topic exactly once across concurrent submits", async function () {
+      const subSpy = sinon.spy(pubsub, "sub");
+      const txn = fakeTxn();
+
+      // Fire three concurrent submits before any ack arrives.
+      const p1 = backend.submit(txn);
+      const p2 = backend.submit(txn);
+      const p3 = backend.submit(txn);
+
+      // Wait for them to publish their requests.
+      await new Promise((r) => setTimeout(r, 5));
+
+      // Only one sub() call for the response channel.
+      const respChannel = responseTopic(chainId, eoa);
+      const subCalls = subSpy.getCalls().filter((c) => c.args[0] === respChannel);
+      expect(subCalls.length).to.equal(1);
+
+      // Don't leak the pending submits.
+      void p1.catch(() => undefined);
+      void p2.catch(() => undefined);
+      void p3.catch(() => undefined);
+    });
+
+    it("unsubscribes on disconnect", async function () {
+      const txn = fakeTxn();
+      void backend.submit(txn).catch(() => undefined);
+      await new Promise((r) => setTimeout(r, 5));
+
+      const respChannel = responseTopic(chainId, eoa);
+      // Manual external subscriber to detect whether backend's listener is still active.
+      const received: string[] = [];
+      await pubsub.sub(respChannel, (msg) => received.push(msg));
+
+      const unsubSpy = sinon.spy(pubsub, "unsub");
+      await backend.disconnect();
+
+      const unsubCalls = unsubSpy.getCalls().filter((c) => c.args[0] === respChannel);
+      expect(unsubCalls.length).to.equal(1);
+    });
+
+    it("rejects pending submits on disconnect", async function () {
+      const txn = fakeTxn();
+      const submitPromise = backend.submit(txn);
+      await new Promise((r) => setTimeout(r, 5));
+
+      await backend.disconnect();
+
+      let err: Error | undefined;
+      try {
+        await submitPromise;
+      } catch (e) {
+        err = e as Error;
+      }
+      expect(err).to.exist;
+      expect(err?.message).to.equal("Backend closed");
+    });
+
+    it("rejects new submits after disconnect", async function () {
+      await backend.disconnect();
+      let err: Error | undefined;
+      try {
+        await backend.submit(fakeTxn());
+      } catch (e) {
+        err = e as Error;
+      }
+      expect(err?.message).to.equal("Backend is closed");
+    });
+  });
+});

--- a/test/TransactionManager.classify.ts
+++ b/test/TransactionManager.classify.ts
@@ -1,0 +1,58 @@
+import { ethers } from "ethers";
+import { expect } from "./utils";
+import { classifyAckFailure } from "../src/transactionManager/TransactionManager";
+
+function ethersError(code: string, extra: Record<string, unknown> = {}): Error {
+  return Object.assign(new Error("test error"), { code, ...extra });
+}
+
+describe("TransactionManager classifyAckFailure", function () {
+  it("classifies INSUFFICIENT_FUNDS", function () {
+    const result = classifyAckFailure(ethersError(ethers.errors.INSUFFICIENT_FUNDS));
+    expect(result.reason).to.equal("insufficient_funds");
+  });
+
+  it("classifies INVALID_ARGUMENT as validation", function () {
+    const result = classifyAckFailure(ethersError(ethers.errors.INVALID_ARGUMENT));
+    expect(result.reason).to.equal("validation");
+  });
+
+  it("classifies MISSING_ARGUMENT as validation", function () {
+    const result = classifyAckFailure(ethersError(ethers.errors.MISSING_ARGUMENT));
+    expect(result.reason).to.equal("validation");
+  });
+
+  it("classifies UNEXPECTED_ARGUMENT as validation", function () {
+    const result = classifyAckFailure(ethersError(ethers.errors.UNEXPECTED_ARGUMENT));
+    expect(result.reason).to.equal("validation");
+  });
+
+  it("classifies UNPREDICTABLE_GAS_LIMIT with revert reason as simulation", function () {
+    const result = classifyAckFailure(
+      ethersError(ethers.errors.UNPREDICTABLE_GAS_LIMIT, { reason: "execution reverted: foo" })
+    );
+    expect(result.reason).to.equal("simulation");
+  });
+
+  it("classifies UNPREDICTABLE_GAS_LIMIT without revert reason as unknown", function () {
+    const result = classifyAckFailure(ethersError(ethers.errors.UNPREDICTABLE_GAS_LIMIT, { reason: "out of gas" }));
+    expect(result.reason).to.equal("unknown");
+  });
+
+  it("classifies REPLACEMENT_UNDERPRICED as unknown (TransactionClient retries internally)", function () {
+    const result = classifyAckFailure(ethersError(ethers.errors.REPLACEMENT_UNDERPRICED));
+    expect(result.reason).to.equal("unknown");
+  });
+
+  it("classifies a non-ethers error as unknown", function () {
+    const result = classifyAckFailure(new Error("network glitch"));
+    expect(result.reason).to.equal("unknown");
+    expect(result.message).to.equal("network glitch");
+  });
+
+  it("classifies a non-Error throw as unknown", function () {
+    const result = classifyAckFailure("string thrown");
+    expect(result.reason).to.equal("unknown");
+    expect(result.message).to.equal("string thrown");
+  });
+});

--- a/test/TransactionManager.lifecycle.ts
+++ b/test/TransactionManager.lifecycle.ts
@@ -1,0 +1,268 @@
+import { ethers } from "ethers";
+import { expect, createSpyLogger, winston } from "./utils";
+import { TransactionReceipt } from "@ethersproject/abstract-provider";
+import { MemoryPubSub } from "./mocks/MemoryPubSub";
+import { MemoryCache } from "./mocks/MemoryCache";
+import { MockedTransactionClient } from "./mocks/MockTransactionClient";
+import { TransactionManager, requestTopic, responseTopic } from "../src/transactionManager/TransactionManager";
+import {
+  AckMessage,
+  decodeResponse,
+  encodeRequest,
+  FinalMessage,
+  ResponseMessage,
+  SubmissionRequest,
+} from "../src/transactionManager/wire";
+
+// Build a SubmissionRequest. By default the mocked TransactionClient returns
+// success; appending an object with `{ result }` to args steers it to a
+// failure path with the given reason.
+function buildRequest(opts: { id?: string; chainId?: number; failureReason?: string } = {}): SubmissionRequest {
+  const id = opts.id ?? `test-${Math.random().toString(36).slice(2, 10)}`;
+  const chainId = opts.chainId ?? 1;
+  const args: unknown[] = ["0x0000000000000000000000000000000000000001", 0];
+  if (opts.failureReason !== undefined) {
+    args.push({ result: opts.failureReason });
+  }
+  return {
+    id,
+    chainId,
+    to: "0x0000000000000000000000000000000000000002",
+    abi: '[{"name":"transfer","type":"function","inputs":[{"name":"to","type":"address"},{"name":"amount","type":"uint256"}],"outputs":[{"type":"bool"}],"stateMutability":"nonpayable"}]',
+    method: "transfer",
+    args,
+    value: undefined,
+    gasLimit: undefined,
+    gasLimitMultiplier: undefined,
+    confirmations: undefined,
+    message: undefined,
+    mrkdwn: undefined,
+  };
+}
+
+function fakeReceipt(hash: string, status: 0 | 1 = 1): TransactionReceipt {
+  return {
+    transactionHash: hash,
+    blockHash: "0x" + "bb".repeat(32),
+    blockNumber: 100,
+    status,
+    gasUsed: ethers.BigNumber.from(21_000),
+    effectiveGasPrice: ethers.BigNumber.from(1_000_000_000),
+    logs: [],
+    confirmations: 1,
+    cumulativeGasUsed: ethers.BigNumber.from(21_000),
+    transactionIndex: 0,
+    contractAddress: "",
+    type: 0,
+    byzantium: true,
+    from: "0x0",
+    to: "0x0",
+    logsBloom: "0x",
+  } as unknown as TransactionReceipt;
+}
+
+async function collectResponses(
+  pubsub: MemoryPubSub,
+  topic: string,
+  predicate: (msgs: ResponseMessage[]) => boolean,
+  timeoutMs = 500
+): Promise<ResponseMessage[]> {
+  const received: ResponseMessage[] = [];
+  const listener = (payload: string): void => {
+    received.push(decodeResponse(payload));
+  };
+  await pubsub.sub(topic, listener);
+  const start = Date.now();
+  try {
+    while (!predicate(received) && Date.now() - start < timeoutMs) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+  } finally {
+    await pubsub.unsub(topic, listener);
+  }
+  return received;
+}
+
+describe("TransactionManager lifecycle", function () {
+  let logger: winston.Logger;
+  // Single shared broker — in real Redis everything routes through one server.
+  // The publisher/subscriber pair exists only to dodge Redis's SUBSCRIBE-state
+  // restriction; the in-memory mock has no such restriction.
+  let broker: MemoryPubSub;
+  let cache: MemoryCache;
+  let txnClient: MockedTransactionClient;
+  let abortController: AbortController;
+  let wallet: ethers.Wallet;
+  let reqTopic: string;
+  let respTopic: string;
+  const chainId = 1;
+
+  beforeEach(function () {
+    ({ spyLogger: logger } = createSpyLogger());
+    broker = new MemoryPubSub();
+    cache = new MemoryCache();
+    txnClient = new MockedTransactionClient(logger);
+    abortController = new AbortController();
+    wallet = ethers.Wallet.createRandom();
+    reqTopic = requestTopic(chainId, wallet.address.toLowerCase());
+    respTopic = responseTopic(chainId, wallet.address.toLowerCase());
+  });
+
+  function newManager(overrides: Partial<Parameters<typeof makeOpts>[0]> = {}) {
+    const opts = makeOpts(overrides);
+    return new TransactionManager(opts);
+  }
+
+  function makeOpts(overrides: Partial<{ runIdentifier: string; leaseRenewIntervalSec: number }> = {}) {
+    return {
+      chainId,
+      signer: wallet,
+      runIdentifier: overrides.runIdentifier ?? "test-run-1",
+      publisher: broker,
+      subscriber: broker,
+      cache,
+      logger,
+      abortController,
+      txnClient,
+      // Short renewal so any lease loss is detectable within test timeouts.
+      leaseRenewIntervalSec: overrides.leaseRenewIntervalSec ?? 60,
+      leaseTtlSec: 120,
+    };
+  }
+
+  it("emits ack success + final success on happy path", async function () {
+    const hash = ethers.utils.id("happy-path");
+    txnClient.waitOverride = async () => fakeReceipt(hash, 1);
+
+    const manager = newManager();
+    const running = manager.start();
+    // Wait until manager has subscribed to its request topic.
+    await new Promise((r) => setTimeout(r, 20));
+
+    const req = buildRequest();
+    const responsesPromise = collectResponses(broker, respTopic, (msgs) => msgs.length >= 2, 1000);
+    await broker.pub(reqTopic, encodeRequest(req));
+    const responses = await responsesPromise;
+
+    abortController.abort();
+    await running;
+
+    expect(responses).to.have.length(2);
+    const ack = responses[0] as AckMessage;
+    const final = responses[1] as FinalMessage;
+    expect(ack.phase).to.equal("ack");
+    expect(ack.ok).to.equal(true);
+    if (ack.ok) {
+      expect(ack.id).to.equal(req.id);
+      expect(ack.hash).to.be.a("string");
+    }
+    expect(final.phase).to.equal("final");
+    expect(final.ok).to.equal(true);
+    if (final.ok) {
+      expect(final.receipt.status).to.equal(1);
+    }
+  });
+
+  it("emits ack failure on simulation failure", async function () {
+    const manager = newManager();
+    const running = manager.start();
+    await new Promise((r) => setTimeout(r, 20));
+
+    const req = buildRequest({ failureReason: "revert: bad state" });
+    const responsesPromise = collectResponses(broker, respTopic, (msgs) => msgs.length >= 1, 500);
+    await broker.pub(reqTopic, encodeRequest(req));
+    const responses = await responsesPromise;
+
+    abortController.abort();
+    await running;
+
+    expect(responses).to.have.length(1);
+    const ack = responses[0] as AckMessage;
+    expect(ack.phase).to.equal("ack");
+    expect(ack.ok).to.equal(false);
+    if (!ack.ok) {
+      expect(ack.reason).to.equal("simulation");
+      expect(ack.error).to.match(/bad state/);
+    }
+  });
+
+  it("emits final failure on reverted receipt", async function () {
+    const hash = ethers.utils.id("reverted-path");
+    txnClient.waitOverride = async () => fakeReceipt(hash, 0);
+
+    const manager = newManager();
+    const running = manager.start();
+    await new Promise((r) => setTimeout(r, 20));
+
+    const req = buildRequest();
+    const responsesPromise = collectResponses(broker, respTopic, (msgs) => msgs.length >= 2, 1000);
+    await broker.pub(reqTopic, encodeRequest(req));
+    const responses = await responsesPromise;
+
+    abortController.abort();
+    await running;
+
+    const final = responses[1] as FinalMessage;
+    expect(final.phase).to.equal("final");
+    expect(final.ok).to.equal(false);
+    if (!final.ok) {
+      expect(final.reason).to.equal("reverted");
+    }
+  });
+
+  it("processes multiple concurrent requests sequentially", async function () {
+    txnClient.waitOverride = async () => fakeReceipt(ethers.utils.id("multi"), 1);
+
+    const manager = newManager();
+    const running = manager.start();
+    await new Promise((r) => setTimeout(r, 20));
+
+    const reqs = [buildRequest({ id: "r1" }), buildRequest({ id: "r2" }), buildRequest({ id: "r3" })];
+    const responsesPromise = collectResponses(
+      broker,
+      respTopic,
+      (msgs) => msgs.filter((m) => m.phase === "ack").length >= 3,
+      1500
+    );
+    await Promise.all(reqs.map((r) => broker.pub(reqTopic, encodeRequest(r))));
+    const responses = await responsesPromise;
+
+    abortController.abort();
+    await running;
+
+    const acks = responses.filter((m) => m.phase === "ack");
+    expect(acks.length).to.equal(3);
+    // ACKs preserve arrival order (chain serialisation).
+    expect(acks.map((m) => m.id)).to.deep.equal(["r1", "r2", "r3"]);
+  });
+
+  it("drains in-flight work when aborted mid-stream", async function () {
+    txnClient.waitOverride = async () => fakeReceipt(ethers.utils.id("drain"), 1);
+
+    const manager = newManager();
+    const running = manager.start();
+    await new Promise((r) => setTimeout(r, 20));
+
+    const responsesPromise = collectResponses(
+      broker,
+      respTopic,
+      (msgs) => msgs.filter((m) => m.phase === "final").length >= 2,
+      1500
+    );
+
+    await broker.pub(reqTopic, encodeRequest(buildRequest({ id: "drain-1" })));
+    await broker.pub(reqTopic, encodeRequest(buildRequest({ id: "drain-2" })));
+
+    // Abort almost immediately — both requests should still drain through the
+    // chain and inFlight, emitting their finals before start() resolves.
+    await new Promise((r) => setTimeout(r, 5));
+    abortController.abort();
+
+    const responses = await responsesPromise;
+    await running;
+
+    const finals = responses.filter((m) => m.phase === "final");
+    expect(finals.length).to.equal(2);
+    expect(finals.map((m) => m.id).sort()).to.deep.equal(["drain-1", "drain-2"]);
+  });
+});

--- a/test/TransactionManager.wire.ts
+++ b/test/TransactionManager.wire.ts
@@ -1,0 +1,160 @@
+import { expect } from "./utils";
+import {
+  AckMessage,
+  FinalMessage,
+  ResponseMessage,
+  SubmissionRequest,
+  decodeAck,
+  decodeFinal,
+  decodeRequest,
+  decodeResponse,
+  encodeAck,
+  encodeFinal,
+  encodeRequest,
+} from "../src/transactionManager_/wire";
+
+const baseRequest: SubmissionRequest = {
+  id: "req-1",
+  chainId: 1,
+  to: "0x0000000000000000000000000000000000000001",
+  abi: [],
+  method: "transfer",
+  args: ["0xRecipient", "0x1"],
+  value: "0x0",
+  gasLimit: "0x5208",
+  gasLimitMultiplier: 1.2,
+  confirmations: 1,
+  message: "test",
+  mrkdwn: "test",
+};
+
+describe("TransactionManager wire", function () {
+  describe("SubmissionRequest", function () {
+    it("round-trips a populated request", function () {
+      const decoded = decodeRequest(encodeRequest(baseRequest));
+      expect(decoded).to.deep.equal(baseRequest);
+    });
+
+    it("accepts an ABI provided as a JSON string", function () {
+      const req: SubmissionRequest = { ...baseRequest, abi: '[{"type":"function"}]' };
+      const decoded = decodeRequest(encodeRequest(req));
+      expect(decoded.abi).to.equal('[{"type":"function"}]');
+    });
+
+    it("rejects payload missing a required field", function () {
+      const malformed = JSON.stringify({ ...baseRequest, id: undefined });
+      expect(() => decodeRequest(malformed)).to.throw();
+    });
+
+    it("rejects payload with wrong field type", function () {
+      const malformed = JSON.stringify({ ...baseRequest, chainId: "1" });
+      expect(() => decodeRequest(malformed)).to.throw();
+    });
+  });
+
+  describe("AckMessage", function () {
+    it("round-trips a success ack", function () {
+      const ack: AckMessage = { id: "req-1", phase: "ack", ok: true, hash: "0xabc", nonce: 42 };
+      expect(decodeAck(encodeAck(ack))).to.deep.equal(ack);
+    });
+
+    it("round-trips a failure ack", function () {
+      const ack: AckMessage = {
+        id: "req-1",
+        phase: "ack",
+        ok: false,
+        reason: "simulation",
+        error: "execution reverted",
+      };
+      expect(decodeAck(encodeAck(ack))).to.deep.equal(ack);
+    });
+
+    it("rejects an unknown failure reason", function () {
+      const malformed = JSON.stringify({
+        id: "req-1",
+        phase: "ack",
+        ok: false,
+        reason: "not-a-real-reason",
+        error: "oops",
+      });
+      expect(() => decodeAck(malformed)).to.throw();
+    });
+
+    it("rejects ack with success shape but no hash", function () {
+      const malformed = JSON.stringify({ id: "req-1", phase: "ack", ok: true, nonce: 1 });
+      expect(() => decodeAck(malformed)).to.throw();
+    });
+  });
+
+  describe("FinalMessage", function () {
+    const successFinal: FinalMessage = {
+      id: "req-1",
+      phase: "final",
+      ok: true,
+      hash: "0xabc",
+      receipt: {
+        blockNumber: 100,
+        blockHash: "0xblock",
+        status: 1,
+        gasUsed: "0x5208",
+        effectiveGasPrice: "0x3b9aca00",
+        logs: [{ address: "0xLog", topics: ["0xtopic"], data: "0xdata" }],
+      },
+    };
+
+    it("round-trips a success final", function () {
+      expect(decodeFinal(encodeFinal(successFinal))).to.deep.equal(successFinal);
+    });
+
+    it("round-trips a confirmation-timeout failure final", function () {
+      const final: FinalMessage = {
+        id: "req-1",
+        phase: "final",
+        ok: false,
+        hash: "0xabc",
+        reason: "confirmation",
+        error: "timeout",
+      };
+      expect(decodeFinal(encodeFinal(final))).to.deep.equal(final);
+    });
+
+    it("round-trips a revert failure with no hash", function () {
+      // hash is optional; verify a payload without it decodes cleanly.
+      const raw = '{"id":"req-1","phase":"final","ok":false,"reason":"reverted","error":"status=0"}';
+      const decoded = decodeFinal(raw);
+      expect(decoded.id).to.equal("req-1");
+      expect(decoded.ok).to.equal(false);
+      if (decoded.ok === false) {
+        expect(decoded.reason).to.equal("reverted");
+        expect(decoded.hash).to.equal(undefined);
+      }
+    });
+
+    it("rejects a receipt with status outside {0,1}", function () {
+      const malformed = JSON.stringify({
+        ...successFinal,
+        receipt: { ...successFinal.receipt, status: 2 },
+      });
+      expect(() => decodeFinal(malformed)).to.throw();
+    });
+  });
+
+  describe("decodeResponse", function () {
+    it("decodes an ack payload", function () {
+      const ack: ResponseMessage = { id: "x", phase: "ack", ok: true, hash: "0x1", nonce: 0 };
+      expect(decodeResponse(JSON.stringify(ack))).to.deep.equal(ack);
+    });
+
+    it("decodes a final payload", function () {
+      const raw = '{"id":"x","phase":"final","ok":false,"reason":"confirmation","error":"timeout"}';
+      const decoded = decodeResponse(raw);
+      expect(decoded.phase).to.equal("final");
+      expect(decoded.ok).to.equal(false);
+    });
+
+    it("rejects a payload that matches neither variant", function () {
+      const malformed = JSON.stringify({ id: "x", phase: "other" });
+      expect(() => decodeResponse(malformed)).to.throw();
+    });
+  });
+});

--- a/test/TransactionManager.wire.ts
+++ b/test/TransactionManager.wire.ts
@@ -11,7 +11,7 @@ import {
   encodeAck,
   encodeFinal,
   encodeRequest,
-} from "../src/transactionManager_/wire";
+} from "../src/transactionManager/wire";
 
 const baseRequest: SubmissionRequest = {
   id: "req-1",

--- a/test/mocks/MemoryCache.ts
+++ b/test/mocks/MemoryCache.ts
@@ -1,0 +1,49 @@
+// In-memory RedisCacheInterface stand-in for tests. TTL honoured but
+// otherwise no eviction; sufficient for InstanceCoordinator's get/set.
+
+import { RedisCacheInterface } from "../../src/cache/Redis";
+
+interface Entry {
+  value: unknown;
+  expiresAt?: number;
+}
+
+export class MemoryCache implements RedisCacheInterface {
+  private readonly store = new Map<string, Entry>();
+
+  async get<T>(key?: string): Promise<T | null> {
+    if (key === undefined) {
+      return null;
+    }
+    const entry = this.store.get(key);
+    if (entry === undefined) {
+      return null;
+    }
+    if (entry.expiresAt !== undefined && entry.expiresAt < Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value as T;
+  }
+
+  async set<T>(key: string, value: T, ttl?: number): Promise<string | undefined> {
+    this.store.set(key, {
+      value,
+      expiresAt: ttl !== undefined ? Date.now() + ttl * 1000 : undefined,
+    });
+    return "OK";
+  }
+
+  async decr(_key: string): Promise<number> {
+    throw new Error("MemoryCache.decr not implemented");
+  }
+  async decrBy(_key: string, _amount: number): Promise<number> {
+    throw new Error("MemoryCache.decrBy not implemented");
+  }
+  async incr(_key: string): Promise<number> {
+    throw new Error("MemoryCache.incr not implemented");
+  }
+  async incrBy(_key: string, _amount: number): Promise<number> {
+    throw new Error("MemoryCache.incrBy not implemented");
+  }
+}

--- a/test/mocks/MemoryPubSub.ts
+++ b/test/mocks/MemoryPubSub.ts
@@ -1,0 +1,53 @@
+// In-memory RedisPubSub stand-in for tests. Same surface as RedisPubSub:
+// pub/sub/unsub/disconnect. Listeners are invoked synchronously from pub().
+
+import { interfaces } from "@across-protocol/sdk";
+
+type Listener = (message: string, channel: string) => void;
+
+export class MemoryPubSub implements interfaces.PubSubMechanismInterface {
+  private readonly channels = new Map<string, Set<Listener>>();
+  private closed = false;
+
+  async pub(channel: string, message: string): Promise<number> {
+    if (this.closed) {
+      throw new Error("MemoryPubSub is closed");
+    }
+    const listeners = this.channels.get(channel);
+    if (listeners === undefined) {
+      return 0;
+    }
+    for (const listener of [...listeners]) {
+      listener(message, channel);
+    }
+    return listeners.size;
+  }
+
+  async sub(channel: string, listener: Listener): Promise<void> {
+    if (this.closed) {
+      throw new Error("MemoryPubSub is closed");
+    }
+    let listeners = this.channels.get(channel);
+    if (listeners === undefined) {
+      listeners = new Set();
+      this.channels.set(channel, listeners);
+    }
+    listeners.add(listener);
+  }
+
+  async unsub(channel: string, listener: Listener): Promise<void> {
+    const listeners = this.channels.get(channel);
+    if (listeners === undefined) {
+      return;
+    }
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      this.channels.delete(channel);
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    this.closed = true;
+    this.channels.clear();
+  }
+}


### PR DESCRIPTION
This permits multiple bots to share a single EOA with centralised transaction lifecycle management, nonce tracking etc. This is experimental but should permit more app-level features to be added for a given EOA without leading to increased congestion on the chain.