### PR TITLE
fix(RedisClient): set explicit keepAlive and pingInterval

### DIFF
--- a/src/utils/Redis.ts
+++ b/src/utils/Redis.ts
@@ -39,9 +39,10 @@ export async function connectRedisClient(logger?: winston.Logger, url = REDIS_UR
       url,
       socket: {
         reconnectStrategy,
-        // Enable TCP keepalive (initial delay 5s). node-redis v5's default is
-        // also 5_000, but we pin it explicitly to guard against config drift.
-        keepAlive: 5_000,
+        // Enable TCP keepalive with an explicit 5s initial delay. node-redis v5
+        // defaults to the same value, but we pin it to guard against drift.
+        keepAlive: true,
+        keepAliveInitialDelay: 5_000,
       },
       // Send a Redis-level PING every 30s when the connection is idle. This
       // surfaces a half-open socket faster than TCP keepalive alone and keeps

--- a/src/utils/Redis.ts
+++ b/src/utils/Redis.ts
@@ -35,7 +35,20 @@ export async function connectRedisClient(logger?: winston.Logger, url = REDIS_UR
 
   let redisClient: RedisClient | undefined = undefined;
   try {
-    redisClient = createClient({ url, socket: { reconnectStrategy } });
+    redisClient = createClient({
+      url,
+      socket: {
+        reconnectStrategy,
+        // Enable TCP keepalive (initial delay 5s). node-redis v5's default is
+        // also 5_000, but we pin it explicitly to guard against config drift.
+        keepAlive: 5_000,
+      },
+      // Send a Redis-level PING every 30s when the connection is idle. This
+      // surfaces a half-open socket faster than TCP keepalive alone and keeps
+      // the connection warm against any intermediary (VPC connector / LB)
+      // that may evict idle TCP flows.
+      pingInterval: 30_000,
+    });
     redisClient.on("error", (err) => logger?.warn({ at: "RedisClient", message: "Redis error", cause: String(err) }));
     await redisClient.connect();
     return redisClient;


### PR DESCRIPTION
## Summary

`createClient` in `src/utils/Redis.ts` is invoked today with only `reconnectStrategy`, so the node-redis v5 defaults silently govern socket-level health:

- **TCP keepalive**: defaults to `5_000` ms initial delay (fine, but implicit and easy to lose to future refactors).
- **`pingInterval`**: unset by default, so the connection stays silent when idle and a half-open socket is only discovered on the next real command.

This PR:

- Pins `socket.keepAlive: 5_000` to lock in the default explicitly.
- Adds `pingInterval: 30_000` so the client sends a Redis-level PING every 30 s while idle.

The Redis PING surfaces a half-open socket within ~30 s instead of on the next command, and keeps the connection warm against any intermediary (GCP VPC connector, LB) that might evict idle TCP flows.

No behavior change for callers — this only tunes the underlying socket and protocol-level liveness.

## Context

This is the second of two relayer-side cleanups for the synchronized ECONNRESET bursts we've been seeing across every Redis-using bot (`relayer-primary`/`secondary`/`usdh`/`sepolia`, `gasless-relayer-sepolia`, `inventory-manager-primary`, `arweave`, `persistent-address-handler`). The first is #3441 (log debounce). The structural root cause — `BASIC`-tier Memorystore single-node reboots taking out every client at once — is being addressed separately on the infra side.

## Test plan

- [ ] Local smoke: run a bot pointed at a local Redis with `--client list` open in another shell; verify PINGs appear ~every 30 s when idle.
- [ ] Confirm no regression on initial connect latency or memory usage.

## Docs

No `AGENTS.md` / `README.md` updates — this change tunes node-redis socket/protocol knobs without touching any module map or public interface.