### PR TITLE
docs: add BUILD to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,5 @@ We publish pre-releases to signal to users about potential releases that are ris
 ### Documenting changes
 
 Every merged PR into `master` should be following the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format, as documented in [CONTRIBUTING.md](https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md).
+
+BUILD


### PR DESCRIPTION
## Summary
- Appends `BUILD` to the end of README.md.

## Test plan
- Documentation-only change; no tests run.