### PR TITLE
fix(monitor): label warn vs error in balance threshold alert

### DIFF
--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -657,12 +657,14 @@ export class Monitor {
                   symbol = this.getTokenInfo(token, chainId).symbol;
                 }
               }
+              const levelTag = trippedThreshold.level === "error" ? "[ERROR]" : "[WARN]";
+              const thresholdLabel = trippedThreshold.level === "error" ? "Error threshold" : "Warn threshold";
               return {
                 level: trippedThreshold.level,
-                text: `  ${getNetworkName(chainId)} ${symbol} balance for ${blockExplorerLink(
+                text: `  ${levelTag} ${getNetworkName(chainId)} ${symbol} balance for ${blockExplorerLink(
                   account.toNative(),
                   chainId
-                )} is ${formatUnits(balance, decimals)}. Threshold: ${trippedThreshold.threshold}`,
+                )} is ${formatUnits(balance, decimals)}. ${thresholdLabel}: ${trippedThreshold.threshold}`,
               };
             }
           }


### PR DESCRIPTION
## Summary
- The balance-threshold alert in `Monitor.checkBalances()` combined warn-tripped and error-tripped balances into one Slack message logged at the max level, so each line looked identical (just `Threshold: X`).
- Operators could not tell which balance was actually pageable vs which was just a warning.
- Prefix each line with `[ERROR]`/`[WARN]` and rename the per-line threshold label so the cause of the page is obvious.

Example rendering:
```
Some balance(s) are below the configured threshold!
  [ERROR] Mainnet ABT balance for ... is 12.576. Error threshold: 14
  [WARN] Solana SOL balance for ... is 0.467789051. Warn threshold: 0.5
```

Requested in Slack.

## Test plan
- [ ] Manual: trigger a warn-only alert and confirm `[WARN]` prefix and `Warn threshold: ...` label.
- [ ] Manual: trigger an error-only alert and confirm `[ERROR]` prefix and `Error threshold: ...` label.
- [ ] Manual: trigger a mixed batch (one warn + one error tripped) and confirm both lines have their own prefix/label and the message pages at error level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)