### PR TITLE
improve(logs): sanitize simulation-failure reason before logging

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -16,6 +16,7 @@ import {
   getProvider,
   Multicall2Call,
   assert,
+  sanitizeSimulationReason,
 } from "../utils";
 import { AugmentedTransaction, TransactionClient } from "./TransactionClient";
 import lodash from "lodash";
@@ -520,7 +521,7 @@ export class MultiCallerClient {
           return {
             target: getTarget(txn.transaction.contract.address),
             args: txn.transaction.args,
-            reason: txn.reason,
+            reason: sanitizeSimulationReason(txn.reason),
             message: txn.transaction.message,
             mrkdwn: txn.transaction.mrkdwn,
           };

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -39,6 +39,33 @@ export type Multicall2Call = {
   target: string;
 };
 
+// Path segments shaped like opaque API keys (≥16 base64/hex/url-safe chars).
+// Conservative: leaves origins and short path components (e.g. "/v2") intact.
+const RPC_KEY_PATH_SEGMENT = /\/[A-Za-z0-9_-]{16,}/g;
+
+// Redact API-key-like path segments from any URL embedded in the input. Used
+// to scrub RPC provider URLs (Alchemy/Infura/QuickNode/etc.) before they're
+// surfaced to Slack/Datadog warning logs.
+export function redactRpcSecrets(s: string): string {
+  return s.replace(RPC_KEY_PATH_SEGMENT, "/<redacted>");
+}
+
+// Reduce a simulation-failure reason to a single short line suitable for
+// human-readable warning logs. Prefers the inner "execution reverted: …"
+// string when present (e.g. when the failure bubbles up from the SDK's
+// RetryProvider as a multi-provider aggregate error wrapping an ethers
+// stack trace), and always redacts any embedded RPC URLs.
+export function sanitizeSimulationReason(reason: string | undefined): string {
+  if (!reason) {
+    return "unknown error";
+  }
+  const revertMatch = reason.match(/execution reverted:?\s*([^"\\\n]+)/i);
+  const extracted = revertMatch
+    ? revertMatch[1].trim()
+    : (reason.split("\n").find((line) => line.trim().length > 0) ?? reason).trim();
+  return redactRpcSecrets(extracted).slice(0, 200);
+}
+
 export function getMultisender(chainId: number, baseSigner: Signer): Contract | undefined {
   return sdkUtils.getMulticall3(chainId, baseSigner);
 }

--- a/test/TransactionUtils.ts
+++ b/test/TransactionUtils.ts
@@ -1,0 +1,56 @@
+import { expect } from "./utils";
+import { redactRpcSecrets, sanitizeSimulationReason } from "../src/utils/TransactionUtils";
+
+describe("redactRpcSecrets", function () {
+  it("redacts long alphanumeric path segments (API keys)", function () {
+    expect(redactRpcSecrets("https://arb-mainnet.g.alchemy.com/v2/kt6OLQDAKLbTH_m5aVlOHPTyg_bbAImP")).to.equal(
+      "https://arb-mainnet.g.alchemy.com/v2/<redacted>"
+    );
+  });
+
+  it("leaves short path components alone", function () {
+    expect(redactRpcSecrets("https://example.com/v2/foo")).to.equal("https://example.com/v2/foo");
+  });
+
+  it("redacts keys embedded in surrounding text", function () {
+    const input = 'url="https://arb-mainnet.g.alchemy.com/v2/kt6OLQDAKLbTH_m5aVlOHPTyg_bbAImP", code=SERVER_ERROR';
+    expect(redactRpcSecrets(input)).to.equal(
+      'url="https://arb-mainnet.g.alchemy.com/v2/<redacted>", code=SERVER_ERROR'
+    );
+  });
+});
+
+describe("sanitizeSimulationReason", function () {
+  it("returns 'unknown error' for empty input", function () {
+    expect(sanitizeSimulationReason(undefined)).to.equal("unknown error");
+    expect(sanitizeSimulationReason("")).to.equal("unknown error");
+  });
+
+  it("passes short reasons through unchanged", function () {
+    expect(sanitizeSimulationReason("RelayFilled")).to.equal("RelayFilled");
+  });
+
+  it("extracts the inner revert string from a multi-provider aggregate error", function () {
+    const noisy =
+      "Not enough providers succeeded. Errors:\n" +
+      "Provider https://arb-mainnet.g.alchemy.com failed with error: Error: processing response error " +
+      '(body="{\\"jsonrpc\\":\\"2.0\\",\\"id\\":71,\\"error\\":{\\"code\\":3,' +
+      '\\"message\\":\\"execution reverted: ERC20: burn amount exceeds balance\\",\\"data\\":\\"0x...\\"}}", ' +
+      'url="https://arb-mainnet.g.alchemy.com/v2/kt6OLQDAKLbTH_m5aVlOHPTyg_bbAImP", code=SERVER_ERROR)\n' +
+      "    at Logger.makeError (/across-relayer/node_modules/@ethersproject/logger/lib/index.js:238:21)";
+    expect(sanitizeSimulationReason(noisy)).to.equal("ERC20: burn amount exceeds balance");
+  });
+
+  it("redacts secrets even when no revert string is found", function () {
+    const noisy =
+      "Network request failed against https://arb-mainnet.g.alchemy.com/v2/kt6OLQDAKLbTH_m5aVlOHPTyg_bbAImP";
+    expect(sanitizeSimulationReason(noisy)).to.equal(
+      "Network request failed against https://arb-mainnet.g.alchemy.com/v2/<redacted>"
+    );
+  });
+
+  it("caps output length at 200 chars", function () {
+    const long = "x".repeat(500);
+    expect(sanitizeSimulationReason(long)).to.have.lengthOf(200);
+  });
+});


### PR DESCRIPTION
## Summary

When `estimateGas` fails inside the SDK's `RetryProvider`, the error bubbling up to `willSucceed` carries the multi-provider aggregate message — a long, multi-line string containing the ethers stack trace and the underlying RPC body. `MultiCallerClient#logSimulationFailures` (`src/clients/MultiCallerClient.ts:516-530`) dumps that verbatim into Slack/Datadog, where it's both unreadable and (worse) **leaks the failed provider's URL with its API key in cleartext**.

Example of the current output (real failure from prod, redacted here):

```
reason: "Not enough providers succeeded. Errors:\nProvider https://arb-mainnet.g.alchemy.com failed with error: Error: processing response error (body=...{\"message\":\"execution reverted: ERC20: burn amount exceeds balance\"...}..., url=\"https://arb-mainnet.g.alchemy.com/v2/<API_KEY>\", code=SERVER_ERROR, version=web/5.7.1)\n    at Logger.makeError (/across-relayer/node_modules/@ethersproject/logger/lib/index.js:238:21)\n    at Logger.throwError (...)\n    ... <truncated, ~2KB total>"
```

After this change, the same failure produces:

```
reason: "ERC20: burn amount exceeds balance"
```

## Approach

New `sanitizeSimulationReason` helper in `src/utils/TransactionUtils.ts`:
- Extracts the inner `execution reverted: <reason>` string when present.
- Falls back to the first non-empty line otherwise.
- Redacts API-key-shaped path segments (`/[A-Za-z0-9_-]{16,}` → `/<redacted>`) from any embedded URLs via the also-exported `redactRpcSecrets`.
- Caps the result at 200 chars.

Applied at the log site only (`MultiCallerClient#logSimulationFailures`). Classification via `canIgnoreRevertReason` still operates on the raw reason, so existing filter behavior is unchanged.

## Out of scope (follow-ups)

- `TransactionClient#submit` (`src/clients/TransactionClient.ts:233-241`) has a similar issue — it logs `error.message` and `stringifyThrownValue(error)`, which can also contain the same multi-provider blob with leaked URLs. Worth a follow-up.
- Upstream fix in `@across-protocol/sdk` `RetryProvider`: stop concatenating `err.stack` into the aggregate message; emit a short summary and put per-provider details on `error.cause`. Cleanest long-term.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean
- [x] New unit tests in `test/TransactionUtils.ts` covering: short reason passthrough, multi-provider revert extraction, API-key redaction (both for known-provider URLs and standalone), and 200-char cap. All 8 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)