### PR TITLE
feat(deposit-address): publish withdraw_executed events to GCP Pub/Sub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -317,8 +317,8 @@ ARWEAVE_GATEWAYS='[{"host":"arweave.org", "port": 443, "protocol":"https"}]'
 # on the topic). Required when the gate above is true.
 # PUBSUB_GCP_PROJECT_ID=
 
-# Topic short name. Production: topic-deposit-address-withdraw. Sandbox:
-# topic-deposit-address-withdraw-sandbox. Required when the gate above is true.
+# Topic short name. Production: topic-deposit-address-execution. Sandbox:
+# topic-deposit-address-execution-sandbox. Required when the gate above is true.
 # PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC=
 
 ################################################################################

--- a/.env.example
+++ b/.env.example
@@ -283,6 +283,45 @@ ARWEAVE_WALLET_JWK=$({"kty":"", "e":"", "n":"", "d":"", "p":"", "q":"", "dp":"",
 ARWEAVE_GATEWAYS='[{"host":"arweave.org", "port": 443, "protocol":"https"}]'
 
 ################################################################################
+####################### Deposit Address Handler ################################
+################################################################################
+
+# Endpoint of the across-indexer API serving counterfactual deposit-address messages.
+# INDEXER_API_ENDPOINT=
+
+# Polling interval in seconds for the indexer endpoint above. Defaults to 1.
+# INDEXER_API_POLLING_INTERVAL=1
+
+# Swap API base URL used for fetching deposit-execute and signed-withdraw quotes.
+# API_ENDPOINT=
+
+# Swap API key. Required when running the deposit-address handler.
+# SWAP_API_KEY=
+
+# JSON list of chains on which the bot is willing to deploy / execute / withdraw
+# from counterfactual deposit addresses.
+# RELAYER_ORIGIN_CHAINS=[1, 10, 8453]
+
+# When "true", the bot processes mis_route / intent_refund transfers via the
+# refund-withdraw path. Default is false.
+# WITHDRAW_ENABLED=false
+
+# --- Withdraw lifecycle PubSub publisher (GCP) ---
+# When true, publishes a `withdraw_executed` message to GCP Pub/Sub after each
+# confirmed refund withdraw. Consumer: across-indexer
+# (indexer/packages/indexer/src/pubsub/DepositAddressWithdrawConsumer.ts).
+# ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER=false
+
+# GCP project that hosts the topic (may differ from the bot's runtime project —
+# cross-project publish works when the runtime SA holds roles/pubsub.publisher
+# on the topic). Required when the gate above is true.
+# PUBSUB_GCP_PROJECT_ID=
+
+# Topic short name. Production: topic-deposit-address-withdraw. Sandbox:
+# topic-deposit-address-withdraw-sandbox. Required when the gate above is true.
+# PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC=
+
+################################################################################
 ########################### Testing Configuration ##############################
 ################################################################################
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,12 +25,15 @@ Keep all relevant `AGENTS.md` and `README.md` files updated in the same change w
 - Rebalancer behavior and adapters: `src/rebalancer/README.md`
 - Refiller behavior: `src/refiller/README.md`
 - Dataworker root-bundle flow: `src/dataworker/README.md`
+- Deposit-address handler and withdraw lifecycle: `src/deposit-address/README.md`
 - Shared runtime clients: `src/clients/README.md`
+- Cross-bot messaging transports (Redis pub/sub + GCP Pub/Sub publisher): `src/messaging/`
 - Finalization-specific workflows: `src/finalizer/*` and `src/cctp-finalizer/*`
 - UMA and smart-contract context: `docs/uma.md` and `docs/smart-contracts.md`
 - Relayer fill and repayment deep dives: `docs/relayer-fill-decision-flow.md` and `docs/repayment-selection.md`
 - Inventory deep dives: `docs/repayment-eligibility.md` and `docs/inventory-virtual-balance-model.md`
 - Rebalancer modularity deep dive: `docs/rebalancer-mode-adapter-architecture.md`
+- Deposit-address withdraw lifecycle Pub/Sub contract: `docs/deposit-address-withdraw-pubsub.md`
 
 ## Bot types
 
@@ -43,6 +46,7 @@ The main bot types in `src/`:
 - `finalizer`: Completes delayed cross-chain flows and multi-step bridge finalization tasks.
 - `monitor`: Runs monitoring and reporting checks.
 - `gasless`: Handles gasless relay flows.
+- `deposit-address`: Polls the across-indexer for counterfactual deposit-address transfers and executes the resulting deposits or refund withdraws.
 
 ## Directory tree
 
@@ -58,6 +62,7 @@ relayer-v2/
 │   ├── cctp-finalizer/           # CCTP-focused finalization runtime and utility modules.
 │   ├── monitor/                  # Monitoring and operational health checks.
 │   ├── gasless/                  # Gasless relay runtime.
+│   ├── deposit-address/          # Counterfactual deposit-address handler: deposit + refund-withdraw paths.
 │   ├── hyperliquid/              # Hyperliquid-specific execution and integration flows.
 │   ├── clients/                  # Shared clients for events, txs, inventory, pricing, and bridges.
 │   │   ├── ProfitClient.ts       # Profitability evaluation for potential fills.
@@ -67,6 +72,9 @@ relayer-v2/
 │   │   ├── SpokePoolClient.ts    # SpokePool event/state client wrappers.
 │   │   └── bridges/              # Bridge adapter selection and cross-chain transfer helpers.
 │   ├── caching/                  # Redis-backed and in-memory cache helpers.
+│   ├── messaging/                # Cross-bot messaging transports.
+│   │   ├── redis/                # Redis pub/sub wrapper (handover signaling).
+│   │   └── gcp/                  # GCP Pub/Sub publisher (lifecycle events to the indexer).
 │   ├── adapter/                  # Chain/exchange adapter abstractions.
 │   ├── interfaces/               # Shared interfaces and cross-module types.
 │   ├── libexec/                  # Websocket/event listener execution helpers.

--- a/docs/deposit-address-withdraw-pubsub.md
+++ b/docs/deposit-address-withdraw-pubsub.md
@@ -14,11 +14,12 @@ The Pub/Sub topic carries lifecycle events from the bot to the indexer so the ro
 
 - **Topic host project:** `data-hub-pubsub-3360` (a dedicated GCP project used as the pub/sub hub).
 - **Topics:**
-  - `topic-deposit-address-withdraw` — production.
-  - `topic-deposit-address-withdraw-sandbox` — non-production.
+  - `topic-deposit-address-execution` — production.
+  - `topic-deposit-address-execution-sandbox` — non-production.
+  - The "execution" naming is intentionally broader than "withdraw" — the same topic is the future home for any deposit-address execution lifecycle event (e.g. `deposit_executed` for the correct-transfer path), even though only `withdraw_executed` is emitted today.
 - **Subscriptions** (consumer side, not the bot's concern):
-  - `subscription-deposit-address-withdraw-indexer` → indexer pulls in prod.
-  - `subscription-deposit-address-withdraw-sandbox-indexer` → indexer pulls in sandbox.
+  - `subscription-deposit-address-execution-indexer` → indexer pulls in prod.
+  - `subscription-deposit-address-execution-sandbox-indexer` → indexer pulls in sandbox.
 - **Publisher service account:** `cloudrun-bots-across-spoke-sa@bots-across-3839.iam.gserviceaccount.com` — the SA both prod and `-test` bot handlers run as, granted `roles/pubsub.publisher` on both topics. The bot's runtime project (`bots-across-3839`) is therefore **different** from the topic host project; cross-project publish is supported because the IAM grant lives on the topic.
 - **No message ordering, no DLT, no Avro schema** — the consumer validates payload shape at the app layer and is poison-pill safe (ack on malformed, nack only on transient DB error).
 

--- a/docs/deposit-address-withdraw-pubsub.md
+++ b/docs/deposit-address-withdraw-pubsub.md
@@ -59,7 +59,7 @@ The publisher sends the payload as the `data` field of the Pub/Sub message (UTF-
 `DepositAddressHandler._publishWithdrawExecuted` in `src/deposit-address/DepositAddressHandler.ts`:
 
 1. Runs only after a refund withdraw has been confirmed on-chain **and** the depositKey has been persisted to Redis. Ordering matters: we never publish without first committing to "this depositKey is done", which prevents handover from racing the publish into a duplicate withdraw.
-2. Filters `receipt.logs` for ERC-20 `Transfer(address,address,uint256)` events whose `address` matches the token contract and whose `from` topic matches the deposit address. Picks the **last** match (handles Multicall3-bundled withdraws where intermediate transfers may also appear). Zero matches → warn + skip the publish (do not raise).
+2. Filters `receipt.logs` for ERC-20 `Transfer(address,address,uint256)` events whose `address` matches the token contract, whose `from` topic matches the deposit address, AND whose `to` topic matches `routeParams.refundAddress`. The `to` match disambiguates fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address in one tx. Picks the **last** match as a final tiebreaker (handles Multicall3-bundled withdraws where intermediate transfers to the same refund address may also appear). Zero matches → warn + skip the publish (do not raise).
 3. Builds the payload above and calls `GcpPubSubPublisher.publishJson`.
 4. Wraps the call in try/catch; on failure, logs at `error` level with `notificationPath: "across-bot-error"` and continues. The withdraw is on-chain and Redis-persisted — there is no rollback and no in-process retry.
 

--- a/docs/deposit-address-withdraw-pubsub.md
+++ b/docs/deposit-address-withdraw-pubsub.md
@@ -59,7 +59,7 @@ The publisher sends the payload as the `data` field of the Pub/Sub message (UTF-
 `DepositAddressHandler._publishWithdrawExecuted` in `src/deposit-address/DepositAddressHandler.ts`:
 
 1. Runs only after a refund withdraw has been confirmed on-chain **and** the depositKey has been persisted to Redis. Ordering matters: we never publish without first committing to "this depositKey is done", which prevents handover from racing the publish into a duplicate withdraw.
-2. Filters `receipt.logs` for the single ERC-20 `Transfer(address,address,uint256)` event whose `address` matches the token contract and whose `from` topic matches the deposit address. Zero or multiple matches → warn + skip the publish (do not raise).
+2. Filters `receipt.logs` for ERC-20 `Transfer(address,address,uint256)` events whose `address` matches the token contract and whose `from` topic matches the deposit address. Picks the **last** match (handles Multicall3-bundled withdraws where intermediate transfers may also appear). Zero matches → warn + skip the publish (do not raise).
 3. Builds the payload above and calls `GcpPubSubPublisher.publishJson`.
 4. Wraps the call in try/catch; on failure, logs at `error` level with `notificationPath: "across-bot-error"` and continues. The withdraw is on-chain and Redis-persisted — there is no rollback and no in-process retry.
 
@@ -79,7 +79,7 @@ The publisher sends the payload as the `data` field of the Pub/Sub message (UTF-
 | --- | --- | --- |
 | GCP publish raises after internal retries | Log + continue. | Indexer row stays `auto_pending`. Ops reconciles manually. |
 | Bot crashes between Redis persist and publish | No replay on next start. | Same as above; one dropped event per crash. |
-| Receipt missing the expected Transfer log (e.g. odd Multicall3 result) | Warn + skip publish. | Indexer row stays `auto_pending`. Withdraw is still on-chain and reflected via the bot's existing log. |
+| Receipt missing any Transfer log out of the deposit address | Warn + skip publish. | Indexer row stays `auto_pending`. Withdraw is still on-chain and reflected via the bot's existing log. |
 | Indexer message missing `blockNumber` / `logIndex` | Type-system / runtime error. | We treat the fields as required; the indexer API always populates them. A drift would fail loudly rather than silently skip. |
 
 ## Contributor recommendations

--- a/docs/deposit-address-withdraw-pubsub.md
+++ b/docs/deposit-address-withdraw-pubsub.md
@@ -1,0 +1,90 @@
+# Deposit-address withdraw lifecycle — Pub/Sub contract
+
+This document describes the cross-repo Pub/Sub contract between the relayer-v2 `DepositAddressHandler` (publisher, this repo) and the across-indexer's `DepositAddressWithdrawConsumer` (consumer, sibling `indexer` repo).
+
+## Current behavior
+
+### Why the message exists
+
+The across-indexer inserts one `deposit_address_transfer_withdraw` row at classification time with `status = auto_pending` for every bot-eligible refund-bound transfer (mis_route / intent_refund). Without an out-of-band signal, those rows stay `auto_pending` forever — the indexer cannot watch the bot's chain activity, and the bot is the only system that knows when a refund withdraw has confirmed on-chain.
+
+The Pub/Sub topic carries lifecycle events from the bot to the indexer so the row transitions to `executed`.
+
+### Topology
+
+- **Topic host project:** `data-hub-pubsub-3360` (a dedicated GCP project used as the pub/sub hub).
+- **Topics:**
+  - `topic-deposit-address-withdraw` — production.
+  - `topic-deposit-address-withdraw-sandbox` — non-production.
+- **Subscriptions** (consumer side, not the bot's concern):
+  - `subscription-deposit-address-withdraw-indexer` → indexer pulls in prod.
+  - `subscription-deposit-address-withdraw-sandbox-indexer` → indexer pulls in sandbox.
+- **Publisher service account:** `cloudrun-bots-across-spoke-sa@bots-across-3839.iam.gserviceaccount.com` — the SA both prod and `-test` bot handlers run as, granted `roles/pubsub.publisher` on both topics. The bot's runtime project (`bots-across-3839`) is therefore **different** from the topic host project; cross-project publish is supported because the IAM grant lives on the topic.
+- **No message ordering, no DLT, no Avro schema** — the consumer validates payload shape at the app layer and is poison-pill safe (ack on malformed, nack only on transient DB error).
+
+### Payload
+
+The consumer's validator (`isDepositAddressWithdrawPayload` in `indexer/packages/indexer/src/pubsub/DepositAddressWithdrawConsumer.ts`) accepts two shapes:
+
+```ts
+type WithdrawExecutedPayload = {
+  type: "withdraw_executed";
+  chainId: number;       // withdraw tx chain
+  blockNumber: number;   // withdraw tx block
+  txHash: string;        // withdraw tx hash, lowercase hex
+  logIndex: number;      // logIndex of the ERC20 Transfer leaving the deposit address
+  erc20Transfer: {
+    chainId: number;
+    blockNumber: number;
+    txHash: string;
+    logIndex: number;
+  };
+};
+
+type WithdrawFailedPayload = {
+  type: "withdraw_failed";
+  erc20Transfer: { chainId: number; blockNumber: number; txHash: string; logIndex: number };
+  reason: string;
+};
+```
+
+The bot currently emits **only `withdraw_executed`**. `withdraw_failed` is reserved by the contract but not produced — the bot retries internally on most failure paths and does not track a "retries exhausted" terminal state.
+
+The `erc20Transfer` block is the lookup key the consumer uses to find the row (`(chainId, blockNumber, transactionHash, logIndex)` on the `deposit_address_transfer` table); the top-level fields populate the withdraw-tx columns on the row being transitioned.
+
+The publisher sends the payload as the `data` field of the Pub/Sub message (UTF-8 JSON). No message attributes are used; the consumer ignores them.
+
+### Producer mechanics (this repo)
+
+`DepositAddressHandler._publishWithdrawExecuted` in `src/deposit-address/DepositAddressHandler.ts`:
+
+1. Runs only after a refund withdraw has been confirmed on-chain **and** the depositKey has been persisted to Redis. Ordering matters: we never publish without first committing to "this depositKey is done", which prevents handover from racing the publish into a duplicate withdraw.
+2. Filters `receipt.logs` for the single ERC-20 `Transfer(address,address,uint256)` event whose `address` matches the token contract and whose `from` topic matches the deposit address. Zero or multiple matches → warn + skip the publish (do not raise).
+3. Builds the payload above and calls `GcpPubSubPublisher.publishJson`.
+4. Wraps the call in try/catch; on failure, logs at `error` level with `notificationPath: "across-bot-error"` and continues. The withdraw is on-chain and Redis-persisted — there is no rollback and no in-process retry.
+
+### Consumer mechanics (sibling `indexer` repo)
+
+`DepositAddressWithdrawConsumer.handleMessage`:
+
+- Locates the `DepositAddressTransfer` row by the inbound `erc20Transfer` identifiers; ack + skip if missing.
+- Locates the joined `DepositAddressTransferWithdraw` row; ack + skip if missing (classification is the only insert path).
+- `withdraw_executed` → sets status `executed`, fills the withdraw-tx columns, clears `metadata.failureReason`.
+- `withdraw_failed` → sets status `failed`, sets `metadata.failureReason`, nulls the withdraw-tx columns. **`executed` is sticky in the failed direction** — a `withdraw_failed` against an already-`executed` row is rejected race-safely via a conditional UPDATE.
+- Idempotency: replays converge to the same row state. Out-of-order arrival is tolerated because `executed` cannot regress to `failed`.
+
+### Failure modes and trade-offs
+
+| Failure | Bot behavior | Consequence |
+| --- | --- | --- |
+| GCP publish raises after internal retries | Log + continue. | Indexer row stays `auto_pending`. Ops reconciles manually. |
+| Bot crashes between Redis persist and publish | No replay on next start. | Same as above; one dropped event per crash. |
+| Receipt missing the expected Transfer log (e.g. odd Multicall3 result) | Warn + skip publish. | Indexer row stays `auto_pending`. Withdraw is still on-chain and reflected via the bot's existing log. |
+| Indexer message missing `blockNumber` / `logIndex` | Type-system / runtime error. | We treat the fields as required; the indexer API always populates them. A drift would fail loudly rather than silently skip. |
+
+## Contributor recommendations
+
+- **Don't add `withdraw_failed` emission without first defining a terminal-failure model in the bot.** The consumer rejects late `failed`-after-`executed` via the conditional UPDATE, so spurious failed events do not corrupt state — but they do generate noise and false WARN logs on the indexer. If you need failure observability, prefer extending the bot's logging first and only graduate to a Pub/Sub message when there's a clear `executed-or-failed-forever` decision point.
+- **Don't rely on ordering.** The consumer handles out-of-order arrivals via last-write-wins + executed-sticky. If you find yourself wanting ordering keys, prefer adding a `decidedAt` timestamp in the payload and resolving precedence on the consumer side.
+- **Keep the schema additive.** New fields should be optional on the consumer until the producer rolls out; the producer should default new fields when emitting until both sides ship.
+- **Avoid persistent at-least-once delivery on the producer side** unless an ops case forces it. The cost is a new Redis state shape and drainage logic; the benefit is recovering from rare, narrow windows of bot crash. Today's "best-effort + ops reconciliation" is intentionally chosen.

--- a/docs/deposit-address-withdraw-pubsub.md
+++ b/docs/deposit-address-withdraw-pubsub.md
@@ -24,35 +24,41 @@ The Pub/Sub topic carries lifecycle events from the bot to the indexer so the ro
 
 ### Payload
 
+Every Pub/Sub message uses a shared envelope: `{ type, data }`. `type` is the message-type discriminator; `data` carries a body whose shape depends on `type`. New message types are added by introducing new `type` values; existing types are versioned by changing the `data` shape and rolling producer + consumer in lockstep.
+
 The consumer's validator (`isDepositAddressWithdrawPayload` in `indexer/packages/indexer/src/pubsub/DepositAddressWithdrawConsumer.ts`) accepts two shapes:
 
 ```ts
 type WithdrawExecutedPayload = {
   type: "withdraw_executed";
-  chainId: number;       // withdraw tx chain
-  blockNumber: number;   // withdraw tx block
-  txHash: string;        // withdraw tx hash, lowercase hex
-  logIndex: number;      // logIndex of the ERC20 Transfer leaving the deposit address
-  erc20Transfer: {
-    chainId: number;
-    blockNumber: number;
-    txHash: string;
-    logIndex: number;
+  data: {
+    chainId: number;       // withdraw tx chain
+    blockNumber: number;   // withdraw tx block
+    txHash: string;        // withdraw tx hash, lowercase hex
+    logIndex: number;      // logIndex of the ERC20 Transfer leaving the deposit address
+    erc20Transfer: {
+      chainId: number;
+      blockNumber: number;
+      txHash: string;
+      logIndex: number;
+    };
   };
 };
 
 type WithdrawFailedPayload = {
   type: "withdraw_failed";
-  erc20Transfer: { chainId: number; blockNumber: number; txHash: string; logIndex: number };
-  reason: string;
+  data: {
+    erc20Transfer: { chainId: number; blockNumber: number; txHash: string; logIndex: number };
+    reason: string;
+  };
 };
 ```
 
 The bot currently emits **only `withdraw_executed`**. `withdraw_failed` is reserved by the contract but not produced — the bot retries internally on most failure paths and does not track a "retries exhausted" terminal state.
 
-The `erc20Transfer` block is the lookup key the consumer uses to find the row (`(chainId, blockNumber, transactionHash, logIndex)` on the `deposit_address_transfer` table); the top-level fields populate the withdraw-tx columns on the row being transitioned.
+The `data.erc20Transfer` block is the lookup key the consumer uses to find the row (`(chainId, blockNumber, transactionHash, logIndex)` on the `deposit_address_transfer` table); the sibling fields under `data` populate the withdraw-tx columns on the row being transitioned.
 
-The publisher sends the payload as the `data` field of the Pub/Sub message (UTF-8 JSON). No message attributes are used; the consumer ignores them.
+The publisher serializes the envelope as a UTF-8 JSON string and sends it as the GCP Pub/Sub message `data` (the transport-level Pub/Sub field — not to be confused with the application-level `data` inside our envelope). No message attributes are used; the consumer ignores them.
 
 ### Producer mechanics (this repo)
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@ethersproject/abstract-signer": "^5.7.0",
     "@ethersproject/bignumber": "^5.7.0",
     "@google-cloud/kms": "^5.4.0",
+    "@google-cloud/pubsub": "^5.2.0",
     "@google-cloud/storage": "^7.19.0",
     "@layerzerolabs/lz-v2-utilities": "^3.0.147",
     "@maticnetwork/maticjs": "^3.6.0",

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -22,11 +22,14 @@ import {
   BigNumber,
   normalizeDepositAddressMessage,
   toAddressType,
+  TransactionReceipt,
 } from "../utils";
 import { getRedisCache, RedisCacheInterface } from "../cache/Redis";
 import { DepositAddressMessage } from "../interfaces";
 import { AcrossSwapApiClient, TransactionClient, SwapApiResponse, SignedWithdrawResponse } from "../clients";
 import { AcrossIndexerApiClient } from "../clients/AcrossIndexerApiClient";
+import { GcpPubSubPublisher, getGcpPubSubPublisher } from "../messaging/gcp";
+import { buildWithdrawExecutedPayload } from "./withdrawPayload";
 import ERC20_ABI from "../common/abi/MinimalERC20.json";
 
 /**
@@ -83,6 +86,7 @@ export class DepositAddressHandler {
 
   private transactionClient;
   private redisCache: RedisCacheInterface | undefined;
+  private withdrawPublisher: GcpPubSubPublisher | undefined;
 
   public constructor(
     readonly logger: winston.Logger,
@@ -108,6 +112,10 @@ export class DepositAddressHandler {
     this.signerAddress = EvmAddress.from(await this.baseSigner.getAddress());
     this.redisCache = await getRedisCache(this.logger);
     assert(isDefined(this.redisCache), "DepositAddressHandler: requires a Redis cache for handover state");
+
+    if (this.config.enableDepositAddressWithdrawPublisher) {
+      this.withdrawPublisher = getGcpPubSubPublisher(this.logger, this.config.pubSubGcpProjectId);
+    }
 
     // Exit if OS instructs us to do so.
     process.on("SIGHUP", () => {
@@ -437,6 +445,7 @@ export class DepositAddressHandler {
       this.executedWithdrawKeys.add(depositKey);
       withdrawCommitted = true;
       await this._persistWithdrawnKeysRedis();
+      await this._publishWithdrawExecuted(receipt, depositMessage);
     } finally {
       if (!withdrawCommitted) {
         this.observedExecutedWithdraws[chainId].delete(depositKey);
@@ -507,6 +516,65 @@ export class DepositAddressHandler {
     const { redisCache } = this;
     const redisKey = this.getWithdrawnKeysRedisKey();
     await redisCache.set(redisKey, JSON.stringify([...this.executedWithdrawKeys]));
+  }
+
+  /**
+   * Best-effort publish of a `withdraw_executed` lifecycle event to GCP Pub/Sub. Payload shape
+   * is locked by the consumer (`isDepositAddressWithdrawPayload` in
+   * `indexer/packages/indexer/src/pubsub/DepositAddressWithdrawConsumer.ts`).
+   *
+   * The withdraw is already on-chain by the time we get here; a publish failure never rolls
+   * back state and never throws to the caller. The downside is that a dropped publish leaves
+   * the indexer row in `auto_pending` — accepted trade-off for v1, see the module README.
+   */
+  private async _publishWithdrawExecuted(
+    receipt: TransactionReceipt,
+    depositMessage: DepositAddressMessage
+  ): Promise<void> {
+    if (!isDefined(this.withdrawPublisher)) {
+      return;
+    }
+    const payload = buildWithdrawExecutedPayload(receipt, depositMessage);
+    if (!isDefined(payload)) {
+      this.logger.warn({
+        at: "DepositAddressHandler#_publishWithdrawExecuted",
+        message: "Skipping publish: expected exactly one ERC20 Transfer log from deposit address",
+        depositAddress: depositMessage.depositAddress,
+        token: depositMessage.erc20Transfer.contractAddress,
+        txHash: receipt.transactionHash,
+      });
+      return;
+    }
+
+    try {
+      const messageId = await this.withdrawPublisher.publishJson(
+        this.config.pubSubDepositAddressWithdrawTopic,
+        payload
+      );
+      this.logger.debug({
+        at: "DepositAddressHandler#_publishWithdrawExecuted",
+        message: "Published withdraw_executed",
+        messageId,
+        payload,
+      });
+    } catch (err) {
+      this.logger.error({
+        at: "DepositAddressHandler#_publishWithdrawExecuted",
+        message: "Failed to publish withdraw_executed to GCP Pub/Sub",
+        topic: this.config.pubSubDepositAddressWithdrawTopic,
+        payload,
+        err: err instanceof Error ? err.message : String(err),
+        notificationPath: "across-bot-error",
+      });
+    }
+  }
+
+  /** Releases the Pub/Sub client. Idempotent. Safe to call when the publisher is not configured. */
+  public async disconnect(): Promise<void> {
+    if (isDefined(this.withdrawPublisher)) {
+      await this.withdrawPublisher.close();
+      this.withdrawPublisher = undefined;
+    }
   }
 
   private async initiateDeposit(depositMessage: DepositAddressMessage): Promise<void> {

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -538,7 +538,7 @@ export class DepositAddressHandler {
     if (!isDefined(payload)) {
       this.logger.warn({
         at: "DepositAddressHandler#_publishWithdrawExecuted",
-        message: "Skipping publish: expected exactly one ERC20 Transfer log from deposit address",
+        message: "Skipping publish: no ERC20 Transfer log from deposit address found in receipt",
         depositAddress: depositMessage.depositAddress,
         token: depositMessage.erc20Transfer.contractAddress,
         txHash: receipt.transactionHash,

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -538,8 +538,9 @@ export class DepositAddressHandler {
     if (!isDefined(payload)) {
       this.logger.warn({
         at: "DepositAddressHandler#_publishWithdrawExecuted",
-        message: "Skipping publish: no ERC20 Transfer log from deposit address found in receipt",
+        message: "Skipping publish: no ERC20 Transfer (deposit address → refund address) found in receipt",
         depositAddress: depositMessage.depositAddress,
+        refundAddress: depositMessage.routeParams.refundAddress,
         token: depositMessage.erc20Transfer.contractAddress,
         txHash: receipt.transactionHash,
       });

--- a/src/deposit-address/DepositAddressHandlerConfig.ts
+++ b/src/deposit-address/DepositAddressHandlerConfig.ts
@@ -14,6 +14,13 @@ export class DepositAddressHandlerConfig extends CommonConfig {
   swapApiKey: string;
   withdrawEnabled: boolean;
 
+  /** Gate for publishing `withdraw_executed` events to GCP Pub/Sub. */
+  enableDepositAddressWithdrawPublisher: boolean;
+  /** GCP project that hosts the withdraw-lifecycle topic. Required when the publisher gate is on. */
+  pubSubGcpProjectId: string;
+  /** Short topic name (e.g. `topic-deposit-address-withdraw`). Required when the publisher gate is on. */
+  pubSubDepositAddressWithdrawTopic: string;
+
   constructor(env: ProcessEnv) {
     super(env, { botIdentifier: "across-deposit-address-handler" });
 
@@ -27,6 +34,9 @@ export class DepositAddressHandlerConfig extends CommonConfig {
       SWAP_API_KEY,
       INITIALIZATION_RETRY_ATTEMPTS,
       WITHDRAW_ENABLED,
+      ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER,
+      PUBSUB_GCP_PROJECT_ID,
+      PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC,
     } = env;
     this.indexerPollingInterval = Number(INDEXER_API_POLLING_INTERVAL ?? 1); // Default to 1s
     this.indexerApiEndpoint = String(INDEXER_API_ENDPOINT);
@@ -44,5 +54,19 @@ export class DepositAddressHandlerConfig extends CommonConfig {
     this.apiTimeoutOverride = Number(API_TIMEOUT_OVERRIDE ?? 3000); // In ms
     this.initializationRetryAttempts = Number(INITIALIZATION_RETRY_ATTEMPTS ?? 3);
     this.withdrawEnabled = WITHDRAW_ENABLED === "true";
+
+    this.enableDepositAddressWithdrawPublisher = ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER === "true";
+    this.pubSubGcpProjectId = PUBSUB_GCP_PROJECT_ID?.trim() ?? "";
+    this.pubSubDepositAddressWithdrawTopic = PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC?.trim() ?? "";
+    if (this.enableDepositAddressWithdrawPublisher) {
+      if (!this.pubSubGcpProjectId) {
+        throw new Error("PUBSUB_GCP_PROJECT_ID is required when ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER=true");
+      }
+      if (!this.pubSubDepositAddressWithdrawTopic) {
+        throw new Error(
+          "PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC is required when ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER=true"
+        );
+      }
+    }
   }
 }

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -1,0 +1,96 @@
+# `src/deposit-address` — Deposit Address Handler
+
+The deposit-address handler polls the across-indexer for ERC-20 transfers that have landed on counterfactual deposit addresses and either executes them as deposits or refunds them back to the user.
+
+## Runtime entrypoint
+
+`runDepositAddressHandler` in [`index.ts`](./index.ts) wires up:
+
+1. `DepositAddressHandlerConfig` from env.
+2. Dispatcher keys for transaction signing.
+3. `DepositAddressHandler` instance, then `initialize()`.
+4. Background polling loop (`pollAndExecute`) on the configured interval.
+5. Handover via Redis (`InstanceCoordinator`) — exits cleanly when another instance takes over.
+
+Cleanup in the `finally` block closes the Pub/Sub publisher and Redis clients.
+
+## Indexer message classification
+
+The indexer tags each ERC-20 transfer with a `transferClassification`:
+
+| Classification | Path |
+| --- | --- |
+| `correct_transfer` | Deposit path — execute the funded deposit on the origin chain. |
+| `mis_route` | Refund-withdraw path — return funds to the user via the signed-withdraw flow. |
+| `intent_refund` | Refund-withdraw path — same flow as `mis_route`. |
+| anything else | Dropped (forward-compat). |
+
+The deposit path is always active. The refund-withdraw path is gated by `WITHDRAW_ENABLED`.
+
+## Redis persistence
+
+Two sets persist across runs so handover does not double-spend or double-refund:
+
+- `deposit-address:executed:<botIdentifier>` — set of `erc20Transfer.transactionHash` for successfully executed deposits.
+- `deposit-address:withdrawn-deposit-keys:<botIdentifier>` — set of `depositKey` (`depositAddress:transactionHash`) for successfully executed refund withdraws.
+
+On each poll, entries whose source messages are no longer returned by the indexer are pruned — the indexer has its own TTL and stops returning expired messages.
+
+## Refund-withdraw flow (high level)
+
+1. Filter on `relayerOriginChains`; skip if the refund chain is not configured.
+2. Skip if the depositKey is already in the executed-withdraws set (Redis or in-memory in-flight).
+3. Read on-chain balance of `depositAddress`; skip if below the transfer amount (defends against reorged indexer messages and concurrent withdraws via other paths).
+4. Fetch a signed-withdraw quote from the swap API. The response bundles deploy + signed-withdraw into a single Multicall3 call when the deposit clone is not yet on-chain.
+5. Submit the tx via `TransactionClient`; wait for confirmation.
+6. Persist the depositKey to Redis.
+7. Publish a `withdraw_executed` lifecycle event to GCP Pub/Sub (if the publisher gate is on).
+
+## Withdraw lifecycle Pub/Sub publish
+
+When `ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER=true`, every confirmed refund withdraw produces one message on the configured GCP Pub/Sub topic. The consumer lives at `indexer/packages/indexer/src/pubsub/DepositAddressWithdrawConsumer.ts` (sibling repo) and transitions the corresponding `deposit_address_transfer_withdraw` row from `auto_pending` to `executed`.
+
+### Env
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER` | No (default `false`) | Master gate. When false, no Pub/Sub client is constructed. |
+| `PUBSUB_GCP_PROJECT_ID` | When gate is on | GCP project that **hosts the topic** (may differ from the bot's runtime project — cross-project publish is supported when the runtime SA holds `roles/pubsub.publisher` on the topic in the host project). |
+| `PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC` | When gate is on | Short topic name (e.g. `topic-deposit-address-withdraw` in prod, `…-sandbox` in non-prod). |
+
+Auth uses Application Default Credentials. In Cloud Run / GKE the workload SA provides them; locally set `GOOGLE_APPLICATION_CREDENTIALS`.
+
+### Payload (locked by the consumer)
+
+```jsonc
+{
+  "type": "withdraw_executed",
+  "chainId":     <withdraw tx chain>,
+  "blockNumber": <withdraw tx block number>,
+  "txHash":      "<withdraw tx hash>",
+  "logIndex":    <logIndex of the ERC20 Transfer leaving the deposit address>,
+  "erc20Transfer": {
+    "chainId":     <inbound transfer chain>,
+    "blockNumber": <inbound transfer block number>,
+    "txHash":      "<inbound transfer tx hash>",
+    "logIndex":    <inbound transfer logIndex>
+  }
+}
+```
+
+All integer fields are `number`; tx hashes are lowercase hex strings. The `erc20Transfer` block identifies the original user transfer (the indexer keys rows on it); the top-level fields identify the withdraw transaction the bot just sent. The `logIndex` of the withdraw is the index of the ERC-20 `Transfer(address,address,uint256)` event whose `from` is the deposit address and whose token contract matches `erc20Transfer.contractAddress`.
+
+### Failure semantics
+
+Publish is best-effort. The withdraw is already on-chain and persisted in Redis before we publish; if the GCP client throws (after its own internal retries), we log at error level with `notificationPath: "across-bot-error"` and return — we do **not** roll back state, retry, or raise.
+
+The intentional trade-off: a dropped publish leaves the indexer row in `auto_pending` until ops reconciles. We do **not** replay executed-but-unpublished withdraws on startup (Redis does not persist per-key publish state). Both are accepted for v1; revisit if dropouts become an ops pain point.
+
+Failure events (`withdraw_failed`) are **not** emitted today. The bot retries internally on quote-API and tx-submit failures, so there is no clean "terminal failure" signal to publish. The consumer schema accepts them; producing them is deferred.
+
+## Related modules
+
+- [`../messaging/gcp`](../messaging/gcp/) — thin `GcpPubSubPublisher` wrapper used here.
+- [`../messaging/redis`](../messaging/redis/) — Redis pub/sub used for instance handover (`InstanceCoordinator`).
+- [`../clients/AcrossSwapApiClient.ts`](../clients/AcrossSwapApiClient.ts) — swap-API quotes (deposit-execute + signed-withdraw).
+- [`../clients/AcrossIndexerApiClient.ts`](../clients/AcrossIndexerApiClient.ts) — indexer message polling.

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -62,23 +62,27 @@ Auth uses Application Default Credentials. In Cloud Run / GKE the workload SA pr
 
 ### Payload (locked by the consumer)
 
+Every Pub/Sub message uses an envelope: `{ "type": "<message_type>", "data": <type-specific body> }`. The envelope shape is shared by all current and future message types so the consumer can dispatch on `type` and validate `data` against the matching schema. Today only one type is emitted:
+
 ```jsonc
 {
   "type": "withdraw_executed",
-  "chainId":     <withdraw tx chain>,
-  "blockNumber": <withdraw tx block number>,
-  "txHash":      "<withdraw tx hash>",
-  "logIndex":    <logIndex of the ERC20 Transfer leaving the deposit address>,
-  "erc20Transfer": {
-    "chainId":     <inbound transfer chain>,
-    "blockNumber": <inbound transfer block number>,
-    "txHash":      "<inbound transfer tx hash>",
-    "logIndex":    <inbound transfer logIndex>
+  "data": {
+    "chainId":     <withdraw tx chain>,
+    "blockNumber": <withdraw tx block number>,
+    "txHash":      "<withdraw tx hash>",
+    "logIndex":    <logIndex of the ERC20 Transfer leaving the deposit address>,
+    "erc20Transfer": {
+      "chainId":     <inbound transfer chain>,
+      "blockNumber": <inbound transfer block number>,
+      "txHash":      "<inbound transfer tx hash>",
+      "logIndex":    <inbound transfer logIndex>
+    }
   }
 }
 ```
 
-All integer fields are `number`; tx hashes are lowercase hex strings. The `erc20Transfer` block identifies the original user transfer (the indexer keys rows on it); the top-level fields identify the withdraw transaction the bot just sent. The `logIndex` of the withdraw is the index of the ERC-20 `Transfer(address,address,uint256)` event whose `address` matches `erc20Transfer.contractAddress`, whose `from` is the deposit address, and whose `to` is the user's `routeParams.refundAddress`. Matching on `to` is necessary to disambiguate fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address in one tx (one to the user, one to a fee recipient). If multiple Transfer logs still satisfy all three filters (e.g. a Multicall3-bundled withdraw with intermediate hops to the same refund address), the **last** match is used.
+All integer fields are `number`; tx hashes are lowercase hex strings. The `erc20Transfer` block identifies the original user transfer (the indexer keys rows on it); the sibling fields identify the withdraw transaction the bot just sent. The `logIndex` of the withdraw is the index of the ERC-20 `Transfer(address,address,uint256)` event whose `address` matches `erc20Transfer.contractAddress`, whose `from` is the deposit address, and whose `to` is the user's `routeParams.refundAddress`. Matching on `to` is necessary to disambiguate fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address in one tx (one to the user, one to a fee recipient). If multiple Transfer logs still satisfy all three filters (e.g. a Multicall3-bundled withdraw with intermediate hops to the same refund address), the **last** match is used.
 
 ### Failure semantics
 

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -78,7 +78,7 @@ Auth uses Application Default Credentials. In Cloud Run / GKE the workload SA pr
 }
 ```
 
-All integer fields are `number`; tx hashes are lowercase hex strings. The `erc20Transfer` block identifies the original user transfer (the indexer keys rows on it); the top-level fields identify the withdraw transaction the bot just sent. The `logIndex` of the withdraw is the index of the ERC-20 `Transfer(address,address,uint256)` event whose `from` is the deposit address and whose token contract matches `erc20Transfer.contractAddress`.
+All integer fields are `number`; tx hashes are lowercase hex strings. The `erc20Transfer` block identifies the original user transfer (the indexer keys rows on it); the top-level fields identify the withdraw transaction the bot just sent. The `logIndex` of the withdraw is the index of the ERC-20 `Transfer(address,address,uint256)` event whose `from` is the deposit address and whose token contract matches `erc20Transfer.contractAddress`. If multiple such transfers appear in one receipt (e.g. a Multicall3-bundled withdraw with intermediate hops), the **last** match is used — that is the final settlement out of the deposit address.
 
 ### Failure semantics
 

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -78,7 +78,7 @@ Auth uses Application Default Credentials. In Cloud Run / GKE the workload SA pr
 }
 ```
 
-All integer fields are `number`; tx hashes are lowercase hex strings. The `erc20Transfer` block identifies the original user transfer (the indexer keys rows on it); the top-level fields identify the withdraw transaction the bot just sent. The `logIndex` of the withdraw is the index of the ERC-20 `Transfer(address,address,uint256)` event whose `from` is the deposit address and whose token contract matches `erc20Transfer.contractAddress`. If multiple such transfers appear in one receipt (e.g. a Multicall3-bundled withdraw with intermediate hops), the **last** match is used — that is the final settlement out of the deposit address.
+All integer fields are `number`; tx hashes are lowercase hex strings. The `erc20Transfer` block identifies the original user transfer (the indexer keys rows on it); the top-level fields identify the withdraw transaction the bot just sent. The `logIndex` of the withdraw is the index of the ERC-20 `Transfer(address,address,uint256)` event whose `address` matches `erc20Transfer.contractAddress`, whose `from` is the deposit address, and whose `to` is the user's `routeParams.refundAddress`. Matching on `to` is necessary to disambiguate fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address in one tx (one to the user, one to a fee recipient). If multiple Transfer logs still satisfy all three filters (e.g. a Multicall3-bundled withdraw with intermediate hops to the same refund address), the **last** match is used.
 
 ### Failure semantics
 

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -56,7 +56,7 @@ When `ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER=true`, every confirmed refund wi
 | --- | --- | --- |
 | `ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER` | No (default `false`) | Master gate. When false, no Pub/Sub client is constructed. |
 | `PUBSUB_GCP_PROJECT_ID` | When gate is on | GCP project that **hosts the topic** (may differ from the bot's runtime project — cross-project publish is supported when the runtime SA holds `roles/pubsub.publisher` on the topic in the host project). |
-| `PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC` | When gate is on | Short topic name (e.g. `topic-deposit-address-withdraw` in prod, `…-sandbox` in non-prod). |
+| `PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC` | When gate is on | Short topic name (e.g. `topic-deposit-address-execution` in prod, `…-sandbox` in non-prod). |
 
 Auth uses Application Default Credentials. In Cloud Run / GKE the workload SA provides them; locally set `GOOGLE_APPLICATION_CREDENTIALS`.
 

--- a/src/deposit-address/index.ts
+++ b/src/deposit-address/index.ts
@@ -28,6 +28,7 @@ export async function runDepositAddressHandler(_logger: winston.Logger, baseSign
 
     logger.debug({ at: "DepositAddressHandler#index", message: `Time to run: ${(Date.now() - start) / 1000}s` });
   } finally {
+    await relayer.disconnect();
     await disconnectRedisClients(logger);
   }
 }

--- a/src/deposit-address/withdrawPayload.ts
+++ b/src/deposit-address/withdrawPayload.ts
@@ -3,8 +3,12 @@ import { TransactionReceipt, utils } from "../utils";
 
 export const ERC20_TRANSFER_TOPIC = utils.id("Transfer(address,address,uint256)");
 
-export type WithdrawExecutedPayload = {
-  type: "withdraw_executed";
+/**
+ * Body of a `withdraw_executed` lifecycle event. Carried in the `data` field of the
+ * outer envelope so future message types can attach their own `data` shape under the
+ * same `{ type, data }` skeleton.
+ */
+export type WithdrawExecutedData = {
   chainId: number;
   blockNumber: number;
   txHash: string;
@@ -15,6 +19,11 @@ export type WithdrawExecutedPayload = {
     txHash: string;
     logIndex: number;
   };
+};
+
+export type WithdrawExecutedPayload = {
+  type: "withdraw_executed";
+  data: WithdrawExecutedData;
 };
 
 /**
@@ -28,8 +37,10 @@ export type WithdrawExecutedPayload = {
  * a Multicall3-bundled withdraw with intermediate hops to the same refund address), the
  * **last** match is used — that is the final settlement out of the deposit address.
  *
- * The payload shape is locked by the indexer consumer
- * (`indexer/packages/indexer/src/pubsub/DepositAddressWithdrawConsumer.ts`).
+ * The envelope shape `{ type, data }` is shared by every Pub/Sub message the bot publishes;
+ * `data`'s shape varies per `type`. The consumer at
+ * `indexer/packages/indexer/src/pubsub/DepositAddressWithdrawConsumer.ts` keys on `type`
+ * and validates `data` against the matching schema.
  */
 export function buildWithdrawExecutedPayload(
   receipt: TransactionReceipt,
@@ -54,15 +65,17 @@ export function buildWithdrawExecutedPayload(
 
   return {
     type: "withdraw_executed",
-    chainId: Number(erc20Transfer.chainId),
-    blockNumber: receipt.blockNumber,
-    txHash: receipt.transactionHash.toLowerCase(),
-    logIndex: transferLog.logIndex,
-    erc20Transfer: {
+    data: {
       chainId: Number(erc20Transfer.chainId),
-      blockNumber: erc20Transfer.blockNumber,
-      txHash: erc20Transfer.transactionHash.toLowerCase(),
-      logIndex: erc20Transfer.logIndex,
+      blockNumber: receipt.blockNumber,
+      txHash: receipt.transactionHash.toLowerCase(),
+      logIndex: transferLog.logIndex,
+      erc20Transfer: {
+        chainId: Number(erc20Transfer.chainId),
+        blockNumber: erc20Transfer.blockNumber,
+        txHash: erc20Transfer.transactionHash.toLowerCase(),
+        logIndex: erc20Transfer.logIndex,
+      },
     },
   };
 }

--- a/src/deposit-address/withdrawPayload.ts
+++ b/src/deposit-address/withdrawPayload.ts
@@ -1,0 +1,60 @@
+import { DepositAddressMessage } from "../interfaces";
+import { TransactionReceipt, utils } from "../utils";
+
+export const ERC20_TRANSFER_TOPIC = utils.id("Transfer(address,address,uint256)");
+
+export type WithdrawExecutedPayload = {
+  type: "withdraw_executed";
+  chainId: number;
+  blockNumber: number;
+  txHash: string;
+  logIndex: number;
+  erc20Transfer: {
+    chainId: number;
+    blockNumber: number;
+    txHash: string;
+    logIndex: number;
+  };
+};
+
+/**
+ * Builds the `withdraw_executed` payload published to GCP Pub/Sub. Returns `undefined` when
+ * the receipt does not contain exactly one ERC20 `Transfer` event with the expected
+ * `(address=token, from=depositAddress)` — caller should warn and skip.
+ *
+ * The payload shape is locked by the indexer consumer
+ * (`indexer/packages/indexer/src/pubsub/DepositAddressWithdrawConsumer.ts`).
+ */
+export function buildWithdrawExecutedPayload(
+  receipt: TransactionReceipt,
+  depositMessage: DepositAddressMessage
+): WithdrawExecutedPayload | undefined {
+  const { erc20Transfer, depositAddress } = depositMessage;
+  const token = erc20Transfer.contractAddress;
+
+  const paddedFrom = utils.hexZeroPad(depositAddress.toLowerCase(), 32);
+  const transferLogs = receipt.logs.filter(
+    (log) =>
+      log.address.toLowerCase() === token.toLowerCase() &&
+      log.topics[0] === ERC20_TRANSFER_TOPIC &&
+      log.topics[1]?.toLowerCase() === paddedFrom
+  );
+  if (transferLogs.length !== 1) {
+    return undefined;
+  }
+  const transferLog = transferLogs[0];
+
+  return {
+    type: "withdraw_executed",
+    chainId: Number(erc20Transfer.chainId),
+    blockNumber: receipt.blockNumber,
+    txHash: receipt.transactionHash.toLowerCase(),
+    logIndex: transferLog.logIndex,
+    erc20Transfer: {
+      chainId: Number(erc20Transfer.chainId),
+      blockNumber: erc20Transfer.blockNumber,
+      txHash: erc20Transfer.transactionHash.toLowerCase(),
+      logIndex: erc20Transfer.logIndex,
+    },
+  };
+}

--- a/src/deposit-address/withdrawPayload.ts
+++ b/src/deposit-address/withdrawPayload.ts
@@ -19,13 +19,14 @@ export type WithdrawExecutedPayload = {
 
 /**
  * Builds the `withdraw_executed` payload published to GCP Pub/Sub. Returns `undefined` when
- * the receipt contains no ERC20 `Transfer` event with the expected
- * `(address=token, from=depositAddress)` — caller should warn and skip.
+ * the receipt contains no ERC20 `Transfer` event matching the expected
+ * `(address=token, from=depositAddress, to=refundAddress)` — caller should warn and skip.
  *
- * When the receipt contains multiple matching Transfer logs (e.g. a Multicall3-bundled
- * withdraw that emits intermediate transfers), the **last** match is used. The final
- * Transfer out of the deposit address is the one that settles funds to the user, so its
- * logIndex is the canonical reference for the indexer row.
+ * The `to=refundAddress` constraint disambiguates fee-on-transfer / tax / burn tokens that
+ * emit several `Transfer` events from the deposit address in one tx (one to the user, one
+ * to a fee recipient, etc.). If multiple Transfer logs still match all three filters (e.g.
+ * a Multicall3-bundled withdraw with intermediate hops to the same refund address), the
+ * **last** match is used — that is the final settlement out of the deposit address.
  *
  * The payload shape is locked by the indexer consumer
  * (`indexer/packages/indexer/src/pubsub/DepositAddressWithdrawConsumer.ts`).
@@ -34,15 +35,17 @@ export function buildWithdrawExecutedPayload(
   receipt: TransactionReceipt,
   depositMessage: DepositAddressMessage
 ): WithdrawExecutedPayload | undefined {
-  const { erc20Transfer, depositAddress } = depositMessage;
+  const { erc20Transfer, depositAddress, routeParams } = depositMessage;
   const token = erc20Transfer.contractAddress;
 
   const paddedFrom = utils.hexZeroPad(depositAddress.toLowerCase(), 32);
+  const paddedTo = utils.hexZeroPad(routeParams.refundAddress.toLowerCase(), 32);
   const transferLogs = receipt.logs.filter(
     (log) =>
       log.address.toLowerCase() === token.toLowerCase() &&
       log.topics[0] === ERC20_TRANSFER_TOPIC &&
-      log.topics[1]?.toLowerCase() === paddedFrom
+      log.topics[1]?.toLowerCase() === paddedFrom &&
+      log.topics[2]?.toLowerCase() === paddedTo
   );
   if (transferLogs.length === 0) {
     return undefined;

--- a/src/deposit-address/withdrawPayload.ts
+++ b/src/deposit-address/withdrawPayload.ts
@@ -19,8 +19,13 @@ export type WithdrawExecutedPayload = {
 
 /**
  * Builds the `withdraw_executed` payload published to GCP Pub/Sub. Returns `undefined` when
- * the receipt does not contain exactly one ERC20 `Transfer` event with the expected
+ * the receipt contains no ERC20 `Transfer` event with the expected
  * `(address=token, from=depositAddress)` — caller should warn and skip.
+ *
+ * When the receipt contains multiple matching Transfer logs (e.g. a Multicall3-bundled
+ * withdraw that emits intermediate transfers), the **last** match is used. The final
+ * Transfer out of the deposit address is the one that settles funds to the user, so its
+ * logIndex is the canonical reference for the indexer row.
  *
  * The payload shape is locked by the indexer consumer
  * (`indexer/packages/indexer/src/pubsub/DepositAddressWithdrawConsumer.ts`).
@@ -39,10 +44,10 @@ export function buildWithdrawExecutedPayload(
       log.topics[0] === ERC20_TRANSFER_TOPIC &&
       log.topics[1]?.toLowerCase() === paddedFrom
   );
-  if (transferLogs.length !== 1) {
+  if (transferLogs.length === 0) {
     return undefined;
   }
-  const transferLog = transferLogs[0];
+  const transferLog = transferLogs[transferLogs.length - 1];
 
   return {
     type: "withdraw_executed",

--- a/src/interfaces/DepositAddress.ts
+++ b/src/interfaces/DepositAddress.ts
@@ -11,6 +11,8 @@ export type DepositAddressTransferClassification = "correct_transfer" | "mis_rou
 
 export interface Erc20Transfer {
   chainId: string;
+  blockNumber: number;
+  logIndex: number;
   from: string;
   to: string;
   amount: string;

--- a/src/messaging/gcp/PubSub.ts
+++ b/src/messaging/gcp/PubSub.ts
@@ -1,0 +1,65 @@
+import { PubSub } from "@google-cloud/pubsub";
+import winston from "winston";
+import { isDefined } from "../../utils/TypeGuards";
+
+/**
+ * GcpPubSubPublisher wraps a Google Cloud Pub/Sub `PubSub` client and publishes JSON-encoded
+ * messages to a topic. The client library handles batching, retries, and ADC-based auth on
+ * its own; this wrapper exists so call sites get consistent logging and a `close()` shape
+ * that matches the Redis pub/sub helper.
+ *
+ * Auth uses Application Default Credentials. In Cloud Run / GKE the runtime service account
+ * supplies them automatically; locally, set `GOOGLE_APPLICATION_CREDENTIALS` to a key file
+ * with `roles/pubsub.publisher` on the target topic.
+ *
+ * `projectId` should be the project that *hosts the topic*, which may differ from the
+ * project the bot runs in (cross-project publish is supported when the runtime SA has
+ * publisher rights on the topic in the host project).
+ */
+export class GcpPubSubPublisher {
+  constructor(
+    private readonly client: PubSub,
+    private readonly projectId: string,
+    private readonly logger?: winston.Logger
+  ) {}
+
+  /**
+   * Publishes a JSON-encoded message to `topicName`. Returns the GCP-assigned message id.
+   * Throws if the client library exhausts its internal retries.
+   */
+  async publishJson(topicName: string, payload: unknown): Promise<string> {
+    const data = Buffer.from(JSON.stringify(payload), "utf8");
+    const messageId = await this.client.topic(topicName).publishMessage({ data });
+    return messageId;
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.client.close();
+    } catch (err) {
+      this.logger?.warn({
+        at: "GcpPubSubPublisher#close",
+        message: "Error closing GCP Pub/Sub client",
+        projectId: this.projectId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+/**
+ * Builds a {@link GcpPubSubPublisher} bound to `projectId`. Returns `undefined` when
+ * running in test mode or when `projectId` is missing — callers must null-check.
+ *
+ * Mirrors the test short-circuit in `src/messaging/redis/PubSub.ts#getRedisPubSub`.
+ */
+export function getGcpPubSubPublisher(logger?: winston.Logger, projectId?: string): GcpPubSubPublisher | undefined {
+  if (isDefined(process.env.RELAYER_TEST)) {
+    return undefined;
+  }
+  if (!isDefined(projectId) || projectId.length === 0) {
+    return undefined;
+  }
+  const client = new PubSub({ projectId });
+  return new GcpPubSubPublisher(client, projectId, logger);
+}

--- a/src/messaging/gcp/index.ts
+++ b/src/messaging/gcp/index.ts
@@ -1,0 +1,1 @@
+export * from "./PubSub";

--- a/test/DepositAddressHandler.publish.ts
+++ b/test/DepositAddressHandler.publish.ts
@@ -131,12 +131,17 @@ describe("buildWithdrawExecutedPayload", function () {
     expect(buildWithdrawExecutedPayload(receipt, depositMessage())).to.be.undefined;
   });
 
-  it("returns undefined when multiple matching Transfer logs exist", function () {
+  it("picks the LAST matching Transfer log when multiple exist (e.g. Multicall3-bundled withdraw)", function () {
     const receipt = fakeReceipt([
+      // Intermediate transfer from the deposit address (e.g., to an internal router).
       { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(OTHER_ADDRESS)] },
+      // Unrelated log between the two matches.
+      { address: OTHER_TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(OTHER_ADDRESS), topicAddress(DEPOSIT_ADDRESS)] },
+      // Final settlement transfer from the deposit address — this is the one we want.
       { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(OTHER_ADDRESS)] },
     ]);
-    expect(buildWithdrawExecutedPayload(receipt, depositMessage())).to.be.undefined;
+    const payload = buildWithdrawExecutedPayload(receipt, depositMessage());
+    expect(payload?.logIndex).to.equal(2);
   });
 });
 

--- a/test/DepositAddressHandler.publish.ts
+++ b/test/DepositAddressHandler.publish.ts
@@ -96,15 +96,17 @@ describe("buildWithdrawExecutedPayload", function () {
     expect(payload).to.not.be.undefined;
     expect(payload).to.deep.equal({
       type: "withdraw_executed",
-      chainId: 1,
-      blockNumber: 1_234_567,
-      txHash: REFUND_TX.toLowerCase(),
-      logIndex: 4,
-      erc20Transfer: {
+      data: {
         chainId: 1,
-        blockNumber: 1_000_000,
-        txHash: INBOUND_TX,
+        blockNumber: 1_234_567,
+        txHash: REFUND_TX.toLowerCase(),
         logIndex: 4,
+        erc20Transfer: {
+          chainId: 1,
+          blockNumber: 1_000_000,
+          txHash: INBOUND_TX,
+          logIndex: 4,
+        },
       },
     });
   });
@@ -120,7 +122,7 @@ describe("buildWithdrawExecutedPayload", function () {
       },
     ]);
     const payload = buildWithdrawExecutedPayload(receipt, message);
-    expect(payload?.logIndex).to.equal(0);
+    expect(payload?.data.logIndex).to.equal(0);
   });
 
   it("returns undefined when no Transfer (depositAddress -> refundAddress) exists in the receipt", function () {
@@ -146,7 +148,7 @@ describe("buildWithdrawExecutedPayload", function () {
       { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(REFUND_ADDRESS)] },
     ]);
     const payload = buildWithdrawExecutedPayload(receipt, depositMessage());
-    expect(payload?.logIndex).to.equal(1);
+    expect(payload?.data.logIndex).to.equal(1);
   });
 
   it("picks the LAST matching Transfer log when multiple deposit->refund transfers exist (e.g. Multicall3-bundled withdraw)", function () {
@@ -162,7 +164,7 @@ describe("buildWithdrawExecutedPayload", function () {
       { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(REFUND_ADDRESS)] },
     ]);
     const payload = buildWithdrawExecutedPayload(receipt, depositMessage());
-    expect(payload?.logIndex).to.equal(2);
+    expect(payload?.data.logIndex).to.equal(2);
   });
 });
 

--- a/test/DepositAddressHandler.publish.ts
+++ b/test/DepositAddressHandler.publish.ts
@@ -1,0 +1,156 @@
+import { expect } from "chai";
+import { utils, TransactionReceipt } from "../src/utils";
+import { DepositAddressMessage } from "../src/interfaces/DepositAddress";
+import { buildWithdrawExecutedPayload, ERC20_TRANSFER_TOPIC } from "../src/deposit-address/withdrawPayload";
+import { getGcpPubSubPublisher } from "../src/messaging/gcp";
+
+const DEPOSIT_ADDRESS = "0x000000000000000000000000000000000000C0DE";
+const OTHER_ADDRESS = "0x000000000000000000000000000000000000BEEF";
+const TOKEN = "0x000000000000000000000000000000000000DEAD";
+const OTHER_TOKEN = "0x0000000000000000000000000000000000005678";
+const REFUND_TX = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefABCD";
+const INBOUND_TX = "0x1111111111111111111111111111111111111111111111111111111111111111";
+
+function topicAddress(address: string): string {
+  return utils.hexZeroPad(address.toLowerCase(), 32);
+}
+
+function depositMessage(): DepositAddressMessage {
+  return {
+    depositAddress: DEPOSIT_ADDRESS,
+    paramsHash: "0x" + "0".repeat(64),
+    salt: "0x" + "0".repeat(64),
+    counterfactualDepositContractAddress: "0x000000000000000000000000000000000000A1A1",
+    counterfactualFactoryContractAddress: "0x000000000000000000000000000000000000A2A2",
+    adminWithdrawManagerContractAddress: "0x000000000000000000000000000000000000A3A3",
+    shouldSponsorAccountCreation: false,
+    counterfactualMaterials: {
+      withdrawLeaf: {
+        leafHash: "0x" + "0".repeat(64),
+        merkleProof: [],
+        encodedParams: "0x",
+        implementationAddress: "0x000000000000000000000000000000000000A4A4",
+      },
+    },
+    routeParams: {
+      inputToken: TOKEN,
+      outputToken: TOKEN,
+      originChainId: "1",
+      destinationChainId: "10",
+      recipient: "0x0000000000000000000000000000000000001111",
+      refundAddress: "0x0000000000000000000000000000000000002222",
+    },
+    erc20Transfer: {
+      chainId: "1",
+      blockNumber: 1_000_000,
+      logIndex: 4,
+      from: "0x0000000000000000000000000000000000002222",
+      to: DEPOSIT_ADDRESS,
+      amount: "5000",
+      contractAddress: TOKEN,
+      transactionHash: INBOUND_TX,
+      transferClassification: "intent_refund",
+    },
+  };
+}
+
+function fakeReceipt(logs: Array<Partial<TransactionReceipt["logs"][number]>>): TransactionReceipt {
+  return {
+    blockNumber: 1_234_567,
+    transactionHash: REFUND_TX,
+    logs: logs.map((l, i) => ({
+      transactionIndex: 0,
+      blockNumber: 1_234_567,
+      transactionHash: REFUND_TX,
+      address: TOKEN,
+      topics: [],
+      data: "0x",
+      logIndex: i,
+      blockHash: "0x" + "0".repeat(64),
+      removed: false,
+      ...l,
+    })),
+  } as unknown as TransactionReceipt;
+}
+
+describe("buildWithdrawExecutedPayload", function () {
+  it("picks the ERC20 Transfer log with from = depositAddress and address = token", function () {
+    const receipt = fakeReceipt([
+      // Unrelated event from the same token contract (e.g., Approval-like) — wrong topic[0].
+      { address: TOKEN, topics: ["0x" + "f".repeat(64), topicAddress(OTHER_ADDRESS), topicAddress(DEPOSIT_ADDRESS)] },
+      // Transfer from another address — wrong topic[1].
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(OTHER_ADDRESS), topicAddress(DEPOSIT_ADDRESS)] },
+      // Multicall3 deploy log — wrong contract address.
+      {
+        address: OTHER_TOKEN,
+        topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(OTHER_ADDRESS)],
+      },
+      // The match.
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(OTHER_ADDRESS)] },
+    ]);
+
+    const payload = buildWithdrawExecutedPayload(receipt, depositMessage());
+    expect(payload).to.not.be.undefined;
+    expect(payload).to.deep.equal({
+      type: "withdraw_executed",
+      chainId: 1,
+      blockNumber: 1_234_567,
+      txHash: REFUND_TX.toLowerCase(),
+      logIndex: 3,
+      erc20Transfer: {
+        chainId: 1,
+        blockNumber: 1_000_000,
+        txHash: INBOUND_TX,
+        logIndex: 4,
+      },
+    });
+  });
+
+  it("matches case-insensitively on addresses (mixed-case token and deposit address)", function () {
+    const message = depositMessage();
+    message.depositAddress = DEPOSIT_ADDRESS; // checksummed
+    message.erc20Transfer.contractAddress = TOKEN.toUpperCase().replace("0X", "0x");
+    const receipt = fakeReceipt([
+      {
+        address: TOKEN.toLowerCase(),
+        topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(OTHER_ADDRESS)],
+      },
+    ]);
+    const payload = buildWithdrawExecutedPayload(receipt, message);
+    expect(payload?.logIndex).to.equal(0);
+  });
+
+  it("returns undefined when no matching Transfer log exists", function () {
+    const receipt = fakeReceipt([
+      {
+        address: OTHER_TOKEN,
+        topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(OTHER_ADDRESS)],
+      },
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(OTHER_ADDRESS), topicAddress(DEPOSIT_ADDRESS)] },
+    ]);
+    expect(buildWithdrawExecutedPayload(receipt, depositMessage())).to.be.undefined;
+  });
+
+  it("returns undefined when multiple matching Transfer logs exist", function () {
+    const receipt = fakeReceipt([
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(OTHER_ADDRESS)] },
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(OTHER_ADDRESS)] },
+    ]);
+    expect(buildWithdrawExecutedPayload(receipt, depositMessage())).to.be.undefined;
+  });
+});
+
+describe("getGcpPubSubPublisher", function () {
+  it("returns undefined under RELAYER_TEST", function () {
+    // The mocha runner already sets RELAYER_TEST=true (see the `test` package script),
+    // so this asserts the short-circuit fires for the real test invocation.
+    expect(process.env.RELAYER_TEST).to.equal("true");
+    expect(getGcpPubSubPublisher(undefined, "any-project")).to.be.undefined;
+  });
+
+  it("returns undefined when projectId is missing", function () {
+    // The RELAYER_TEST short-circuit fires first, so this primarily documents intent.
+    expect(getGcpPubSubPublisher(undefined, "")).to.be.undefined;
+    expect(getGcpPubSubPublisher(undefined, undefined)).to.be.undefined;
+  });
+});

