### PR TITLE
fix(dataworker): reuse SVM instruction params PDA when sized to fit

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2925,14 +2925,26 @@ export class Dataworker {
       vault,
     });
 
-    // Optionally close the existing instruction params account and add an instruction which loads new data into the instruction params PDA.
+    const relayerRefundLeafParamsEncoder = SvmSpokeClient.getExecuteRelayerRefundLeafParamsEncoder();
+    const relayerRefundLeafBytes = relayerRefundLeafParamsEncoder.encode({
+      rootBundleId,
+      relayerRefundLeaf: toSvmRelayerRefundLeaf(leaf),
+      proof,
+    });
+
+    // PDA auto-closes via `close = signer`; existence here implies a prior crashed run. Reuse if sized to fit.
     const instructionParamsAccount = await fetchEncodedAccount(provider, instructionParamsPda);
-    // If the account exists, define the instruction needed to close the instruction account.
-    if (instructionParamsAccount.exists) {
+    const needsClose =
+      instructionParamsAccount.exists && instructionParamsAccount.data.length < relayerRefundLeafBytes.length;
+    const needsInit = !instructionParamsAccount.exists || needsClose;
+    let txSignature;
+    if (needsClose) {
       this.logger.debug({
         at: "Dataworker#executeRelayerRefundLeafSvm",
-        message: "Need to close existing instruction params account",
+        message: "Existing instruction params account is undersized; closing and reinitializing",
         instructionParamsAccount: instructionParamsAccount.address,
+        existingSize: instructionParamsAccount.data.length,
+        requiredSize: relayerRefundLeafBytes.length,
       });
       const closeInstructionParamsIx = SvmSpokeClient.getCloseInstructionParamsInstruction({
         signer: kitKeypair,
@@ -2951,34 +2963,35 @@ export class Dataworker {
         signature: closeSig,
       });
     }
-    // First, add an instruction which initializes a new instruction params PDA for the relayer refund leaf.
-    const relayerRefundLeafParamsEncoder = SvmSpokeClient.getExecuteRelayerRefundLeafParamsEncoder();
-    const relayerRefundLeafBytes = relayerRefundLeafParamsEncoder.encode({
-      rootBundleId,
-      relayerRefundLeaf: toSvmRelayerRefundLeaf(leaf),
-      proof,
-    });
-    const initializeInstructionParamsIx = SvmSpokeClient.getInitializeInstructionParamsInstruction({
-      signer: kitKeypair,
-      instructionParams: instructionParamsPda,
-      totalSize: relayerRefundLeafBytes.length,
-    });
-
-    const initInstructionParamsTx = pipe(
-      createTransactionMessage({ version: 0 }),
-      (tx) => setTransactionMessageFeePayer(kitKeypair.address, tx),
-      (tx) => setTransactionMessageLifetimeUsingBlockhash(recentBlockhash.value, tx),
-      (tx) => appendTransactionMessageInstructions([initializeInstructionParamsIx], tx)
-    );
-    let txSignature;
-    txSignature = await sendAndConfirmSolanaTransaction(initInstructionParamsTx, provider);
-    this.logger.debug({
-      at: "Dataworker#executeRelayerRefundLeafSvm",
-      message: "Initialized instruction params account",
-      instructionParamsAccount: instructionParamsAccount.address,
-      allocatedMemory: relayerRefundLeafBytes.length,
-      txSignature,
-    });
+    if (needsInit) {
+      const initializeInstructionParamsIx = SvmSpokeClient.getInitializeInstructionParamsInstruction({
+        signer: kitKeypair,
+        instructionParams: instructionParamsPda,
+        totalSize: relayerRefundLeafBytes.length,
+      });
+      const initInstructionParamsTx = pipe(
+        createTransactionMessage({ version: 0 }),
+        (tx) => setTransactionMessageFeePayer(kitKeypair.address, tx),
+        (tx) => setTransactionMessageLifetimeUsingBlockhash(recentBlockhash.value, tx),
+        (tx) => appendTransactionMessageInstructions([initializeInstructionParamsIx], tx)
+      );
+      txSignature = await sendAndConfirmSolanaTransaction(initInstructionParamsTx, provider);
+      this.logger.debug({
+        at: "Dataworker#executeRelayerRefundLeafSvm",
+        message: "Initialized instruction params account",
+        instructionParamsAccount: instructionParamsAccount.address,
+        allocatedMemory: relayerRefundLeafBytes.length,
+        txSignature,
+      });
+    } else {
+      this.logger.debug({
+        at: "Dataworker#executeRelayerRefundLeafSvm",
+        message: "Reusing existing instruction params account",
+        instructionParamsAccount: instructionParamsAccount.address,
+        existingSize: instructionParamsAccount.data.length,
+        requiredSize: relayerRefundLeafBytes.length,
+      });
+    }
 
     // Then add an instruction which populates that initialized PDA with the data of the relayer refund leaf.
     for (let i = 0; i <= relayerRefundLeafBytes.length / INSTRUCTION_PARAMS_MAX_WRITE_SIZE; ++i) {


### PR DESCRIPTION
Skip the close+init pair on the instruction_params PDA when an existing PDA from a previously crashed run is already large enough to hold the current refund leaf payload. Only close+reinit when the existing buffer is undersized.

executeRelayerRefundLeaf auto-closes the PDA via Anchor's close = signer constraint, so a stale PDA at the start of _executeRelayerRefundLeafSvm only persists when a prior run crashed before reaching the execute step. The unconditional close+init in that recovery path races stale-RPC preflight simulation: the close TX confirms before some providers update their view of the slot, so init's preflight sees the still-allocated PDA and account(init) rejects deterministically. Before SDK v4.3.159 this was masked by quorum retries; after fast-fail on SVM_TRANSACTION_PREFLIGHT_FAILURE it surfaces on every recovery (PD-325142 and prior dataworker pages).

Reuse is safe because the codama-encoded payload puts the 8-byte Anchor discriminator at offset 0, the fragment-write loop overwrites starting at offset 0, and Anchor's Account<T>::try_deserialize reads only the schema-required prefix and ignores trailing bytes. WriteInstructionParamsFragment bounds-checks against the allocated size, so reuse is only attempted after verifying the existing buffer is at least as large as the new payload.

Scope: _executeRelayerRefundLeafSvm only. _executeSlowFillLeafSvm and SvmFillerClient's fill-relay-via-instruction-params path can take the same fix in follow-ups. Does not introduce padded totalSize on init.

Slack thread: PD-325142 (https://risk-labs.pagerduty.com/incidents/Q2WQ66XKTQ8YIU). Upstream SDK change that exposed this: across-protocol/sdk@e8ab986.