### PR TITLE
chore: bump @across-protocol/sdk 4.3.161 -> 4.3.163

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.109",
     "@across-protocol/contracts": "5.0.10",
-    "@across-protocol/sdk": "4.3.161",
+    "@across-protocol/sdk": "4.3.163",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.3.161":
-  version "4.3.161"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.161.tgz#cc37d9812ad2a3d25ad0bc29335f3710f3521ef1"
-  integrity sha512-Ber9fJ9YTKHQzXc7ujojnB/Dj8iSVtNQijUdyKSFjTeeCGek7jsulWcFMV6EdVrDvOM38/AqRj6dv8NGW55sIA==
+"@across-protocol/sdk@4.3.163":
+  version "4.3.163"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.163.tgz#5a9ca6afb40cf20d6e771a813f45b56355a8a9d5"
+  integrity sha512-lerUqx8dwhAcov6tDislEAYUMXUeQlOgsYJ/dwR+qt+Cy5gOE4ObM1bRbYFLZvapil+UywHdruGEAelkbuxadQ==
   dependencies:
     "@across-protocol/constants" "^3.1.110"
     "@across-protocol/contracts" "5.0.10"


### PR DESCRIPTION
## Summary

Picks up the SVM dataworker fix from across-protocol/sdk#1445.

- `getWidestPossibleExpectedBlockRange`'s SVM end-slot resolution now walks back through skipped slots via `getNearestSlotTime`, which catches `SVM_SLOT_SKIPPED` / `SVM_LONG_TERM_STORAGE_SLOT_SKIPPED` internally.
- Fixes the `SolanaError: Slot N was skipped, or missing due to ledger jump to recent snapshot` crash seen on `zion-across-disputer` (slot 422438019).
- The old `getLatestFinalizedSlotWithBlock` helper was deleted in the SDK and inlined at its only call site; no relayer code changes were required.

## Test plan
- [x] `yarn install` regenerates `yarn.lock` cleanly (only the SDK entry changes).
- [ ] Watch the next `zion-across-disputer` dataworker run after deploy and confirm the slot-skipped error no longer fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)