### PR TITLE
fix(finalizer): resolve Binance pending rebalance symbols via equivalence remapping

### DIFF
--- a/src/finalizer/utils/binance.ts
+++ b/src/finalizer/utils/binance.ts
@@ -11,6 +11,7 @@ import {
   floatToBN,
   bnZero,
   getTokenInfo,
+  getTokenInfoFromSymbol,
   groupObjectCountsByProp,
   isEVMSpokePoolClient,
   assert,
@@ -345,7 +346,9 @@ export function getPositivePendingRebalanceAmountsByBinanceCoin(pendingRebalance
   for (const [_chainId, tokenBalances] of Object.entries(pendingRebalances)) {
     const chainId = Number(_chainId);
     for (const [token, amount] of Object.entries(tokenBalances)) {
-      const { decimals } = getTokenInfo(EvmAddress.from(resolveAcrossToken(token, chainId, true)), chainId);
+      // Pending rebalances are keyed by logical symbol (e.g. "USDC") even where the on-chain symbol
+      // differs (e.g. "USDC-BNB" on BSC); getTokenInfoFromSymbol routes through TOKEN_EQUIVALENCE_REMAPPING.
+      const { decimals } = getTokenInfoFromSymbol(token, chainId);
       const binanceCoin = resolveBinanceCoinSymbol(token);
       totals[binanceCoin] = (totals[binanceCoin] ?? 0) + Number(formatUnits(amount, decimals));
     }

--- a/test/BinanceFinalizer.ts
+++ b/test/BinanceFinalizer.ts
@@ -37,6 +37,16 @@ describe("Binance finalizer helpers", function () {
     expect(deductions).to.deep.equal({ USDC: 60 });
   });
 
+  it("resolves logical USDC symbol on BSC where the on-chain symbol is USDC-BNB", function () {
+    const deductions = getPositivePendingRebalanceAmountsByBinanceCoin({
+      [CHAIN_IDs.BSC]: {
+        USDC: toBNWei("50", 18),
+      },
+    });
+
+    expect(deductions).to.deep.equal({ USDC: 50 });
+  });
+
   it("subtracts credited, swap, and pending rebalance amounts from orphan sweep candidates", function () {
     const sweepableBalance = getSweepableOrphanBinanceBalance(250_000, 10_000, 20_000, 30_000);
 

--- a/test/BinanceFinalizer.ts
+++ b/test/BinanceFinalizer.ts
@@ -47,6 +47,16 @@ describe("Binance finalizer helpers", function () {
     expect(deductions).to.deep.equal({ USDC: 50 });
   });
 
+  it("resolves logical USDT symbol on BSC where the on-chain symbol is USDT-BNB", function () {
+    const deductions = getPositivePendingRebalanceAmountsByBinanceCoin({
+      [CHAIN_IDs.BSC]: {
+        USDT: toBNWei("75", 18),
+      },
+    });
+
+    expect(deductions).to.deep.equal({ USDT: 75 });
+  });
+
   it("subtracts credited, swap, and pending rebalance amounts from orphan sweep candidates", function () {
     const sweepableBalance = getSweepableOrphanBinanceBalance(250_000, 10_000, 20_000, 30_000);
 


### PR DESCRIPTION
## Summary

The Binance finalizer added in #3347 throws `AssertionError: Token USDC not found on chain 56` whenever the pending-rebalance map contains a USDC entry for BSC, taking down the whole finalizer run for chain 56.

The `BinanceStablecoinSwapAdapter.getPendingRebalances` keys entries by the order's logical token symbol (`sourceToken` / `destinationToken`, e.g. `"USDC"`) against the Binance entrypoint chain. When the entrypoint resolves to BSC, you get `{ 56: { "USDC": <amount> } }`. The finalizer's new `getPositivePendingRebalanceAmountsByBinanceCoin` then calls `resolveAcrossToken("USDC", 56, true)`, but `TOKEN_SYMBOLS_MAP["USDC"]` has no address on chain 56 — BSC's USDC is registered as the separate symbol `USDC-BNB`. The assert fires and rejects the chain-56 finalizer promise.

This switches the decimals lookup to `getTokenInfoFromSymbol`, which routes through `TOKEN_EQUIVALENCE_REMAPPING` and matches how the rebalancer adapter itself resolves token info (`_getTokenInfo` → `getTokenInfoFromSymbol`). The values stored in the pendingRebalances map were already produced via the same equivalence-aware path, so decimals stay consistent.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test --grep "Binance finalizer helpers"` (added a BSC USDC case that reproduces the original crash without the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
