### PR TITLE
fix: add missing sponsoredCCTPDstPeriphery addresses

### DIFF
--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -258,6 +258,10 @@ export const CONTRACT_ADDRESSES: {
       address: "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
       abi: CCTP_V2_TOKEN_MESSENGER_ABI,
     },
+    sponsoredCCTPDstPeriphery: {
+      address: "0x647aFB7d935Ff0aaE4F0DdEfE0499d13AdE69178",
+      abi: SPONSORED_CCTP_DST_PERIPHERY_ABI,
+    },
   },
   [CHAIN_IDs.OPTIMISM]: {
     daiOptimismBridge: {
@@ -291,6 +295,10 @@ export const CONTRACT_ADDRESSES: {
       address: "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
       abi: CCTP_V2_TOKEN_MESSENGER_ABI,
     },
+    sponsoredCCTPDstPeriphery: {
+      address: "0x7caAe751f8eAfEC5646A730d86c6Ae2d47a31Ca6",
+      abi: SPONSORED_CCTP_DST_PERIPHERY_ABI,
+    },
     spokePoolPeriphery: {
       abi: SPOKE_POOL_PERIPHERY_ABI,
     },
@@ -318,6 +326,10 @@ export const CONTRACT_ADDRESSES: {
     cctpV2TokenMessenger: {
       address: "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
       abi: CCTP_V2_TOKEN_MESSENGER_ABI,
+    },
+    sponsoredCCTPDstPeriphery: {
+      address: "0x02a00425f619C5e2B25e3d138Fe80a71201B007E",
+      abi: SPONSORED_CCTP_DST_PERIPHERY_ABI,
     },
     nativeToken: {
       address: "0x0000000000000000000000000000000000001010",
@@ -429,6 +441,10 @@ export const CONTRACT_ADDRESSES: {
       address: "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
       abi: CCTP_V2_TOKEN_MESSENGER_ABI,
     },
+    sponsoredCCTPDstPeriphery: {
+      address: "0x219044ECb0Eb0b3f0D8A614A9633A89f0b5f81f8",
+      abi: SPONSORED_CCTP_DST_PERIPHERY_ABI,
+    },
     ovmStandardBridge: {
       address: "0x4200000000000000000000000000000000000010",
       abi: OVM_L2_STANDARD_BRIDGE_ABI,
@@ -520,6 +536,10 @@ export const CONTRACT_ADDRESSES: {
       address: "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
       abi: CCTP_V2_TOKEN_MESSENGER_ABI,
     },
+    sponsoredCCTPDstPeriphery: {
+      address: "0x087B70E43BF01359678E7b927bbAC76D175F3293",
+      abi: SPONSORED_CCTP_DST_PERIPHERY_ABI,
+    },
   },
   [CHAIN_IDs.BLAST]: {
     ovmStandardBridge: {
@@ -564,6 +584,10 @@ export const CONTRACT_ADDRESSES: {
     cctpV2TokenMessenger: {
       address: "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
       abi: CCTP_V2_TOKEN_MESSENGER_ABI,
+    },
+    sponsoredCCTPDstPeriphery: {
+      address: "0xc384694df2Be9c381d596DEd22f2A69D3aBA07d3",
+      abi: SPONSORED_CCTP_DST_PERIPHERY_ABI,
     },
     arbSys: {
       address: "0x0000000000000000000000000000000000000064",
@@ -615,6 +639,10 @@ export const CONTRACT_ADDRESSES: {
     cctpV2TokenMessenger: {
       address: "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
       abi: CCTP_V2_TOKEN_MESSENGER_ABI,
+    },
+    sponsoredCCTPDstPeriphery: {
+      address: "0x6BD167bff542Ab595F0296333d70202aE09CC334",
+      abi: SPONSORED_CCTP_DST_PERIPHERY_ABI,
     },
     l2MessageService: {
       address: "0x508Ca82Df566dCD1B0DE8296e70a96332cD644ec",


### PR DESCRIPTION
## Problem

The CCTP finalizer's `getDestination()` (`src/cctp-finalizer/utils/evmUtils.ts:107`) looks up `sponsoredCCTPDstPeriphery` by **destination chain** for sponsored/gasless CCTP burns. Several CCTP_USDC destination chains had no entry in `CONTRACT_ADDRESSES`, so finalization failed with:

```
Missing CONTRACT_ADDRESSES abi: 42161/sponsoredCCTPDstPeriphery
```

(observed on Arbitrum; the same gap existed for other chains.)

## Change

Add the `SponsoredCCTPDstPeriphery_CCTP_USDC` (destination side) entry for the missing chains:

| Chain | Address |
|---|---|
| Monad | `0x647aFB7d935Ff0aaE4F0DdEfE0499d13AdE69178` |
| Optimism | `0x7caAe751f8eAfEC5646A730d86c6Ae2d47a31Ca6` |
| Polygon | `0x02a00425f619C5e2B25e3d138Fe80a71201B007E` |
| World Chain | `0x219044ECb0Eb0b3f0D8A614A9633A89f0b5f81f8` |
| Ink | `0x087B70E43BF01359678E7b927bbAC76D175F3293` |
| Arbitrum | `0xc384694df2Be9c381d596DEd22f2A69D3aBA07d3` |
| Linea | `0x6BD167bff542Ab595F0296333d70202aE09CC334` |

## Not included (flagging for follow-up)

Existing entries for **Mainnet**, **Base**, and **HyperEVM** differ from the current deployment table and may also need updating. Left out of this PR to keep it scoped to the missing chains.

## Test

`yarn build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)