### PR TITLE
feat(EventListener): extend viem wss reconnect window

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,14 @@ RPC_PROVIDER_KEY_DRPC=<DRPC_KEY>
 RPC_PROVIDER_KEY_INFURA=<INFURA_KEY>
 
 
+# The relayer SpokePool event listeners subscribe over wss when available. viem's defaults give up
+# on a hung socket after 5 attempts × 2 s; the values below extend the reconnect window so realistic
+# provider blips ride through without losing the subscription. Tunable per deployment.
+# RPC_WSS_RECONNECT_ATTEMPTS=60
+# RPC_WSS_RECONNECT_DELAY_MS=5000
+# RPC_WSS_KEEPALIVE_INTERVAL_MS=30000
+
+
 # NODE_QUORUM controls how many RPC providers per chain must agree on certain
 # responses before the result will be used. This protects the relayer bot
 # against invalid responses being received from any individual provider.

--- a/src/clients/EventListener.ts
+++ b/src/clients/EventListener.ts
@@ -14,6 +14,14 @@ import {
   winston,
 } from "../utils";
 
+// viem's default wss reconnect is 5 attempts × 2 s (~10 s window) before the socket is abandoned
+// permanently — short enough that a routine provider blip lands us in a dead-socket state with no
+// further events. Bump the window so realistic outages ride through; viem re-issues the active
+// eth_subscribe requests against the new socket on each successful reconnect.
+const WSS_RECONNECT_ATTEMPTS = Number(process.env.RPC_WSS_RECONNECT_ATTEMPTS ?? 60);
+const WSS_RECONNECT_DELAY_MS = Number(process.env.RPC_WSS_RECONNECT_DELAY_MS ?? 5_000);
+const WSS_KEEPALIVE_INTERVAL_MS = Number(process.env.RPC_WSS_KEEPALIVE_INTERVAL_MS ?? 30_000);
+
 function resolveProviders(chainId: number, quorum = 1) {
   const protocol = process.env[`RPC_PROVIDERS_TRANSPORT_${chainId}`] ?? "wss";
   assert(protocol === "wss" || protocol === "https");
@@ -26,7 +34,13 @@ function resolveProviders(chainId: number, quorum = 1) {
   const viemChain = getViemChain(chainId);
   const providers = Object.entries(urls).map(([provider, url]) => {
     const headers = getProviderHeaders(provider, chainId);
-    const transport = protocol === "wss" ? webSocket(url) : http(url, { fetchOptions: { headers } });
+    const transport =
+      protocol === "wss"
+        ? webSocket(url, {
+            reconnect: { attempts: WSS_RECONNECT_ATTEMPTS, delay: WSS_RECONNECT_DELAY_MS },
+            keepAlive: { interval: WSS_KEEPALIVE_INTERVAL_MS },
+          })
+        : http(url, { fetchOptions: { headers } });
 
     return createPublicClient({
       chain: viemChain,


### PR DESCRIPTION
## Summary
- viem's `webSocket()` transport defaults to **5 attempts × 2 s** (~10 s window) before silently abandoning a hung socket. If the reconnect cap is exceeded the cached client stays in-place but the active `eth_subscribe` subscriptions are dropped, so the listener child process keeps running with no events flowing. We've been hitting this on World Chain (`zion-across-relayer-usdh`).
- Pass explicit `reconnect`/`keepAlive` settings to `webSocket()` in `src/clients/EventListener.ts`, defaulting to **60 attempts × 5 s (~5 min)** and a 30 s keepalive ping. viem re-issues active `eth_subscribe` requests against the new socket on each successful reconnect, so no callsite changes are needed.
- Env-overridable via `RPC_WSS_RECONNECT_ATTEMPTS`, `RPC_WSS_RECONNECT_DELAY_MS`, `RPC_WSS_KEEPALIVE_INTERVAL_MS` (documented in `.env.example`).

## Test plan
- [x] `yarn typecheck`
- [x] `eslint` + `prettier --check` clean on changed files
- [ ] Deploy to one bot and confirm subscriptions survive a forced provider disconnect

## Follow-ups (not in this PR)
- Parent-side restart of the listener child on non-zero exit (`SpokePoolClient#childExit` is a no-op today).
- Staleness watchdog (no block seen for N seconds → abort) paired with the above restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)