### PR TITLE
fix(rebalancer/hyperliquid): emit "Creating new order" log only after Redis order is created

### DIFF
--- a/src/rebalancer/adapters/hyperliquid.ts
+++ b/src/rebalancer/adapters/hyperliquid.ts
@@ -247,15 +247,10 @@ export class HyperliquidStablecoinSwapAdapter extends BaseAdapter {
     const cloid = await this._redisGetNextCloid();
 
     if (sourceChain !== HYPEREVM) {
-      // Bridge this token into HyperEVM first
-      this.logger.info({
-        at: "HyperliquidStablecoinSwapAdapter.initializeRebalance",
-        message: `🍻 Creating new order ${cloid} by first bridging ${sourceFormatter(amountToTransfer)} ${sourceTokenInfo.symbol} into HyperEVM from ${getNetworkName(sourceChain)} before depositing into Hypercore in order to acquire ${destinationTokenInfo.symbol} on ${getNetworkName(destinationChain)}`,
-        expectedOutput: destinationFormatter(amountToTransfer),
-      });
-
+      // The info-level "Creating new order" announcement must run after `_redisCreateOrder`
+      // so user-visible Slack logs reflect only orders that actually progressed past the
+      // bridge submission, not pre-flight simulation failures or transient crashes.
       const amountReceivedFromBridge = await this._bridgeToChain(sourceToken, sourceChain, HYPEREVM, amountToTransfer);
-
       await this._redisCreateOrder(
         cloid,
         STATUS.PENDING_BRIDGE_TO_HYPEREVM,
@@ -263,14 +258,13 @@ export class HyperliquidStablecoinSwapAdapter extends BaseAdapter {
         amountReceivedFromBridge,
         this.baseSignerAddress
       );
-      return amountReceivedFromBridge;
-    } else {
       this.logger.info({
         at: "HyperliquidStablecoinSwapAdapter.initializeRebalance",
-        message: `🍻 Creating new order ${cloid} by first transferring ${sourceFormatter(amountToTransfer)} ${sourceTokenInfo.symbol} into Hypercore from ${getNetworkName(sourceChain)} in order to acquire ${destinationTokenInfo.symbol} on ${getNetworkName(destinationChain)}`,
+        message: `🍻 Creating new order ${cloid} by first bridging ${sourceFormatter(amountToTransfer)} ${sourceTokenInfo.symbol} into HyperEVM from ${getNetworkName(sourceChain)} before depositing into Hypercore in order to acquire ${destinationTokenInfo.symbol} on ${getNetworkName(destinationChain)}`,
         expectedOutput: destinationFormatter(amountToTransfer),
       });
-
+      return amountReceivedFromBridge;
+    } else {
       await this._depositToHypercore(sourceToken, amountToTransfer);
       await this._redisCreateOrder(
         cloid,
@@ -279,6 +273,11 @@ export class HyperliquidStablecoinSwapAdapter extends BaseAdapter {
         amountToTransfer,
         this.baseSignerAddress
       );
+      this.logger.info({
+        at: "HyperliquidStablecoinSwapAdapter.initializeRebalance",
+        message: `🍻 Creating new order ${cloid} by first transferring ${sourceFormatter(amountToTransfer)} ${sourceTokenInfo.symbol} into Hypercore from ${getNetworkName(sourceChain)} in order to acquire ${destinationTokenInfo.symbol} on ${getNetworkName(destinationChain)}`,
+        expectedOutput: destinationFormatter(amountToTransfer),
+      });
       return amountToTransfer;
     }
   }


### PR DESCRIPTION
## Summary

- Move the info-level `🍻 Creating new order ${cloid}` log in `HyperliquidStablecoinSwapAdapter.initializeRebalance` (`src/rebalancer/adapters/hyperliquid.ts`) to fire **after** `_redisCreateOrder` succeeds, in both the bridge and direct-Hypercore branches.
- No behavior change beyond log ordering.

## Why

The `🍻 Creating new order` info log is the user-visible "new rebalance" announcement in `#zion-across-swap-rebalancer`. Today it fires *before* `_bridgeToChain` (or `_depositToHypercore`) runs, so a pre-flight failure publishes a misleading "Creating new order" line even when no order is actually persisted.

For example, GCP logs for run-identifier `2b242b27-17dc-43c5-8020-b11c0599de32` (Wed Jun 3 2026 01:06:23 UTC):

```
01:06:23.639  HyperliquidStablecoinSwapAdapter.initializeRebalance  🍻 Creating new order 0x2390d4c1… (bridge 130,121.46 USDT Optimism→HyperEVM)
01:06:23.739  swapRebalancer                                         There was an execution error!
```

The execution error 100ms later was a `eth_estimateGas` revert on the OFT messenger with `ERC20: burn amount exceeds balance` — `_bridgeToChain` never got a tx into the mempool, and no Redis order was created — but the user-visible "Creating new order" log had already been published. The serverless Hub then retried the bot with a `…r` `RUN_IDENTIFIER` (`risk-labs/serverless-orchestration/src/ServerlessHub.js:289-307`), which produced a second "Creating new order" line with a different `cloid`, creating the appearance of duplicate orders even though nothing actually happened on-chain.

Moving the info log to after `_redisCreateOrder` keeps the announcement aligned with orders that have actually progressed past the underlying tx submission. The debug-level trace upstream still records the attempt.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [ ] Verify on next swap-rebalancer run that the Slack `🍻 Creating new order` message only appears for orders that actually have a Redis entry, and that pre-flight crashes no longer publish a misleading announcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)