### PR TITLE
docs(constants): lock the Tron USDT bridge invariant for the finalizer

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -536,6 +536,12 @@ export const CUSTOM_BRIDGE: Record<number, Record<string, L1BridgeConstructor<Ba
   [CHAIN_IDs.TEMPO]: {
     [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: TokenSplitterBridge,
   },
+  // Tron USDT L1 -> L2 must stay on OFTBridge. The binanceFinalizer is registered for BSC only
+  // (finalizer/index.ts) and assumes any UNTAGGED Mainnet-network Binance deposit is BSC-bound;
+  // routing the legacy InventoryClient's Mainnet -> Tron USDT refill through BinanceCEXBridge here
+  // would have that finalizer mis-withdraw the deposit on BSC. Tron USDT routing through Binance is
+  // owned by the swap-rebalancer (BinanceStablecoinSwapAdapter), which tags its deposits SWAP and is
+  // skipped by binanceFinalizer.
   [CHAIN_IDs.TRON]: {
     [TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.MAINNET]]: OFTBridge,
   },
@@ -679,6 +685,11 @@ export const CUSTOM_L2_BRIDGE: Record<number, Record<string, L2BridgeConstructor
   [CHAIN_IDs.TEMPO]: {
     [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: L2TokenSplitterBridge,
   },
+  // Tron USDT L2 -> L1 must stay on OFTL2Bridge. The binanceFinalizer is registered for BSC only
+  // (finalizer/index.ts) and treats any UNTAGGED non-ETH Binance deposit as ETH-bound for its single
+  // BSC pair; routing the legacy InventoryClient's Tron USDT excess drain through L2BinanceCEXBridge
+  // here would compete with the same code path. Tron USDT routing through Binance is owned by the
+  // swap-rebalancer (BinanceStablecoinSwapAdapter), which tags SWAP and is skipped by binanceFinalizer.
   [CHAIN_IDs.TRON]: {
     [TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.MAINNET]]: OFTL2Bridge,
   },


### PR DESCRIPTION
## Summary

Documentation-only. Add invariant comments at the two `Constants.ts` sites that map Tron USDT to `OFTBridge` / `OFTL2Bridge`, capturing why they must not be flipped to `BinanceCEXBridge` / `L2BinanceCEXBridge` without also refactoring the [`binanceFinalizer`](https://github.com/across-protocol/relayer/blob/master/src/finalizer/utils/binance.ts).

No runtime behavior change.

## Why

`binanceFinalizer` is registered for the BSC↔Mainnet pair only ([`src/finalizer/index.ts:77-79`](https://github.com/across-protocol/relayer/blob/master/src/finalizer/index.ts#L77-L79)). Its withdraw-network selection in [`src/finalizer/utils/binance.ts:157-168`](https://github.com/across-protocol/relayer/blob/master/src/finalizer/utils/binance.ts#L157-L168) iterates `[BSC, ETH]` and:

- treats any UNTAGGED Mainnet-network deposit as BSC-bound, and
- treats any UNTAGGED non-Mainnet deposit as Mainnet-bound for that single BSC pair.

That assumption holds today because Tron USDT routing through Binance is owned by the **swap-rebalancer** (`BinanceStablecoinSwapAdapter`, added in [commit 1eaddd5](https://github.com/across-protocol/relayer/commit/1eaddd5184c15d27d4f3b19c5f8e448eecdfdc30) / [PR #3386](https://github.com/across-protocol/relayer/pull/3386)), which tags its deposits + withdrawals as `BinanceTransactionType.SWAP`. The finalizer filters those out at [`binance.ts:90-91`](https://github.com/across-protocol/relayer/blob/master/src/finalizer/utils/binance.ts#L90-L91) and [`:145`](https://github.com/across-protocol/relayer/blob/master/src/finalizer/utils/binance.ts#L145).

If the bridge constructors at `Constants.ts:540` (L1 → L2) or `:683` (L2 → L1) are ever swapped to a Binance variant, the legacy `InventoryClient` would start producing UNTAGGED Mainnet-network and TRX-network Binance deposits, and the BSC finalizer would mis-route them. There's no PR-time check that catches that — a 2-line change is enough to mis-route real money.

This PR adds explanatory comments so that constraint travels with the code. The companion configurama PR [UMAprotocol/configurama#XX](https://github.com/UMAprotocol/configurama/pulls) (linked once that one lands) removes the legacy InventoryClient's Tron USDT entry so the two systems don't compete.

Related: [OPS-439](https://linear.app/uma/issue/OPS-439).

## Test plan

- [ ] CI lint + tests pass (no runtime change).
- [ ] Grep confirms the comments land directly above `[CHAIN_IDs.TRON]: { [TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.MAINNET]]: OFTBridge }` and the L2 sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
