### PR TITLE
fix(dataworker): pin minContextSlot on SVM refund-leaf dependency sends

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -137,6 +137,11 @@ const ERROR_DISPUTE_REASONS = new Set(["insufficient-dataworker-lookback", "out-
 // instruction is 900 bytes.
 const INSTRUCTION_PARAMS_MAX_WRITE_SIZE = 900;
 
+// Polling parameters for `sendAndConfirmSolanaTransactionWithSlot` when sending the chain of dependency-write txs that
+// precede an SVM relayer-refund-leaf execution. 25 cycles × 600 ms ≈ 15s, ~1.5 slots per cycle on Solana mainnet.
+const SVM_REFUND_LEAF_SEND_POLL_CYCLES = 25;
+const SVM_REFUND_LEAF_SEND_POLL_DELAY_MS = 600;
+
 const { getMessageHash, getRelayEventKey } = sdkUtils;
 
 // Create a type for storing a collection of roots
@@ -2957,9 +2962,13 @@ export class Dataworker {
     // SDK's `RetrySolanaRpcFactory` transparently retries.
     let minContextSlot: bigint | undefined;
     const sendPinned = async (tx: Parameters<typeof sendAndConfirmSolanaTransactionWithSlot>[0]): Promise<string> => {
-      const { signature, confirmedSlot } = await sendAndConfirmSolanaTransactionWithSlot(tx, provider, 25, 600, {
-        minContextSlot,
-      });
+      const { signature, confirmedSlot } = await sendAndConfirmSolanaTransactionWithSlot(
+        tx,
+        provider,
+        SVM_REFUND_LEAF_SEND_POLL_CYCLES,
+        SVM_REFUND_LEAF_SEND_POLL_DELAY_MS,
+        { minContextSlot }
+      );
       if (isDefined(confirmedSlot) && (minContextSlot === undefined || confirmedSlot > minContextSlot)) {
         minContextSlot = confirmedSlot;
       }

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -54,6 +54,7 @@ import {
   createDefaultTransaction,
   getNativeTokenAddressForChain,
   stringifyThrownValue,
+  sendAndConfirmSolanaTransactionWithSlot,
 } from "../utils";
 import { getRedisCache } from "../cache/Redis";
 import {
@@ -2946,6 +2947,24 @@ export class Dataworker {
       instructionParamsAccount.exists && instructionParamsAccount.data.length < relayerRefundLeafBytes.length;
     const needsInit = !instructionParamsAccount.exists || needsClose;
     let txSignature;
+    // Track the most recent confirmed slot from a dependency-write tx so we
+    // can pin subsequent `sendTransaction` preflights with `minContextSlot`.
+    // Without this, a receiving RPC that is one slot behind the just-confirmed
+    // write runs preflight against stale state (instruction-params PDA
+    // appears empty / wrong size) and rejects with `SolanaError: Transaction
+    // simulation failed` even though the on-chain state is correct. With it,
+    // a behind RPC returns `MinContextSlotNotReached` immediately, which the
+    // SDK's `RetrySolanaRpcFactory` transparently retries.
+    let minContextSlot: bigint | undefined;
+    const sendPinned = async (tx: Parameters<typeof sendAndConfirmSolanaTransactionWithSlot>[0]): Promise<string> => {
+      const { signature, confirmedSlot } = await sendAndConfirmSolanaTransactionWithSlot(tx, provider, 25, 600, {
+        minContextSlot,
+      });
+      if (isDefined(confirmedSlot) && (minContextSlot === undefined || confirmedSlot > minContextSlot)) {
+        minContextSlot = confirmedSlot;
+      }
+      return signature;
+    };
     if (needsClose) {
       this.logger.debug({
         at: "Dataworker#executeRelayerRefundLeafSvm",
@@ -2963,7 +2982,7 @@ export class Dataworker {
         (tx) => setTransactionMessageFeePayer(kitKeypair.address, tx),
         (tx) => appendTransactionMessageInstructions([closeInstructionParamsIx], tx)
       );
-      const closeSig = await sendAndConfirmSolanaTransaction(closeInstructionParamsTx, provider);
+      const closeSig = await sendPinned(closeInstructionParamsTx);
       this.logger.debug({
         at: "Dataworker#executeRelayerRefundLeafSvm",
         message: "Closed instruction params PDA",
@@ -2981,7 +3000,7 @@ export class Dataworker {
         (tx) => setTransactionMessageFeePayer(kitKeypair.address, tx),
         (tx) => appendTransactionMessageInstructions([initializeInstructionParamsIx], tx)
       );
-      txSignature = await sendAndConfirmSolanaTransaction(initInstructionParamsTx, provider);
+      txSignature = await sendPinned(initInstructionParamsTx);
       this.logger.debug({
         at: "Dataworker#executeRelayerRefundLeafSvm",
         message: "Initialized instruction params account",
@@ -3015,7 +3034,7 @@ export class Dataworker {
         (tx) => setTransactionMessageFeePayer(kitKeypair.address, tx),
         (tx) => appendTransactionMessageInstructions([writeInstructionParamsIx], tx)
       );
-      txSignature = await sendAndConfirmSolanaTransaction(writeInstructionParamsTx, provider);
+      txSignature = await sendPinned(writeInstructionParamsTx);
       this.logger.debug({
         at: "Dataworker#executeRelayerRefundLeafSvm",
         message: "Wrote relayer refund leaf data to instruction params account",
@@ -3042,7 +3061,7 @@ export class Dataworker {
       (tx) => setTransactionMessageFeePayer(kitKeypair.address, tx),
       (tx) => appendTransactionMessageInstructions([lookupTableIx], tx)
     );
-    txSignature = await sendAndConfirmSolanaTransaction(createLookupTableTx, provider);
+    txSignature = await sendPinned(createLookupTableTx);
     await waitForNewSolanaBlock(provider, 1);
 
     this.logger.debug({
@@ -3064,7 +3083,7 @@ export class Dataworker {
         (tx) => setTransactionMessageFeePayer(kitKeypair.address, tx),
         (tx) => appendTransactionMessageInstructions([deactivateLutIx], tx)
       );
-      const deactivateLutSignature = await sendAndConfirmSolanaTransaction(deactivateLutTx, provider);
+      const deactivateLutSignature = await sendPinned(deactivateLutTx);
       this.logger.debug({
         at: "Dataworker#executeRelayerRefundLeafSvm",
         message: "Deactivated address lookup table",
@@ -3119,7 +3138,7 @@ export class Dataworker {
             (tx) => setTransactionMessageFeePayer(kitKeypair.address, tx),
             (tx) => appendTransactionMessageInstructions([extendLookupTableIx], tx)
           );
-          await sendAndConfirmSolanaTransaction(extendLutTx, provider);
+          await sendPinned(extendLutTx);
           // @dev Every time we extend an ALT, we need to wait for a new solana block so that the table has
           // sufficient time to "activate." https://solana.com/developers/courses/program-optimization/lookup-tables#6-modify-main-to-use-lookup-tables
           await waitForNewSolanaBlock(provider, 1);
@@ -3131,7 +3150,7 @@ export class Dataworker {
           (tx) => appendTransactionMessageInstructions([executeRelayerRefundLeafIx], tx),
           (tx) => compressTransactionMessageUsingAddressLookupTables(tx, addressLookupTableDefinitions.lookupTableMap)
         );
-        refundLeafSignature = await sendAndConfirmSolanaTransaction(executeRelayerRefundLeafTx, provider);
+        refundLeafSignature = await sendPinned(executeRelayerRefundLeafTx);
       } else {
         // This is case 2. Some refundAddresses do not have ATAs for the l2TokenAddress.
         this.logger.warn({
@@ -3186,7 +3205,7 @@ export class Dataworker {
               (tx) => setTransactionMessageFeePayer(kitKeypair.address, tx),
               (tx) => appendTransactionMessageInstructions([initializeClaimAccountIx], tx)
             );
-            txSignature = await sendAndConfirmSolanaTransaction(initializeClaimAccountTx, provider);
+            txSignature = await sendPinned(initializeClaimAccountTx);
             this.logger.debug({
               at: "Dataworker#executeRelayerRefundLeafSvm",
               message: "Initialized claim account",
@@ -3213,7 +3232,7 @@ export class Dataworker {
             (tx) => setTransactionMessageFeePayer(kitKeypair.address, tx),
             (tx) => appendTransactionMessageInstructions([extendLookupTableIx], tx)
           );
-          await sendAndConfirmSolanaTransaction(extendLutTx, provider);
+          await sendPinned(extendLutTx);
           // @dev Every time we extend an ALT, we need to wait for a new solana block so that the table has
           // sufficient time to "activate." https://solana.com/developers/courses/program-optimization/lookup-tables#6-modify-main-to-use-lookup-tables
           await waitForNewSolanaBlock(provider, 1);
@@ -3225,7 +3244,7 @@ export class Dataworker {
           (tx) => appendTransactionMessageInstructions([executeRelayerRefundLeafDeferredIx], tx),
           (tx) => compressTransactionMessageUsingAddressLookupTables(tx, addressLookupTableDefinitions.lookupTableMap)
         );
-        refundLeafSignature = await sendAndConfirmSolanaTransaction(executeRelayerRefundLeafDeferredTx, provider);
+        refundLeafSignature = await sendPinned(executeRelayerRefundLeafDeferredTx);
         const claimRelayerRefund = async (
           refundAddress: KitAddress<string>,
           claimAccount: KitAddress<string>,
@@ -3254,7 +3273,7 @@ export class Dataworker {
           const claimRelayerRefundTx = pipe(await createDefaultTransaction(provider, kitKeypair), (tx) =>
             appendTransactionMessageInstructions([claimRelayerRefundIx], tx)
           );
-          return await sendAndConfirmSolanaTransaction(claimRelayerRefundTx, provider);
+          return await sendPinned(claimRelayerRefundTx);
         };
         // Zip the claimAccounts with the recipient ATA and then claim all refunds corresponding to refund accounts with ATAs.
         const recipientTokenAccounts = claimAccounts.map((claimAccount, idx) => {

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -50,7 +50,19 @@ export async function withFreshBlockhash<T extends SolanaUnsignedTransaction>(pr
   return setTransactionMessageLifetimeUsingBlockhash(blockhash, tx);
 }
 
-export async function signAndSendTransaction(provider: SVMProvider, _unsignedTxn: SolanaUnsignedTransaction) {
+// Options for the SVM submit path. `minContextSlot` pins the receiving RPC's
+// preflight simulation to a slot >= the value supplied, so that a node which
+// hasn't yet ingested a prior dependency tx returns the explicit
+// `MinContextSlotNotReached` error (which the SDK's retry layer recovers
+// transparently) instead of running preflight against stale state. See
+// https://solana.com/docs/rpc/http/sendtransaction.
+export type SolanaSendOptions = { minContextSlot?: bigint };
+
+export async function signAndSendTransaction(
+  provider: SVMProvider,
+  _unsignedTxn: SolanaUnsignedTransaction,
+  opts: SolanaSendOptions = {}
+) {
   const priorityFeeOverride = process.env["SVM_PRIORITY_FEE_OVERRIDE"];
   const unsignedTxn = isDefined(priorityFeeOverride)
     ? updateOrAppendSetComputeUnitPriceInstruction(BigInt(priorityFeeOverride) as MicroLamports, _unsignedTxn)
@@ -59,35 +71,75 @@ export async function signAndSendTransaction(provider: SVMProvider, _unsignedTxn
   const signedTransaction = await signTransactionMessageWithSigners(txWithFreshBlockhash);
   const serializedTx = getBase64EncodedWireTransaction(signedTransaction);
   return provider
-    .sendTransaction(serializedTx, { preflightCommitment: "confirmed", skipPreflight: false, encoding: "base64" })
+    .sendTransaction(serializedTx, {
+      preflightCommitment: "confirmed",
+      skipPreflight: false,
+      encoding: "base64",
+      ...(isDefined(opts.minContextSlot) ? { minContextSlot: opts.minContextSlot } : {}),
+    })
     .send();
 }
 
-export async function sendAndConfirmSolanaTransaction(
+// Internal helper: send + poll. Returns the signature and (when reached) the
+// slot at which confirmation was observed so callers can chain
+// `minContextSlot` into subsequent dependent sends.
+async function _sendAndPoll(
   unsignedTransaction: SolanaUnsignedTransaction,
   provider: SVMProvider,
-  cycles = 25,
-  pollingDelay = 600 // 1.5 slots on Solana.
-): Promise<string> {
+  cycles: number,
+  pollingDelay: number,
+  opts: SolanaSendOptions
+): Promise<{ signature: string; confirmedSlot: bigint | undefined }> {
   const delay = (ms: number) => {
     return new Promise((resolve) => setTimeout(resolve, ms));
   };
-  const txSignature = await signAndSendTransaction(provider, unsignedTransaction);
+  const txSignature = await signAndSendTransaction(provider, unsignedTransaction, opts);
   let confirmed = false;
+  let confirmedSlot: bigint | undefined;
   let _cycles = 0;
   while (!confirmed && _cycles < cycles) {
     const txStatus = await provider.getSignatureStatuses([txSignature]).send();
     // Index 0 since we are only sending a single transaction in this method.
-    confirmed =
-      txStatus?.value?.[0]?.confirmationStatus === "confirmed" ||
-      txStatus?.value?.[0]?.confirmationStatus === "finalized";
+    const entry = txStatus?.value?.[0];
+    confirmed = entry?.confirmationStatus === "confirmed" || entry?.confirmationStatus === "finalized";
+    if (confirmed && isDefined(entry?.slot)) {
+      confirmedSlot = entry.slot;
+    }
     // If the transaction wasn't confirmed, wait `pollingInterval` and retry.
     if (!confirmed) {
       await delay(pollingDelay);
       _cycles++;
     }
   }
-  return txSignature;
+  return { signature: txSignature, confirmedSlot };
+}
+
+export async function sendAndConfirmSolanaTransaction(
+  unsignedTransaction: SolanaUnsignedTransaction,
+  provider: SVMProvider,
+  cycles = 25,
+  pollingDelay = 600, // 1.5 slots on Solana.
+  opts: SolanaSendOptions = {}
+): Promise<string> {
+  const { signature } = await _sendAndPoll(unsignedTransaction, provider, cycles, pollingDelay, opts);
+  return signature;
+}
+
+// Variant of `sendAndConfirmSolanaTransaction` that additionally returns the
+// slot at which the tx was confirmed (extracted from `getSignatureStatuses`).
+// Use this when the next send depends on this tx's on-chain effects, then
+// pass `confirmedSlot` as `opts.minContextSlot` to the dependent send so an
+// RPC that hasn't yet ingested this tx fails with `MinContextSlotNotReached`
+// (which the SDK's `RetrySolanaRpcFactory` retries) instead of running
+// preflight against stale state.
+export async function sendAndConfirmSolanaTransactionWithSlot(
+  unsignedTransaction: SolanaUnsignedTransaction,
+  provider: SVMProvider,
+  cycles = 25,
+  pollingDelay = 600,
+  opts: SolanaSendOptions = {}
+): Promise<{ signature: string; confirmedSlot: bigint | undefined }> {
+  return _sendAndPoll(unsignedTransaction, provider, cycles, pollingDelay, opts);
 }
 
 export async function simulateSolanaTransaction(unsignedTransaction: SolanaUnsignedTransaction, provider: SVMProvider) {

--- a/test/TransactionUtils.svm.ts
+++ b/test/TransactionUtils.svm.ts
@@ -1,0 +1,109 @@
+import { expect } from "./utils";
+import {
+  createTransactionMessage,
+  generateKeyPairSigner,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  type Blockhash,
+} from "@solana/kit";
+import {
+  sendAndConfirmSolanaTransaction,
+  sendAndConfirmSolanaTransactionWithSlot,
+} from "../src/utils/TransactionUtils";
+
+// A 32-byte all-zero base58 string is a valid Blockhash shape for offline
+// signing in tests. Using a fixed value keeps the test deterministic without
+// requiring a running validator.
+const FAKE_BLOCKHASH = "11111111111111111111111111111111" as Blockhash;
+
+type CapturedSendOptions = { minContextSlot?: bigint } & Record<string, unknown>;
+
+const buildSignableTx = async () => {
+  const signer = await generateKeyPairSigner();
+  const txMessage = pipe(createTransactionMessage({ version: 0 }), (tx) =>
+    setTransactionMessageFeePayerSigner(signer, tx)
+  );
+  return txMessage;
+};
+
+const makeFakeProvider = (statusValueByPollCall: Array<unknown>) => {
+  const fakeSignature = "5tkH59X6n7zVJ4r3z2hG5L9rA1bC2dE4fG6h8jK0mN1pQ3sT5uV7wY9aB1cD3eF6";
+  const sendInvocations: Array<CapturedSendOptions> = [];
+  let pollIndex = 0;
+  const provider = {
+    getLatestBlockhash: () => ({
+      send: async () => ({ value: { blockhash: FAKE_BLOCKHASH, lastValidBlockHeight: 1_000n } }),
+    }),
+    sendTransaction: (_serializedTx: string, opts: CapturedSendOptions) => {
+      sendInvocations.push(opts);
+      return { send: async () => fakeSignature };
+    },
+    getSignatureStatuses: (_sigs: string[]) => ({
+      send: async () => ({ value: [statusValueByPollCall[Math.min(pollIndex++, statusValueByPollCall.length - 1)]] }),
+    }),
+  };
+  return { provider, sendInvocations, fakeSignature };
+};
+
+describe("TransactionUtils — SVM send pinning", function () {
+  describe("sendAndConfirmSolanaTransactionWithSlot", function () {
+    it("threads `minContextSlot` into sendTransaction options and returns the confirmed slot", async function () {
+      const txMessage = await buildSignableTx();
+      const { provider, sendInvocations, fakeSignature } = makeFakeProvider([
+        { confirmationStatus: "confirmed", slot: 12_345n, err: null, confirmations: 1n },
+      ]);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await sendAndConfirmSolanaTransactionWithSlot(txMessage as any, provider as any, 5, 1, {
+        minContextSlot: 999n,
+      });
+
+      expect(result.signature).to.equal(fakeSignature);
+      expect(result.confirmedSlot).to.equal(12_345n);
+      expect(sendInvocations).to.have.lengthOf(1);
+      expect(sendInvocations[0].minContextSlot).to.equal(999n);
+      // The existing send options must still be set on every send for parity with the prior behavior.
+      expect(sendInvocations[0].preflightCommitment).to.equal("confirmed");
+      expect(sendInvocations[0].skipPreflight).to.equal(false);
+    });
+
+    it("omits `minContextSlot` from sendTransaction options when no opts are supplied", async function () {
+      const txMessage = await buildSignableTx();
+      const { provider, sendInvocations } = makeFakeProvider([
+        { confirmationStatus: "confirmed", slot: 5n, err: null, confirmations: 1n },
+      ]);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await sendAndConfirmSolanaTransactionWithSlot(txMessage as any, provider as any, 5, 1);
+      expect(sendInvocations[0].minContextSlot).to.equal(undefined);
+    });
+
+    it("returns `confirmedSlot=undefined` when confirmation never reaches confirmed/finalized", async function () {
+      const txMessage = await buildSignableTx();
+      const { provider } = makeFakeProvider([
+        { confirmationStatus: "processed", slot: 1n, err: null, confirmations: 0n },
+        { confirmationStatus: "processed", slot: 2n, err: null, confirmations: 0n },
+      ]);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await sendAndConfirmSolanaTransactionWithSlot(txMessage as any, provider as any, 2, 1);
+      expect(result.confirmedSlot).to.equal(undefined);
+    });
+  });
+
+  describe("sendAndConfirmSolanaTransaction (backwards-compat)", function () {
+    it("still returns just a signature string and threads `minContextSlot` when supplied", async function () {
+      const txMessage = await buildSignableTx();
+      const { provider, sendInvocations, fakeSignature } = makeFakeProvider([
+        { confirmationStatus: "finalized", slot: 7n, err: null, confirmations: 2n },
+      ]);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const sig = await sendAndConfirmSolanaTransaction(txMessage as any, provider as any, 5, 1, {
+        minContextSlot: 42n,
+      });
+      expect(sig).to.equal(fakeSignature);
+      expect(sendInvocations[0].minContextSlot).to.equal(42n);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the cross-slot race that's been paging oncall 1–2x/day for the past month on `zion-across-l2-executor-solana` (PD-325402, PD-325403, PD-325400, PD-325420, plus the May 23 storm of ~30).

## Root cause

`_executeRelayerRefundLeafSvm` issues a sequence of dependent SVM txs: `init / write fragments → LUT create → LUT extend → execute`. The dataworker GCP logs (`bots-across-3839`, `across-spoke-2c-8g`) show the execute's `sendTransaction` preflight runs ~73ms after the last data-write confirms — well inside Solana's ~400ms slot propagation window. If the RPC the relayer routes `sendTransaction` to is one slot behind the just-confirmed write, its preflight runs against stale instruction-params PDA state and returns `SolanaError: Transaction simulation failed`. The next dataworker cycle ~4 minutes later (when state has propagated) succeeds — every observed failure was followed by a success on the same `{rootBundleId, leafId}`.

## Fix

Pin every dependent send to `minContextSlot = slot-at-which-the-previous-dependency-confirmed`. The Solana JSON-RPC spec lets a receiving node reject with the explicit `MinContextSlotNotReached` code if its tip is behind the requested slot, instead of running preflight against stale state. The SDK's existing `RetrySolanaRpcFactory` already retries on transient RPC errors, so the retry happens transparently and the next cycle's state propagates before the retry fires.

## Changes

- **`src/utils/TransactionUtils.ts`**
  - Add `SolanaSendOptions { minContextSlot?: bigint }` and thread it through `signAndSendTransaction` to `provider.sendTransaction(..., { minContextSlot })`.
  - Add `sendAndConfirmSolanaTransactionWithSlot(...)` returning `{ signature, confirmedSlot }`. Reads the slot from `getSignatureStatuses[0].slot` (already available in the polling loop).
  - Existing `sendAndConfirmSolanaTransaction` keeps its `Promise<string>` signature; `minContextSlot` is opt-in via the new last param.

- **`src/dataworker/Dataworker.ts` `_executeRelayerRefundLeafSvm`**
  - Add a local `sendPinned()` closure that captures `confirmedSlot` from each send and threads it forward as `minContextSlot` to the next send. The chain only advances forward.
  - Route every dependency send (close/init params, write fragments, LUT create, both LUT extend loops, execute, executeDeferred, claim-account init, claim, deactivateLut) through `sendPinned`.

- **`test/TransactionUtils.svm.ts`** — 4 tests covering slot extraction, `minContextSlot` threading into options, opt-out when not supplied, `confirmedSlot=undefined` when polling never confirms, and backwards-compat for the existing API.

## Pairs with

[#3448](https://github.com/across-protocol/relayer/pull/3448) (fix C, surface SolanaError context in logs). Together these should eliminate the page class entirely; if a SolanaError does propagate post-B, the C diagnostic ensures it carries the program-level `__code` + RPC `value.err` + program logs.

## Scope

Deliberately narrow. Other SVM call sites (`_executeSlowFillLeafSvm`, `SvmFillerClient`, CCTP finalizer, claims) are untouched — they don't issue an init/write/execute sequence that exposes the same cross-slot race. If post-deploy logs surface similar `MinContextSlotNotReached` retries on other paths, they can be wired the same way in a follow-up.

## Test plan

- [x] `yarn typecheck:fast`
- [x] `yarn lint`
- [x] `RELAYER_TEST=true yarn hardhat test test/TransactionUtils.svm.ts` (4 passing)
- [ ] Post-deploy: confirm the `zion-across-l2-executor-solana` PD page class drops to zero. If a `MinContextSlotNotReached` propagates instead of being retried, it'd show up in Datadog at the same call site — that would indicate the SDK's retries are exhausted (RPC pool genuinely far behind) and warrants tuning retry count, not reverting this PR.