### PR TITLE
chore: bump @across-protocol/sdk to 4.3.159

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.109",
     "@across-protocol/contracts": "5.0.10",
-    "@across-protocol/sdk": "4.3.158",
+    "@across-protocol/sdk": "4.3.159",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.3.158":
-  version "4.3.158"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.158.tgz#37b7157e8d968c0a36924f9e8c9e50ea7e932682"
-  integrity sha512-NX14mM3uUbLFIvtdKF8r76eJu9pSdn5qqBxOhgQsVmEXdiA4iLOIgPcfGHjd/RfPMiRhL2KESS11YbJFOg017g==
+"@across-protocol/sdk@4.3.159":
+  version "4.3.159"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.159.tgz#3f2b362286cfb817e2cf82cf058c5f43aaf8039f"
+  integrity sha512-53E+AdC5BREUePEVguIn3MBC5anFIi0158PvjcxaBDOGIxfz/PQhQmfMtBhjk1Y3lKrzTgUgoM+LwDCwo0mdNw==
   dependencies:
     "@across-protocol/constants" "^3.1.110"
     "@across-protocol/contracts" "5.0.10"


### PR DESCRIPTION
Bumps @across-protocol/sdk from 4.3.158 to 4.3.159 for SVM provider improvements around preflight retries.