### PR TITLE
dataworker: compact tabular Slack summary for root bundle proposals

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -489,6 +489,8 @@ export class Dataworker {
     }
 
     // 4. Propose roots to HubPool contract.
+    // Full leaf JSON is included here so it stays visible in debug logs after the Slack notification
+    // (mrkdwn body, built in enqueueRootBundleProposal) was switched to a compact tabular summary.
     this.logger.debug({
       at: "Dataworker#propose",
       message: "Enqueuing new root bundle proposal txn",
@@ -497,6 +499,9 @@ export class Dataworker {
       poolRebalanceRoot: rootBundleData.poolRebalanceTree.getHexRoot(),
       relayerRefundRoot: rootBundleData.relayerRefundTree.getHexRoot(),
       slowRelayRoot: rootBundleData.slowFillTree.getHexRoot(),
+      poolRebalanceLeaves: rootBundleData.poolRebalanceLeaves,
+      relayerRefundLeaves: rootBundleData.relayerRefundLeaves,
+      slowRelayLeaves: rootBundleData.slowFillLeaves,
     });
     if (submitProposals) {
       this.enqueueRootBundleProposal(
@@ -2566,14 +2571,13 @@ export class Dataworker {
         method: "proposeRootBundle", // method called.
         args: [bundleEndBlocks, poolRebalanceLeaves.length, poolRebalanceRoot, relayerRefundRoot, slowRelayRoot], // props sent with function call.
         message: "Proposed new root bundle 🌱", // message sent to logger.
-        mrkdwn: PoolRebalanceUtils.generateMarkdownForRootBundle(
+        mrkdwn: PoolRebalanceUtils.generateSlackSummaryForRootBundle(
           this.clients.hubPoolClient,
           chainIds,
           hubPoolChainId,
           bundleBlockRange,
           [...poolRebalanceLeaves],
           poolRebalanceRoot,
-          [...relayerRefundLeaves],
           relayerRefundRoot,
           [...slowRelayLeaves],
           slowRelayRoot

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -1,4 +1,5 @@
 import { utils as sdkUtils } from "@across-protocol/sdk";
+import { utils as ethersUtils } from "ethers";
 import { HubPoolClient } from "../clients";
 import { PendingRootBundle, PoolRebalanceLeaf, RelayerRefundLeaf, SlowFillLeaf } from "../interfaces";
 import {
@@ -199,6 +200,223 @@ export function generateMarkdownForRootBundle(
     "\t*SlowRelay*\n" +
     `\t${slowRelayMsg}`
   );
+}
+
+// Format a wei-scaled balance as a fixed-point decimal string with sensible precision:
+//   - exactly zero               → "" (suppress) or "0" depending on suppressZero
+//   - |x| >= 1                   → 2 decimal places, thousands-separated (e.g. "-4,166.85")
+//   - 0 < |x| < 1                → 4 significant figures, no scientific notation (e.g. "0.0000000123")
+// formatUnits gives us a non-scientific decimal string from any BigNumber input, so all formatting
+// reduces to string slicing — no float math, no precision loss.
+function formatBalanceAmount(weiVal: BigNumber | string, decimals: number, suppressZero: boolean): string {
+  const raw = ethersUtils.formatUnits(BigNumber.from(weiVal.toString()), decimals);
+  const isZero = /^-?0(?:\.0*)?$/.test(raw);
+  if (isZero) {
+    return suppressZero ? "" : "0";
+  }
+  const negative = raw.startsWith("-");
+  const [intPart, fracPart = ""] = raw.replace(/^-/, "").split(".");
+  const sign = negative ? "-" : "";
+  if (intPart !== "0") {
+    const truncatedFrac = (fracPart + "00").slice(0, 2);
+    const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    return `${sign}${grouped}.${truncatedFrac}`;
+  }
+  const firstNonZero = fracPart.search(/[1-9]/);
+  if (firstNonZero === -1) {
+    return suppressZero ? "" : "0";
+  }
+  const sigFigs = fracPart.slice(firstNonZero, firstNonZero + 4);
+  const leadingZeros = fracPart.slice(0, firstNonZero);
+  return `${sign}0.${leadingZeros}${sigFigs}`;
+}
+
+// Lay out `rows` as a fixed-width text table. Numeric columns (align: "decimal") are right-aligned on
+// the decimal point so columns of mixed-magnitude values still line up visually; text columns are
+// left-aligned. Blank cells are padded with spaces so column shape is preserved.
+type ColumnAlign = "left" | "right" | "decimal";
+function renderTable(headers: string[], aligns: ColumnAlign[], rows: string[][]): string {
+  const cols = headers.length;
+  const widths: { left: number; right: number; total: number }[] = [];
+  for (let c = 0; c < cols; c++) {
+    if (aligns[c] === "decimal") {
+      let maxLeft = 0;
+      let maxRight = 0;
+      for (const row of rows) {
+        const cell = row[c] ?? "";
+        if (cell === "") {
+          continue;
+        }
+        const idx = cell.indexOf(".");
+        if (idx === -1) {
+          maxLeft = Math.max(maxLeft, cell.length);
+        } else {
+          maxLeft = Math.max(maxLeft, idx);
+          maxRight = Math.max(maxRight, cell.length - idx);
+        }
+      }
+      const headerWidth = headers[c].length;
+      const total = Math.max(maxLeft + maxRight, headerWidth);
+      widths.push({ left: maxLeft, right: maxRight, total });
+    } else {
+      const total = Math.max(headers[c].length, ...rows.map((row) => (row[c] ?? "").length));
+      widths.push({ left: 0, right: 0, total });
+    }
+  }
+
+  const renderCell = (cell: string, c: number): string => {
+    const w = widths[c];
+    if (aligns[c] === "decimal") {
+      if (cell === "") {
+        return " ".repeat(w.total);
+      }
+      const idx = cell.indexOf(".");
+      const leftPart = idx === -1 ? cell : cell.slice(0, idx);
+      const rightPart = idx === -1 ? "" : cell.slice(idx);
+      // Pad to (left, right) to align on the decimal point, then right-pad with spaces so the
+      // column fits the header width when the header is wider than any data row.
+      return (leftPart.padStart(w.left) + rightPart.padEnd(w.right)).padEnd(w.total);
+    }
+    if (aligns[c] === "right") {
+      return (cell ?? "").padStart(w.total);
+    }
+    return (cell ?? "").padEnd(w.total);
+  };
+
+  const lines = [headers.map((h, c) => renderCell(h, c)).join("  ")];
+  for (const row of rows) {
+    lines.push(row.map((cell, c) => renderCell(cell, c)).join("  "));
+  }
+  return lines.join("\n");
+}
+
+// Compact Slack summary for a root bundle proposal. Replaces the per-leaf JSON dump with two tables
+// (bundle blocks, pool rebalance) plus the relayer-refund and slow-relay roots. Paused chains
+// (startBlock === endBlock) collapse into a single line carrying the paused block number. Pool
+// rebalance leaves with no token activity (netSendAmounts, runningBalances, bundleLpFees all zero
+// for every l1Token) are listed by chainId on a "quiet leaves" line. Full leaf JSON is intended to
+// be emitted separately as a debug log alongside this summary.
+export function generateSlackSummaryForRootBundle(
+  hubPoolClient: HubPoolClient,
+  chainIdListForBundleEvaluationBlockNumbers: number[],
+  hubPoolChainId: number,
+  bundleBlockRange: number[][],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  poolRebalanceLeaves: any[],
+  poolRebalanceRoot: string,
+  relayerRefundRoot: string,
+  slowRelayLeaves: SlowFillLeaf[],
+  slowRelayRoot: string
+): string {
+  // ----- Bundle blocks table -----
+  const activeBlockRows: string[][] = [];
+  const pausedEntries: string[] = [];
+  bundleBlockRange.forEach((range, index) => {
+    const chainId = chainIdListForBundleEvaluationBlockNumbers[index];
+    const [startBlock, endBlock] = range;
+    const name = getNetworkName(chainId);
+    if (startBlock === endBlock) {
+      pausedEntries.push(`${chainId} ${name} @${startBlock.toLocaleString("en-US")}`);
+    } else {
+      activeBlockRows.push([
+        chainId.toString(),
+        name,
+        startBlock.toLocaleString("en-US"),
+        endBlock.toLocaleString("en-US"),
+      ]);
+    }
+  });
+  const bundleBlocksTable = renderTable(
+    ["chainId", "chain", "start", "end"],
+    ["right", "left", "right", "right"],
+    activeBlockRows
+  );
+  const pausedLine = pausedEntries.length > 0 ? `\n🥶 paused: ${pausedEntries.join(" · ")}` : "";
+
+  // ----- Pool rebalance table -----
+  const tokenDecimals = (chainId: number, token: Address): number | undefined => {
+    try {
+      return hubPoolClient.getTokenInfoForAddress(token, chainId).decimals;
+    } catch {
+      return undefined;
+    }
+  };
+  const tokenSymbol = (chainId: number, token: Address): string => {
+    try {
+      return hubPoolClient.getTokenInfoForAddress(token, chainId).symbol;
+    } catch {
+      return "UNKNOWN";
+    }
+  };
+  const formatLeafAmount = (chainId: number, token: Address, weiVal: BigNumber | string): string => {
+    const decimals = tokenDecimals(chainId, token);
+    if (decimals === undefined) {
+      return weiVal.toString();
+    }
+    return formatBalanceAmount(weiVal, decimals, /* suppressZero */ true);
+  };
+
+  const poolRebalanceRows: string[][] = [];
+  const quietLeafEntries: string[] = [];
+  poolRebalanceLeaves.forEach((leaf) => {
+    const chainId: number = leaf.chainId;
+    const l1Tokens: EvmAddress[] = leaf.l1Tokens ?? [];
+    const netSendAmounts: (BigNumber | string)[] = leaf.netSendAmounts ?? [];
+    const runningBalances: (BigNumber | string)[] = leaf.runningBalances ?? [];
+    const bundleLpFees: (BigNumber | string)[] = leaf.bundleLpFees ?? [];
+    const chainName = getNetworkName(chainId);
+
+    const tokenRows: string[][] = [];
+    l1Tokens.forEach((token, i) => {
+      const netStr = formatLeafAmount(hubPoolChainId, token, netSendAmounts[i] ?? "0");
+      const runStr = formatLeafAmount(hubPoolChainId, token, runningBalances[i] ?? "0");
+      const lpStr = formatLeafAmount(hubPoolChainId, token, bundleLpFees[i] ?? "0");
+      if (netStr === "" && runStr === "" && lpStr === "") {
+        return;
+      }
+      tokenRows.push([tokenSymbol(hubPoolChainId, token), netStr, runStr, lpStr]);
+    });
+
+    if (tokenRows.length === 0) {
+      quietLeafEntries.push(`${chainId} ${chainName}`);
+      return;
+    }
+
+    tokenRows.forEach((row, i) => {
+      poolRebalanceRows.push([i === 0 ? chainId.toString() : "", i === 0 ? chainName : "", ...row]);
+    });
+  });
+
+  const poolRebalanceTable =
+    poolRebalanceRows.length > 0
+      ? renderTable(
+          ["chainId", "chain", "token", "netSendAmounts", "runningBalances", "bundleLpFees"],
+          ["right", "left", "left", "decimal", "decimal", "decimal"],
+          poolRebalanceRows
+        )
+      : "(no pool rebalance activity)";
+  const quietLine = quietLeafEntries.length > 0 ? `\nquiet leaves (all zero): ${quietLeafEntries.join(" · ")}` : "";
+
+  // ----- Slow relay summary (kept compact; full leaves still go to debug) -----
+  const slowRelayLine =
+    slowRelayLeaves.length > 0
+      ? `*SlowRelay* root: \`${shortenHexString(slowRelayRoot)}\` (${slowRelayLeaves.length} leaves — see debug log)`
+      : "*SlowRelay*: No slow relay leaves";
+
+  return [
+    "*Bundle blocks*",
+    "```",
+    bundleBlocksTable,
+    "```" + pausedLine,
+    "",
+    `*PoolRebalance* root: \`${shortenHexString(poolRebalanceRoot)}\``,
+    "```",
+    poolRebalanceTable,
+    "```" + quietLine,
+    "",
+    `*RelayerRefund* root: \`${shortenHexString(relayerRefundRoot)}\` (see debug log for per-leaf detail)`,
+    slowRelayLine,
+  ].join("\n");
 }
 
 export function prettyPrintLeaves<T extends PoolRebalanceLeaf | RelayerRefundLeaf | SlowFillLeaf>(


### PR DESCRIPTION
## Summary
- Replace the per-leaf JSON dump in the proposer Slack notification with two aligned tables (bundle blocks, pool rebalance) plus the relayer-refund / slow-relay roots.
- Paused chains (`startBlock === endBlock`) collapse onto a single `🥶 paused: …` line carrying the paused block number.
- Pool-rebalance leaves where every token is zero across `netSendAmounts`, `runningBalances`, and `bundleLpFees` collapse onto a `quiet leaves (all zero): …` line; field names are preserved verbatim as column headers.
- Numeric formatter is decimal-point-aligned: `|x| >= 1` → 2 decimals with thousand separators; `0 < |x| < 1` → 4 significant figures in fixed-point notation (no scientific). Zero cells suppress to blank so non-zero values pop out.
- Full leaf JSON now lives in the existing `Dataworker#propose` `"Enqueuing new root bundle proposal txn"` debug log under new `poolRebalanceLeaves` / `relayerRefundLeaves` / `slowRelayLeaves` fields, so the structured data is still available for forensics.
- `generateMarkdownForRootBundle` is unchanged; it remains in use by the dispute path.

Example rendered output against a recent proposal lives in the originating Slack thread.

## Test plan
- [x] `yarn tsc --noEmit`
- [x] `yarn lint`
- [x] `yarn test test/Dataworker.proposeRootBundle.ts`
- [x] `yarn test test/Dataworker.validateRootBundle.ts`
- [ ] Eyeball the next live proposer Slack notification to confirm alignment renders as expected on mobile and desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)