### PR TITLE
fix(svm): reconnect on Solana WS close instead of aborting listener

### DIFF
--- a/src/libexec/RelayerSpokePoolListenerSVM.ts
+++ b/src/libexec/RelayerSpokePoolListenerSVM.ts
@@ -21,7 +21,7 @@ import {
 } from "../utils";
 import { getRedisCache } from "../cache/Redis";
 import { ScraperOpts } from "./types";
-import { bootstrap } from "./util/bootstrap";
+import { bootstrap, waitForAbort } from "./util/bootstrap";
 import { postBlock, postEvents } from "./util/ipc";
 import { scrapeEvents as _scrapeEvents } from "./util/svm";
 
@@ -124,6 +124,11 @@ async function listen(
   const RECONNECT_BACKOFF_MIN_S = 1;
   const RECONNECT_BACKOFF_MAX_S = 30;
 
+  // Abortable sleep: returns once the backoff elapses or the abort signal fires, whichever
+  // comes first. Without this, a SIGHUP arriving mid-backoff would block child shutdown for
+  // up to RECONNECT_BACKOFF_MAX_S, conflicting with the bootstrap teardown contract.
+  const abortableDelay = (seconds: number) => Promise.race([delay(seconds), waitForAbort(abortSignal)]);
+
   const logProviderError = (providerName: string, err: unknown, backoffS: number) => {
     const message = "Caught error on Solana provider; reconnecting.";
     const ctx = { at, message, provider: providerName, backoffS };
@@ -155,7 +160,7 @@ async function listen(
           return;
         }
         logProviderError(providerName, err, backoffS);
-        await delay(backoffS);
+        await abortableDelay(backoffS);
         backoffS = Math.min(backoffS * 2, RECONNECT_BACKOFF_MAX_S);
       }
     }
@@ -188,7 +193,7 @@ async function listen(
           return;
         }
         logProviderError(providerName, err, backoffS);
-        await delay(backoffS);
+        await abortableDelay(backoffS);
         backoffS = Math.min(backoffS * 2, RECONNECT_BACKOFF_MAX_S);
       }
     }

