### PR TITLE
chore: bump @across-protocol/sdk to 4.3.160

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.109",
     "@across-protocol/contracts": "5.0.10",
-    "@across-protocol/sdk": "4.3.159",
+    "@across-protocol/sdk": "4.3.160",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.3.159":
-  version "4.3.159"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.159.tgz#3f2b362286cfb817e2cf82cf058c5f43aaf8039f"
-  integrity sha512-53E+AdC5BREUePEVguIn3MBC5anFIi0158PvjcxaBDOGIxfz/PQhQmfMtBhjk1Y3lKrzTgUgoM+LwDCwo0mdNw==
+"@across-protocol/sdk@4.3.160":
+  version "4.3.160"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.160.tgz#e59b6255ab9b4395c5304eb5516e22b038a3b781"
+  integrity sha512-rYT5BYIeDzO+C7/k1+QCSBHczzbdN2rDr9+D53ASouEoCD2UnM6HWkD2d5jpy+evpZPBOVO7h1+4tCaEL4HVSA==
   dependencies:
     "@across-protocol/constants" "^3.1.110"
     "@across-protocol/contracts" "5.0.10"


### PR DESCRIPTION
## Summary

Bump `@across-protocol/sdk` from `4.3.159` to `4.3.160`.

## Why

SDK `4.3.160` ships `across-protocol/sdk@f33ce4d` — `fix(providers): preserve Error prototype and cause across quorum failures`. That fixes `createSendErrorWithMessage`, which previously did `{ ...sendError, ...new Error(message) }` and stripped the Error prototype (and the message itself, since V8's `Error.message` is non-enumerable). The result was that every quorum/fallback failure across both SVM and EVM paths surfaced as a plain object — most visibly as `error: "could not extract error from 'Object' instance {}"` in the dataworker page that motivated #3406.

With this SDK bump the relayer will see real `Error` instances with the wrapper message plus the underlying RPC error in `.cause` next time a quorum failure surfaces.

## Test plan

- [x] `yarn install` regenerates `yarn.lock` cleanly.
- [x] `yarn lint` passes.
- [ ] CI green on PR.