### PR TITLE
chore: bump @across-protocol/sdk to 4.3.161

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.109",
     "@across-protocol/contracts": "5.0.10",
-    "@across-protocol/sdk": "4.3.160",
+    "@across-protocol/sdk": "4.3.161",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.3.160":
-  version "4.3.160"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.160.tgz#e59b6255ab9b4395c5304eb5516e22b038a3b781"
-  integrity sha512-rYT5BYIeDzO+C7/k1+QCSBHczzbdN2rDr9+D53ASouEoCD2UnM6HWkD2d5jpy+evpZPBOVO7h1+4tCaEL4HVSA==
+"@across-protocol/sdk@4.3.161":
+  version "4.3.161"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.161.tgz#cc37d9812ad2a3d25ad0bc29335f3710f3521ef1"
+  integrity sha512-Ber9fJ9YTKHQzXc7ujojnB/Dj8iSVtNQijUdyKSFjTeeCGek7jsulWcFMV6EdVrDvOM38/AqRj6dv8NGW55sIA==
   dependencies:
     "@across-protocol/constants" "^3.1.110"
     "@across-protocol/contracts" "5.0.10"


### PR DESCRIPTION
## Summary

- Bumps `@across-protocol/sdk` from `4.3.160` to `4.3.161`.
- The new version contains [across-protocol/sdk#1443](https://github.com/across-protocol/sdk/pull/1443), which preserves the underlying `SolanaError` type through `QuorumFallbackSolanaRpcFactory`. Previously the factory wrapped slot-skipped errors in a generic `Error`, defeating `_callGetTimestampForSlotWithRetry`'s `isSolanaError(err)` guard and causing `getNearestSlotTime` to throw instead of walking back to the prior valid slot.
- Live symptom (Slack-triaged): `zion-across-l2-executor-solana` (dataworker) crashed with `Not enough providers succeeded on getBlockTime call` whenever the chain head briefly landed in a Solana skipped-slot range. Slot `421829272` was the trigger — reproducible against the public mainnet RPC at the time.

## Test plan

- [x] `yarn install --ignore-scripts` syncs `yarn.lock` cleanly; only `package.json` + `yarn.lock` change.
- [x] `yarn why @across-protocol/sdk` reports `4.3.161` as the resolved version with no other consumers pinning an older copy.
- [ ] CI green on this branch before merge.
- [ ] After deploy, confirm `zion-across-l2-executor-solana` no longer trips on the same getBlockTime stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)