### PR TITLE
fix(dataworker): don't let deactivateLut cleanup mask refund execution error

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -3291,9 +3291,17 @@ export class Dataworker {
       this.logger.error({
         at: "Dataworker#executeRelayerRefundLeafSvm",
         message: "Something failed during the relayer refund leaf execution stage",
-        error: e,
+        cause: e,
       });
-      await deactivateLut();
+      try {
+        await deactivateLut();
+      } catch (err) {
+        this.logger.warn({
+          at: "Dataworker#executeRelayerRefundLeafSvm",
+          message: "deactivateLut cleanup failed after refund execution error",
+          cause: err,
+        });
+      }
       throw e;
     }
     // The refund was successful, so return the signature.


### PR DESCRIPTION
## Summary

Defensive fix for `Dataworker#_executeRelayerRefundLeafSvm`'s error handling:

- Wrap the `deactivateLut()` cleanup call in `try/catch`. Previously, if `deactivateLut()` itself threw (e.g. the same Solana RPC issue that caused the original failure), its error would replace the original `e` and obscure the actual root cause.
- Log the cleanup failure as a `warn` so it's still visible.
- Rename the logger's `error` key to `cause` in the original catch so winston's `error` formatter doesn't swallow the thrown value.

## Context

Triggered by repeated PagerDuty alerts `ServerlessHub ⭢ Some spoke calls returned errors 🚨` on `zion-across-l2-executor-solana` — the underlying logs in `bots-across-3839/across-spoke-2c-8g` show `_executeRelayerRefundLeafSvm` → `deactivateLut` → `sendAndConfirmSolanaTransaction` failing on Chainstack Solana mainnet RPC with `SolanaError: Transaction simulation failed`. Today's PD: PD-325201. The wrap-cleanup pattern lets us see the original execution error in logs even when the LUT-deactivation cleanup also flakes.

This is a logging/safety patch only — no behavior change for the happy path or for the thrown error contract (the original `e` is still rethrown).

## Docs

Per AGENTS.md guidance: no `README.md` / `AGENTS.md` updates — this change does not alter behavior, configuration, interfaces, or runtime flow.

## Test plan

- [x] `yarn typecheck` passes locally
- [x] `yarn lint` passes locally
- [ ] CI green
- [ ] Reviewer confirms log keys (`cause`) render as expected in winston output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