--- a/test/DepositAddressHandler.publish.ts
+++ b/test/DepositAddressHandler.publish.ts
@@ -5,7 +5,8 @@ import { buildWithdrawExecutedPayload, ERC20_TRANSFER_TOPIC } from "../src/depos
 import { getGcpPubSubPublisher } from "../src/messaging/gcp";
 
 const DEPOSIT_ADDRESS = "0x000000000000000000000000000000000000C0DE";
-const OTHER_ADDRESS = "0x000000000000000000000000000000000000BEEF";
+const REFUND_ADDRESS = "0x0000000000000000000000000000000000002222";
+const FEE_RECIPIENT = "0x000000000000000000000000000000000000BEEF";
 const TOKEN = "0x000000000000000000000000000000000000DEAD";
 const OTHER_TOKEN = "0x0000000000000000000000000000000000005678";
 const REFUND_TX = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefABCD";
@@ -38,13 +39,13 @@ function depositMessage(): DepositAddressMessage {
       originChainId: "1",
       destinationChainId: "10",
       recipient: "0x0000000000000000000000000000000000001111",
-      refundAddress: "0x0000000000000000000000000000000000002222",
+      refundAddress: REFUND_ADDRESS,
     },
     erc20Transfer: {
       chainId: "1",
       blockNumber: 1_000_000,
       logIndex: 4,
-      from: "0x0000000000000000000000000000000000002222",
+      from: REFUND_ADDRESS,
       to: DEPOSIT_ADDRESS,
       amount: "5000",
       contractAddress: TOKEN,
@@ -74,19 +75,21 @@ function fakeReceipt(logs: Array<Partial<TransactionReceipt["logs"][number]>>): 
 }
 
 describe("buildWithdrawExecutedPayload", function () {
-  it("picks the ERC20 Transfer log with from = depositAddress and address = token", function () {
+  it("picks the Transfer log matching (token, from=depositAddress, to=refundAddress)", function () {
     const receipt = fakeReceipt([
       // Unrelated event from the same token contract (e.g., Approval-like) — wrong topic[0].
-      { address: TOKEN, topics: ["0x" + "f".repeat(64), topicAddress(OTHER_ADDRESS), topicAddress(DEPOSIT_ADDRESS)] },
+      { address: TOKEN, topics: ["0x" + "f".repeat(64), topicAddress(FEE_RECIPIENT), topicAddress(REFUND_ADDRESS)] },
       // Transfer from another address — wrong topic[1].
-      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(OTHER_ADDRESS), topicAddress(DEPOSIT_ADDRESS)] },
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(FEE_RECIPIENT), topicAddress(REFUND_ADDRESS)] },
+      // Transfer to another address — wrong topic[2].
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(FEE_RECIPIENT)] },
       // Multicall3 deploy log — wrong contract address.
       {
         address: OTHER_TOKEN,
-        topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(OTHER_ADDRESS)],
+        topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(REFUND_ADDRESS)],
       },
       // The match.
