### PR TITLE
fix(svm): silence FillRelay txn failures (debug, not error)

### DIFF
--- a/src/clients/SvmFillerClient.ts
+++ b/src/clients/SvmFillerClient.ts
@@ -171,7 +171,7 @@ export class SvmFillerClient {
         errorMessage = `Solana error code: ${e.context.__code}`;
       }
 
-      this.logger.error({
+      this.logger.debug({
         at: "SvmFillerClient#executeFillImmediately",
         message: `Failed to send fill transaction (${errorMessage})`,
         mrkdwn,
@@ -253,7 +253,7 @@ export class SvmFillerClient {
           errorMessage = `Solana error code: ${e.context.__code}`;
         }
 
-        this.logger.error({
+        this.logger.debug({
           at: "SvmFillerClient#executeTxnQueue",
           message: `Failed to send fill transaction (${errorMessage})`,
           mrkdwn,

--- a/src/clients/SvmFillerClient.ts
+++ b/src/clients/SvmFillerClient.ts
@@ -49,15 +49,15 @@ type QueuedSvmFill = {
   mrkdwn: string;
 };
 
-// Known-benign FillRelay error codes (recoverable: another relayer won the race, or our outer loop retries).
-// EVM parity: `knownRevertReasons` / `canIgnoreRevertReason` in MultiCallerClient.ts.
+// Known-benign Solana error codes for fillRelay / slowFillRequest submission (recoverable: another
+// actor won the race, or our outer loop retries). EVM parity: `knownRevertReasons` in MultiCallerClient.ts.
 const knownSolanaFillErrorCodes = new Set<number>([arch.svm.SVM_TRANSACTION_PREFLIGHT_FAILURE]);
 const retryDelaySeconds = 1;
 
-// Suppression is gated on both the tx kind (only fillRelay — slow-fill request failures stay loud)
-// and the error code (only the known-benign codes). Either dimension alone would be too broad.
-function canIgnoreSvmFillError(kind: SvmTxKind, e: unknown): boolean {
-  return kind === "fillRelay" && isSolanaError(e) && knownSolanaFillErrorCodes.has(e.context.__code);
+// Both fillRelay and slowFillRequest preflight failures can be recoverable races (another actor won
+// the race, or our outer loop retries), so suppression is gated only on the benign error code.
+function canIgnoreSvmFillError(e: unknown): boolean {
+  return isSolanaError(e) && knownSolanaFillErrorCodes.has(e.context.__code);
 }
 
 export class SvmFillerClient {
@@ -193,9 +193,7 @@ export class SvmFillerClient {
         errorMessage = `Solana error code: ${e.context.__code}`;
       }
 
-      // executeFillImmediately only builds fillRelay txs (via buildFillRelayTxPromises), so the kind
-      // is fixed at the call site.
-      const ignorable = canIgnoreSvmFillError("fillRelay", e);
+      const ignorable = canIgnoreSvmFillError(e);
       this.logger[ignorable ? "debug" : "error"]({
         at: "SvmFillerClient#executeFillImmediately",
         message: `Failed to send fill transaction (${errorMessage})`,
@@ -279,7 +277,7 @@ export class SvmFillerClient {
           errorMessage = `Solana error code: ${e.context.__code}`;
         }
 
-        const ignorable = canIgnoreSvmFillError(kind, e);
+        const ignorable = canIgnoreSvmFillError(e);
         this.logger[ignorable ? "debug" : "error"]({
           at: "SvmFillerClient#executeTxnQueue",
           message: `Failed to send fill transaction (${errorMessage})`,

--- a/src/clients/SvmFillerClient.ts
+++ b/src/clients/SvmFillerClient.ts
@@ -45,8 +45,14 @@ type QueuedSvmFill = {
   mrkdwn: string;
 };
 
-const retryableErrorCodes = [arch.svm.SVM_TRANSACTION_PREFLIGHT_FAILURE];
+// Known-benign FillRelay error codes (recoverable: another relayer won the race, or our outer loop retries).
+// EVM parity: `knownRevertReasons` / `canIgnoreRevertReason` in MultiCallerClient.ts.
+const knownSolanaFillErrorCodes = new Set<number>([arch.svm.SVM_TRANSACTION_PREFLIGHT_FAILURE]);
 const retryDelaySeconds = 1;
+
+function canIgnoreSvmFillError(e: unknown): boolean {
+  return isSolanaError(e) && knownSolanaFillErrorCodes.has(e.context.__code);
+}
 
 export class SvmFillerClient {
   private queuedFills: QueuedSvmFill[] = [];
@@ -171,11 +177,13 @@ export class SvmFillerClient {
         errorMessage = `Solana error code: ${e.context.__code}`;
       }
 
-      this.logger.debug({
+      const ignorable = canIgnoreSvmFillError(e);
+      this.logger[ignorable ? "debug" : "error"]({
         at: "SvmFillerClient#executeFillImmediately",
         message: `Failed to send fill transaction (${errorMessage})`,
         mrkdwn,
         error: e,
+        notificationPath: ignorable ? undefined : "across-error",
       });
       return undefined;
     }
@@ -208,7 +216,7 @@ export class SvmFillerClient {
         code = undefined;
       }
 
-      if (isDefined(code) && retryableErrorCodes.includes(code) && retryAttempt > 0) {
+      if (isDefined(code) && knownSolanaFillErrorCodes.has(code) && retryAttempt > 0) {
         await delay(retryDelaySeconds);
         return this._executeTxnPromisesWithRetry(txPromises, --retryAttempt, confirmAll);
       }
@@ -253,11 +261,13 @@ export class SvmFillerClient {
           errorMessage = `Solana error code: ${e.context.__code}`;
         }
 
-        this.logger.debug({
+        const ignorable = canIgnoreSvmFillError(e);
+        this.logger[ignorable ? "debug" : "error"]({
           at: "SvmFillerClient#executeTxnQueue",
           message: `Failed to send fill transaction (${errorMessage})`,
           mrkdwn,
           error: e,
+          notificationPath: ignorable ? undefined : "across-error",
         });
       }
     }

--- a/src/clients/SvmFillerClient.ts
+++ b/src/clients/SvmFillerClient.ts
@@ -39,8 +39,12 @@ type ReadyTransactionsPromise = Promise<SolanaTransaction[]>;
 /** Promises that resolve to fillRelay transaction(s): one tx, or IP txs then fill. */
 export type SvmFillRelayTxPromises = [ReadyTransactionPromise] | [ReadyTransactionsPromise, ReadyTransactionPromise];
 
+/** Which SpokePool method a queued SVM tx invokes. Gates alerting on submission failures. */
+export type SvmTxKind = "fillRelay" | "slowFillRequest";
+
 type QueuedSvmFill = {
   txPromises: SvmFillRelayTxPromises;
+  kind: SvmTxKind;
   message: string;
   mrkdwn: string;
 };
@@ -50,8 +54,10 @@ type QueuedSvmFill = {
 const knownSolanaFillErrorCodes = new Set<number>([arch.svm.SVM_TRANSACTION_PREFLIGHT_FAILURE]);
 const retryDelaySeconds = 1;
 
-function canIgnoreSvmFillError(e: unknown): boolean {
-  return isSolanaError(e) && knownSolanaFillErrorCodes.has(e.context.__code);
+// Suppression is gated on both the tx kind (only fillRelay — slow-fill request failures stay loud)
+// and the error code (only the known-benign codes). Either dimension alone would be too broad.
+function canIgnoreSvmFillError(kind: SvmTxKind, e: unknown): boolean {
+  return kind === "fillRelay" && isSolanaError(e) && knownSolanaFillErrorCodes.has(e.context.__code);
 }
 
 export class SvmFillerClient {
@@ -118,8 +124,13 @@ export class SvmFillerClient {
     return arch.svm.getSlowFillRequestTx(spokePool, this.provider, relayData, this.signer);
   }
 
-  enqueueFillRelayTxPromises(txPromises: SvmFillRelayTxPromises, message: string, mrkdwn: string): void {
-    this.queuedFills.push({ txPromises, message, mrkdwn });
+  enqueueFillRelayTxPromises(
+    txPromises: SvmFillRelayTxPromises,
+    kind: SvmTxKind,
+    message: string,
+    mrkdwn: string
+  ): void {
+    this.queuedFills.push({ txPromises, kind, message, mrkdwn });
   }
 
   enqueueFill(
@@ -131,11 +142,16 @@ export class SvmFillerClient {
     mrkdwn: string
   ): void {
     const txPromises = this.buildFillRelayTxPromises(spokePool, relayData, repaymentChainId, repaymentAddress);
-    this.enqueueFillRelayTxPromises(txPromises, message, mrkdwn);
+    this.enqueueFillRelayTxPromises(txPromises, "fillRelay", message, mrkdwn);
   }
 
   enqueueSlowFill(spokePool: SvmAddress, relayData: ProtoFill, message: string, mrkdwn: string): void {
-    this.enqueueFillRelayTxPromises([this.buildSlowFillTxPromise(spokePool, relayData)], message, mrkdwn);
+    this.enqueueFillRelayTxPromises(
+      [this.buildSlowFillTxPromise(spokePool, relayData)],
+      "slowFillRequest",
+      message,
+      mrkdwn
+    );
   }
 
   /**
@@ -177,7 +193,9 @@ export class SvmFillerClient {
         errorMessage = `Solana error code: ${e.context.__code}`;
       }
 
-      const ignorable = canIgnoreSvmFillError(e);
+      // executeFillImmediately only builds fillRelay txs (via buildFillRelayTxPromises), so the kind
+      // is fixed at the call site.
+      const ignorable = canIgnoreSvmFillError("fillRelay", e);
       this.logger[ignorable ? "debug" : "error"]({
         at: "SvmFillerClient#executeFillImmediately",
         message: `Failed to send fill transaction (${errorMessage})`,
@@ -237,7 +255,7 @@ export class SvmFillerClient {
     }
 
     const signatures: string[][] = [];
-    for (const { txPromises, message, mrkdwn } of queue) {
+    for (const { txPromises, kind, message, mrkdwn } of queue) {
       try {
         const signatureStrings = await this._executeTxnPromisesWithRetry(txPromises, maxRetries, false);
         const lastSignature = signatureStrings.at(-1);
@@ -261,10 +279,11 @@ export class SvmFillerClient {
           errorMessage = `Solana error code: ${e.context.__code}`;
         }
 
-        const ignorable = canIgnoreSvmFillError(e);
+        const ignorable = canIgnoreSvmFillError(kind, e);
         this.logger[ignorable ? "debug" : "error"]({
           at: "SvmFillerClient#executeTxnQueue",
           message: `Failed to send fill transaction (${errorMessage})`,
+          kind,
           mrkdwn,
           error: e,
           notificationPath: ignorable ? undefined : "across-error",


### PR DESCRIPTION
## Summary

Recent SDK changes — [across-protocol/sdk#1440](https://github.com/across-protocol/sdk/pull/1440) and [#1443](https://github.com/across-protocol/sdk/pull/1443) — preserve `SolanaError` type information through `QuorumFallbackSolanaRpcFactory`. As a side effect, `SvmFillerClient`'s `Failed to send fill transaction (Solana error code: -32002)` log line now consistently fires at **error level with `mrkdwn` set** on every Solana preflight failure (most commonly: a competing relayer landed the fill first, so our preflight rejects). Previously the wrapped `SolanaError` failed the `isSolanaError(e)` typeguard and fell through into a quieter branch, so the alert is effectively a regression.

### Operational context

Last 24h on `zion-across-relayer-primary` saw 8 distinct `-32002` alerts to Slack. Cross-referenced each against the indexer's final `fillTxHash`:

- **6 / 8** were filled by a **competing relayer** while our preflight kept failing — i.e. we lost the race and the Slack alert announced it.
- **2 / 8** were filled by zion itself (one on the next outer-loop iteration — a genuine retry).

In all 8 cases the deposit was filled within ~6 minutes. There is no user-visible incident — these alerts are spamming `#alerts` for what is, by design, a recoverable outcome.

## Change

Downgrade `this.logger.error` → `this.logger.debug` at the two FillRelay-failure catch sites in `src/clients/SvmFillerClient.ts`:

- `executeFillImmediately` (~L174)
- `executeTxnQueue` (~L256)

`simulateQueue`'s `logger.error` with `notificationPath: "across-error"` is unchanged — it's a distinct batch-level signal about simulation health.

`mrkdwn` is retained on the (now debug-level) line so deposit context is preserved for log-trawling diagnosis. Per ops directive, FillRelay-based errors should be silent (a failed fill is recoverable: another relayer fills, or our outer loop re-picks).

## Symmetry follow-up (not in this PR)

The EVM filler (`MultiCallerClient`) already encodes "this revert is fine, don't alert" via `knownRevertReasons` (`"RelayFilled"`, `"relay filled"`, ...) + `canIgnoreRevertReason()`: matching reverts log at `debug`; unexpected ones log at `error` with `notificationPath`. SVM has no equivalent — `SvmFillerClient` treats every fill failure as the same class today.

To bring EVM and SVM to parity, a follow-up should:

1. Extract a `knownSolanaFillErrorCodes` constant (start: `[SVM_TRANSACTION_PREFLIGHT_FAILURE]`) and a `canIgnoreSvmFillError(e)` helper that mirrors `canIgnoreRevertReason`.
2. Use it to gate log level: `debug` for known-benign failures, `warn`/`error` for unexpected ones (wallet / RPC outage / unrecognised codes).
3. Plumb the inner Solana error (`error.data.err`, `error.data.logs`) from the `@solana/rpc-transformers` wrapper into the catch block so fine-grained gating becomes possible — e.g. distinguishing `FillStatus already filled` (silent) from `compute budget exceeded` (worth alerting on).

(2) and (3) are deliberately deferred to keep this PR minimal and immediately deployable.

## Test plan

- [ ] Solana fill that hits `-32002` (preflight failure): no Slack alert; appears at debug level with `mrkdwn` context preserved.
- [ ] Successful Solana fill: unchanged — `"Filled v3 deposit on SVM 🚀"` still logs at info.
- [ ] `simulateQueue` failure path: unchanged — still alerts via `notificationPath: "across-error"`.

---

Originated from a Slack thread investigating a `-32002` alert for deposit `4363585`. Full triage transcript including the regression diagnosis is in-thread.