### PR TITLE
chore: Add SVM support in gasless relayer

### DIFF
--- a/src/clients/SvmFillerClient.ts
+++ b/src/clients/SvmFillerClient.ts
@@ -27,7 +27,7 @@ export const SOLANA_TX_SIZE_LIMIT = 1232; // bytes
 // single transaction contain approve and create ATA instructions.
 export const MAXIMUM_MESSAGE_SIZE = 466; // string length. equals 466/2-1 = 232 bytes.
 
-type ProtoFill = Omit<RelayData, "recipient" | "outputToken"> & {
+export type ProtoFill = Omit<RelayData, "recipient" | "outputToken"> & {
   destinationChainId: number;
   recipient: SvmAddress;
   outputToken: SvmAddress;
@@ -36,8 +36,11 @@ type ProtoFill = Omit<RelayData, "recipient" | "outputToken"> & {
 type ReadyTransactionPromise = Promise<SolanaTransaction>;
 type ReadyTransactionsPromise = Promise<SolanaTransaction[]>;
 
+/** Promises that resolve to fillRelay transaction(s): one tx, or IP txs then fill. */
+export type SvmFillRelayTxPromises = [ReadyTransactionPromise] | [ReadyTransactionsPromise, ReadyTransactionPromise];
+
 type QueuedSvmFill = {
-  txPromises: [ReadyTransactionPromise] | [ReadyTransactionsPromise, ReadyTransactionPromise];
+  txPromises: SvmFillRelayTxPromises;
   message: string;
   mrkdwn: string;
 };
@@ -70,6 +73,49 @@ export class SvmFillerClient {
     return new SvmFillerClient(svmSigner, provider, chainId, logger);
   }
 
+  /**
+   * Returns promises that build the fillRelay transaction(s) for a deposit (single tx or multipart).
+   * Callers can enqueue these via {@link enqueueFillRelayTxPromises} or submit immediately via
+   * {@link executeFillImmediately}.
+   */
+  buildFillRelayTxPromises(
+    spokePool: SvmAddress,
+    relayData: ProtoFill,
+    repaymentChainId: number,
+    repaymentAddress: SDKAddress
+  ): SvmFillRelayTxPromises {
+    assert(
+      repaymentAddress.isValidOn(repaymentChainId),
+      `SvmFillerClient:buildFillRelayTxPromises ${repaymentAddress} not valid on chain ${repaymentChainId}`
+    );
+
+    if (this.isFillMessageTooLarge(relayData)) {
+      return [
+        arch.svm.getIPForFillRelayTxs(
+          spokePool,
+          relayData,
+          repaymentChainId,
+          repaymentAddress,
+          this.signer,
+          this.provider
+        ),
+        arch.svm.getIPFillRelayTx(spokePool, this.provider, relayData, this.signer, repaymentChainId, repaymentAddress),
+      ];
+    }
+
+    return [
+      arch.svm.getFillRelayTx(spokePool, this.provider, relayData, this.signer, repaymentChainId, repaymentAddress),
+    ];
+  }
+
+  buildSlowFillTxPromise(spokePool: SvmAddress, relayData: ProtoFill): ReadyTransactionPromise {
+    return arch.svm.getSlowFillRequestTx(spokePool, this.provider, relayData, this.signer);
+  }
+
+  enqueueFillRelayTxPromises(txPromises: SvmFillRelayTxPromises, message: string, mrkdwn: string): void {
+    this.queuedFills.push({ txPromises, message, mrkdwn });
+  }
+
   enqueueFill(
     spokePool: SvmAddress,
     relayData: ProtoFill,
@@ -78,67 +124,72 @@ export class SvmFillerClient {
     message: string,
     mrkdwn: string
   ): void {
-    assert(
-      repaymentAddress.isValidOn(repaymentChainId),
-      `SvmFillerClient:enqueueFill ${repaymentAddress} not valid on chain ${repaymentChainId}`
-    );
-    if (this.isFillMessageTooLarge(relayData)) {
-      return this._enqueueMultipartFill(spokePool, relayData, repaymentChainId, repaymentAddress, message, mrkdwn);
-    }
-    const fillTxPromise = arch.svm.getFillRelayTx(
-      spokePool,
-      this.provider,
-      relayData,
-      this.signer,
-      repaymentChainId,
-      repaymentAddress
-    );
-    this.queuedFills.push({ txPromises: [fillTxPromise], message, mrkdwn });
+    const txPromises = this.buildFillRelayTxPromises(spokePool, relayData, repaymentChainId, repaymentAddress);
+    this.enqueueFillRelayTxPromises(txPromises, message, mrkdwn);
   }
 
   enqueueSlowFill(spokePool: SvmAddress, relayData: ProtoFill, message: string, mrkdwn: string): void {
-    const slowFillTxPromise = arch.svm.getSlowFillRequestTx(spokePool, this.provider, relayData, this.signer);
-    this.queuedFills.push({ txPromises: [slowFillTxPromise], message, mrkdwn });
+    this.enqueueFillRelayTxPromises([this.buildSlowFillTxPromise(spokePool, relayData)], message, mrkdwn);
   }
 
-  private _enqueueMultipartFill(
+  /**
+   * Builds and submits fillRelay transaction(s) immediately (each tx is sent as soon as it is ready).
+   */
+  async executeFillImmediately(
     spokePool: SvmAddress,
     relayData: ProtoFill,
     repaymentChainId: number,
     repaymentAddress: SDKAddress,
     message: string,
-    mrkdwn: string
-  ): void {
-    const ipTxsPromise = arch.svm.getIPForFillRelayTxs(
-      spokePool,
-      relayData,
-      repaymentChainId,
-      repaymentAddress,
-      this.signer,
-      this.provider
-    );
-    const fillTxPromise = arch.svm.getIPFillRelayTx(
-      spokePool,
-      this.provider,
-      relayData,
-      this.signer,
-      repaymentChainId,
-      repaymentAddress
-    );
-    this.queuedFills.push({ txPromises: [ipTxsPromise, fillTxPromise], message, mrkdwn });
+    mrkdwn: string,
+    maxRetries = 2
+  ): Promise<string | undefined> {
+    const txPromises = this.buildFillRelayTxPromises(spokePool, relayData, repaymentChainId, repaymentAddress);
+
+    try {
+      const signatureStrings = await this._executeTxnPromisesWithRetry(txPromises, maxRetries, true);
+      const lastSignature = signatureStrings.at(-1);
+      this.logger.info({
+        at: "SvmFillerClient#executeFillImmediately",
+        message,
+        mrkdwn,
+        signatures: signatureStrings,
+        explorer: isDefined(lastSignature) ? blockExplorerLink(lastSignature, this.chainId) : undefined,
+      });
+      return lastSignature;
+    } catch (e: unknown) {
+      if (!typeguards.isError(e)) {
+        throw e;
+      }
+
+      let errorMessage = "";
+      if (!isSolanaError(e)) {
+        errorMessage = e?.message ?? "Unknown error";
+      } else {
+        errorMessage = `Solana error code: ${e.context.__code}`;
+      }
+
+      this.logger.error({
+        at: "SvmFillerClient#executeFillImmediately",
+        message: `Failed to send fill transaction (${errorMessage})`,
+        mrkdwn,
+        error: e,
+      });
+      return undefined;
+    }
   }
 
-  async _executeTxnQueueWithRetry(
-    txPromises: (ReadyTransactionPromise | ReadyTransactionsPromise)[],
-    retryAttempt: number
+  private async _executeTxnPromisesWithRetry(
+    txPromises: SvmFillRelayTxPromises,
+    retryAttempt: number,
+    confirmAll: boolean
   ): Promise<string[]> {
     try {
       const transactions = await Promise.all(txPromises);
-      const signatures = [];
-      const transactionBatch = transactions.flat(); // Cast a single transaction or batch into an array.
-      const sendAndConfirm = transactionBatch.length !== 1;
+      const signatures: string[] = [];
+      const transactionBatch = transactions.flat();
+      const sendAndConfirm = confirmAll || transactionBatch.length !== 1;
 
-      // Ordering of the transactions must be preserved.
       for (const transaction of transactionBatch) {
         const txSignature = sendAndConfirm
           ? sendAndConfirmSolanaTransaction(transaction, this.provider)
@@ -157,7 +208,7 @@ export class SvmFillerClient {
 
       if (isDefined(code) && retryableErrorCodes.includes(code) && retryAttempt > 0) {
         await delay(retryDelaySeconds);
-        return this._executeTxnQueueWithRetry(txPromises, --retryAttempt);
+        return this._executeTxnPromisesWithRetry(txPromises, --retryAttempt, confirmAll);
       }
 
       throw e;
@@ -175,11 +226,10 @@ export class SvmFillerClient {
       return [];
     }
 
-    // @dev Execute transactions sequentially, returning signatures of successful ones.
     const signatures: string[][] = [];
     for (const { txPromises, message, mrkdwn } of queue) {
       try {
-        const signatureStrings = await this._executeTxnQueueWithRetry(txPromises, maxRetries);
+        const signatureStrings = await this._executeTxnPromisesWithRetry(txPromises, maxRetries, false);
         const lastSignature = signatureStrings.at(-1);
         this.logger.info({
           at: "SvmFillerClient#executeTxnQueue",
@@ -194,16 +244,16 @@ export class SvmFillerClient {
           throw e;
         }
 
-        let message = "";
+        let errorMessage = "";
         if (!isSolanaError(e)) {
-          message = e?.message ?? "Unknown error";
+          errorMessage = e?.message ?? "Unknown error";
         } else {
-          message = `Solana error code: ${e.context.__code}`;
+          errorMessage = `Solana error code: ${e.context.__code}`;
         }
 
         this.logger.error({
           at: "SvmFillerClient#executeTxnQueue",
-          message: `Failed to send fill transaction (${message})`,
+          message: `Failed to send fill transaction (${errorMessage})`,
           mrkdwn,
           error: e,
         });

--- a/src/clients/SvmFillerClient.ts
+++ b/src/clients/SvmFillerClient.ts
@@ -149,13 +149,15 @@ export class SvmFillerClient {
     try {
       const signatureStrings = await this._executeTxnPromisesWithRetry(txPromises, maxRetries, true);
       const lastSignature = signatureStrings.at(-1);
-      this.logger.info({
-        at: "SvmFillerClient#executeFillImmediately",
-        message,
-        mrkdwn,
-        signatures: signatureStrings,
-        explorer: isDefined(lastSignature) ? blockExplorerLink(lastSignature, this.chainId) : undefined,
-      });
+      if (isDefined(lastSignature)) {
+        this.logger.info({
+          at: "SvmFillerClient#executeFillImmediately",
+          message,
+          mrkdwn,
+          signatures: signatureStrings,
+          explorer: blockExplorerLink(lastSignature, this.chainId),
+        });
+      }
       return lastSignature;
     } catch (e: unknown) {
       if (!typeguards.isError(e)) {

--- a/src/gasless/GaslessRelayer.ts
+++ b/src/gasless/GaslessRelayer.ts
@@ -211,8 +211,10 @@ export class GaslessRelayer {
       this.svmEventsClient = await SvmCpiEventsClient.create(svmProvider);
       this.svmFillerClient = await SvmFillerClient.from(this.baseSigner, svmProvider, svmChainId, this.logger);
       const spokePoolAddress = getSpokePoolAddress(svmChainId);
-      assert(spokePoolAddress.isSVM(), `Expected SVM spoke pool for chain ${svmChainId}`);
-      this.svmSpokePoolAddress = spokePoolAddress as SvmAddress;
+      if (!spokePoolAddress.isSVM()) {
+        throw new Error(`Expected SVM spoke pool for chain ${svmChainId}`);
+      }
+      this.svmSpokePoolAddress = spokePoolAddress;
       this.observedFills[svmChainId] = new Set<string>();
     }
 
@@ -322,35 +324,51 @@ export class GaslessRelayer {
           });
       }),
 
-      mapAsync(this.config.relayerDestinationChains.filter(chainIsEvm), async (destinationChainId) => {
-        const provider = this.providersByChain[destinationChainId];
-        const observedFills = this.observedFills[destinationChainId];
-
-        const searchConfig = await this._getEventSearchConfig(destinationChainId);
-        const destinationSpokePool = getSpokePool(destinationChainId).connect(provider);
-
-        const destinationFilledRelayEvents = await paginatedEventQuery(
-          destinationSpokePool,
-          destinationSpokePool.filters.FilledRelay(),
-          searchConfig
-        );
-        for (const filledRelay of destinationFilledRelayEvents) {
-          const fill = unpackFillEvent(spreadEventWithBlockNumber(filledRelay), destinationChainId);
-          observedFills.add(this._getFilledRelayKey(fill.originChainId, fill.depositId.toString()));
+      mapAsync(this.config.relayerDestinationChains, async (destinationChainId) => {
+        if (chainIsEvm(destinationChainId)) {
+          await this._updateObservedEvmFills(destinationChainId);
+        } else if (chainIsSvm(destinationChainId)) {
+          await this._updateObservedSvmFills(destinationChainId, apiMessages);
         }
       }),
     ]);
+  }
 
-    await this._updateObservedSvmFills(apiMessages);
+  /**
+   * Populates {@link observedFills} for an EVM destination by scanning {@link FilledRelay} events.
+   */
+  private async _updateObservedEvmFills(destinationChainId: number): Promise<void> {
+    const provider = this.providersByChain[destinationChainId];
+    const observedFills = this.observedFills[destinationChainId];
+
+    const searchConfig = await this._getEventSearchConfig(destinationChainId);
+    const destinationSpokePool = getSpokePool(destinationChainId).connect(provider);
+
+    const destinationFilledRelayEvents = await paginatedEventQuery(
+      destinationSpokePool,
+      destinationSpokePool.filters.FilledRelay(),
+      searchConfig
+    );
+    for (const filledRelay of destinationFilledRelayEvents) {
+      const fill = unpackFillEvent(spreadEventWithBlockNumber(filledRelay), destinationChainId);
+      observedFills.add(this._getFilledRelayKey(fill.originChainId, fill.depositId.toString()));
+    }
   }
 
   /**
    * Marks already-filled Solana destination relays in {@link observedFills} by querying fill status per API message.
    */
-  private async _updateObservedSvmFills(apiMessages: AnyGaslessDepositMessage[]): Promise<void> {
+  private async _updateObservedSvmFills(
+    destinationChainId: number,
+    apiMessages: AnyGaslessDepositMessage[]
+  ): Promise<void> {
+    if (!isDefined(this.svmSpokePoolAddress)) {
+      return;
+    }
+
     const svmMessages = apiMessages.filter((msg) => {
-      const { destinationChainId } = extractGaslessDepositFields(msg);
-      return chainIsSvm(destinationChainId) && isDefined(this.svmSpokePoolAddress);
+      const { destinationChainId: msgDestinationChainId } = extractGaslessDepositFields(msg);
+      return msgDestinationChainId === destinationChainId;
     });
 
     await mapAsync(svmMessages, async (depositMessage) => {

--- a/src/gasless/GaslessRelayer.ts
+++ b/src/gasless/GaslessRelayer.ts
@@ -122,6 +122,13 @@ export class GaslessRelayer {
   protected providersByChain: { [chainId: number]: Provider } = {};
   // The object is indexed by `chainId`. An `AuthorizationUsed` event is marked by adding `${token}:${authorizer}:${nonce}` to the respective chain's set.
   protected observedDeposits: { [chainId: number]: Set<string> } = {};
+  /**
+   * Origin deposits observed at init with an SVM {@link Deposit.destinationChainId}, keyed by {@link _getDepositKey}.
+   * Used for fill status / fillRelay instead of synthetic API-derived relay data.
+   */
+  protected cachedSvmOriginDeposits: {
+    [depositKey: string]: Omit<DepositWithBlock, "fromLiteChain" | "toLiteChain" | "quoteBlockNumber">;
+  } = {};
   // The object is indexed by `chainId`. A `FilledRelay` event is marked by adding `${originChainId}:${depositId}` to the respective chain's set.
   protected observedFills: { [chainId: number]: Set<string> } = {};
   // The object is indexed by `chainId`. A SpokePoolPeriphery contract is indexed by the chain ID.
@@ -301,11 +308,18 @@ export class GaslessRelayer {
         originFundsDepositedEvents
           .map((event) => unpackDepositEvent(spreadEventWithBlockNumber(event), originChainId))
           .filter((deposit) => apiMessages.some(({ depositId }) => deposit.depositId.eq(depositId)))
-          .forEach((deposit) =>
-            observedDeposits.add(
-              this._getDepositKey(deposit.inputToken.toNative(), originChainId, deposit.depositId.toString())
-            )
-          );
+          .forEach((deposit) => {
+            const depositKey = this._getDepositKey(
+              deposit.inputToken.toNative(),
+              originChainId,
+              deposit.depositId.toString()
+            );
+            observedDeposits.add(depositKey);
+
+            if (chainIsSvm(deposit.destinationChainId)) {
+              this.cachedSvmOriginDeposits[depositKey] = deposit;
+            }
+          });
       }),
 
       mapAsync(this.config.relayerDestinationChains.filter(chainIsEvm), async (destinationChainId) => {
@@ -340,40 +354,18 @@ export class GaslessRelayer {
     });
 
     await mapAsync(svmMessages, async (depositMessage) => {
-      const relayData = this._relayDataFromApiMessage(depositMessage);
-      const fillStatus = await this._getDestinationFillStatus(relayData);
+      const deposit = this.cachedSvmOriginDeposits[this._getDepositKeyFromMessage(depositMessage)];
+      if (!isDefined(deposit)) {
+        return;
+      }
+
+      const fillStatus = await this._getDestinationFillStatus(deposit);
       if (fillStatus === FillStatus.Filled) {
-        this.observedFills[relayData.destinationChainId].add(
-          this._getFilledRelayKey(relayData.originChainId, relayData.depositId.toString())
+        this.observedFills[deposit.destinationChainId].add(
+          this._getFilledRelayKey(deposit.originChainId, deposit.depositId.toString())
         );
       }
     });
-  }
-
-  private _relayDataFromApiMessage(
-    depositMessage: AnyGaslessDepositMessage
-  ): RelayData & { destinationChainId: number } {
-    if (depositMessage.depositFlowType === "bridge") {
-      return buildSyntheticDeposit(depositMessage);
-    }
-
-    const { originChainId, depositId } = depositMessage;
-    const bd = depositMessage.depositData;
-    return {
-      originChainId,
-      depositor: toAddressType(bd.depositor, originChainId),
-      recipient: toAddressType(bd.recipient, bd.destinationChainId),
-      depositId: toBN(depositId),
-      inputToken: toAddressType(bd.inputToken, originChainId),
-      inputAmount: toBN(depositMessage.minExpectedInputTokenAmount),
-      outputToken: toAddressType(bd.outputToken, bd.destinationChainId),
-      outputAmount: toBN(bd.outputAmount),
-      message: bd.message.startsWith("0x") ? bd.message : "0x" + Buffer.from(bd.message, "utf8").toString("hex"),
-      fillDeadline: bd.fillDeadline,
-      exclusiveRelayer: toAddressType(bd.exclusiveRelayer, bd.destinationChainId),
-      exclusivityDeadline: bd.exclusivityDeadline,
-      destinationChainId: bd.destinationChainId,
-    };
   }
 
   private async _getDestinationFillStatus(deposit: RelayData & { destinationChainId: number }): Promise<FillStatus> {
@@ -415,6 +407,11 @@ export class GaslessRelayer {
     spokePool: string
   ): boolean {
     if (this._isCctpDeposit(deposit.originChainId, spokePool)) {
+      return false;
+    }
+
+    // Solana fills require an on-chain origin deposit; never fill from API-derived synthetic relay data.
+    if (chainIsSvm(deposit.destinationChainId)) {
       return false;
     }
 
@@ -567,7 +564,7 @@ export class GaslessRelayer {
         swapTokenAmount,
       } = extractGaslessDepositFields(depositMessage);
 
-      const depositKey = this._getDepositKey(inputToken.toNative(), originChainId, depositId);
+      const depositKey = this._getDepositKeyFromMessage(depositMessage);
       const fillKey = `${authorizer}:${originChainId}`;
 
       const at = "GaslessRelayer#evaluateApiSignatures";
@@ -1157,6 +1154,11 @@ export class GaslessRelayer {
    */
   protected _getDepositKey(token: string, originChainId: number, depositId: string): string {
     return `${token}:${originChainId}:${depositId}`;
+  }
+
+  protected _getDepositKeyFromMessage(depositMessage: AnyGaslessDepositMessage): string {
+    const { inputToken } = extractGaslessDepositFields(depositMessage);
+    return this._getDepositKey(inputToken.toNative(), depositMessage.originChainId, depositMessage.depositId);
   }
 
   /*

--- a/src/gasless/GaslessRelayer.ts
+++ b/src/gasless/GaslessRelayer.ts
@@ -1,5 +1,6 @@
 import winston from "winston";
 import { GaslessRelayerConfig } from "./GaslessRelayerConfig";
+import { arch } from "@across-protocol/sdk";
 import {
   Address,
   isDefined,
@@ -21,6 +22,7 @@ import {
   mapAsync,
   TransactionReceipt,
   EvmAddress,
+  SvmAddress,
   toBN,
   blockExplorerLink,
   getNetworkName,
@@ -30,6 +32,7 @@ import {
   createFormatFunction,
   toAddressType,
   getSpokePoolPeriphery,
+  getSpokePoolAddress,
   getPermit2,
   compareAddressesSimple,
   ConvertDecimals,
@@ -39,6 +42,10 @@ import {
   toBNWei,
   utils,
   willSucceed,
+  chainIsSvm,
+  chainIsEvm,
+  getSvmProvider,
+  SvmCpiEventsClient,
 } from "../utils";
 import { getRedisCache, RedisCacheInterface } from "../cache/Redis";
 import {
@@ -49,7 +56,7 @@ import {
   GaslessDepositMessage,
   RelayData,
 } from "../interfaces";
-import { AcrossSwapApiClient, TransactionClient } from "../clients";
+import { AcrossSwapApiClient, SvmFillerClient, TransactionClient } from "../clients";
 import EIP3009_ABI from "../common/abi/EIP3009.json";
 import {
   buildGaslessDepositTx,
@@ -68,6 +75,9 @@ import {
 } from "../utils/GaslessUtils";
 
 const DEPOSIT_EVENT = "FundsDeposited";
+
+/** Result of a submitted gasless fill (EVM receipt or Solana signature). */
+export type GaslessFillSubmissionResult = TransactionReceipt | { svmSignature: string };
 
 export enum MessageState {
   INITIAL = 0,
@@ -116,8 +126,14 @@ export class GaslessRelayer {
   protected observedFills: { [chainId: number]: Set<string> } = {};
   // The object is indexed by `chainId`. A SpokePoolPeriphery contract is indexed by the chain ID.
   protected spokePoolPeripheries: { [chainId: number]: Contract } = {};
-  // The object is indexed by `chainId`. A SpokePool contract is indexed by the chain ID.
+  // The object is indexed by `chainId`. A SpokePool contract is indexed by the chain ID (EVM destinations only).
   protected spokePools: { [chainId: number]: Contract } = {};
+  /** Solana destination fill client (at most one SVM destination chain). */
+  protected svmFillerClient?: SvmFillerClient;
+  /** SVM CPI events client for {@link arch.svm.relayFillStatus} on destination Solana. */
+  protected svmEventsClient?: SvmCpiEventsClient;
+  /** Spoke pool program id for the single SVM destination chain (if configured). */
+  protected svmSpokePoolAddress?: SvmAddress;
   /** Permit2 on each origin chain, connected to that chain's provider (nonce bitmap reads). */
   protected permit2Contracts: { [chainId: number]: Contract } = {};
   // Tracks whether a fill is currently in progress for a given user/originChainId combo.
@@ -176,7 +192,24 @@ export class GaslessRelayer {
         this.permit2Contracts[chainId] = getPermit2(chainId).connect(provider);
       }
     });
-    await forEachAsync(this.config.relayerDestinationChains, async (chainId) => {
+    const svmDestinationChains = this.config.relayerDestinationChains.filter(chainIsSvm);
+    assert(
+      svmDestinationChains.length <= 1,
+      `Gasless relayer supports at most one SVM destination chain, got: ${svmDestinationChains.join(", ")}`
+    );
+
+    if (svmDestinationChains.length === 1) {
+      const svmChainId = svmDestinationChains[0];
+      const svmProvider = getSvmProvider(this.redisCache, this.logger, svmChainId);
+      this.svmEventsClient = await SvmCpiEventsClient.create(svmProvider);
+      this.svmFillerClient = await SvmFillerClient.from(this.baseSigner, svmProvider, svmChainId, this.logger);
+      const spokePoolAddress = getSpokePoolAddress(svmChainId);
+      assert(spokePoolAddress.isSVM(), `Expected SVM spoke pool for chain ${svmChainId}`);
+      this.svmSpokePoolAddress = spokePoolAddress as SvmAddress;
+      this.observedFills[svmChainId] = new Set<string>();
+    }
+
+    await forEachAsync(this.config.relayerDestinationChains.filter(chainIsEvm), async (chainId) => {
       this.providersByChain[chainId] ??= await getProvider(chainId);
       this.observedFills[chainId] = new Set<string>();
       this.spokePools[chainId] = getSpokePool(chainId).connect(this.baseSigner.connect(this.providersByChain[chainId]));
@@ -275,7 +308,7 @@ export class GaslessRelayer {
           );
       }),
 
-      mapAsync(this.config.relayerDestinationChains, async (destinationChainId) => {
+      mapAsync(this.config.relayerDestinationChains.filter(chainIsEvm), async (destinationChainId) => {
         const provider = this.providersByChain[destinationChainId];
         const observedFills = this.observedFills[destinationChainId];
 
@@ -293,6 +326,79 @@ export class GaslessRelayer {
         }
       }),
     ]);
+
+    await this._updateObservedSvmFills(apiMessages);
+  }
+
+  /**
+   * Marks already-filled Solana destination relays in {@link observedFills} by querying fill status per API message.
+   */
+  private async _updateObservedSvmFills(apiMessages: AnyGaslessDepositMessage[]): Promise<void> {
+    const svmMessages = apiMessages.filter((msg) => {
+      const { destinationChainId } = extractGaslessDepositFields(msg);
+      return chainIsSvm(destinationChainId) && isDefined(this.svmSpokePoolAddress);
+    });
+
+    await mapAsync(svmMessages, async (depositMessage) => {
+      const relayData = this._relayDataFromApiMessage(depositMessage);
+      const fillStatus = await this._getDestinationFillStatus(relayData);
+      if (fillStatus === FillStatus.Filled) {
+        this.observedFills[relayData.destinationChainId].add(
+          this._getFilledRelayKey(relayData.originChainId, relayData.depositId.toString())
+        );
+      }
+    });
+  }
+
+  private _relayDataFromApiMessage(
+    depositMessage: AnyGaslessDepositMessage
+  ): RelayData & { destinationChainId: number } {
+    if (depositMessage.depositFlowType === "bridge") {
+      return buildSyntheticDeposit(depositMessage);
+    }
+
+    const { originChainId, depositId } = depositMessage;
+    const bd = depositMessage.depositData;
+    return {
+      originChainId,
+      depositor: toAddressType(bd.depositor, originChainId),
+      recipient: toAddressType(bd.recipient, bd.destinationChainId),
+      depositId: toBN(depositId),
+      inputToken: toAddressType(bd.inputToken, originChainId),
+      inputAmount: toBN(depositMessage.minExpectedInputTokenAmount),
+      outputToken: toAddressType(bd.outputToken, bd.destinationChainId),
+      outputAmount: toBN(bd.outputAmount),
+      message: bd.message.startsWith("0x") ? bd.message : "0x" + Buffer.from(bd.message, "utf8").toString("hex"),
+      fillDeadline: bd.fillDeadline,
+      exclusiveRelayer: toAddressType(bd.exclusiveRelayer, bd.destinationChainId),
+      exclusivityDeadline: bd.exclusivityDeadline,
+      destinationChainId: bd.destinationChainId,
+    };
+  }
+
+  private async _getDestinationFillStatus(deposit: RelayData & { destinationChainId: number }): Promise<FillStatus> {
+    const { destinationChainId } = deposit;
+    if (chainIsSvm(destinationChainId)) {
+      const svmEventsClient = this.svmEventsClient;
+      const spokePoolAddress = this.svmSpokePoolAddress;
+      assert(isDefined(svmEventsClient), "Missing svmEventsClient for SVM destination");
+      assert(isDefined(spokePoolAddress), "Missing SVM spoke pool address");
+      assert(deposit.recipient.isSVM() && deposit.outputToken.isSVM(), "SVM fill status requires SVM addresses");
+
+      return arch.svm.relayFillStatus(
+        arch.svm.toAddress(spokePoolAddress),
+        {
+          ...deposit,
+          recipient: deposit.recipient,
+          outputToken: deposit.outputToken,
+        },
+        destinationChainId,
+        svmEventsClient,
+        this.logger
+      );
+    }
+
+    return relayFillStatus(this.spokePools[destinationChainId], deposit, "latest", destinationChainId);
   }
 
   /**
@@ -663,26 +769,21 @@ export class GaslessRelayer {
                 break;
               }
 
-              const txnReceipt = await this.initiateFill(deposit, spokePool);
-              if (isDefined(txnReceipt)) {
+              const fillSubmission = await this.initiateFill(deposit, spokePool);
+              if (isDefined(fillSubmission)) {
                 log("info", `Completed fill on ${destination} for ${origin} deposit.`);
                 fillStatus = FillStatus.Filled;
               }
             } else {
               deposit = buildSyntheticDeposit(bridgeMessage);
-              const txnReceipt = await this.initiateFill(deposit, spokePool);
-              if (isDefined(txnReceipt)) {
+              const fillSubmission = await this.initiateFill(deposit, spokePool);
+              if (isDefined(fillSubmission)) {
                 log("info", `Completed immediate fill on ${destination} for ${origin} deposit.`);
                 fillStatus = FillStatus.Filled;
               }
             }
 
-            fillStatus ??= await relayFillStatus(
-              this.spokePools[destinationChainId],
-              deposit,
-              "latest",
-              destinationChainId
-            );
+            fillStatus ??= await this._getDestinationFillStatus(deposit);
 
             if (fillStatus === FillStatus.Filled) {
               log("info", `Recognised fill on ${destination}.`);
@@ -800,7 +901,7 @@ export class GaslessRelayer {
   protected async initiateFill(
     deposit: RelayData & { destinationChainId: number },
     originChainSpokePool: string
-  ): Promise<TransactionReceipt | null | undefined> {
+  ): Promise<GaslessFillSubmissionResult | null | undefined> {
     const { originChainId, depositId, destinationChainId, outputToken, outputAmount, inputToken, inputAmount } =
       deposit;
 
@@ -831,9 +932,12 @@ export class GaslessRelayer {
       "Cannot fill deposit with mismatching input/output tokens (not same L1 or in allowedPeggedPairs)."
     );
 
-    const spokePool = this.spokePools[destinationChainId];
-
-    const _gaslessFill = buildGaslessFillRelayTx(deposit, spokePool, originChainId, this.signerAddress);
+    const logMessage = "Completed gasless fill 🔮";
+    const mrkdwn = `Completed gasless fill from ${getNetworkName(originChainId)} to ${getNetworkName(
+      destinationChainId
+    )} with output amount ${createFormatFunction(2, 4, false, outputTokenInfo.decimals)(outputAmount)} ${
+      outputTokenInfo.symbol
+    } and deposit ID ${depositId}`;
 
     if (!this.config.sendingTransactionsEnabled) {
       this.logger.debug({
@@ -843,14 +947,45 @@ export class GaslessRelayer {
       return null;
     }
 
+    if (chainIsSvm(destinationChainId)) {
+      const svmFillerClient = this.svmFillerClient;
+      const spokePoolAddress = this.svmSpokePoolAddress;
+      assert(isDefined(svmFillerClient), "Missing svmFillerClient for SVM destination");
+      assert(isDefined(spokePoolAddress), "Missing SVM spoke pool address");
+      assert(
+        deposit.recipient.isSVM() && deposit.outputToken.isSVM(),
+        "SVM fill requires SVM recipient and outputToken"
+      );
+
+      const svmSignature = await svmFillerClient.executeFillImmediately(
+        spokePoolAddress,
+        {
+          ...deposit,
+          recipient: deposit.recipient,
+          outputToken: deposit.outputToken,
+        },
+        originChainId,
+        this.signerAddress,
+        logMessage,
+        mrkdwn
+      );
+      if (!isDefined(svmSignature)) {
+        this.logger.warn({
+          at: "GaslessRelayer#initiateFill",
+          message: "Failed to submit gasless SVM fill",
+          depositId,
+        });
+        return null;
+      }
+      return { svmSignature };
+    }
+
+    const spokePool = this.spokePools[destinationChainId];
+    const _gaslessFill = buildGaslessFillRelayTx(deposit, spokePool, originChainId, this.signerAddress);
     const gaslessFill = {
       ..._gaslessFill,
-      message: "Completed gasless fill 🔮",
-      mrkdwn: `Completed gasless fill from ${getNetworkName(originChainId)} to ${getNetworkName(
-        destinationChainId
-      )} with output amount ${createFormatFunction(2, 4, false, outputTokenInfo.decimals)(outputAmount)} ${
-        outputTokenInfo.symbol
-      } and deposit ID ${depositId}`,
+      message: logMessage,
+      mrkdwn,
     };
 
     const txReceipt = await sendAndConfirmTransaction(gaslessFill, this.transactionClient);

--- a/test/GaslessRelayer.ts
+++ b/test/GaslessRelayer.ts
@@ -7,7 +7,7 @@ import {
   RelayData,
   SwapAndBridgeGaslessDepositMessage,
 } from "../src/interfaces";
-import { GaslessRelayer, MessageState } from "../src/gasless/GaslessRelayer";
+import { GaslessFillSubmissionResult, GaslessRelayer, MessageState } from "../src/gasless/GaslessRelayer";
 import { GaslessRelayerConfig } from "../src/gasless/GaslessRelayerConfig";
 import SPOKE_POOL_PERIPHERY_ABI from "../src/common/abi/SpokePoolPeriphery.json";
 import PERMIT2_ABI from "../src/common/abi/Permit2.json";
@@ -114,7 +114,7 @@ class TestableGaslessRelayer extends GaslessRelayer {
   public getPeripheryContractFn: (chainId: number) => Contract = (chainId) => this.spokePoolPeripheries[chainId];
   public queryGaslessApiFn: () => Promise<AnyGaslessDepositMessage[]> = async () => [];
   public initiateDepositFn: (msg: AnyGaslessDepositMessage) => Promise<TransactionReceipt | null> = async () => null;
-  public initiateFillFn: (deposit: GaslessDeposit) => Promise<TransactionReceipt | null> = async () => null;
+  public initiateFillFn: (deposit: GaslessDeposit) => Promise<GaslessFillSubmissionResult | null> = async () => null;
   public extractDepositFromReceiptFn: (receipt: TransactionReceipt, chainId: number) => StrippedDeposit = () => {
     throw new Error("extractDepositFromReceiptFn not configured");
   };
@@ -140,7 +140,7 @@ class TestableGaslessRelayer extends GaslessRelayer {
   protected override async initiateFill(
     deposit: StrippedDeposit,
     originChainSpokePool: string
-  ): Promise<TransactionReceipt | null> {
+  ): Promise<GaslessFillSubmissionResult | null> {
     this.initiateFillCalls++;
 
     // Validate that non-CCTP deposits pass the correct spokePool address

--- a/test/GaslessRelayer.ts
+++ b/test/GaslessRelayer.ts
@@ -1077,6 +1077,21 @@ describe("GaslessRelayer", function () {
         ).to.be.false;
       });
 
+      it("Returns false when destination is Solana", function () {
+        process.env[`RELAYER_GASLESS_FILL_IMMEDIATE_USD_THRESHOLD_${ORIGIN_CHAIN_ID}`] = "10";
+        const result = relayer.testFillImmediate(
+          {
+            originChainId: ORIGIN_CHAIN_ID,
+            destinationChainId: CHAIN_IDs.SOLANA,
+            outputToken: EvmAddress.from(USDC_BASE),
+            outputAmount: toBN("1000000"),
+            exclusivityParameter: 1700000000,
+          },
+          fakeSpokePoolAddress
+        );
+        expect(result).to.be.false;
+      });
+
       it("Returns false for non-stablecoin tokens regardless of amount", function () {
         // WETH is not USDC/USDT, so fillImmediate is always false.
         process.env[`RELAYER_GASLESS_FILL_IMMEDIATE_USD_THRESHOLD_${ORIGIN_CHAIN_ID}`] = "10";


### PR DESCRIPTION
Adding SVM support in gasless relayer. 
Also, refactoring SvmFillerClient so it can send fill tx right away and not needing to enqueue it.