-      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(OTHER_ADDRESS)] },
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(REFUND_ADDRESS)] },
     ]);
 
     const payload = buildWithdrawExecutedPayload(receipt, depositMessage());
@@ -96,7 +99,7 @@ describe("buildWithdrawExecutedPayload", function () {
       chainId: 1,
       blockNumber: 1_234_567,
       txHash: REFUND_TX.toLowerCase(),
-      logIndex: 3,
+      logIndex: 4,
       erc20Transfer: {
         chainId: 1,
         blockNumber: 1_000_000,
@@ -106,39 +109,57 @@ describe("buildWithdrawExecutedPayload", function () {
     });
   });
 
-  it("matches case-insensitively on addresses (mixed-case token and deposit address)", function () {
+  it("matches case-insensitively on token, depositAddress, and refundAddress", function () {
     const message = depositMessage();
-    message.depositAddress = DEPOSIT_ADDRESS; // checksummed
     message.erc20Transfer.contractAddress = TOKEN.toUpperCase().replace("0X", "0x");
+    message.routeParams.refundAddress = REFUND_ADDRESS.toUpperCase().replace("0X", "0x");
     const receipt = fakeReceipt([
       {
         address: TOKEN.toLowerCase(),
-        topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(OTHER_ADDRESS)],
+        topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(REFUND_ADDRESS)],
       },
     ]);
     const payload = buildWithdrawExecutedPayload(receipt, message);
     expect(payload?.logIndex).to.equal(0);
   });
 
-  it("returns undefined when no matching Transfer log exists", function () {
+  it("returns undefined when no Transfer (depositAddress -> refundAddress) exists in the receipt", function () {
     const receipt = fakeReceipt([
+      // Right shape but wrong token.
       {
         address: OTHER_TOKEN,
-        topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(OTHER_ADDRESS)],
+        topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(REFUND_ADDRESS)],
       },
-      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(OTHER_ADDRESS), topicAddress(DEPOSIT_ADDRESS)] },
+      // Inbound transfer (from = refundAddress) — wrong direction.
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(REFUND_ADDRESS), topicAddress(DEPOSIT_ADDRESS)] },
     ]);
     expect(buildWithdrawExecutedPayload(receipt, depositMessage())).to.be.undefined;
   });
 
