### PR TITLE
feat(swap-rebalancer): support Tron USDT Binance routes

### DIFF
--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -23,7 +23,7 @@ Routes are assembled by the rebalancer construction layer and passed at client i
 
 The built-in production route set is generated in `src/rebalancer/buildRebalanceRoutes.ts`. It covers:
 
-- stablecoin swap routes between `USDC` and `USDT` on Binance and Hyperliquid,
+- stablecoin swap routes between `USDC` and `USDT` on Binance and Hyperliquid, excluding Tron from Hyperliquid,
 - same-asset routes for `USDC` via CCTP and on direct Binance-supported USDC networks via Binance, and for `USDT` via OFT and on direct Binance-supported USDT networks via Binance,
 - Binance-only `WETH <-> USDC` and `WETH <-> USDT` routes sourced or settled through mainnet. `WETH <-> WETH` route handling exists in the adapter, but no cross-chain `WETH <-> WETH` routes are generated while WETH Binance support is limited to mainnet.
 
@@ -35,10 +35,12 @@ Route construction keeps two token-keyed chain maps:
 Operational note:
 
 - Same-asset `USDC <-> USDC` and `USDT <-> USDT` Binance routes are included deliberately so they can compete on estimated cost against CCTP/OFT paths, but they are only generated when both chains are direct Binance networks for that asset.
+- USDT on Tron is treated as a direct Binance `TRX` network for both deposits and withdrawals. Tron USDT Binance routes deposit to and withdraw from Binance directly, rather than bridging through an OFT entrypoint network first.
 - Updating Binance venue support for a token does not automatically widen rebalancer support. New chains should usually be added to both maps intentionally after inventory/config/runtime review.
 - Current route construction limits Binance `WETH` support to mainnet because the rebalancer's native-ETH deposit path relies on the mainnet Atomic Depositor and transfer proxy wiring.
 - If additional direct Binance ETH networks are enabled later, same-coin `WETH <-> WETH` routes skip the spot swap leg and treat on-chain `WETH` as Binance `ETH`.
 - Intermediate on-chain bridge legs into or out of Binance remain restricted to `USDC` and `USDT`; current `WETH` routes therefore source or settle through mainnet rather than bridging WETH into another Binance ETH network.
+- Hyperliquid routes intentionally exclude Tron even when Tron USDT is configured, and same-asset USDT routes involving Tron use Binance rather than OFT.
 
 ### Rebalancer Adapter
 

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -23,6 +23,7 @@ import {
   getBinanceTradeFees,
   getFillCommission,
   getBinanceTransactionTypeKey,
+  getEthersCompatibleAddress,
   isFailedBinanceWithdrawal,
   isSameBinanceCoin,
   isTerminalBinanceWithdrawal,
@@ -48,6 +49,7 @@ import {
   winston,
   deriveBinanceSpotMarketMeta,
   convertBinanceRouteAmount,
+  toAddressType,
 } from "../../utils";
 import { OrderDetails, RebalanceRoute } from "../utils/interfaces";
 import { STATUS } from "../utils/utils";
@@ -1094,18 +1096,15 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         amountToDeposit
       );
     } else {
-      const erc20 = new Contract(sourceTokenInfo.address.toNative(), ERC20.abi, connectedSigner);
-      const txn: AugmentedTransaction = {
-        contract: erc20,
-        method: "transfer",
-        args: [depositAddress.address, amountToDeposit],
-        chainId: sourceChain,
-        nonMulticall: true,
-        unpermissioned: false,
-        ensureConfirmation: true,
-        message: `Deposited ${amountReadable} ${sourceToken} to Binance on chain ${getNetworkName(sourceChain)}`,
-        mrkdwn: `Deposited ${amountReadable} ${sourceToken} to Binance on chain ${getNetworkName(sourceChain)}`,
-      };
+      const txn = this._buildDirectBinanceTokenDepositTransaction(
+        sourceToken,
+        sourceChain,
+        sourceTokenInfo.address.toNative(),
+        connectedSigner,
+        depositAddress.address,
+        amountToDeposit,
+        amountReadable
+      );
       txnHash = await this._submitTransaction(txn);
     }
     // Set the TTL to 30 minutes so that the Binance sweeper finalizer only attempts to pull back these deposited
@@ -1116,6 +1115,33 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       message: `Deposited ${amountReadable} ${sourceToken} to Binance from chain ${getNetworkName(sourceChain)}`,
       redisDepositTypeKey: getBinanceTransactionTypeKey(sourceChain, txnHash),
     });
