### PR TITLE
improve(dataworker): align SVM refund-leaf log with EVM format

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2502,53 +2502,57 @@ export class Dataworker {
     ).filter(isDefined);
 
     await forEachAsync(fundedLeaves, async (leaf) => {
-      const symbol = this.getTokenInfo(leaf.l2TokenAddress, chainId);
-      const { message, mrkdwn } = formatRelayerRefundLeafExecutionLog({
+      const leafLogArgs = {
         rootBundleId,
         relayerRefundRoot: relayerRefundTree.getHexRoot(),
         leafId: leaf.leafId,
         chainId,
-        symbol,
+        symbol: this.getTokenInfo(leaf.l2TokenAddress, chainId),
         amountToReturn: leaf.amountToReturn,
-      });
-      if (submitExecution) {
-        if (isEVMSpokePoolClient(client)) {
-          const valueToPassViaPayable = msgValuesByLeafId.get(leaf.leafId);
-          const ethersLeaf = {
-            ...leaf,
-            l2TokenAddress: leaf.l2TokenAddress.toEvmAddress(),
-            refundAddresses: leaf.refundAddresses.map((refundAddress) => refundAddress.toEvmAddress()),
-          };
-          this.clients.multiCallerClient.enqueueTransaction({
-            value: valueToPassViaPayable,
-            contract: client.spokePool,
-            chainId,
-            method: "executeRelayerRefundLeaf",
-            args: [rootBundleId, ethersLeaf, relayerRefundTree.getHexProof(leaf)],
-            message,
-            mrkdwn,
-            // If mainnet, send through Multicall3 so it can be batched with PoolRebalanceLeaf executions, otherwise
-            // SpokePool.multicall() is fine.
-            unpermissioned: Number(chainId) === this.clients.hubPoolClient.chainId,
-            // If simulating mainnet execution, can fail as it may require funds to be sent from
-            // pool rebalance leaf.
-            canFailInSimulation: leaf.chainId === this.clients.hubPoolClient.chainId,
-          });
-        } else if (isSVMSpokePoolClient(client)) {
-          const signature = await this._executeRelayerRefundLeafSvm(
-            client,
-            leaf,
-            rootBundleId,
-            relayerRefundTree.getHexProof(leaf)
-          );
-          this.logger.info({
-            at: "Dataworker#_executeRelayerRefundLeaves",
-            message: `${message} (${blockExplorerLink(signature, chainId)})`,
-            mrkdwn,
-          });
-        }
-      } else {
-        this.logger.debug({ at: "Dataworker#_executeRelayerRefundLeaves", message: mrkdwn });
+      };
+      if (!submitExecution) {
+        this.logger.debug({
+          at: "Dataworker#_executeRelayerRefundLeaves",
+          message: formatRelayerRefundLeafExecutionLog(leafLogArgs).mrkdwn,
+        });
+        return;
+      }
+      if (isEVMSpokePoolClient(client)) {
+        const valueToPassViaPayable = msgValuesByLeafId.get(leaf.leafId);
+        const ethersLeaf = {
+          ...leaf,
+          l2TokenAddress: leaf.l2TokenAddress.toEvmAddress(),
+          refundAddresses: leaf.refundAddresses.map((refundAddress) => refundAddress.toEvmAddress()),
+        };
+        this.clients.multiCallerClient.enqueueTransaction({
+          value: valueToPassViaPayable,
+          contract: client.spokePool,
+          chainId,
+          method: "executeRelayerRefundLeaf",
+          args: [rootBundleId, ethersLeaf, relayerRefundTree.getHexProof(leaf)],
+          // TransactionClient#submit appends `(<explorer>)` from the tx response.
+          ...formatRelayerRefundLeafExecutionLog(leafLogArgs),
+          // If mainnet, send through Multicall3 so it can be batched with PoolRebalanceLeaf executions, otherwise
+          // SpokePool.multicall() is fine.
+          unpermissioned: Number(chainId) === this.clients.hubPoolClient.chainId,
+          // If simulating mainnet execution, can fail as it may require funds to be sent from
+          // pool rebalance leaf.
+          canFailInSimulation: leaf.chainId === this.clients.hubPoolClient.chainId,
+        });
+      } else if (isSVMSpokePoolClient(client)) {
+        const signature = await this._executeRelayerRefundLeafSvm(
+          client,
+          leaf,
+          rootBundleId,
+          relayerRefundTree.getHexProof(leaf)
+        );
+        this.logger.info({
+          at: "Dataworker#_executeRelayerRefundLeaves",
+          ...formatRelayerRefundLeafExecutionLog({
+            ...leafLogArgs,
+            explorerLink: blockExplorerLink(signature, chainId),
+          }),
+        });
       }
     });
   }

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2538,9 +2538,8 @@ export class Dataworker {
           );
           this.logger.info({
             at: "Dataworker#_executeRelayerRefundLeaves",
-            message: "Executed RelayerRefundLeaf 🌿!",
+            message: `Executed RelayerRefundLeaf 🌿! (${blockExplorerLink(signature, chainId)})`,
             mrkdwn,
-            signature: blockExplorerLink(signature, chainId),
           });
         }
       } else {

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -86,6 +86,7 @@ import {
   persistDataToArweave,
 } from "../dataworker/DataworkerUtils";
 import { _buildRelayerRefundRoot, _buildSlowRelayRoot, generateValidationKey } from "./DataworkerUtils";
+import { formatRelayerRefundLeafExecutionLog } from "./RelayerRefundUtils";
 import _ from "lodash";
 import {
   ARBITRUM_ORBIT_L1L2_MESSAGE_FEE_DATA,
@@ -2502,10 +2503,14 @@ export class Dataworker {
 
     await forEachAsync(fundedLeaves, async (leaf) => {
       const symbol = this.getTokenInfo(leaf.l2TokenAddress, chainId);
-
-      const mrkdwn = `rootBundleId: ${rootBundleId}\nrelayerRefundRoot: ${relayerRefundTree.getHexRoot()}\nLeaf: ${
-        leaf.leafId
-      }\nchainId: ${chainId}\ntoken: ${symbol}\namount: ${leaf.amountToReturn.toString()}`;
+      const { message, mrkdwn } = formatRelayerRefundLeafExecutionLog({
+        rootBundleId,
+        relayerRefundRoot: relayerRefundTree.getHexRoot(),
+        leafId: leaf.leafId,
+        chainId,
+        symbol,
+        amountToReturn: leaf.amountToReturn,
+      });
       if (submitExecution) {
         if (isEVMSpokePoolClient(client)) {
           const valueToPassViaPayable = msgValuesByLeafId.get(leaf.leafId);
@@ -2520,7 +2525,7 @@ export class Dataworker {
             chainId,
             method: "executeRelayerRefundLeaf",
             args: [rootBundleId, ethersLeaf, relayerRefundTree.getHexProof(leaf)],
-            message: "Executed RelayerRefundLeaf 🌿!",
+            message,
             mrkdwn,
             // If mainnet, send through Multicall3 so it can be batched with PoolRebalanceLeaf executions, otherwise
             // SpokePool.multicall() is fine.
@@ -2538,7 +2543,7 @@ export class Dataworker {
           );
           this.logger.info({
             at: "Dataworker#_executeRelayerRefundLeaves",
-            message: `Executed RelayerRefundLeaf 🌿! (${blockExplorerLink(signature, chainId)})`,
+            message: `${message} (${blockExplorerLink(signature, chainId)})`,
             mrkdwn,
           });
         }

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2,6 +2,7 @@ import assert from "assert";
 import { Contract } from "ethers";
 import { utils as sdkUtils, arch } from "@across-protocol/sdk";
 import {
+  blockExplorerLink,
   bnZero,
   winston,
   EMPTY_MERKLE_ROOT,
@@ -2537,8 +2538,10 @@ export class Dataworker {
           );
           this.logger.info({
             at: "Dataworker#_executeRelayerRefundLeaves",
-            message: mrkdwn,
+            message: "Executed RelayerRefundLeaf 🌿!",
+            mrkdwn,
             signature,
+            explorer: blockExplorerLink(signature, chainId),
           });
         }
       } else {

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2530,14 +2530,14 @@ export class Dataworker {
           chainId,
           method: "executeRelayerRefundLeaf",
           args: [rootBundleId, ethersLeaf, relayerRefundTree.getHexProof(leaf)],
-          // TransactionClient#submit appends `(<explorer>)` from the tx response.
-          ...formatRelayerRefundLeafExecutionLog(leafLogArgs),
           // If mainnet, send through Multicall3 so it can be batched with PoolRebalanceLeaf executions, otherwise
           // SpokePool.multicall() is fine.
           unpermissioned: Number(chainId) === this.clients.hubPoolClient.chainId,
           // If simulating mainnet execution, can fail as it may require funds to be sent from
           // pool rebalance leaf.
           canFailInSimulation: leaf.chainId === this.clients.hubPoolClient.chainId,
+          // TransactionClient#submit appends `(<explorer>)` from the tx response.
+          ...formatRelayerRefundLeafExecutionLog(leafLogArgs),
         });
       } else if (isSVMSpokePoolClient(client)) {
         const signature = await this._executeRelayerRefundLeafSvm(

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2540,8 +2540,7 @@ export class Dataworker {
             at: "Dataworker#_executeRelayerRefundLeaves",
             message: "Executed RelayerRefundLeaf 🌿!",
             mrkdwn,
-            signature,
-            explorer: blockExplorerLink(signature, chainId),
+            signature: blockExplorerLink(signature, chainId),
           });
         }
       } else {

--- a/src/dataworker/RelayerRefundUtils.ts
+++ b/src/dataworker/RelayerRefundUtils.ts
@@ -29,9 +29,10 @@ export function sortRefundAddresses(refunds: Refund, chainId: number): Address[]
     .map((address) => toAddressType(address, chainId));
 }
 
-// Shared `{ message, mrkdwn }` for a relayer-refund-leaf execution log. EVM passes this through
-// MultiCallerClient (TransactionClient renders the explorer link from the tx response); SVM logs
-// directly and appends `(${blockExplorerLink(signature, chainId)})` to `message` to match.
+// Shared `{ message, mrkdwn }` for a relayer-refund-leaf execution log. Both EVM and SVM call
+// this with the same args; pass `explorerLink` when the explorer link is known at log time (SVM
+// has the signature in hand). EVM omits it and lets TransactionClient#submit append the
+// parenthetical from the tx response in the same `<message> (<explorer>): <mrkdwn>` shape.
 export function formatRelayerRefundLeafExecutionLog(args: {
   rootBundleId: number;
   relayerRefundRoot: string;
@@ -39,9 +40,11 @@ export function formatRelayerRefundLeafExecutionLog(args: {
   chainId: number;
   symbol: string;
   amountToReturn: BigNumber;
+  explorerLink?: string;
 }): { message: string; mrkdwn: string } {
+  const baseMessage = "Executed RelayerRefundLeaf 🌿!";
   return {
-    message: "Executed RelayerRefundLeaf 🌿!",
+    message: args.explorerLink ? `${baseMessage} (${args.explorerLink})` : baseMessage,
     mrkdwn:
       `rootBundleId: ${args.rootBundleId}\n` +
       `relayerRefundRoot: ${args.relayerRefundRoot}\n` +

--- a/src/dataworker/RelayerRefundUtils.ts
+++ b/src/dataworker/RelayerRefundUtils.ts
@@ -29,6 +29,29 @@ export function sortRefundAddresses(refunds: Refund, chainId: number): Address[]
     .map((address) => toAddressType(address, chainId));
 }
 
+// Shared `{ message, mrkdwn }` for a relayer-refund-leaf execution log. EVM passes this through
+// MultiCallerClient (TransactionClient renders the explorer link from the tx response); SVM logs
+// directly and appends `(${blockExplorerLink(signature, chainId)})` to `message` to match.
+export function formatRelayerRefundLeafExecutionLog(args: {
+  rootBundleId: number;
+  relayerRefundRoot: string;
+  leafId: number;
+  chainId: number;
+  symbol: string;
+  amountToReturn: BigNumber;
+}): { message: string; mrkdwn: string } {
+  return {
+    message: "Executed RelayerRefundLeaf 🌿!",
+    mrkdwn:
+      `rootBundleId: ${args.rootBundleId}\n` +
+      `relayerRefundRoot: ${args.relayerRefundRoot}\n` +
+      `Leaf: ${args.leafId}\n` +
+      `chainId: ${args.chainId}\n` +
+      `token: ${args.symbol}\n` +
+      `amount: ${args.amountToReturn.toString()}`,
+  };
+}
+
 // Sort leaves by chain ID and then L2 token address in ascending order. Assign leaves unique, ascending ID's
 // beginning from 0.
 export function sortRelayerRefundLeaves(relayerRefundLeaves: RelayerRefundLeafWithGroup[]): RelayerRefundLeaf[] {


### PR DESCRIPTION
## Summary
- Extract `formatRelayerRefundLeafExecutionLog` in `src/dataworker/RelayerRefundUtils.ts` so EVM and SVM `_executeRelayerRefundLeaves` paths derive `{ message, mrkdwn }` from one source of truth.
- EVM forwards them through `MultiCallerClient.enqueueTransaction`; `TransactionClient#submit` appends the `(<explorer>)` from the tx response (`src/clients/TransactionClient.ts:247`).
- SVM logs directly with `` `${message} (${blockExplorerLink(signature, chainId)})` `` so the Solana signature becomes a clickable Solscan link in the same parenthetical shape EVM uses.

From this Slack log (before):
```
*zion-across-l2-executor-solana* (Dataworker#_executeRelayerRefundLeaves)⭢rootBundleId: 10302
relayerRefundRoot: 0x84e509…
Leaf: 30
chainId: 34268394551451
token: USDC
amount: 0
  • signature: okJ1EJBo9z4…
```
To (after):
```
*zion-across-l2-executor-solana* (Dataworker#_executeRelayerRefundLeaves)⭢Executed RelayerRefundLeaf 🌿! (<https://solscan.io/tx/okJ1EJBo9z4…|okJ1EJ…JLC5xs>)
rootBundleId: 10302
relayerRefundRoot: 0x84e509…
Leaf: 30
chainId: 34268394551451
token: USDC
amount: 0
```

## Test plan
- [x] `yarn build` passes locally.
- [ ] Confirm next SVM refund-leaf execution in `#zion-across-l2-executor-solana` shows the new header with a clickable Solscan link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)