-  it("picks the LAST matching Transfer log when multiple exist (e.g. Multicall3-bundled withdraw)", function () {
+  it("disambiguates fee-on-transfer tokens by selecting the deposit->refund transfer, not the deposit->fee transfer", function () {
+    // Typical fee-on-transfer token: a single user-facing transfer emits two ERC20 Transfer
+    // events from the sender — one to the recipient, one to a fee recipient.
     const receipt = fakeReceipt([
-      // Intermediate transfer from the deposit address (e.g., to an internal router).
-      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(OTHER_ADDRESS)] },
+      // Fee leg — same `from`, but `to` is the fee recipient, not the user.
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(FEE_RECIPIENT)] },
+      // Settlement leg — the one we want.
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(REFUND_ADDRESS)] },
+    ]);
+    const payload = buildWithdrawExecutedPayload(receipt, depositMessage());
+    expect(payload?.logIndex).to.equal(1);
+  });
+
+  it("picks the LAST matching Transfer log when multiple deposit->refund transfers exist (e.g. Multicall3-bundled withdraw)", function () {
+    const receipt = fakeReceipt([
+      // Intermediate transfer from the deposit address to the refund address.
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(REFUND_ADDRESS)] },
       // Unrelated log between the two matches.
-      { address: OTHER_TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(OTHER_ADDRESS), topicAddress(DEPOSIT_ADDRESS)] },
+      {
+        address: OTHER_TOKEN,
+        topics: [ERC20_TRANSFER_TOPIC, topicAddress(FEE_RECIPIENT), topicAddress(REFUND_ADDRESS)],
+      },
       // Final settlement transfer from the deposit address — this is the one we want.
-      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(OTHER_ADDRESS)] },
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(REFUND_ADDRESS)] },
     ]);
     const payload = buildWithdrawExecutedPayload(receipt, depositMessage());
     expect(payload?.logIndex).to.equal(2);