+  }
+
+  private _buildDirectBinanceTokenDepositTransaction(
+    sourceToken: string,
+    sourceChain: number,
+    sourceTokenAddress: string,
+    connectedSigner: Signer,
+    depositAddress: string,
+    amountToDeposit: BigNumber,
+    amountReadable: string
+  ): AugmentedTransaction {
+    const erc20 = new Contract(
+      this._getEthersCompatibleAddress(sourceChain, sourceTokenAddress),
+      ERC20.abi,
+      connectedSigner
+    );
+    return {
+      contract: erc20,
+      method: "transfer",
+      args: [this._getEthersCompatibleAddress(sourceChain, depositAddress), amountToDeposit],
+      chainId: sourceChain,
+      nonMulticall: true,
+      unpermissioned: false,
+      ensureConfirmation: true,
+      message: `Deposited ${amountReadable} ${sourceToken} to Binance on chain ${getNetworkName(sourceChain)}`,
+      mrkdwn: `Deposited ${amountReadable} ${sourceToken} to Binance on chain ${getNetworkName(sourceChain)}`,
+    };
   }
 
   private async _depositNativeEthToBinanceViaAtomicDepositor(
@@ -1471,11 +1497,12 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   ): Promise<BinanceWithdrawal[]> {
     const binanceToken = resolveBinanceCoinSymbol(token);
     assert(isDefined(BINANCE_NETWORKS[chain]), "Chain should be a Binance network");
+    const recipientAddress = this._getBinanceRecipientAddress(chain, account);
     return (await getBinanceWithdrawals(this.binanceApiClient, binanceToken, startTime)).filter(
       (withdrawal) =>
         withdrawal.coin === binanceToken &&
         withdrawal.network === BINANCE_NETWORKS[chain] &&
-        withdrawal.recipient.toLowerCase() === account.toLowerCase() &&
+        withdrawal.recipient.toLowerCase() === recipientAddress.toLowerCase() &&
         isTerminalBinanceWithdrawal(withdrawal.status)
     );
   }
@@ -1580,7 +1607,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     try {
       withdrawalId = await submitBinanceWithdrawal(this.binanceApiClient, {
         coin: binanceDestinationCoin,
-        address: this.baseSignerAddress.toNative(),
+        address: this._getBinanceRecipientAddress(destinationEntrypointNetwork, this.baseSignerAddress.toNative()),
         amount: Number(amountToWithdraw),
         network: BINANCE_NETWORKS[destinationEntrypointNetwork],
         transactionFeeFlag: false,
@@ -1613,6 +1640,14 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       finalDestinationChain: destinationChain,
     });
     return true;
+  }
+
+  private _getEthersCompatibleAddress(chainId: number, address: string): string {
+    return getEthersCompatibleAddress(chainId, address);
+  }
+
+  private _getBinanceRecipientAddress(chainId: number, account: string): string {
+    return toAddressType(account, chainId).toNative();
   }
 
   private async _wrapEth(chainId: number, amount: BigNumber): Promise<void> {

--- a/src/rebalancer/buildRebalanceRoutes.ts
+++ b/src/rebalancer/buildRebalanceRoutes.ts
@@ -11,7 +11,7 @@ type ChainSelector = (rebalancerConfig: RebalancerConfig) => number[];
 // set so we can track venue support without automatically enabling every listed network operationally.
 const BINANCE_NETWORKS_BY_SYMBOL: Record<SupportedToken, readonly number[]> = {
   USDC: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.BASE, CHAIN_IDs.BSC],
-  USDT: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.BSC],
+  USDT: [CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM, CHAIN_IDs.MAINNET, CHAIN_IDs.BSC, CHAIN_IDs.TRON],
   // Live Binance ETH networkList currently includes ARBITRUM, BASE, BSC, ETH, OPTIMISM, SCROLL, and ZKSYNCERA.
   // The rebalancer support list below stays narrower until we intentionally enable more of those networks. We filter
   // this further by limiting to chains where we have an Atomic Depositor contract.
