### PR TITLE
fix(swapRebalancer): align Binance pre-deposit TTL with OFT bridge

### DIFF
--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -84,6 +84,13 @@ Binance account assumption:
 When adapters create new orders, order detail keys are stored with `REBALANCER_PENDING_ORDER_TTL` (default: 1 hour).
 If this env var is unset, the rebalancer uses the 1-hour default.
 
+Adapters may also pass a `ttlOverride` to `BaseAdapter._redisCreateOrder` to extend the default for routes whose
+expected finality outlives 1 hour. Long-finality OFT pre-deposit bridges (currently USDT0 from HyperEVM, ~12h) use
+`getOftPreDepositOrderTtlOverride` from `oftAdapter.ts` so both `OftAdapter` and adapters that delegate their
+pre-deposit bridge to OFT (e.g. `BinanceStablecoinSwapAdapter`) keep their pending-order TTL aligned with the
+underlying bridge. Note that `_redisUpdateOrderStatus` does not refresh the TTL, so the value set at creation is the
+lifetime of the whole order across all status transitions.
+
 If an order does not finalize before the TTL expires, order details and associated pending-order status tracking are
 eventually pruned from Redis cache state. At that point, operators should rely on adapter lifecycle reconciliation
 (including `sweepIntermediateBalances`) to recover stranded intermediate capital instead of assuming pending-order cache

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -60,7 +60,7 @@ import { AugmentedTransaction, MultiCallerClient } from "../../clients";
 import { RebalancerConfig } from "../RebalancerConfig";
 import { getContractEntry } from "../../common";
 import { CctpAdapter } from "./cctpAdapter";
-import { OftAdapter } from "./oftAdapter";
+import { OftAdapter, getOftPreDepositOrderTtlOverride } from "./oftAdapter";
 import WETH_ABI from "../../common/abi/Weth.json";
 
 export class BinanceStablecoinSwapAdapter extends BaseAdapter {
@@ -840,12 +840,18 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
         binanceDepositNetwork,
         amountToTransfer
       );
