### PR TITLE
fix(dataworker): surface SolanaError context in SVM refund leaf failures

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -53,6 +53,7 @@ import {
   toKitAddress,
   createDefaultTransaction,
   getNativeTokenAddressForChain,
+  stringifyThrownValue,
 } from "../utils";
 import { getRedisCache } from "../cache/Redis";
 import {
@@ -113,6 +114,7 @@ import {
   some,
   fetchEncodedAccount,
   compressTransactionMessageUsingAddressLookupTables,
+  isSolanaError,
   type Address as KitAddress,
   type KeyPairSigner,
 } from "@solana/kit";
@@ -3284,10 +3286,21 @@ export class Dataworker {
         });
       }
     } catch (err) {
+      // Mirror SvmFillerClient: when the underlying failure is a SolanaError
+      // (e.g. simulation rejected by the spoke), surface the program-level
+      // `__code` in the message so the page that fires upstream identifies
+      // the actual cause instead of a generic "simulation failed". The
+      // SolanaError's `.context` (with `value.err` / program logs) is now
+      // captured by `stringifyThrownValue` and flows into the umbrella
+      // `index.ts` error log too.
+      const solanaErrorCode = isSolanaError(err) ? err.context.__code : undefined;
       this.logger.error({
         at: "Dataworker#executeRelayerRefundLeafSvm",
-        message: "Something failed during the relayer refund leaf execution stage",
-        error: err,
+        message:
+          solanaErrorCode !== undefined
+            ? `Something failed during the relayer refund leaf execution stage (Solana error code: ${solanaErrorCode})`
+            : "Something failed during the relayer refund leaf execution stage",
+        error: stringifyThrownValue(err),
       });
       try {
         await deactivateLut();
@@ -3295,7 +3308,7 @@ export class Dataworker {
         this.logger.warn({
           at: "Dataworker#executeRelayerRefundLeafSvm",
           message: "deactivateLut cleanup failed after refund execution error",
-          error: err,
+          error: stringifyThrownValue(err),
         });
       }
       throw err;

--- a/src/utils/LogUtils.ts
+++ b/src/utils/LogUtils.ts
@@ -2,12 +2,43 @@ export type DefaultLogLevels = "debug" | "info" | "warn" | "error";
 
 export function stringifyThrownValue(value: unknown): string {
   if (value instanceof Error) {
-    const errToString = value.toString();
-    return value.stack
-      ? value.stack
-      : value.message || errToString !== "[object Object]"
-        ? errToString
-        : `could not extract error from 'Error' instance ${errToString}`;
+    const stackOrToString = value.stack || value.toString();
+
+    // `.stack` (and `.toString()`) only carry `name`/`message`/the stack.
+    // Capture extra structured fields attached to the error instance — most
+    // notably the `context` on `@solana/errors` `SolanaError` (which carries
+    // `__code` plus the RPC response's `value.err` and program `logs`) and
+    // any `cause` chain. Without these, errors that propagate up through
+    // catch sites lose the program-level detail that explains *why* a tx
+    // simulation failed.
+    const extras: Record<string, unknown> = {};
+    const context = (value as { context?: unknown }).context;
+    if (context !== undefined && context !== null) {
+      extras.context = context;
+    }
+    const cause = (value as { cause?: unknown }).cause;
+    if (cause !== undefined && cause !== null) {
+      extras.cause = cause instanceof Error ? stringifyThrownValue(cause) : cause;
+    }
+
+    if (Object.keys(extras).length === 0) {
+      return value.stack
+        ? value.stack
+        : value.message || stackOrToString !== "[object Object]"
+          ? stackOrToString
+          : `could not extract error from 'Error' instance ${stackOrToString}`;
+    }
+
+    let extrasSerialized: string;
+    try {
+      extrasSerialized = JSON.stringify(extras);
+    } catch {
+      // Best-effort: if the extras can't be serialized (cyclic / exotic
+      // types beyond the BigInt/Set patches in extensions.ts) fall back to
+      // the stack alone so we never lose the primary diagnostic.
+      return stackOrToString;
+    }
+    return `${stackOrToString}\n${extrasSerialized}`;
   } else if (value instanceof Object) {
     const objStringified = JSON.stringify(value);
     return objStringified !== "{}"

--- a/test/LogUtils.ts
+++ b/test/LogUtils.ts
@@ -1,0 +1,66 @@
+import { expect } from "./utils";
+import { stringifyThrownValue } from "../src/utils/LogUtils";
+
+describe("stringifyThrownValue", function () {
+  it("returns the stack for a plain Error (backwards compatible)", function () {
+    const err = new Error("plain failure");
+    const out = stringifyThrownValue(err);
+    expect(out).to.include("plain failure");
+    expect(out).to.include(err.stack ?? "");
+  });
+
+  it("captures `context` on Error instances (SolanaError shape)", function () {
+    // Shape mirrors `@solana/errors` SolanaError, which the @solana/kit RPC
+    // layer throws with `__code` plus the RPC response's `value.err` and
+    // program `logs` attached on `context`.
+    class FakeSolanaError extends Error {
+      readonly context: { __code: number; value?: { err?: unknown; logs?: string[] } };
+      constructor(message: string, context: FakeSolanaError["context"]) {
+        super(message);
+        this.context = context;
+      }
+    }
+    const err = new FakeSolanaError("Transaction simulation failed", {
+      __code: 4615012,
+      value: {
+        err: { InstructionError: [0, { Custom: 6011 }] },
+        logs: ["Program log: AnchorError caused by account: instruction_params"],
+      },
+    });
+
+    const out = stringifyThrownValue(err);
+    expect(out).to.include("Transaction simulation failed");
+    expect(out).to.include("__code");
+    expect(out).to.include("4615012");
+    expect(out).to.include("InstructionError");
+    expect(out).to.include("instruction_params");
+  });
+
+  it("captures `cause` on Error instances and recurses for nested Errors", function () {
+    const innerSolanaShape = Object.assign(new Error("inner simulation failed"), {
+      context: { __code: 4615012 },
+    });
+    const wrapper = new Error("wrapper failed");
+    (wrapper as Error & { cause: unknown }).cause = innerSolanaShape;
+
+    const out = stringifyThrownValue(wrapper);
+    expect(out).to.include("wrapper failed");
+    expect(out).to.include("inner simulation failed");
+    expect(out).to.include("4615012");
+  });
+
+  it("ignores absent context/cause and returns the stack", function () {
+    const err = new Error("nothing extra");
+    const out = stringifyThrownValue(err);
+    expect(out).to.equal(err.stack ?? err.toString());
+  });
+
+  it("handles non-Error objects via JSON.stringify", function () {
+    expect(stringifyThrownValue({ a: 1, b: "two" })).to.equal('{"a":1,"b":"two"}');
+  });
+
+  it("handles primitive thrown values", function () {
+    expect(stringifyThrownValue("oops")).to.equal("ThrownValue: oops");
+    expect(stringifyThrownValue(42)).to.equal("ThrownValue: 42");
+  });
+});


### PR DESCRIPTION
## Summary

The umbrella `dataworker ⭢ There was an execution error!` PD page fired twice last night (PD-325402 + PD-325403) and has been firing 1–2x/day for the past month on `zion-across-l2-executor-solana`. Every page carries only the generic `SolanaError: Transaction simulation failed` stack with no `__code`, no program logs, no `value.err` — so each page is uninvestigable. Tonight's pages both turned out to be the *same* refund leaf (bundle 10703, leaf 30) which then succeeded 4 min later in the next cycle, but you can't tell that from the page alone.

Root cause for the dropped context: `stringifyThrownValue` only returns `error.stack`, and the inner `_executeRelayerRefundLeafSvm` catch passes the raw err to winston which serializes Error instances via `JSON.stringify` (dropping the SolanaError `context` attached on the instance). So even when the SVM spoke returns `InstructionError` with a full program-log array, none of it reaches Datadog or PD.

## Changes

- **`src/utils/LogUtils.ts`** — `stringifyThrownValue` now appends a JSON serialization of `error.context` and `error.cause` when present. Plain `Error`s still return the stack only (backwards compatible). Any `SolanaError` caller automatically gains `__code` + RPC `value.err` + program `logs` in the umbrella `index.ts` page payload.
- **`src/dataworker/Dataworker.ts`** — `_executeRelayerRefundLeafSvm` catch now mirrors `SvmFillerClient`: detects `isSolanaError`, includes the Solana `__code` in the log message, and routes both the inner error log and the LUT-cleanup warn through `stringifyThrownValue` so the structured field also carries context.
- **`test/LogUtils.ts`** — covers SolanaError-shape context extraction, nested `cause` chains, backwards-compat for plain Errors, and non-Error thrown values.

## Pairs with

A forthcoming SDK PR will add `minContextSlot`-pinned simulation in `QuorumFallbackRpcFactory` to eliminate the underlying simulation race (the data-write tx confirms ~73ms before the simulate call fans out across RPCs; nodes that haven't yet ingested the write reject simulation against stale state). This PR is the diagnostic that makes the *next* page actionable regardless of which fix lands first.

## Test plan

- [x] `yarn typecheck:fast`
- [x] `yarn lint`
- [x] `RELAYER_TEST=true yarn hardhat test test/LogUtils.ts` (6 passing)
- [ ] Watch the next page on `zion-across-l2-executor-solana` — confirm the umbrella `index.ts` error log now carries `context.__code` + `context.value.err` + program logs.