@@ -27,6 +27,7 @@ const REBALANCE_CHAINS_BY_SYMBOL: Record<SupportedToken, readonly number[]> = {
     CHAIN_IDs.UNICHAIN,
     CHAIN_IDs.MONAD,
     CHAIN_IDs.BSC,
+    CHAIN_IDs.TRON,
   ],
   USDC: [
     CHAIN_IDs.HYPEREVM,
@@ -75,7 +76,26 @@ function canUseHyperliquidStablecoinRoute({
   sourceChain: number;
   destinationChain: number;
 }): boolean {
-  return sourceChain !== CHAIN_IDs.BSC && destinationChain !== CHAIN_IDs.BSC;
+  return (
+    sourceChain !== CHAIN_IDs.BSC &&
+    destinationChain !== CHAIN_IDs.BSC &&
+    sourceChain !== CHAIN_IDs.TRON &&
+    destinationChain !== CHAIN_IDs.TRON
+  );
+}
+
+function canUseSameAssetBridgeRoute(
+  token: SupportedToken,
+  sourceChain: number,
+  destinationChain: number
+): token is StableToken {
+  if (!hasSameAssetBridgeAdapter(token)) {
+    return false;
+  }
+  if (sourceChain === CHAIN_IDs.BSC || destinationChain === CHAIN_IDs.BSC) {
+    return false;
+  }
+  return token !== "USDT" || (sourceChain !== CHAIN_IDs.TRON && destinationChain !== CHAIN_IDs.TRON);
 }
 
 function buildSameAssetRoutes(rebalancerConfig: RebalancerConfig, token: SupportedToken): RebalanceRoute[] {
@@ -92,7 +112,7 @@ function buildSameAssetRoutes(rebalancerConfig: RebalancerConfig, token: Support
         continue;
       }
 
-      if (hasSameAssetBridgeAdapter(token) && sourceChain !== CHAIN_IDs.BSC && destinationChain !== CHAIN_IDs.BSC) {
+      if (canUseSameAssetBridgeRoute(token, sourceChain, destinationChain)) {
         routes.push({
           sourceChain,
           sourceToken: token,

--- a/src/rebalancer/index.ts
+++ b/src/rebalancer/index.ts
@@ -101,7 +101,7 @@ async function initializeRebalancerRun(_logger: winston.Logger, baseSigner: Sign
   };
 }
 
-function loadCumulativeModeBalances(
+export function loadCumulativeModeBalances(
   rebalancerConfig: RebalancerConfig,
   inventoryClient: InventoryClient
 ): {
@@ -120,7 +120,6 @@ function loadCumulativeModeBalances(
       .map(Number)
       .forEach((chainId) => {
         const l2TokenInfo = getTokenInfoFromSymbol(token, chainId);
-        assert(l2TokenInfo.address.isEVM());
         const currentBalance = inventoryClient.tokenClient.getBalance(chainId, l2TokenInfo.address);
         currentBalances[chainId] ??= {};
         currentBalances[chainId][token] = currentBalance;

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -5,13 +5,21 @@ import { CctpAdapter } from "../src/rebalancer/adapters/cctpAdapter";
 import { OftAdapter } from "../src/rebalancer/adapters/oftAdapter";
 import { RebalancerConfig } from "../src/rebalancer/RebalancerConfig";
 import {
+  BINANCE_NETWORKS,
+  BINANCE_READ_RECV_WINDOW_MS,
+  BINANCE_WITHDRAW_RECV_WINDOW_MS,
+  BINANCE_WITHDRAWAL_STATUS,
+  BigNumber,
   CHAIN_IDs,
   EvmAddress,
+  getEthersCompatibleAddress,
   resolveBinanceCoinSymbol,
   convertBinanceRouteAmount,
   deriveBinanceSpotMarketMeta,
   isSameBinanceCoin,
   supportsBinanceIntermediateBridgeToken,
+  TOKEN_SYMBOLS_MAP,
+  toAddressType,
 } from "../src/utils";
 
 describe("Binance adapter helpers", function () {
@@ -257,6 +265,135 @@ describe("Binance adapter helpers", function () {
     expect(debug.calledOnce).to.equal(true);
     expect(debug.getCall(0).args[0].error).to.include("[RW00441]");
     expect(debug.getCall(0).args[0].error).to.include("required unlock confirmations for withdrawal");
+  });
+
+  it("builds Tron direct deposit transfers with ethers-compatible addresses", async function () {
+    const adapter = await makeAdapter();
+    const [signer] = await ethers.getSigners();
+    const amount = toBNWei("100", 6);
+    const tronUsdt = TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.TRON];
+    const tronDepositAddress = toAddressType(await signer.getAddress(), CHAIN_IDs.TRON).toNative();
+    const internals = adapter as unknown as {
+      _buildDirectBinanceTokenDepositTransaction(
+        sourceToken: string,
+        sourceChain: number,
+        sourceTokenAddress: string,
+        connectedSigner: typeof signer,
+        depositAddress: string,
+        amountToDeposit: BigNumber,
+        amountReadable: string
+      ): { contract: { address: string }; method: string; args: unknown[]; chainId: number };
+    };
+
+    const txn = internals._buildDirectBinanceTokenDepositTransaction(
+      "USDT",
+      CHAIN_IDs.TRON,
+      tronUsdt,
+      signer,
+      tronDepositAddress,
+      amount,
+      "100"
+    );
+
+    expect(txn.chainId).to.equal(CHAIN_IDs.TRON);
+    expect(txn.method).to.equal("transfer");
+    expect(txn.contract.address).to.equal(getEthersCompatibleAddress(CHAIN_IDs.TRON, tronUsdt));
+    expect(txn.args).to.deep.equal([getEthersCompatibleAddress(CHAIN_IDs.TRON, tronDepositAddress), amount]);
+  });
+
+  it("submits Tron withdrawals to the signer native Tron address on the TRX network", async function () {
+    const [signer] = await ethers.getSigners();
+    const withdrawStub = sinon
+      .stub()
+      .rejects(
+        new Error(
+          "[RW00441] Your deposits of 2.13569561 BTC in value have not met the required unlock confirmations for withdrawal."
+        )
+      );
+    const adapter = new BinanceStablecoinSwapAdapter(
+      TEST_LOGGER,
+      {} as RebalancerConfig,
+      signer,
+      {} as CctpAdapter,
+      {} as OftAdapter
+    );
+    const internals = adapter as unknown as {
+      baseSignerAddress: EvmAddress;
+      binanceApiClient: { withdraw: sinon.SinonStub };
+      _withdraw(cloid: string, quantity: number, destinationToken: string, destinationChain: number): Promise<boolean>;
+      _getEntrypointNetwork(chainId: number, token: string): Promise<number>;
+      _getTokenInfo(token: string, chainId: number): { decimals: number };
+    };
+    internals.baseSignerAddress = EvmAddress.from(await signer.getAddress());
+    internals.binanceApiClient = { withdraw: withdrawStub };
+    sinon.stub(internals, "_getEntrypointNetwork").resolves(CHAIN_IDs.TRON);
+    sinon.stub(internals, "_getTokenInfo").returns({ decimals: 6 });
+
+    const result = await internals._withdraw("cloid", 100, "USDT", CHAIN_IDs.TRON);
+
+    const payload = withdrawStub.getCall(0).args[0];
+    expect(result).to.equal(false);
+    expect(payload).to.deep.equal({
+      coin: "USDT",
+      address: toAddressType(await signer.getAddress(), CHAIN_IDs.TRON).toNative(),
+      amount: 100,
+      network: BINANCE_NETWORKS[CHAIN_IDs.TRON],
+      transactionFeeFlag: false,
+      recvWindow: BINANCE_WITHDRAW_RECV_WINDOW_MS,
+    });
+  });
+
+  it("matches Tron withdrawal history against the signer native Tron address", async function () {
+    const adapter = await makeAdapter();
+    const [signer] = await ethers.getSigners();
+    const tronRecipient = toAddressType(await signer.getAddress(), CHAIN_IDs.TRON).toNative();
+    const withdrawHistoryStub = sinon.stub().resolves([
+      {
+        amount: "100",
+        transactionFee: "1",
+        address: tronRecipient,
+        id: "matching-withdrawal",
+        txId: "tron-tx",
+        network: BINANCE_NETWORKS[CHAIN_IDs.TRON],
+        status: BINANCE_WITHDRAWAL_STATUS.COMPLETED,
+        applyTime: new Date(0).toISOString(),
+      },
+      {
+        amount: "100",
+        transactionFee: "1",
+        address: await signer.getAddress(),
+        id: "evm-form-withdrawal",
+        txId: "evm-form-tx",
+        network: BINANCE_NETWORKS[CHAIN_IDs.TRON],
+        status: BINANCE_WITHDRAWAL_STATUS.COMPLETED,
+        applyTime: new Date(0).toISOString(),
+      },
+    ]);
+    const internals = adapter as unknown as {
+      binanceApiClient: { withdrawHistory: sinon.SinonStub };
+      _getInitiatedBinanceWithdrawals(
+        token: string,
+        chain: number,
+        startTime: number,
+        account: string
+      ): Promise<Array<{ id: string; recipient: string }>>;
+    };
+    internals.binanceApiClient = { withdrawHistory: withdrawHistoryStub };
+
+    const withdrawals = await internals._getInitiatedBinanceWithdrawals(
+      "USDT",
+      CHAIN_IDs.TRON,
+      123,
+      await signer.getAddress()
+    );
+
+    expect(withdrawals.map((withdrawal) => withdrawal.id)).to.deep.equal(["matching-withdrawal"]);
+    expect(withdrawals[0].recipient).to.equal(tronRecipient);
+    expect(withdrawHistoryStub.getCall(0).args[0]).to.deep.equal({
+      coin: "USDT",
+      startTime: 123,
+      recvWindow: BINANCE_READ_RECV_WINDOW_MS,
+    });
   });
 
   it("keeps pending WETH credit until a finalized Binance withdrawal is wrapped", async function () {

--- a/test/Rebalancer.loadCumulativeModeBalances.ts
+++ b/test/Rebalancer.loadCumulativeModeBalances.ts
@@ -1,0 +1,53 @@
+import { InventoryClient } from "../src/clients";
+import { loadCumulativeModeBalances } from "../src/rebalancer";
+import { RebalancerConfig } from "../src/rebalancer/RebalancerConfig";
+import { BigNumber, bnZero, CHAIN_IDs, getTokenInfoFromSymbol, toBNWei } from "../src/utils";
+import { expect } from "./utils";
+
+describe("loadCumulativeModeBalances", function () {
+  it("loads configured Tron token balances without requiring an EVM remote token address", function () {
+    const config = new RebalancerConfig({
+      HUB_CHAIN_ID: String(CHAIN_IDs.MAINNET),
+      REBALANCER_CONFIG: JSON.stringify({
+        cumulativeTargetBalances: {
+          USDT: {
+            targetBalance: "1000",
+            thresholdBalance: "500",
+            priorityTier: 0,
+            chains: {
+              [CHAIN_IDs.TRON]: 0,
+              [CHAIN_IDs.OPTIMISM]: 0,
+            },
+          },
+        },
+        maxAmountsToTransfer: {
+          USDT: "100",
+        },
+      }),
+    });
+    const tronUsdt = getTokenInfoFromSymbol("USDT", CHAIN_IDs.TRON).address;
+    const optimismUsdt = getTokenInfoFromSymbol("USDT", CHAIN_IDs.OPTIMISM).address;
+    const tronBalance = toBNWei("123", 6);
+    const optimismBalance = toBNWei("456", 6);
+    const cumulativeBalance = toBNWei("1000", 6);
+    const balances: { [chainId: number]: { [token: string]: BigNumber } } = {
+      [CHAIN_IDs.TRON]: { [tronUsdt.toNative()]: tronBalance },
+      [CHAIN_IDs.OPTIMISM]: { [optimismUsdt.toNative()]: optimismBalance },
+    };
+    const inventoryClient = {
+      tokenClient: {
+        getBalance: (chainId: number, token: typeof tronUsdt): BigNumber =>
+          balances[chainId]?.[token.toNative()] ?? bnZero,
+      },
+      getCumulativeBalanceWithApproximateUpcomingRefunds: () => cumulativeBalance,
+    } as unknown as InventoryClient;
+
+    expect(tronUsdt.isTVM()).to.equal(true);
+
+    const result = loadCumulativeModeBalances(config, inventoryClient);
+
+    expect(result.currentBalances[CHAIN_IDs.TRON].USDT).to.equal(tronBalance);
+    expect(result.currentBalances[CHAIN_IDs.OPTIMISM].USDT).to.equal(optimismBalance);
+    expect(result.cumulativeBalances.USDT).to.equal(cumulativeBalance);
+  });
+});

--- a/test/RebalancerClient.buildRebalanceRoutes.ts
+++ b/test/RebalancerClient.buildRebalanceRoutes.ts
@@ -93,6 +93,63 @@ function buildSyntheticRebalancerConfigWithMainnet(): RebalancerConfig {
     }),
   });
 }
+
+function buildSyntheticRebalancerConfigWithTron(): RebalancerConfig {
+  return new RebalancerConfig({
+    HUB_CHAIN_ID: String(CHAIN_IDs.MAINNET),
+    REBALANCER_CONFIG: JSON.stringify({
+      cumulativeTargetBalances: {
+        USDT: {
+          targetBalance: "1000",
+          thresholdBalance: "500",
+          priorityTier: 0,
+          chains: {
+            [CHAIN_IDs.TRON]: 0,
+            [CHAIN_IDs.OPTIMISM]: 0,
+            [CHAIN_IDs.BSC]: 0,
+          },
+        },
+        USDC: {
+          targetBalance: "1000",
+          thresholdBalance: "500",
+          priorityTier: 0,
+          chains: {
+            [CHAIN_IDs.HYPEREVM]: 0,
+            [CHAIN_IDs.BASE]: 0,
+            [CHAIN_IDs.OPTIMISM]: 0,
+          },
+        },
+      },
+      maxAmountsToTransfer: {
+        USDT: "100",
+        USDC: "100",
+      },
+      maxPendingOrders: {
+        hyperliquid: 3,
+        binance: 3,
+      },
+    }),
+  });
+}
+
+function routeExists(
+  routes: ReturnType<typeof buildRebalanceRoutes>,
+  sourceChain: number,
+  sourceToken: string,
+  destinationChain: number,
+  destinationToken: string,
+  adapter: string
+): boolean {
+  return routes.some(
+    (route) =>
+      route.sourceChain === sourceChain &&
+      route.sourceToken === sourceToken &&
+      route.destinationChain === destinationChain &&
+      route.destinationToken === destinationToken &&
+      route.adapter === adapter
+  );
+}
+
 describe("buildRebalanceRoutes", function () {
   it("builds the exact stablecoin route families implied by synthetic config", async function () {
     const config = buildSyntheticRebalancerConfig();
@@ -206,5 +263,28 @@ describe("buildRebalanceRoutes", function () {
     expect(hasRoute(CHAIN_IDs.MAINNET, "WETH", CHAIN_IDs.MAINNET, "WETH", "binance")).to.equal(false);
     expect(hasRoute(CHAIN_IDs.OPTIMISM, "WETH", CHAIN_IDs.MAINNET, "WETH", "binance")).to.equal(false);
     expect(hasRoute(CHAIN_IDs.MAINNET, "WETH", CHAIN_IDs.OPTIMISM, "WETH", "binance")).to.equal(false);
+  });
+
+  it("builds Tron USDT Binance routes without adding Tron Hyperliquid or OFT routes", async function () {
+    const config = buildSyntheticRebalancerConfigWithTron();
+
+    const routes = buildRebalanceRoutes(config);
+    const hasRoute = (
+      sourceChain: number,
+      sourceToken: string,
+      destinationChain: number,
+      destinationToken: string,
+      adapter: string
+    ) => routeExists(routes, sourceChain, sourceToken, destinationChain, destinationToken, adapter);
+
+    expect(hasRoute(CHAIN_IDs.TRON, "USDT", CHAIN_IDs.BASE, "USDC", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.BASE, "USDC", CHAIN_IDs.TRON, "USDT", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.TRON, "USDT", CHAIN_IDs.OPTIMISM, "USDT", "binance")).to.equal(true);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDT", CHAIN_IDs.TRON, "USDT", "binance")).to.equal(true);
+
+    expect(hasRoute(CHAIN_IDs.TRON, "USDT", CHAIN_IDs.BASE, "USDC", "hyperliquid")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.BASE, "USDC", CHAIN_IDs.TRON, "USDT", "hyperliquid")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.TRON, "USDT", CHAIN_IDs.OPTIMISM, "USDT", "oft")).to.equal(false);
+    expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDT", CHAIN_IDs.TRON, "USDT", "oft")).to.equal(false);
   });
 });


### PR DESCRIPTION
## Summary
- Add Tron as a direct Binance USDT deposit/withdrawal network for swap rebalancer route generation.
- Convert Tron addresses between native and ethers-compatible formats for Binance deposits, withdrawals, and withdrawal-history matching.
- Exclude Tron from Hyperliquid/OFT route families where direct Binance routing is intended.
- Fix cumulative balance loading so non-EVM remote token addresses such as Tron USDT do not trip the EVM-only assertion.

## Review Notes
- Ran a review pass on the branch diff against `origin/master` and fixed the runtime assertion hit by configured Tron USDT cumulative balances.
- Added regression coverage for the cumulative balance loader and Tron Binance route/address handling.

## Tests
- `git diff --check cc2c253502218ca99f1e4930e9bc041a75b67036`
- `yarn test test/Rebalancer.loadCumulativeModeBalances.ts test/RebalancerClient.buildRebalanceRoutes.ts test/BinanceAdapter.helpers.ts`
- `yarn typecheck`