### PR TITLE
improve(svm): extract code/wasClean from Solana WS close and route log level

### DIFF
--- a/src/libexec/RelayerSpokePoolListenerSVM.ts
+++ b/src/libexec/RelayerSpokePoolListenerSVM.ts
@@ -124,14 +124,42 @@ async function listen(
   const RECONNECT_BACKOFF_MIN_S = 1;
   const RECONNECT_BACKOFF_MAX_S = 30;
 
+  // CloseEvent exposes code/wasClean/reason as prototype getters, so winston serializes
+  // the cause as {} (or "[object CloseEvent]") and drops the only useful fields. Project
+  // them onto own properties before logging.
+  const extractCloseEventSignal = (cause: unknown): { code?: number; wasClean?: boolean; reason?: string } => {
+    if (cause === null || typeof cause !== "object") {
+      return {};
+    }
+    const { code, wasClean, reason } = cause as {
+      code?: unknown;
+      wasClean?: unknown;
+      reason?: unknown;
+    };
+    return {
+      code: typeof code === "number" ? code : undefined,
+      wasClean: typeof wasClean === "boolean" ? wasClean : undefined,
+      reason: typeof reason === "string" ? reason : undefined,
+    };
+  };
+
   const logProviderError = (providerName: string, err: unknown, backoffS: number) => {
     const message = "Caught error on Solana provider; reconnecting.";
-    const ctx = { at, message, provider: providerName, backoffS };
+    const baseCtx = { at, message, provider: providerName, backoffS };
     if (arch.svm.isSolanaError(err)) {
-      logger.warn({ ...ctx, cause: err.cause });
+      const { code, wasClean, reason } = extractCloseEventSignal(err.cause);
+      const ctx = { ...baseCtx, code, wasClean, reason };
+      // 1006 with no close frame is the documented Chainstack shared-gateway rotation
+      // (https://docs.chainstack.com/docs/error-reference); demote to debug. Anything
+      // else (e.g. 1011 Internal Error from Alchemy, unknown codes) stays at warn.
+      if (code === 1006 && wasClean === false) {
+        logger.debug(ctx);
+      } else {
+        logger.warn(ctx);
+      }
     } else {
       const cause = typeguards.isError(err) ? err.message : "unknown cause";
-      logger.warn({ ...ctx, cause });
+      logger.warn({ ...baseCtx, cause });
     }
   };
 

--- a/src/libexec/RelayerSpokePoolListenerSVM.ts
+++ b/src/libexec/RelayerSpokePoolListenerSVM.ts
@@ -124,30 +124,18 @@ async function listen(
   const RECONNECT_BACKOFF_MIN_S = 1;
   const RECONNECT_BACKOFF_MAX_S = 30;
 
-  // CloseEvent exposes code/wasClean/reason as prototype getters, so winston serializes
-  // the cause as {} (or "[object CloseEvent]") and drops the only useful fields. Project
-  // them onto own properties before logging.
-  const extractCloseEventSignal = (cause: unknown): { code?: number; wasClean?: boolean; reason?: string } => {
-    if (cause === null || typeof cause !== "object") {
-      return {};
-    }
-    const { code, wasClean, reason } = cause as {
-      code?: unknown;
-      wasClean?: unknown;
-      reason?: unknown;
-    };
-    return {
-      code: typeof code === "number" ? code : undefined,
-      wasClean: typeof wasClean === "boolean" ? wasClean : undefined,
-      reason: typeof reason === "string" ? reason : undefined,
-    };
-  };
+  // SolanaError.cause is a WebSocket CloseEvent. The CloseEvent interface is global via
+  // @types/node (undici-types), so we narrow with a structural guard and let TS infer
+  // code/wasClean/reason. Projecting them onto own properties is still required because
+  // winston serializes the CloseEvent prototype-getter fields as {}.
+  const isCloseEvent = (x: unknown): x is CloseEvent =>
+    typeof x === "object" && x !== null && "code" in x && "wasClean" in x && "reason" in x;
 
   const logProviderError = (providerName: string, err: unknown, backoffS: number) => {
     const message = "Caught error on Solana provider; reconnecting.";
     const baseCtx = { at, message, provider: providerName, backoffS };
-    if (arch.svm.isSolanaError(err)) {
-      const { code, wasClean, reason } = extractCloseEventSignal(err.cause);
+    if (arch.svm.isSolanaError(err) && isCloseEvent(err.cause)) {
+      const { code, wasClean, reason } = err.cause;
       const ctx = { ...baseCtx, code, wasClean, reason };
       // 1006 with no close frame is the documented Chainstack shared-gateway rotation
       // (https://docs.chainstack.com/docs/error-reference); demote to debug. Anything
@@ -157,10 +145,10 @@ async function listen(
       } else {
         logger.warn(ctx);
       }
-    } else {
-      const cause = typeguards.isError(err) ? err.message : "unknown cause";
-      logger.warn({ ...baseCtx, cause });
+      return;
     }
+    const cause = typeguards.isError(err) ? err.message : "unknown cause";
+    logger.warn({ ...baseCtx, cause });
   };
 
   const readSlot = async (provider: WSProvider, providerName: string) => {


### PR DESCRIPTION
## Summary

The reconnect-on-close warn introduced in #3417 logs the raw `SolanaError.cause`, which is a Node `CloseEvent`. `CloseEvent` exposes `code`, `wasClean`, and `reason` as **prototype getters**, so winston serializes the cause as `{}` (Cloud Logging) or `"[object CloseEvent]"` (winston transport) and the only useful fields are dropped. Slack sees them only because its formatter walks the prototype — which is also why we get the giant `initEvent`/`stopImmediatePropagation`/etc dump in the Slack message.

This change projects the three scalars (`code`, `wasClean`, `reason`) onto own properties before logging, drops the rest of the `CloseEvent`, and routes the log level on the extracted signal:

- `code === 1006 && wasClean === false` → `debug`. This is the documented [Chainstack shared-gateway rotation](https://docs.chainstack.com/docs/error-reference) at a wallclock 10-min cadence and is operational noise.
- Anything else (notably `code: 1011, wasClean: true, reason: "Internal Error"` from Alchemy, plus unknown codes) → `warn`, unchanged.

Empirical justification (`bots-across-3839`, 7 days 2026-05-21 → 2026-05-28, both `primary` + `usdh`):

|                                | Alchemy | Chainstack |
| ------------------------------ | ------: | ---------: |
| `code: 1011, wasClean: true`   |    2922 |          0 |
| `code: 1006, wasClean: false`  |      11 |        305 |

So 1006-vs-1011 is essentially a clean per-provider split: Chainstack 1006 is the wallclock-rotation noise we already know about; Alchemy 1011 is the *current* high-volume signal (~417/day/bot) and stays at warn so it remains alertable. The full structured log now looks like:

```jsonc
{
  "at": "RelayerSpokePoolListenerSVM::listen",
  "message": "Caught error on Solana provider; reconnecting.",
  "provider": "wss://solana-mainnet.g.alchemy.com",
  "backoffS": 1,
  "code": 1011,
  "wasClean": true,
  "reason": "Internal Error"
}
```

…instead of the previous `cause: {}` (GCP) or full `CloseEvent` dump (Slack).

## Test plan

- [x] `yarn tsc --noEmit` clean
- [x] `yarn eslint` clean on changed file
- [x] `yarn prettier --check` clean on changed file
- [ ] No runtime test — the helper is straightforward field projection of a 3-field shape, and the routing is one ternary. Happy to add a unit test if preferred.
- [ ] After merge: 1006-Chainstack-noise should disappear from `#zbot-across-relayer-*` Slack channels; 1011-Alchemy warns should continue to appear, now structured rather than dumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
