### PR TITLE
fix(test): align ProfitClient flake helper with real client comparison

### DIFF
--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -127,11 +127,8 @@ describe("ProfitClient: Consider relay profit", () => {
   ): Pick<FillProfit, "grossRelayerFeeUsd" | "netRelayerFeePct" | "netRelayerFeeUsd" | "profitable"> => {
     const grossRelayerFeeUsd = inputAmountUsd.sub(outputAmountUsd).sub(lpFeeUsd);
     const netRelayerFeeUsd = grossRelayerFeeUsd.sub(gasCostUsd);
-    // Mirror ProfitClient.calculateFillProfitability: compare netRelayerFeePct (floor-divided) against
-    // minRelayerFeePct directly. Comparing the equivalent USD thresholds instead (netRelayerFeeUsd >=
-    // outputAmountUsd * minRelayerFeePct / fixedPoint) is mathematically equivalent in real arithmetic
-    // but diverges by 1 wei at the boundary under integer math, producing flaky results when the random
-    // token prices happen to land near the threshold.
+    // Mirror ProfitClient.calculateFillProfitability's integer-math comparison; comparing the
+    // equivalent USD threshold diverges by 1 wei at the boundary and flakes.
     const netRelayerFeePct = outputAmountUsd.gt(bnZero)
       ? netRelayerFeeUsd.mul(fixedPoint).div(outputAmountUsd)
       : bnZero;

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -127,10 +127,15 @@ describe("ProfitClient: Consider relay profit", () => {
   ): Pick<FillProfit, "grossRelayerFeeUsd" | "netRelayerFeePct" | "netRelayerFeeUsd" | "profitable"> => {
     const grossRelayerFeeUsd = inputAmountUsd.sub(outputAmountUsd).sub(lpFeeUsd);
     const netRelayerFeeUsd = grossRelayerFeeUsd.sub(gasCostUsd);
-    const netRelayerFeePct = netRelayerFeeUsd.mul(fixedPoint).div(outputAmountUsd);
-
-    const minRelayerFeeUsd = outputAmountUsd.mul(minRelayerFeePct).div(fixedPoint);
-    const profitable = netRelayerFeeUsd.gte(minRelayerFeeUsd);
+    // Mirror ProfitClient.calculateFillProfitability: compare netRelayerFeePct (floor-divided) against
+    // minRelayerFeePct directly. Comparing the equivalent USD thresholds instead (netRelayerFeeUsd >=
+    // outputAmountUsd * minRelayerFeePct / fixedPoint) is mathematically equivalent in real arithmetic
+    // but diverges by 1 wei at the boundary under integer math, producing flaky results when the random
+    // token prices happen to land near the threshold.
+    const netRelayerFeePct = outputAmountUsd.gt(bnZero)
+      ? netRelayerFeeUsd.mul(fixedPoint).div(outputAmountUsd)
+      : bnZero;
+    const profitable = netRelayerFeePct.gte(minRelayerFeePct);
 
     return {
       grossRelayerFeeUsd,


### PR DESCRIPTION
## Summary

- `test/ProfitClient.ConsiderProfitability.ts` has a recurring flake on `"Considers LP fees when computing profitability"` (line 451). Same shard, same assertion, has fired against multiple unrelated PRs and against master itself.
- Root cause: the `testProfitability` helper compares `netRelayerFeeUsd` against the USD-equivalent threshold `outputAmountUsd * minRelayerFeePct / fixedPoint`, while the real `ProfitClient.calculateFillProfitability` compares `netRelayerFeePct` (floor-divided) against `minRelayerFeePct` directly. The two formulations are mathematically equivalent in real arithmetic but diverge by 1 wei at the boundary under integer math. Token prices are randomised at file scope (`random(0.1, 21000, true)`) and on rare iterations they land near the boundary, producing a disagreement.
- Fix: compute the comparison in `testProfitability` exactly as `calculateFillProfitability` does (`netRelayerFeePct.gte(minRelayerFeePct)`), so the helper and the production code agree at the boundary.

## Reproduction

Demonstrated by reverting the fix and running the test 60× locally:

```
Old code: 59 passing, 1 failing out of 60
New code: 30 passing, 0 failing out of 30
```

The 1/60 failure matched the CI output exactly: `AssertionError: expected false to equal true at ProfitClient.ConsiderProfitability.ts:451`.

The boundary-math demo (Python script, BigInt-equivalent):

```
outputAmountUsd     = 1234567890123456789
minRelayerFeePct    = 100000000000000             (= 1 bp)
minRelayerFeeUsd    = 123456789012345
netRelayerFeeUsd    = 123456789012345             (set equal to min)
netRelayerFeePct    = 99999999999999              (< mrf=100000000000000)

TEST  netRelayerFeeUsd >= minRelayerFeeUsd   -> True
REAL  netRelayerFeePct >= minRelayerFeePct   -> False
```

## Out of scope

- The random token pricing at file scope (`random(0.1, 21000, true)`) is left as-is. It exercises a useful range of price magnitudes and is no longer flake-inducing now that the helper agrees with the real client at the boundary.
- The other random-derived test (`"Considers gas cost when computing profitability"`) also calls `testProfitability` and benefits from the same fix.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `prettier --check` clean
- [x] 30/30 local runs of the affected test pass with the fix; 1/60 fails without.

🤖 Generated with [Claude Code](https://claude.com/claude-code)