+      // Mirror the underlying OFT bridge's pending-order TTL. Without this, long-finality
+      // bridges (e.g. USDT0 from HyperEVM, ~12h to land on Arbitrum) outlive this adapter's
+      // default 1h TTL and get silently pruned by BaseAdapter._redisCleanupPendingOrders
+      // while the bridge is still in flight — losing the swap context entirely.
+      const preDepositTtlOverride = getOftPreDepositOrderTtlOverride(rebalanceRoute);
       await this._redisCreateOrder(
         cloid,
         STATUS.PENDING_BRIDGE_PRE_DEPOSIT,
         rebalanceRoute,
         amountReceivedFromBridge,
-        this.baseSignerAddress
+        this.baseSignerAddress,
+        preDepositTtlOverride
       );
       return amountReceivedFromBridge;
     } else {

--- a/src/rebalancer/adapters/oftAdapter.ts
+++ b/src/rebalancer/adapters/oftAdapter.ts
@@ -33,6 +33,26 @@ import { MultiCallerClient } from "../../clients";
 import { EVM_OFT_MESSENGERS, IOFT_ABI_FULL, OFT_DEFAULT_FEE_CAP, OFT_FEE_CAP_OVERRIDES } from "../../common";
 import { OFT_NO_EID, PRODUCTION_NETWORKS } from "@across-protocol/constants";
 
+// USDT0 transfers from HyperEVM take ~12 hours to finalize, so set a TTL of 24 hours to be safe.
+const HYPEREVM_USDT_OFT_BRIDGE_TTL_SECONDS = 24 * 60 * 60;
+
+/**
+ * Pending-order TTL override for OFT pre-deposit bridge legs whose finality window outlives the
+ * rebalancer's default 1h TTL. Returns `undefined` for routes that fit in the default.
+ *
+ * Exported so adapters that delegate their pre-deposit bridge to `OftAdapter` (e.g.
+ * `BinanceStablecoinSwapAdapter`) can keep their own pending-order TTL aligned with the
+ * underlying bridge's expected duration, instead of silently expiring at 1h while the
+ * bridge is still in flight.
+ */
+export function getOftPreDepositOrderTtlOverride(
+  rebalanceRoute: Pick<RebalanceRoute, "sourceToken" | "sourceChain">
+): number | undefined {
+  return rebalanceRoute.sourceToken === "USDT" && rebalanceRoute.sourceChain === CHAIN_IDs.HYPEREVM
+    ? HYPEREVM_USDT_OFT_BRIDGE_TTL_SECONDS
+    : undefined;
+}
+
 export class OftAdapter extends BaseAdapter {
   REDIS_PREFIX = OFT_PENDING_BRIDGE_REDIS_PREFIX;
 
@@ -93,11 +113,7 @@ export class OftAdapter extends BaseAdapter {
       rebalanceRoute.destinationChain,
       amountToTransfer
     );
-    // USDT0 transfers from HyperEVM take ~12 hours to finalize, so set a TTL of 24 hours to be safe.
-    const ttlOverride =
-      rebalanceRoute.sourceToken === "USDT" && rebalanceRoute.sourceChain === CHAIN_IDs.HYPEREVM
-        ? 24 * 60 * 60
-        : undefined;
+    const ttlOverride = getOftPreDepositOrderTtlOverride(rebalanceRoute);
     await this._redisCreateOrder(
       txnHash,
       STATUS.PENDING_BRIDGE_PRE_DEPOSIT,


### PR DESCRIPTION
## Summary

The `BinanceStablecoinSwapAdapter` created its `PENDING_BRIDGE_PRE_DEPOSIT` order with the default 1h Redis TTL even when the underlying bridge was a long-finality OFT route (USDT0 from HyperEVM, ~12h). The order was then silently pruned by `BaseAdapter._redisCleanupPendingOrders` while the bridge was still in flight, so the entire swap context (deposit-to-Binance, market order, withdraw-to-destination, "Order has finalized" Slack message) was lost.

`OftAdapter` already handles this for its own pending-order entry via a 24h `ttlOverride` in `initializeRebalance`. This PR extracts that decision into `getOftPreDepositOrderTtlOverride` and re-uses it in `BinanceStablecoinSwapAdapter` so both adapters keep the same TTL on the same underlying bridge.

### Repro

For order `0xa7baaec4e0bdc6effd2c833033b057e1` (Slack: zbot-across-rebalancer-circle-hypercore) the swap-rebalancer logs in `bots-across-3839` show:

- `+0m` — order created, status `PENDING_BRIDGE_PRE_DEPOSIT`
- `+56m` — `"Not enough USDT balance on Binance deposit network 42161 to progress the order ... with status PENDING_BRIDGE_TO_BINANCE_NETWORK"` (the OFT bridge from HyperEVM hadn't landed yet)
- `+60m` — `BaseAdapter._redisCleanupPendingOrders: "Deleting expired order details for cloid ... from status set binance-stablecoin-swap:pending-bridge-pre-deposit:..."`

The OFT adapter's own entry kept the bridge tracked (24h TTL), but the Binance adapter's swap tag was lost when its entry was pruned, so the eventual Binance deposit was no longer recognized as belonging to a swap.

## Changes

- `src/rebalancer/adapters/oftAdapter.ts` — extract `getOftPreDepositOrderTtlOverride(rebalanceRoute)` and use it inside `OftAdapter.initializeRebalance` (no behavior change for OFT).
- `src/rebalancer/adapters/binance.ts` — pass `getOftPreDepositOrderTtlOverride(rebalanceRoute)` to `_redisCreateOrder` on the pre-deposit-bridge path. Only USDT routes go through OFT today (`_bridgeToChain` switches on token); USDC goes through CCTP, which has short finality (≤~20m) and stays on the default 1h TTL.
- `src/rebalancer/README.md` — short note on per-adapter TTL overrides and the fact that `_redisUpdateOrderStatus` does not refresh the TTL.

## Notes / follow-ups

- TTL is only set at order creation. `_redisUpdateOrderStatus` (`baseAdapter.ts:153-170`) does not refresh it, so the value set up front is the lifetime of the whole order across all status transitions. The 24h budget cleanly covers the ~12h OFT leg + Binance deposit + market order + Binance withdrawal.
- Independent follow-up worth considering: make `_redisCleanupPendingOrders` emit a `warn` (or Slack alert) when it expires an order with `PENDING_BRIDGE_*` / `PENDING_DEPOSIT` / etc., so future silent drops become visible.
- Operational mitigation if this happens again before this lands: set `REBALANCER_PENDING_ORDER_TTL=86400` on the swap-rebalancer pod (overrides the default for *all* orders).

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test test/PendingBridgeAdapters.ts test/BinanceAdapter.helpers.ts test/BinanceAdapter.conversions.ts`
- [ ] Reviewer to confirm whether a unit test for the new TTL override path should be added in `test/PendingBridgeAdapters.ts` or `test/BinanceAdapter.*.ts` — no existing test exercises `_redisCreateOrder`'s TTL.
- [ ] After deploy, verify the next HyperEVM USDT swap order survives past 1h in Redis and emits the "Order has finalized" Slack message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)