### PR TITLE
improve(dataworker): treat SVM refund-leaf already-claimed races as benign

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -4,6 +4,7 @@ import { utils as sdkUtils, arch } from "@across-protocol/sdk";
 import {
   blockExplorerLink,
   bnZero,
+  describeSolanaError,
   winston,
   EMPTY_MERKLE_ROOT,
   sortEventsDescending,
@@ -3288,14 +3289,16 @@ export class Dataworker {
         at: "Dataworker#executeRelayerRefundLeafSvm",
         message: "Something failed during the relayer refund leaf execution stage",
         error: err,
+        ...describeSolanaError(err),
       });
       try {
         await deactivateLut();
-      } catch (err) {
+      } catch (cleanupErr) {
         this.logger.warn({
           at: "Dataworker#executeRelayerRefundLeafSvm",
           message: "deactivateLut cleanup failed after refund execution error",
-          error: err,
+          error: cleanupErr,
+          ...describeSolanaError(cleanupErr),
         });
       }
       throw err;

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -3291,18 +3291,21 @@ export class Dataworker {
         });
       }
     } catch (err) {
-      // Log at `debug` regardless of branch — this catch must not page on its own.
+      // This catch must not page on its own; the top-level catch in `index.ts` (which logs at
+      // `error` with `notificationPath: "across-error"`) is the single PD-paging surface for this
+      // path. This avoids the double page we used to see: previously this site logged at `error`
+      // and then rethrew, so the top-level catch paged a second time for the same exception.
       //   - Benign `ClaimedMerkleLeaf` race (the on-chain `is_claimed` check at
       //     programs/svm-spoke/src/instructions/bundle.rs trips when another actor lands the
-      //     leaf between our pre-flight `getRelayerRefundExecutions()` filter and now):
-      //     swallow after LUT cleanup; return undefined so the caller skips the success-path
-      //     "Executed RelayerRefundLeaf" info log.
-      //   - Any other failure: rethrow. The top-level catch in `index.ts` will log at `error`
-      //     with `notificationPath: "across-error"`, which is what fires the PD page.
-      // This avoids the double page we used to see: previously this site logged at `error` and
-      // then rethrew, so the top-level catch paged a second time for the same exception.
+      //     leaf between our pre-flight `getRelayerRefundExecutions()` filter and now): log at
+      //     `debug`, swallow after LUT cleanup, return undefined so the caller skips the
+      //     success-path "Executed RelayerRefundLeaf" info log.
+      //   - Any other failure: log at `warn` so the structured SVM context (`describeSolanaError`,
+      //     `rootBundleId`, `leafId`) is preserved in Cloud Logging in prod even when `LOG_LEVEL`
+      //     excludes debug — the top-level `stringifyThrownValue` only carries the stack — then
+      //     rethrow. `warn` doesn't page; the rethrow reaches `index.ts` which does.
       const alreadyClaimed = isSvmLeafAlreadyClaimedError(err);
-      this.logger.debug({
+      this.logger[alreadyClaimed ? "debug" : "warn"]({
         at: "Dataworker#executeRelayerRefundLeafSvm",
         message: alreadyClaimed
           ? "Refund leaf was already claimed on chain; skipping"
@@ -3312,9 +3315,11 @@ export class Dataworker {
         error: err,
         ...describeSolanaError(err),
       });
+      let cleanupErr: unknown;
       try {
         await deactivateLut();
-      } catch (cleanupErr) {
+      } catch (e) {
+        cleanupErr = e;
         this.logger.warn({
           at: "Dataworker#executeRelayerRefundLeafSvm",
           message: "deactivateLut cleanup failed after refund execution error",
@@ -3323,6 +3328,13 @@ export class Dataworker {
         });
       }
       if (alreadyClaimed) {
+        // The leaf was already claimed (no real failure), so we'd normally swallow. But if LUT
+        // cleanup also failed, don't return silently — the LUT was created fresh from a recent
+        // slot just for this attempt and is not persisted elsewhere, so a swallowed cleanup
+        // leaves it active/funded until rent runs out. Surface it so the top-level catch pages.
+        if (cleanupErr !== undefined) {
+          throw cleanupErr;
+        }
         return undefined;
       }
       throw err;

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -3291,13 +3291,18 @@ export class Dataworker {
         });
       }
     } catch (err) {
-      // The on-chain `is_claimed` check at programs/svm-spoke/src/instructions/bundle.rs returns
-      // `CommonError::ClaimedMerkleLeaf` when another actor (concurrent dataworker, manual exec)
-      // landed this leaf between our pre-flight `getRelayerRefundExecutions()` filter and now.
-      // Treat as benign: log at debug, clean up the LUT we created, and return undefined so the
-      // caller skips the success-path "Executed RelayerRefundLeaf" info log.
+      // Log at `debug` regardless of branch — this catch must not page on its own.
+      //   - Benign `ClaimedMerkleLeaf` race (the on-chain `is_claimed` check at
+      //     programs/svm-spoke/src/instructions/bundle.rs trips when another actor lands the
+      //     leaf between our pre-flight `getRelayerRefundExecutions()` filter and now):
+      //     swallow after LUT cleanup; return undefined so the caller skips the success-path
+      //     "Executed RelayerRefundLeaf" info log.
+      //   - Any other failure: rethrow. The top-level catch in `index.ts` will log at `error`
+      //     with `notificationPath: "across-error"`, which is what fires the PD page.
+      // This avoids the double page we used to see: previously this site logged at `error` and
+      // then rethrew, so the top-level catch paged a second time for the same exception.
       const alreadyClaimed = isSvmLeafAlreadyClaimedError(err);
-      this.logger[alreadyClaimed ? "debug" : "error"]({
+      this.logger.debug({
         at: "Dataworker#executeRelayerRefundLeafSvm",
         message: alreadyClaimed
           ? "Refund leaf was already claimed on chain; skipping"

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -5,6 +5,7 @@ import {
   blockExplorerLink,
   bnZero,
   describeSolanaError,
+  isSvmLeafAlreadyClaimedError,
   winston,
   EMPTY_MERKLE_ROOT,
   sortEventsDescending,
@@ -2547,13 +2548,18 @@ export class Dataworker {
           rootBundleId,
           relayerRefundTree.getHexProof(leaf)
         );
-        this.logger.info({
-          at: "Dataworker#_executeRelayerRefundLeaves",
-          ...formatRelayerRefundLeafExecutionLog({
-            ...leafLogArgs,
-            explorerLink: blockExplorerLink(signature, chainId),
-          }),
-        });
+        // `undefined` means we caught a benign race (leaf was claimed on chain by another actor);
+        // `_executeRelayerRefundLeafSvm` already logged the skip at debug. Avoid the success-path info
+        // log so we don't claim we executed a leaf we didn't.
+        if (isDefined(signature)) {
+          this.logger.info({
+            at: "Dataworker#_executeRelayerRefundLeaves",
+            ...formatRelayerRefundLeafExecutionLog({
+              ...leafLogArgs,
+              explorerLink: blockExplorerLink(signature, chainId),
+            }),
+          });
+        }
       }
     });
   }
@@ -2889,7 +2895,7 @@ export class Dataworker {
     leaf: RelayerRefundLeaf,
     rootBundleId: number,
     relayerRefundLeafHexProof: string[]
-  ): Promise<string> {
+  ): Promise<string | undefined> {
     // Parse relevant info from the relayer refund leaf/dataworker.
     const { spokePoolAddress } = spokePoolClient;
     assert(isDefined(spokePoolAddress), "_executeRelayerRefundLeafSvm: SpokePoolClient missing spokePoolAddress");
@@ -3285,9 +3291,19 @@ export class Dataworker {
         });
       }
     } catch (err) {
-      this.logger.error({
+      // The on-chain `is_claimed` check at programs/svm-spoke/src/instructions/bundle.rs returns
+      // `CommonError::ClaimedMerkleLeaf` when another actor (concurrent dataworker, manual exec)
+      // landed this leaf between our pre-flight `getRelayerRefundExecutions()` filter and now.
+      // Treat as benign: log at debug, clean up the LUT we created, and return undefined so the
+      // caller skips the success-path "Executed RelayerRefundLeaf" info log.
+      const alreadyClaimed = isSvmLeafAlreadyClaimedError(err);
+      this.logger[alreadyClaimed ? "debug" : "error"]({
         at: "Dataworker#executeRelayerRefundLeafSvm",
-        message: "Something failed during the relayer refund leaf execution stage",
+        message: alreadyClaimed
+          ? "Refund leaf was already claimed on chain; skipping"
+          : "Something failed during the relayer refund leaf execution stage",
+        rootBundleId,
+        leafId: leaf.leafId,
         error: err,
         ...describeSolanaError(err),
       });
@@ -3300,6 +3316,9 @@ export class Dataworker {
           error: cleanupErr,
           ...describeSolanaError(cleanupErr),
         });
+      }
+      if (alreadyClaimed) {
+        return undefined;
       }
       throw err;
     }

--- a/src/utils/LogUtils.ts
+++ b/src/utils/LogUtils.ts
@@ -55,3 +55,31 @@ export function describeSolanaError(err: unknown): { solanaError?: SolanaErrorDe
   }
   return { solanaError };
 }
+
+// Anchor emits a `Program log: AnchorError ... Error Code: <Name>. Error Number: <N>. Error Message: ...`
+// line in the simulation logs whenever a `#[error_code]` variant fires. Match by name rather than the
+// numeric code because the SVM SpokePool program declares two `#[error_code]` enums (`CommonError`,
+// `SvmError`) that both default-start at offset 6000 and collide at the wire level — the deployed-IDL
+// gap means only `SvmError` is exposed as numbered constants, so name-matching is the only reliable
+// path to disambiguate `ClaimedMerkleLeaf` from e.g. `SvmError::InvalidRefund`.
+const SVM_LEAF_ALREADY_CLAIMED_LOG_FRAGMENT = "Error Code: ClaimedMerkleLeaf";
+
+/**
+ * True iff `err` is a Solana preflight failure whose simulation logs indicate that the targeted
+ * relayer-refund merkle leaf has already been claimed on chain (`CommonError::ClaimedMerkleLeaf`
+ * in `programs/svm-spoke/src/instructions/bundle.rs`). Use to suppress benign races between
+ * concurrent dataworker actors.
+ */
+export function isSvmLeafAlreadyClaimedError(err: unknown): boolean {
+  if (!arch.svm.isSolanaError(err)) {
+    return false;
+  }
+  if (err.context.__code !== arch.svm.SVM_TRANSACTION_PREFLIGHT_FAILURE) {
+    return false;
+  }
+  const logs = err.context.logs;
+  if (!Array.isArray(logs)) {
+    return false;
+  }
+  return logs.some((line) => typeof line === "string" && line.includes(SVM_LEAF_ALREADY_CLAIMED_LOG_FRAGMENT));
+}

--- a/src/utils/LogUtils.ts
+++ b/src/utils/LogUtils.ts
@@ -1,3 +1,5 @@
+import { arch } from "@across-protocol/sdk";
+
 export type DefaultLogLevels = "debug" | "info" | "warn" | "error";
 
 export function stringifyThrownValue(value: unknown): string {
@@ -16,4 +18,40 @@ export function stringifyThrownValue(value: unknown): string {
   } else {
     return `ThrownValue: ${value?.toString()}`;
   }
+}
+
+type SolanaErrorDescription = {
+  name: string;
+  message?: string;
+  code: number;
+  context: unknown;
+  cause?: SolanaErrorDescription | { message: string };
+};
+
+// Winston's `error` formatter (in @risk-labs/logger) collapses a SolanaError to its `.stack` string,
+// which drops `.context` (the RPC simulation result: `logs`, `accounts`, `unitsConsumed`) and `.cause`
+// (the underlying `InstructionError` / `TransactionError`). Spread the result of this helper into a
+// log payload alongside `error: err` to keep both the human-readable stack and the structured
+// diagnostic fields.
+export function describeSolanaError(err: unknown): { solanaError?: SolanaErrorDescription } {
+  if (!arch.svm.isSolanaError(err)) {
+    return {};
+  }
+  const solanaError: SolanaErrorDescription = {
+    name: err.name,
+    code: err.context.__code,
+    context: err.context,
+  };
+  if (err instanceof Error) {
+    solanaError.message = err.message;
+  }
+  if (err.cause !== undefined) {
+    const describedCause = describeSolanaError(err.cause);
+    if (describedCause.solanaError) {
+      solanaError.cause = describedCause.solanaError;
+    } else if (err.cause instanceof Error) {
+      solanaError.cause = { message: err.cause.message };
+    }
+  }
+  return { solanaError };
 }

--- a/test/LogUtils.ts
+++ b/test/LogUtils.ts
@@ -1,6 +1,10 @@
-import { SolanaError, SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE } from "@solana/kit";
+import {
+  SolanaError,
+  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
+  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SLOT_SKIPPED,
+} from "@solana/kit";
 import { expect } from "./utils";
-import { describeSolanaError } from "../src/utils/LogUtils";
+import { describeSolanaError, isSvmLeafAlreadyClaimedError } from "../src/utils/LogUtils";
 
 describe("describeSolanaError", function () {
   it("returns an empty object for non-Solana errors", function () {
@@ -25,5 +29,66 @@ describe("describeSolanaError", function () {
     expect(result.solanaError?.code).to.equal(SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE);
     expect(result.solanaError?.context).to.include({ logs: preflightContext.logs });
     expect(result.solanaError?.message).to.be.a("string");
+  });
+});
+
+describe("isSvmLeafAlreadyClaimedError", function () {
+  const claimedLogLine =
+    "Program log: AnchorError caused by account: state. Error Code: ClaimedMerkleLeaf. Error Number: 6010. Error Message: Leaf already claimed!.";
+
+  it("returns false for non-Solana errors", function () {
+    expect(isSvmLeafAlreadyClaimedError(new Error("nope"))).to.be.false;
+    expect(isSvmLeafAlreadyClaimedError("string")).to.be.false;
+    expect(isSvmLeafAlreadyClaimedError(undefined)).to.be.false;
+  });
+
+  it("returns false when the SolanaError isn't a preflight failure", function () {
+    // SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SLOT_SKIPPED requires a `slot` field in context.
+    const err = new SolanaError(SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SLOT_SKIPPED, { slot: 12345 });
+    expect(isSvmLeafAlreadyClaimedError(err)).to.be.false;
+  });
+
+  it("returns false when the preflight logs don't mention ClaimedMerkleLeaf", function () {
+    const err = new SolanaError(SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE, {
+      accounts: null,
+      logs: [
+        "Program log: Instruction: ExecuteRelayerRefundLeaf",
+        "Program log: AnchorError caused by account: vault. Error Code: InsufficientSpokePoolBalanceToExecuteLeaf. Error Number: 6013. Error Message: Insufficient spoke pool balance to execute leaf.",
+      ],
+      returnData: null,
+      unitsConsumed: 1234n,
+    });
+    expect(isSvmLeafAlreadyClaimedError(err)).to.be.false;
+  });
+
+  it("returns true when the preflight logs contain the ClaimedMerkleLeaf error code line", function () {
+    const err = new SolanaError(SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE, {
+      accounts: null,
+      logs: ["Program log: Instruction: ExecuteRelayerRefundLeaf", claimedLogLine],
+      returnData: null,
+      unitsConsumed: 1234n,
+    });
+    expect(isSvmLeafAlreadyClaimedError(err)).to.be.true;
+  });
+
+  it("works on a structurally-cloned SolanaError (JSON round-trip)", function () {
+    const cloned = JSON.parse(
+      JSON.stringify({
+        name: "SolanaError",
+        context: {
+          __code: SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
+          logs: [claimedLogLine],
+        },
+      })
+    );
+    expect(isSvmLeafAlreadyClaimedError(cloned)).to.be.true;
+  });
+
+  it("returns false when the preflight context has no logs array", function () {
+    const err = {
+      name: "SolanaError",
+      context: { __code: SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE },
+    };
+    expect(isSvmLeafAlreadyClaimedError(err)).to.be.false;
   });
 });

--- a/test/LogUtils.ts
+++ b/test/LogUtils.ts
@@ -1,0 +1,29 @@
+import { SolanaError, SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE } from "@solana/kit";
+import { expect } from "./utils";
+import { describeSolanaError } from "../src/utils/LogUtils";
+
+describe("describeSolanaError", function () {
+  it("returns an empty object for non-Solana errors", function () {
+    expect(describeSolanaError(new Error("nope"))).to.deep.equal({});
+    expect(describeSolanaError("oops")).to.deep.equal({});
+    expect(describeSolanaError(undefined)).to.deep.equal({});
+  });
+
+  it("extracts code and context from a SolanaError", function () {
+    const preflightContext = {
+      accounts: null,
+      logs: ["Program log: refund leaf already executed"],
+      returnData: null,
+      unitsConsumed: 4321n,
+    };
+    const err = new SolanaError(SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE, {
+      ...preflightContext,
+      cause: new Error("simulation failed"),
+    });
+    const result = describeSolanaError(err);
+    expect(result.solanaError).to.exist;
+    expect(result.solanaError?.code).to.equal(SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE);
+    expect(result.solanaError?.context).to.include({ logs: preflightContext.logs });
+    expect(result.solanaError?.message).to.be.a("string");
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on #3422 (the `describeSolanaError` log surfacing). Target the stack-base branch for now; switch base to `master` after #3422 merges.

Two changes to `Dataworker._executeRelayerRefundLeafSvm`'s catch block, both motivated by the same incident pattern — repeated PD pages from this code path that are either benign or duplicates of a single root failure:

1. **Benign `ClaimedMerkleLeaf` race**: another actor (concurrent dataworker instance, manual execution, etc.) lands the relayer-refund merkle leaf between our pre-flight `getRelayerRefundExecutions()` filter (`Dataworker.ts:2284`) and the simulate-and-send. On-chain this surfaces as `programs/svm-spoke/src/instructions/bundle.rs:124` returning `CommonError::ClaimedMerkleLeaf`; previously the dataworker treated it like any other failure — `logger.error` + rethrow + `Process exited with code 1`. EVM has the analog handled already via `MultiCallerClient.knownRevertReasons` (`"ClaimedMerkleLeaf"`, `"RelayFilled"`).
2. **Double PD page for any failure**: the catch logged at `error` with `notificationPath: "across-error"` and then rethrew. The top-level catch in `index.ts:87-97` also logs the same exception at `error` with `notificationPath: "across-error"`. Result: one logical failure → two PD incidents (e.g. `Q0A7GJYKZ18A0B` + `Q0087SNOQP7PI1` on 2026-06-04 19:49:42Z, same `run-identifier 4b6e3c86…`, same stack).

Incident pattern this fixes: cluster of failures on 2026-05-23 and the 2026-06-04 double-page were all consistent with these two issues.

### Change

- New `isSvmLeafAlreadyClaimedError(err)` in `src/utils/LogUtils.ts`. Returns true iff `err` is a SolanaError with `__code === SVM_TRANSACTION_PREFLIGHT_FAILURE` and its simulation `logs[]` contain Anchor's `"Error Code: ClaimedMerkleLeaf"` line.
- In `_executeRelayerRefundLeafSvm` catch (`Dataworker.ts:3293`): **always log at `debug`** — this catch no longer pages on its own.
  - Benign `ClaimedMerkleLeaf`: `debug` + LUT cleanup + `return undefined`.
  - Any other failure: `debug` + rethrow. The top-level catch in `index.ts` (which already logs at `error` with `notificationPath: "across-error"`) is the single PD-paging surface for this path. `forEachAsync` → `Promise.all` propagates the rejection from the caller, so we are confident reachability holds.
- Caller in `_executeRelayerRefundLeaves` SVM branch (`Dataworker.ts:2544`): skip the `"Executed RelayerRefundLeaf"` info log when the returned signature is `undefined` (we'd be claiming we executed a leaf we didn't).
- Return type widened from `Promise<string>` to `Promise<string | undefined>`.

### Trade-off — diagnostic context at the top-level catch

`stringifyThrownValue` flattens the error at `index.ts:89` to its stack only. The structured fields this catch builds (`describeSolanaError`, `rootBundleId`, `leafId`) therefore live at `debug` level only. That's fine if `LOG_LEVEL` includes `debug` in production (dataworker bot is one-shot, `pollingDelay === 0`, so `startupLogLevel` is `debug` — but `LOG_LEVEL` is configured independently; verify in `bots-across-3839`). If debug isn't captured in prod, the follow-up is to either (a) attach the structured context to the rethrown error so the top-level `stringifyThrownValue` carries it, or (b) keep this catch at `warn` instead of `debug` so it surfaces in Cloud Logging without paging.

### Why match by log line instead of numeric code

The SVM SpokePool program declares two `#[error_code]` enums (`CommonError`, `SvmError`) in `programs/svm-spoke/src/error.rs`. Both default-start at offset 6000 in Anchor 0.31, so they collide numerically — `ClaimedMerkleLeaf` and `SvmError::InvalidRefund` both serialize to 6010 on the wire. The published `@across-protocol/contracts` IDL further compounds this: `anchor idl build` only emits the last declared enum, so the generated client (`dist/src/svm/clients/SvmSpoke/errors/svmSpoke.js`) ships only `SvmError` constants — no `SVM_SPOKE_ERROR__CLAIMED_MERKLE_LEAF` exists. The only reliable disambiguator is the Anchor program-log line, which `describeSolanaError` (added in #3422) now surfaces.

(A separate `across-protocol/contracts` PR has been proposed to post-process the IDL so both enums ship — once that lands, this matcher can swap to a numeric code without breaking on disambiguation.)

### Out of scope (follow-ups)

- Same treatment for the deferred-refund `claimRelayerRefund` path (`Dataworker.ts:3232-3255`) — has its own race on `claimAccount`, and the same double-page issue if anything in it throws.
- Moving `isSvmLeafAlreadyClaimedError` into `@across-protocol/sdk` next to `describeSolanaError` (deferred until the SDK PR with `describeSolanaError` lands + bumps).
- EVM-side `ClaimedMerkleLeaf` already covered via `knownRevertReasons`; no change here.
- Audit other `Dataworker` catches for the same double-page pattern (any catch that `logger.error`s with `notificationPath: "across-error"` and rethrows).

### Doc updates

No `README.md` / `AGENTS.md` updates needed — internal behavior tweak to a private catch path; no interface or operator-facing contract change.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `npx hardhat test test/LogUtils.ts` (6 new tests for `isSvmLeafAlreadyClaimedError`: non-Solana, non-preflight, preflight without ClaimedMerkleLeaf, preflight with it, JSON round-tripped error, missing `logs` array)
- [x] `npx hardhat test test/Dataworker.executeRelayerRefunds.ts` (existing EVM coverage still green)
- [ ] Deploy + confirm: (a) a real refund-leaf-already-claimed race fires as `debug` rather than `error`, (b) a forced non-benign failure pages exactly once (from `index.ts`, not from this catch).

Threads:
- [#bot-monitoring 1779869895.829509](https://risklabs.slack.com/archives/C03GHT4RV42/p1779869895829509) — original ClaimedMerkleLeaf surfacing.
- [#crisis 1780602669.885619](https://risklabs.slack.com/archives/C0B5K0N75PD/p1780602669885619) — 2026-06-04 double-page motivating the `debug`-everywhere change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)