### PR TITLE
fix(finalizer): suppress MegaETH ProposalNotValidated() in viem patch

### DIFF
--- a/patches/viem+2.47.10.patch
+++ b/patches/viem+2.47.10.patch
@@ -67,6 +67,20 @@ index d8a07c5..6146d65 100644
          return !l2BlockNumber || blockNumber > l2BlockNumber
              ? { ...game, l2BlockNumber: blockNumber }
              : null;
+diff --git a/node_modules/viem/_cjs/op-stack/actions/getWithdrawalStatus.js b/node_modules/viem/_cjs/op-stack/actions/getWithdrawalStatus.js
+index eefc218..bf0a036 100644
+--- a/node_modules/viem/_cjs/op-stack/actions/getWithdrawalStatus.js
++++ b/node_modules/viem/_cjs/op-stack/actions/getWithdrawalStatus.js
+@@ -148,6 +148,9 @@ async function getWithdrawalStatus(client, parameters) {
+                     'OptimismPortal: proven withdrawal has not matured yet',
+                     'OptimismPortal: output proposal has not been finalized yet',
+                     'OptimismPortal: output proposal in air-gap',
++                    // MegaETH's Portal-2 reverts with ProposalNotValidated() while the
++                    // dispute game is still resolving; treat as waiting, not as error.
++                    'ProposalNotValidated',
+                 ],
+             };
+             const errors = [
 diff --git a/node_modules/viem/_esm/chains/definitions/megaeth.js b/node_modules/viem/_esm/chains/definitions/megaeth.js
 index 3347805..8a1093c 100644
 --- a/node_modules/viem/_esm/chains/definitions/megaeth.js
@@ -136,6 +150,20 @@ index d283a6c..56f6663 100644
          return !l2BlockNumber || blockNumber > l2BlockNumber
              ? { ...game, l2BlockNumber: blockNumber }
              : null;
+diff --git a/node_modules/viem/_esm/op-stack/actions/getWithdrawalStatus.js b/node_modules/viem/_esm/op-stack/actions/getWithdrawalStatus.js
+index 2c88ff1..8e12b65 100644
+--- a/node_modules/viem/_esm/op-stack/actions/getWithdrawalStatus.js
++++ b/node_modules/viem/_esm/op-stack/actions/getWithdrawalStatus.js
+@@ -181,6 +181,9 @@ export async function getWithdrawalStatus(client, parameters) {
+                     'OptimismPortal: proven withdrawal has not matured yet',
+                     'OptimismPortal: output proposal has not been finalized yet',
+                     'OptimismPortal: output proposal in air-gap',
++                    // MegaETH's Portal-2 reverts with ProposalNotValidated() while the
++                    // dispute game is still resolving; treat as waiting, not as error.
++                    'ProposalNotValidated',
+                 ],
+             };
+             // Pick out the error message and/or error name
 diff --git a/node_modules/viem/_types/clients/createClient.d.ts b/node_modules/viem/_types/clients/createClient.d.ts
 index 1697039..85e7e81 100644
 --- a/node_modules/viem/_types/clients/createClient.d.ts
@@ -178,3 +206,17 @@ index 41b4d70..7527021 100644
 +  },
    sourceId,
  })
+diff --git a/node_modules/viem/op-stack/actions/getWithdrawalStatus.ts b/node_modules/viem/op-stack/actions/getWithdrawalStatus.ts
+index 50eb88d..4d9e7a9 100644
+--- a/node_modules/viem/op-stack/actions/getWithdrawalStatus.ts
++++ b/node_modules/viem/op-stack/actions/getWithdrawalStatus.ts
+@@ -314,6 +314,9 @@ export async function getWithdrawalStatus<
+           'OptimismPortal: proven withdrawal has not matured yet',
+           'OptimismPortal: output proposal has not been finalized yet',
+           'OptimismPortal: output proposal in air-gap',
++          // MegaETH's Portal-2 reverts with ProposalNotValidated() while the
++          // dispute game is still resolving; treat as waiting, not as error.
++          'ProposalNotValidated',
+         ],
+       }
+ 


### PR DESCRIPTION
## Summary

MegaETH's Portal-2 reverts `checkWithdrawal()` with the custom error `ProposalNotValidated()` while the (gameType 1337) dispute game is still resolving. `viem@2.47.10`'s `getWithdrawalStatus` doesn't recognize this error in its status-mapper table, so the revert escapes as a thrown `ContractFunctionRevertedError` rather than being treated as `waiting-to-finalize`.

Inside `viem_multicallOptimismFinalizations` the per-withdrawal `getWithdrawalStatus` reads run via `Promise.allSettled` through Multicall3 — but a single rejected promise still throws back out through `opStackFinalizer`, producing the log line `Something errored in a finalizer for chain 4326` and short-circuiting sibling withdrawals batched in the same multicall (including older withdrawals that may already be `ready-to-finalize`).

This adds `'ProposalNotValidated'` to viem's `'waiting-to-finalize'` errorCauses bucket via the existing `patches/viem+2.47.10.patch`. viem's `portal2Abi` already declares this custom error, so `error.cause.data.errorName` decodes by name; no selector fallback needed.

Files touched (all inside the patch, no relayer source changes):
- `node_modules/viem/_cjs/op-stack/actions/getWithdrawalStatus.js`
- `node_modules/viem/_esm/op-stack/actions/getWithdrawalStatus.js`
- `node_modules/viem/op-stack/actions/getWithdrawalStatus.ts`

### Incident context

Withdrawal `0xc2602eb3…9f97` on MegaETH (L2 source tx `0xe711a16e…85ab3`, 202.87 WETH) was proven on L1 on 2026-05-06 09:02 UTC against dispute game `0x332f70c1…ec4c0` (L1 tx `0x40af1f4e…d892af`). That dispute game has been `status=IN_PROGRESS`, `resolvedAt=0` for ~16 days — well past the ~7-day resolution latency observed for sibling gameType-1337 games — so `checkWithdrawal` correctly reverts `ProposalNotValidated()`. The stuck-game issue itself is upstream (MegaETH-side resolver) and not addressed here; this PR only stops the cosmetic error from masking other in-flight finalizations.

## Test plan

- [ ] `yarn install` runs `patch-package` cleanly (verified locally on a fresh `node_modules`).
- [ ] In a relayer run hitting MegaETH (chain 4326), confirm `Something errored in a finalizer for chain 4326` no longer fires for the stuck withdrawal `0xc2602eb3…9f97`.
- [ ] Confirm a younger MegaETH withdrawal that *is* ready-to-finalize gets finalized in the same run (i.e. the throw was masking sibling progress).
- [ ] Spot-check that withdrawals that revert with `Unproven` / `OptimismPortal_Unproven` etc. still correctly map to `'ready-to-prove'` (regression guard for the existing entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)