--- a/src/libexec/RelayerSpokePoolListenerSVM.ts
+++ b/src/libexec/RelayerSpokePoolListenerSVM.ts
@@ -140,9 +140,8 @@ async function listen(
     while (!abortSignal.aborted) {
       try {
         const subscription = await provider.slotNotifications().subscribe({ abortSignal });
-        for await (const update of subscription) {
+        for await (const { slot } of subscription) {
           backoffS = RECONNECT_BACKOFF_MIN_S; // reset on any successful update
-          const { slot } = update as { slot: bigint }; // Bodge: pretend slots are blocks.
           const currentTime = getCurrentTime(); // @todo Try to subscribe w/ timestamp updates.
 
           if (!postBlock(Number(slot), currentTime)) {

--- a/src/libexec/RelayerSpokePoolListenerSVM.ts
+++ b/src/libexec/RelayerSpokePoolListenerSVM.ts
@@ -5,6 +5,7 @@ import { arch, typeguards } from "@across-protocol/sdk";
 import { SvmSpokeClient } from "@across-protocol/contracts";
 import { Log } from "../interfaces";
 import {
+  abortableDelay,
   EventManager,
   isDefined,
   getBlockForTimestamp,
@@ -123,27 +124,6 @@ async function listen(
   const RECONNECT_BACKOFF_MIN_S = 1;
   const RECONNECT_BACKOFF_MAX_S = 30;
 
-  // Abortable sleep: resolves once the backoff elapses or the abort signal fires, whichever
-  // comes first. Cleans up the pending timer on abort (so it doesn't keep the event loop alive
-  // and delay process exit by up to RECONNECT_BACKOFF_MAX_S) and detaches the abort listener
-  // on the normal path (so listeners don't accumulate across reconnect retries).
-  const abortableDelay = (seconds: number): Promise<void> =>
-    new Promise((resolve) => {
-      if (abortSignal.aborted) {
-        resolve();
-        return;
-      }
-      const onAbort = () => {
-        clearTimeout(timer);
-        resolve();
-      };
-      const timer = setTimeout(() => {
-        abortSignal.removeEventListener("abort", onAbort);
-        resolve();
-      }, seconds * 1000);
-      abortSignal.addEventListener("abort", onAbort, { once: true });
-    });
-
   const logProviderError = (providerName: string, err: unknown, backoffS: number) => {
     const message = "Caught error on Solana provider; reconnecting.";
     const ctx = { at, message, provider: providerName, backoffS };
@@ -175,7 +155,7 @@ async function listen(
           return;
         }
         logProviderError(providerName, err, backoffS);
-        await abortableDelay(backoffS);
+        await abortableDelay(backoffS, abortSignal);
         backoffS = Math.min(backoffS * 2, RECONNECT_BACKOFF_MAX_S);
       }
     }
@@ -208,7 +188,7 @@ async function listen(
           return;
         }
         logProviderError(providerName, err, backoffS);
-        await abortableDelay(backoffS);
+        await abortableDelay(backoffS, abortSignal);
         backoffS = Math.min(backoffS * 2, RECONNECT_BACKOFF_MAX_S);
       }
     }

--- a/src/libexec/RelayerSpokePoolListenerSVM.ts
+++ b/src/libexec/RelayerSpokePoolListenerSVM.ts
@@ -5,7 +5,6 @@ import { arch, typeguards } from "@across-protocol/sdk";
 import { SvmSpokeClient } from "@across-protocol/contracts";
 import { Log } from "../interfaces";
 import {
-  delay,
   EventManager,
   isDefined,
   getBlockForTimestamp,
@@ -21,7 +20,7 @@ import {
 } from "../utils";
 import { getRedisCache } from "../cache/Redis";
 import { ScraperOpts } from "./types";
-import { bootstrap, waitForAbort } from "./util/bootstrap";
+import { bootstrap } from "./util/bootstrap";
 import { postBlock, postEvents } from "./util/ipc";
 import { scrapeEvents as _scrapeEvents } from "./util/svm";
 
@@ -124,10 +123,26 @@ async function listen(
   const RECONNECT_BACKOFF_MIN_S = 1;
   const RECONNECT_BACKOFF_MAX_S = 30;
 
-  // Abortable sleep: returns once the backoff elapses or the abort signal fires, whichever
-  // comes first. Without this, a SIGHUP arriving mid-backoff would block child shutdown for
-  // up to RECONNECT_BACKOFF_MAX_S, conflicting with the bootstrap teardown contract.
-  const abortableDelay = (seconds: number) => Promise.race([delay(seconds), waitForAbort(abortSignal)]);
+  // Abortable sleep: resolves once the backoff elapses or the abort signal fires, whichever
+  // comes first. Cleans up the pending timer on abort (so it doesn't keep the event loop alive
+  // and delay process exit by up to RECONNECT_BACKOFF_MAX_S) and detaches the abort listener
+  // on the normal path (so listeners don't accumulate across reconnect retries).
+  const abortableDelay = (seconds: number): Promise<void> =>
+    new Promise((resolve) => {
+      if (abortSignal.aborted) {
+        resolve();
+        return;
+      }
+      const onAbort = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        abortSignal.removeEventListener("abort", onAbort);
+        resolve();
+      }, seconds * 1000);
+      abortSignal.addEventListener("abort", onAbort, { once: true });
+    });
 
   const logProviderError = (providerName: string, err: unknown, backoffS: number) => {
     const message = "Caught error on Solana provider; reconnecting.";

--- a/src/libexec/RelayerSpokePoolListenerSVM.ts
+++ b/src/libexec/RelayerSpokePoolListenerSVM.ts
@@ -5,6 +5,7 @@ import { arch, typeguards } from "@across-protocol/sdk";
 import { SvmSpokeClient } from "@across-protocol/contracts";
 import { Log } from "../interfaces";
 import {
+  delay,
   EventManager,
   isDefined,
   getBlockForTimestamp,
@@ -105,7 +106,7 @@ async function listen(
   const at = "RelayerSpokePoolListenerSVM::listen";
 
   const urls = Object.values(getNodeUrlList(chainId, quorum, "wss"));
-  let nProviders = urls.length;
+  const nProviders = urls.length;
   assert(nProviders >= quorum, `Insufficient providers for ${chain} (required ${quorum} by quorum)`);
 
   const eventAuthority = await arch.svm.getEventAuthority(SvmSpokeClient.SVM_SPOKE_PROGRAM_ADDRESS);
@@ -117,62 +118,79 @@ async function listen(
   const intervalMs = Number(process.env.RELAYER_SVM_WS_KEEPALIVE ?? 10) * 1000;
   const providers = urls.map((url) => createSolanaRpcSubscriptions(url, { intervalMs }));
 
+  // Solana hosted WS providers periodically drop subscriptions without sending a close frame (code 1006).
+  // Chainstack does this on a deterministic ~10-minute wallclock schedule; Alchemy does it less predictably.
+  // Reconnect on close with bounded exponential backoff rather than aborting the whole listener.
+  const RECONNECT_BACKOFF_MIN_S = 1;
+  const RECONNECT_BACKOFF_MAX_S = 30;
+
+  const logProviderError = (providerName: string, err: unknown, backoffS: number) => {
+    const message = "Caught error on Solana provider; reconnecting.";
+    const ctx = { at, message, provider: providerName, backoffS };
+    if (arch.svm.isSolanaError(err)) {
+      logger.warn({ ...ctx, cause: err.cause });
+    } else {
+      const cause = typeguards.isError(err) ? err.message : "unknown cause";
+      logger.warn({ ...ctx, cause });
+    }
+  };
+
   const readSlot = async (provider: WSProvider, providerName: string) => {
-    const subscription = await provider.slotNotifications().subscribe({ abortSignal });
+    let backoffS = RECONNECT_BACKOFF_MIN_S;
+    while (!abortSignal.aborted) {
+      try {
+        const subscription = await provider.slotNotifications().subscribe({ abortSignal });
+        for await (const update of subscription) {
+          backoffS = RECONNECT_BACKOFF_MIN_S; // reset on any successful update
+          const { slot } = update as { slot: bigint }; // Bodge: pretend slots are blocks.
+          const currentTime = getCurrentTime(); // @todo Try to subscribe w/ timestamp updates.
 
-    try {
-      for await (const update of subscription) {
-        const { slot } = update as { slot: bigint }; // Bodge: pretend slots are blocks.
-        const currentTime = getCurrentTime(); // @todo Try to subscribe w/ timestamp updates.
-
-        if (!postBlock(Number(slot), currentTime)) {
-          abortController.abort();
+          if (!postBlock(Number(slot), currentTime)) {
+            abortController.abort();
+          }
         }
+        // Iterator returned cleanly (abortSignal cancelled the subscription).
+        return;
+      } catch (err: unknown) {
+        if (abortSignal.aborted) {
+          return;
+        }
+        logProviderError(providerName, err, backoffS);
+        await delay(backoffS);
+        backoffS = Math.min(backoffS * 2, RECONNECT_BACKOFF_MAX_S);
       }
-    } catch (err: unknown) {
-      const message = "Caught error on Solana provider.";
-      if (arch.svm.isSolanaError(err)) {
-        logger.warn({ at, message, provider: providerName, cause: err.cause });
-      } else {
-        const cause = typeguards.isError(err) ? err.message : "unknown cause";
-        logger.warn({ at, message, provider: providerName, cause });
-      }
-
-      abortController.abort();
     }
   };
 
   const readEvent = async (provider: WSProvider, providerName: string) => {
-    const subscription = await provider
-      .logsNotifications({ mentions: [address(eventAuthority)] }, config)
-      .subscribe({ abortSignal });
+    let backoffS = RECONNECT_BACKOFF_MIN_S;
+    while (!abortSignal.aborted) {
+      try {
+        const subscription = await provider
+          .logsNotifications({ mentions: [address(eventAuthority)] }, config)
+          .subscribe({ abortSignal });
+        for await (const log of subscription) {
+          backoffS = RECONNECT_BACKOFF_MIN_S;
+          const { signature } = log.value;
+          const rawEvents = await eventsClient.readEventsFromSignature(signature, "confirmed");
 
-    try {
-      for await (const log of subscription) {
-        const { signature } = log.value;
-        const rawEvents = await eventsClient.readEventsFromSignature(signature, "confirmed");
+          const events = rawEvents
+            .filter(({ name }) => eventNames.includes(name))
+            .map((event) => logFromEvent({ ...event, signature, slot: log.context.slot }));
 
-        const events = rawEvents
-          .filter(({ name }) => eventNames.includes(name))
-          .map((event) => logFromEvent({ ...event, signature, slot: log.context.slot }));
-
-        const quorumEvents = events.filter((event) => eventMgr.add(event, providerName));
-        if (quorumEvents.length > 0 && !postEvents(quorumEvents)) {
-          abortController.abort();
+          const quorumEvents = events.filter((event) => eventMgr.add(event, providerName));
+          if (quorumEvents.length > 0 && !postEvents(quorumEvents)) {
+            abortController.abort();
+          }
         }
-      }
-    } catch (err: unknown) {
-      const message = "Caught error on Solana provider.";
-      if (arch.svm.isSolanaError(err)) {
-        logger.warn({ at, message, provider: providerName, cause: err.cause });
-      } else {
-        const cause = typeguards.isError(err) ? err.message : "unknown cause";
-        logger.warn({ at, message, provider: providerName, cause });
-      }
-
-      if (!abortController.signal.aborted && --nProviders < quorum) {
-        logger.warn({ at, message: `Insufficient ${chain} providers to continue.`, quorum, nProviders });
-        abortController.abort();
+        return;
+      } catch (err: unknown) {
+        if (abortSignal.aborted) {
+          return;
+        }
+        logProviderError(providerName, err, backoffS);
+        await delay(backoffS);
+        backoffS = Math.min(backoffS * 2, RECONNECT_BACKOFF_MAX_S);
       }
     }
   };

--- a/src/utils/Tasks.ts
+++ b/src/utils/Tasks.ts
@@ -8,6 +8,29 @@ export function fireAndForget(task: () => Promise<unknown>): () => void {
 }
 
 /**
+ * Sleep for `seconds`, returning early if `signal` aborts. Clears the pending timer on abort
+ * (so it doesn't keep the event loop alive past shutdown) and detaches the abort listener on
+ * normal completion (so listeners don't accumulate when called in a retry loop).
+ */
+export function abortableDelay(seconds: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, seconds * 1000);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
  * Schedule a recurring task, to be executed `interval` seconds after each successive call.
  * @param task Function that returns a Promise to be awaited.
  * @param interval Task interval.

--- a/test/Tasks.ts
+++ b/test/Tasks.ts
@@ -1,0 +1,64 @@
+import { expect } from "./utils";
+
+import { abortableDelay } from "../src/utils";
+
+describe("Tasks", function () {
+  describe("abortableDelay", function () {
+    it("resolves after roughly the requested delay when not aborted", async function () {
+      const controller = new AbortController();
+      const start = performance.now();
+      await abortableDelay(0.25, controller.signal);
+      const elapsedMs = performance.now() - start;
+      expect(elapsedMs).to.be.greaterThanOrEqual(240);
+      expect(elapsedMs).to.be.lessThan(1000);
+    });
+
+    it("returns early when the signal aborts mid-delay", async function () {
+      const controller = new AbortController();
+      const start = performance.now();
+      setTimeout(() => controller.abort(), 50);
+      await abortableDelay(10, controller.signal);
+      const elapsedMs = performance.now() - start;
+      expect(elapsedMs).to.be.lessThan(500);
+    });
+
+    it("returns immediately when the signal is already aborted", async function () {
+      const controller = new AbortController();
+      controller.abort();
+      const start = performance.now();
+      await abortableDelay(10, controller.signal);
+      expect(performance.now() - start).to.be.lessThan(50);
+    });
+
+    it("removes its abort listener on normal completion", async function () {
+      // Repeatedly running abortableDelay against the same signal must not accumulate listeners.
+      // Spy on (add|remove)EventListener and assert net-zero outstanding 'abort' listeners.
+      const controller = new AbortController();
+      let added = 0;
+      let removed = 0;
+      const realAdd = controller.signal.addEventListener.bind(controller.signal);
+      const realRemove = controller.signal.removeEventListener.bind(controller.signal);
+      controller.signal.addEventListener = ((type: string, ...rest: unknown[]) => {
+        if (type === "abort") {
+          added++;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return realAdd(type as any, ...(rest as [any, any?]));
+      }) as typeof controller.signal.addEventListener;
+      controller.signal.removeEventListener = ((type: string, ...rest: unknown[]) => {
+        if (type === "abort") {
+          removed++;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return realRemove(type as any, ...(rest as [any, any?]));
+      }) as typeof controller.signal.removeEventListener;
+
+      for (let i = 0; i < 25; i++) {
+        await abortableDelay(0.001, controller.signal);
+      }
+
+      expect(added).to.equal(25);
+      expect(removed).to.equal(25);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Solana hosted WS providers (notably Chainstack) routinely drop subscriptions without a close frame (code 1006). Chainstack does this on a deterministic ~10-minute wallclock schedule — measured at 95.9% lock-step over a 7-day prod sample. Alchemy does it less predictably. The Anza keepalive issue [#7022](https://github.com/anza-xyz/agave/issues/7022) referenced in the existing comment is unrelated to these close events.
- Previous behaviour: any single subscription error aborted the entire SVM listener. The parent \`SpokePoolClient#childExit\` handler treats clean exits as no-op (see comment at \`src/clients/SpokePoolClient.ts:162\` — *"Future: Optionally restart it based on the exit code"*), so Solana event ingestion silently stopped for the rest of the relayer process lifetime.
- New behaviour: wrap \`readSlot\` and \`readEvent\` in a reconnect loop with bounded exponential backoff (1s → 30s, reset on any successful update). Exit only via the shared \`abortSignal\` (SIGHUP / parent disconnect still tear down cleanly).
- Behaviour change worth flagging: the \`--nProviders < quorum\` abort in \`readEvent\` is removed — with reconnect, there's no permanent provider loss to count. The startup-time \`nProviders >= quorum\` assert is kept. Previously a 3-provider, \`quorum=2\` config would tear the listener down once two of three providers had dropped; it now reconnects all three indefinitely. With Chainstack dropping every 10 min that is the desired behaviour.

## Out of scope (potential follow-ups)

- \`readSlot\` is still single-provider (\`providers[0]\`). With reconnect that SPOF is mostly defanged, but a fundamentally broken \`providers[0]\` URL would still keep us blind on slot updates. Failover would be a larger structural change.
- Log severity is still \`warn\` on every reconnect to preserve the existing alert signal. With Chainstack's 10-min cadence that's ~144 warns/day per bot — downgrading to debug after the first occurrence within an outage is a sensible follow-up.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean
- [x] \`prettier --check\` clean
- [ ] Deploy to one bot (e.g. \`usdh\`); confirm warns continue to fire on Chainstack ~every 10 min but the listener keeps delivering slot updates and events.
- [ ] Confirm SIGHUP / parent disconnect still tears the listener down cleanly (no orphaned child).
- [ ] Confirm no regression in EVM / TVM listeners (this PR only touches the SVM file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)