### PR TITLE
improve(hyperliquid): enrich excessive-slippage warn with pair + blocked SwapFlows

### DIFF
--- a/src/hyperliquid/HyperliquidExecutor.ts
+++ b/src/hyperliquid/HyperliquidExecutor.ts
@@ -446,11 +446,26 @@ export class HyperliquidExecutor {
     if (bpsFromParity.gt(maxSlippage)) {
       const usdFormatter = createFormatFunction(2, 4, false, 8); // USD is represented w/ 8 decimals.
       const bpsFormatter = createFormatFunction(2, 4, false, 4);
+      const sizeFormatter = createFormatFunction(2, 4, false, pair.baseTokenDecimals);
+      // Fetch the user-level SwapFlows blocked by this rejection so the log identifies
+      // which deposits are held up. Only done in this warning branch to keep the hot path cheap.
+      const blockedSwapFlows = await this.getOutstandingOrdersOnPair(pair);
       this.logger.warn({
         at: "HyperliquidExecutor#updateOrderAmount",
         message: "Not submitting new limit order due to excessive slippage",
+        pair: pair.name,
+        baseToken: pair.baseToken.toNative(),
+        finalToken: pair.finalToken.toNative(),
+        swapHandler: pair.swapHandler.toNative(),
+        orderSize: sizeFormatter(sizeXe8),
         bestAsk: usdFormatter(priceXe8),
-        maxSlippage: bpsFormatter(this.config.maxSlippageBps),
+        bpsFromParity: bpsFormatter(bpsFromParity),
+        maxSlippage: bpsFormatter(maxSlippage),
+        blockedSwapFlows: blockedSwapFlows.map((flow) => ({
+          quoteNonce: flow.quoteNonce,
+          finalRecipient: flow.finalRecipient,
+          evmAmountIn: flow.evmAmountIn.toString(),
+        })),
       });
       return { actionable: false, mrkdwn: "Slippage too high to submit order" };
     }

--- a/src/hyperliquid/HyperliquidExecutor.ts
+++ b/src/hyperliquid/HyperliquidExecutor.ts
@@ -449,7 +449,20 @@ export class HyperliquidExecutor {
       const sizeFormatter = createFormatFunction(2, 4, false, pair.baseTokenDecimals);
       // Fetch the user-level SwapFlows blocked by this rejection so the log identifies
       // which deposits are held up. Only done in this warning branch to keep the hot path cheap.
-      const blockedSwapFlows = await this.getOutstandingOrdersOnPair(pair);
+      // Query against the latest block so events observed after startup are not missed, and
+      // swallow any RPC/pagination errors so a transient enrichment failure cannot abort the task.
+      let blockedSwapFlows: SwapFlowInitialized[] = [];
+      try {
+        const latestBlock = await this.clients.dstProvider.getBlockNumber();
+        blockedSwapFlows = await this.getOutstandingOrdersOnPair(pair, latestBlock);
+      } catch (error) {
+        this.logger.debug({
+          at: "HyperliquidExecutor#updateOrderAmount",
+          message: "Failed to enrich excessive-slippage warning with blocked SwapFlows",
+          pair: pair.name,
+          error,
+        });
+      }
       this.logger.warn({
         at: "HyperliquidExecutor#updateOrderAmount",
         message: "Not submitting new limit order due to excessive slippage",


### PR DESCRIPTION
## Summary

Enriches the `Not submitting new limit order due to excessive slippage` warning emitted by `HyperliquidExecutor#updateOrderAmount` so a single log line is enough to identify *which* pair, *which* SwapHandler, and *which* user-level SwapFlows are being held up by the rejection. Today the warning only carries `bestAsk` and `maxSlippage` — for example, see this prod fire: https://risklabs.slack.com/archives/C0A15N2Q755/p1780111530258689

## Before

```
[warn] zion-across-hyperliquid-executor (HyperliquidExecutor#updateOrderAmount)
  Not submitting new limit order due to excessive slippage
  - bestAsk:      0.9990
  - maxSlippage:  5.00
```

To answer "whose deposits are stuck?" we had to grep config for the pair, look up the SwapHandler on-chain, and re-query SwapFlowInitialized events ourselves.

## After

The warn now includes:

- `pair`, `baseToken`, `finalToken`, `swapHandler` — affected pair + holding contract, no config grep needed.
- `orderSize` — would-be order size in baseToken human units.
- `bpsFromParity` — actual slippage observed, so it's clear how far over the threshold we are.
- `maxSlippage` — now correctly reflects the route-specific override (`maxSlippageByRoute[pair.name] ?? maxSlippageBps`); previously always logged the global default even when an override was active.
- `blockedSwapFlows` — array of `{ quoteNonce, finalRecipient, evmAmountIn }` for each outstanding (un-finalized) `SwapFlowInitialized` on the pair. This is the "which user is being held up" signal the warning is silent about today.

## Cost

`getOutstandingOrdersOnPair(pair)` does two `paginatedEventQuery` calls against HyperEVM RPC. It runs **only inside the warn branch** (slippage actually exceeded), not on every block in steady state. Net cost in normal operation: zero.

## Test plan

- [x] `yarn typecheck` — clean locally.
- [x] `yarn prettier --check src/hyperliquid/HyperliquidExecutor.ts` — clean.
- [ ] Operator deploy — verify the warn line in Slack now carries `pair`, `swapHandler`, `blockedSwapFlows`, etc. Should fire on the same conditions as before (no behavioral change).

## Related

Came out of the broader investigation in https://app.slack.com/client/T90K0AL22/C0AQEHGS56Z/thread/C0AQEHGS56Z-1780148503.175839 (stuck OFT/HyperCore deposit). Independent of #3438 (lookback default bump) — open as a separate PR so each can land on its own merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
