### PR TITLE
improve(dataworker): surface SolanaError context + cause on refund-leaf failures

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -4,6 +4,7 @@ import { utils as sdkUtils, arch } from "@across-protocol/sdk";
 import {
   blockExplorerLink,
   bnZero,
+  describeSolanaError,
   winston,
   EMPTY_MERKLE_ROOT,
   sortEventsDescending,
@@ -3288,14 +3289,16 @@ export class Dataworker {
         at: "Dataworker#executeRelayerRefundLeafSvm",
         message: "Something failed during the relayer refund leaf execution stage",
         error: err,
+        ...describeSolanaError(err),
       });
       try {
         await deactivateLut();
-      } catch (err) {
+      } catch (cleanupErr) {
         this.logger.warn({
           at: "Dataworker#executeRelayerRefundLeafSvm",
           message: "deactivateLut cleanup failed after refund execution error",
-          error: err,
+          error: cleanupErr,
+          ...describeSolanaError(cleanupErr),
         });
       }
       throw err;

--- a/src/utils/LogUtils.ts
+++ b/src/utils/LogUtils.ts
@@ -1,3 +1,5 @@
+import { arch } from "@across-protocol/sdk";
+
 export type DefaultLogLevels = "debug" | "info" | "warn" | "error";
 
 export function stringifyThrownValue(value: unknown): string {
@@ -16,4 +18,40 @@ export function stringifyThrownValue(value: unknown): string {
   } else {
     return `ThrownValue: ${value?.toString()}`;
   }
+}
+
+type SolanaErrorDescription = {
+  name: string;
+  message?: string;
+  code: number;
+  context: unknown;
+  cause?: SolanaErrorDescription | { message: string };
+};
+
+// Winston's `error` formatter (in @risk-labs/logger) collapses a SolanaError to its `.stack` string,
+// which drops `.context` (the RPC simulation result: `logs`, `accounts`, `unitsConsumed`) and `.cause`
+// (the underlying `InstructionError` / `TransactionError`). Spread the result of this helper into a
+// log payload alongside `error: err` to keep both the human-readable stack and the structured
+// diagnostic fields.
+export function describeSolanaError(err: unknown): { solanaError?: SolanaErrorDescription } {
+  if (!arch.svm.isSolanaError(err)) {
+    return {};
+  }
+  const solanaError: SolanaErrorDescription = {
+    name: err.name,
+    code: err.context.__code,
+    context: err.context,
+  };
+  if (err instanceof Error) {
+    solanaError.message = err.message;
+  }
+  if (err.cause !== undefined) {
+    const describedCause = describeSolanaError(err.cause);
+    if (describedCause.solanaError) {
+      solanaError.cause = describedCause.solanaError;
+    } else if (err.cause instanceof Error) {
+      solanaError.cause = { message: err.cause.message };
+    }
+  }
+  return { solanaError };
 }

--- a/test/LogUtils.ts
+++ b/test/LogUtils.ts
@@ -1,0 +1,29 @@
+import { SolanaError, SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE } from "@solana/kit";
+import { expect } from "./utils";
+import { describeSolanaError } from "../src/utils/LogUtils";
+
+describe("describeSolanaError", function () {
+  it("returns an empty object for non-Solana errors", function () {
+    expect(describeSolanaError(new Error("nope"))).to.deep.equal({});
+    expect(describeSolanaError("oops")).to.deep.equal({});
+    expect(describeSolanaError(undefined)).to.deep.equal({});
+  });
+
+  it("extracts code and context from a SolanaError", function () {
+    const preflightContext = {
+      accounts: null,
+      logs: ["Program log: refund leaf already executed"],
+      returnData: null,
+      unitsConsumed: 4321n,
+    };
+    const err = new SolanaError(SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE, {
+      ...preflightContext,
+      cause: new Error("simulation failed"),
+    });
+    const result = describeSolanaError(err);
+    expect(result.solanaError).to.exist;
+    expect(result.solanaError?.code).to.equal(SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE);
+    expect(result.solanaError?.context).to.include({ logs: preflightContext.logs });
+    expect(result.solanaError?.message).to.be.a("string");
+  });
+});


### PR DESCRIPTION
## Summary

`Dataworker#_executeRelayerRefundLeafSvm` catches `SolanaError`s from `@solana/kit` and logs them via `error: err`. The `@risk-labs/logger` formatter collapses `error` to `err.stack`, which drops the two fields you actually need to diagnose a Solana refund-leaf failure:

- `err.context` — for `SEND_TRANSACTION_PREFLIGHT_FAILURE`, this is the `RpcSimulateTransactionResult` with `logs[]`, `accounts`, `returnData`, `unitsConsumed`.
- `err.cause` — the wrapped `TransactionError` / `InstructionError` (e.g. `InstructionError__CUSTOM` with the program error code, `INSUFFICIENT_FUNDS`, `ALREADY_PROCESSED`, etc.).

Production logs today read only `SolanaError: Transaction simulation failed at /across-relayer/node_modules/@solana/rpc-transformers/dist/index.node.cjs:332:22 …` — no way to tell whether it was an already-executed leaf, a stale blockhash, a custom program error, or RPC flake. The exec error from earlier today (run `3bc42214…`, bundle 10444 leaf 30) is one example; there were a dozen more on 2026-05-23.

### Change

- Add `describeSolanaError(err): { solanaError?: { name, message?, code, context, cause? } }` in `src/utils/LogUtils.ts`. No-op for non-Solana errors. Recursively unwraps nested `SolanaError` causes; falls back to `{ message }` for non-Solana `Error` causes.
- Spread it into the existing `logger.error` and the `deactivateLut` cleanup `logger.warn` in `Dataworker._executeRelayerRefundLeafSvm`. `error: err` is preserved (still emits the stack), and the new `solanaError: {...}` field carries the structured diagnostic.

### Why not in the formatter / a top-level catch

The risk-labs `errorStackTracerFormatter` only special-cases `info.error` and is consumed by every winston log; touching it is a much bigger blast radius than I want for a logging tweak. Adding `solanaError` as a sibling key passes through `bigNumberFormatter` and `JsonTransport` cleanly without touching the shared formatter contract. The dataworker is also the first catch in the chain — the top-level handler in `index.ts` rethrows via `stringifyThrownValue` which would also flatten the context, so adding fields here is the right layer.

Related to #3409 (which renamed the same log's `error` → `cause` to similar effect — that rename was reverted in #3410). This change is additive, so it composes either way.

### Sample shape

With the change, a preflight failure now logs (in addition to the stack under `error`):

```json
{
  "solanaError": {
    "name": "SolanaError",
    "message": "Transaction simulation failed",
    "code": -32002,
    "context": {
      "__code": -32002,
      "logs": [
        "Program log: refund leaf already executed"
      ],
      "accounts": null,
      "unitsConsumed": "4321"
    },
    "cause": {
      "name": "SolanaError",
      "code": 4615001,
      "context": { "__code": 4615001, "index": 3 }
    }
  }
}
```

### Doc updates

No `README.md` / `AGENTS.md` updates needed — this is a log-payload tweak, no interface or behavioral change visible to operators or other bots.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `npx hardhat test test/LogUtils.ts` (new unit test for `describeSolanaError`: non-Solana error returns `{}`; SolanaError extracts code, context, message)
- [ ] Deploy + wait for next refund-leaf failure to confirm the new payload shape in `bots-across-3839` Cloud Run logs.

Thread: [#bot-monitoring 1779869895.829509](https://risklabs.slack.com/archives/C03GHT4RV42/p1779869895829509)

🤖 Generated with [Claude Code](https://claude.com/claude-code)