--- a/test/DepositAddressUtils.ts
+++ b/test/DepositAddressUtils.ts
@@ -35,6 +35,8 @@ function tronOriginIndexerMessage(): DepositAddressMessage {
     },
     erc20Transfer: {
       chainId: String(CHAIN_IDs.TRON),
+      blockNumber: 73_500_000,
+      logIndex: 2,
       from: "TQ4T4DgHoezYBTRoZPCspsSgRw38Ni9prA",
       to: "TRiKGHiWuKvDjwgNTmi6ohsucSfLBoLAVu",
       amount: "500000",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1204,10 +1204,27 @@
     arrify "^2.0.0"
     extend "^3.0.2"
 
+"@google-cloud/paginator@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/paginator/-/paginator-6.0.0.tgz#27d477c2e75f7839da13ca681f6427e015ad75d1"
+  integrity sha512-g5nmMnzC+94kBxOKkLGpK1ikvolTFCC3s2qtE4F+1EuArcJ7HHC23RDQVt3Ra3CqpUYZ+oXNKZ8n5Cn5yug8DA==
+  dependencies:
+    extend "^3.0.2"
+
+"@google-cloud/precise-date@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/precise-date/-/precise-date-5.0.0.tgz#31891974143ecdcacce0a6835c285a77b0968477"
+  integrity sha512-9h0Gvw92EvPdE8AK8AgZPbMnH5ftDyPtKm7/KUfcJVaPEPjwGDsJd1QV0H8esBDV4II41R/2lDWH1epBqIoKUw==
+
 "@google-cloud/projectify@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@google-cloud/projectify/-/projectify-4.0.0.tgz#d600e0433daf51b88c1fa95ac7f02e38e80a07be"
   integrity sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==
+
+"@google-cloud/projectify@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/projectify/-/projectify-5.0.0.tgz#9e8ab37e8826fb6678019879111759ab3ca64548"
+  integrity sha512-XXQLaIcLrOAMWvRrzz+mlUGtN6vlVNja3XQbMqRi/V7XJTAVwib3VcKd7oRwyZPkp7rBVlHGcaqdyGRrcnkhlA==
 
 "@google-cloud/promisify@4.0.0", "@google-cloud/promisify@<4.1.0":
   version "4.0.0"
@@ -1223,6 +1240,27 @@
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@google-cloud/promisify/-/promisify-5.0.0.tgz#94e44ba4e5ea410d3c82a03fcb37ca34dbc5d1d5"
   integrity sha512-N8qS6dlORGHwk7WjGXKOSsLjIjNINCPicsOX6gyyLiYk7mq3MtII96NZ9N2ahwA2vnkLmZODOIH9rlNniYWvCQ==
+
+"@google-cloud/pubsub@^5.2.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/pubsub/-/pubsub-5.3.0.tgz#807e7dc7d0163f94ad142316047a1db739591323"
+  integrity sha512-hyUoE85Rj3rRUVk3VU+Selp4MorBwEzsQEqAj6+SE+WabR9LIFitYS6A4R+PyiwVaRk/tggGD8p7bNiIY5sk4w==
+  dependencies:
+    "@google-cloud/paginator" "^6.0.0"
+    "@google-cloud/precise-date" "^5.0.0"
+    "@google-cloud/projectify" "^5.0.0"
+    "@google-cloud/promisify" "^5.0.0"
+    "@opentelemetry/api" "~1.9.0"
+    "@opentelemetry/core" "^1.30.1"
+    "@opentelemetry/semantic-conventions" "~1.39.0"
+    arrify "^2.0.0"
+    extend "^3.0.2"
+    google-auth-library "^10.5.0"
+    google-gax "^5.0.5"
+    heap-js "^2.6.0"
+    is-stream-ended "^0.1.4"
+    lodash.snakecase "^4.1.1"
+    p-defer "^3.0.0"
 
 "@google-cloud/storage@^7.19.0":
   version "7.19.0"
@@ -1862,10 +1900,27 @@
     hex2dec "^1.0.1"
     uuid "^8.0.0"
 
-"@opentelemetry/api@^1.7.0":
+"@opentelemetry/api@^1.7.0", "@opentelemetry/api@~1.9.0":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
   integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
+
+"@opentelemetry/core@^1.30.1":
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.30.1.tgz#a0b468bb396358df801881709ea38299fc30ab27"
+  integrity sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "1.28.0"
+
+"@opentelemetry/semantic-conventions@1.28.0":
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz#337fb2bca0453d0726696e745f50064411f646d6"
+  integrity sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==
+
+"@opentelemetry/semantic-conventions@~1.39.0":
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz#f653b2752171411feb40310b8a8953d7e5c543b7"
+  integrity sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==
 
 "@openzeppelin/contracts-upgradeable-v4@npm:@openzeppelin/contracts-upgradeable@4.9.6":
   version "4.9.6"
@@ -6037,7 +6092,7 @@ globals@^13.19.0, globals@^13.24.0:
   dependencies:
     type-fest "^0.20.2"
 
-google-auth-library@^10.1.0, google-auth-library@^10.6.2:
+google-auth-library@^10.1.0, google-auth-library@^10.5.0, google-auth-library@^10.6.2:
   version "10.6.2"
   resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-10.6.2.tgz#44557c536aec626b7cda48a85b5d026e2c9b74c4"
   integrity sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==
@@ -6079,7 +6134,7 @@ google-gax@^4.0.3:
     retry-request "^7.0.0"
     uuid "^9.0.1"
 
-google-gax@^5.0.0, google-gax@^5.0.2-rc.1:
+google-gax@^5.0.0, google-gax@^5.0.2-rc.1, google-gax@^5.0.5:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-5.0.6.tgz#825a78796e424af9da8110d3caa335a76929b835"
   integrity sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==
@@ -6303,6 +6358,11 @@ he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+heap-js@^2.6.0:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/heap-js/-/heap-js-2.7.1.tgz#3f152279e42214725cac405257554b000b178cc4"
+  integrity sha512-EQfezRg0NCZGNlhlDR3Evrw1FVL2G3LhU7EgPoxufQKruNBSYA8MiRPHeWbU+36o+Fhel0wMwM+sLEiBAlNLJA==
 
 hex2dec@^1.0.1:
   version "1.1.2"
@@ -7149,6 +7209,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.snakecase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
+  integrity sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==
 
 lodash.truncate@^4.4.2:
   version "4.4.2"
@@ -8061,6 +8126,11 @@ ox@0.14.7:
     "@scure/bip39" "^1.6.0"
     abitype "^1.2.3"
     eventemitter3 "5.0.1"
+
+p-defer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-3.0.0.tgz#d1dceb4ee9b2b604b1d94ffec83760175d4e6f83"
+  integrity sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==
 
 p-limit@^3.0.1, p-limit@^3.0.2:
   version "3.1.0"


### PR DESCRIPTION
## Summary

When the bot performs a refund-withdraw (the case where a user accidentally sent the wrong asset, or sent to the wrong chain, and we send their funds back), the across-indexer has no way to know it happened. The corresponding row in its `deposit_address_transfer_withdraw` table sits forever in `auto_pending`, breaking dashboards and any downstream workflow that watches for terminal states.

This PR closes the loop. Every time the bot confirms a refund withdraw on-chain, it publishes a small `withdraw_executed` message to GCP Pub/Sub. The indexer's already-deployed consumer picks it up and transitions the row to `executed`.

The publish is best-effort and gated by an env flag, so it stays off in environments that aren't ready for it and never blocks the bot's primary job.

Linear: [OPS-431](https://linear.app/uma/issue/OPS-431). Pairs with the indexer consumer ([ACB-446](https://linear.app/uma/issue/ACB-446)) and the Terraform provisioning ([UMAprotocol/zion#1703](https://github.com/UMAprotocol/zion/pull/1703), renamed in [#1712](https://github.com/UMAprotocol/zion/pull/1712)).

## Changes

### New module — `src/messaging/gcp/`
- `PubSub.ts` exports `GcpPubSubPublisher` (thin wrapper around `@google-cloud/pubsub`) + `getGcpPubSubPublisher` factory. Auth via ADC; mirrors `src/messaging/redis/PubSub.ts` including the `RELAYER_TEST` short-circuit. Reusable by any bot that needs to publish.
- Added `@google-cloud/pubsub@^5.2.0` to `package.json` (matches the indexer repo's pin).

### Publisher wired into `DepositAddressHandler`
- Three new env vars in `DepositAddressHandlerConfig`:
  - `ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER` (gate, default `false`)
  - `PUBSUB_GCP_PROJECT_ID` (topic host project — may differ from the bot's runtime project; cross-project publish works via the runtime SA's existing publisher IAM grant)
  - `PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC` (short topic name; prod = `topic-deposit-address-execution`, sandbox = `topic-deposit-address-execution-sandbox`)
  - Required-when-enabled validation throws at config construction.
- Publisher constructed in `initialize()`; closed via a new `disconnect()` method called from the entrypoint's `finally` block before Redis cleanup.
- New `_publishWithdrawExecuted` called immediately after `_persistWithdrawnKeysRedis()` in `initiateWithdraw`. Best-effort: try/catch with `notificationPath: "across-bot-error"`, never throws, never rolls back state.

### Payload (locked by the indexer consumer)
Extracted as a pure helper `buildWithdrawExecutedPayload` in `src/deposit-address/withdrawPayload.ts` for testability. Every Pub/Sub message uses the envelope `{ type, data }`; `data`'s shape depends on `type`:

```ts
{
  type: "withdraw_executed",
  data: {
    chainId, blockNumber, txHash, logIndex,                      // the withdraw tx
    erc20Transfer: { chainId, blockNumber, txHash, logIndex }    // the inbound user transfer
  }
}
```

The withdraw-side `logIndex` is the index of the ERC-20 `Transfer(address,address,uint256)` event whose `address` matches `erc20Transfer.contractAddress`, whose `from` is the deposit address, and whose `to` is the user's `routeParams.refundAddress` — pinpointing the funds leaving the PDA and disambiguating fee-on-transfer / tax / burn tokens. If multiple Transfer logs still satisfy all three filters (e.g. a Multicall3-bundled withdraw with intermediate hops), the **last** match wins. The helper returns `undefined` only when no matching log is found, in which case the handler warns and skips the publish.

Only refund-chain identifiers are used (never `routeParams.originChainId`), so wrong-chain mis-routes are handled correctly.

### Interface extension
- `Erc20Transfer` (in `src/interfaces/DepositAddress.ts`) gains required `blockNumber: number` and `logIndex: number` fields. The indexer API already returns them; the bot's interface was just lossy. Required (not optional) so any future drift surfaces loudly.

### Failure semantics — explicit non-goals
- No `withdraw_failed` events. The bot retries internally on quote-API and tx-submit failures and does not yet track a "retries exhausted" terminal state. The consumer schema accepts them; producing them is deferred.
- No startup replay for executed-but-unpublished withdraws. Redis does not persist per-key publish state; a publish dropped during a bot crash leaves the indexer row `auto_pending` until ops reconciles. Accepted for v1.

### Docs
- `.env.example` — new "Deposit Address Handler Configuration" section grouping the handler's existing env vars plus the three new ones.
- `AGENTS.md` — `src/deposit-address/` and `src/messaging/` added to the directory tree; quick-index entries for the new README and deep-dive; deposit-address listed in bot types.
- `src/deposit-address/README.md` (new) — module overview: poll cadence, deposit vs withdraw paths, Redis persistence model, the new PubSub publish (env, payload, failure semantics).
- `docs/deposit-address-withdraw-pubsub.md` (new) — cross-repo Pub/Sub contract deep-dive: topology, IAM, payload, producer/consumer mechanics, failure modes, contributor recommendations.

### Tests
- `test/DepositAddressHandler.publish.ts` (new) — unit tests covering:
  - Picks the right ERC-20 Transfer log when mixed with unrelated logs (wrong-topic, wrong-from, wrong-to, wrong-contract).
  - Case-insensitive matching on token, depositAddress, and refundAddress.
  - Returns `undefined` only when no matching log exists.
  - Fee-on-transfer disambiguation: picks the deposit→refund leg, not the deposit→fee leg.
  - Picks the LAST matching log when multiple deposit→refund transfers exist (e.g. Multicall3-bundled withdraw).
  - `getGcpPubSubPublisher` short-circuits under `RELAYER_TEST` and when `projectId` is missing.
- `test/DepositAddressUtils.ts` — fixture extended with the now-required `blockNumber` / `logIndex` fields.

## Test plan

- [ ] `yarn build` — typecheck clean.
- [ ] `yarn lint` — clean.
- [ ] `yarn test` — full suite green.
- [ ] Targeted: `RELAYER_TEST=true npx hardhat test test/DepositAddressHandler.publish.ts` — all new tests pass.
- [ ] Sandbox smoke (post-deploy): run the bot with `ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER=true`, `PUBSUB_GCP_PROJECT_ID=data-hub-pubsub-3360`, `PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC=topic-deposit-address-execution-sandbox` against a known mis-route message; confirm a JSON payload lands on `subscription-deposit-address-execution-sandbox-indexer` and the indexer row transitions to `executed`.
- [ ] Negative smoke: with the gate off, confirm no GCP client is constructed and no publish calls happen.
- [ ] Failure-path smoke: temporarily revoke the bot SA's publisher role; confirm the bot logs an error with `notificationPath: "across-bot-error"` but continues to process subsequent withdraws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)