### PR TITLE
fix(rebalancer): refresh TokenClient balances before sizing new rebalances

### DIFF
--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -238,7 +238,7 @@ Lifecycle note:
 Runtime entrypoints in `src/rebalancer/`:
 
 - `runCumulativeBalanceRebalancer` (supported operational path).
-- The runtime updates adapter status/sweeps first, then applies adapter-reported pending rebalance adjustments before evaluating new rebalances.
+- The runtime updates adapter status/sweeps first, then refreshes `TokenClient` balances before applying adapter-reported pending rebalance adjustments and evaluating new rebalances. The refresh is required because the sweeps and `updateRebalanceStatuses` calls submit OFT/CCTP/Hypercore transactions that leave the initial `TokenClient.update()` snapshot stale; without it, `rebalanceInventory` can size a new bridge against a pre-burn balance and crash on the underlying simulation revert.
 
 ## Interactions with Other Bots and Clients
 

--- a/src/rebalancer/index.ts
+++ b/src/rebalancer/index.ts
@@ -93,6 +93,20 @@ async function initializeRebalancerRun(_logger: winston.Logger, baseSigner: Sign
     });
   }
 
+  // Refresh on-chain balances before `loadCumulativeModeBalances` reads them. The initial
+  // `tokenClient.update()` above ran before adapter sweeps and `updateRebalanceStatuses`, both
+  // of which submit OFT/CCTP/Hypercore transactions that move funds across chains, so the
+  // cached balances are stale by this point. Without this refresh, `rebalanceInventory` can
+  // size a new bridge against a pre-burn balance and crash on the OFT/CCTP simulation revert
+  // (`ERC20: burn amount exceeds balance`).
+  timerStart = performance.now();
+  await tokenClient.update();
+  logger.debug({
+    at: `index.ts:${logLabel}`,
+    message: "Refreshed TokenClient balances post-status-update",
+    duration: performance.now() - timerStart,
+  });
+
   return {
     rebalancerConfig,
     adaptersToUpdate,


### PR DESCRIPTION
## Summary

- Add a second `tokenClient.update()` call inside `initializeRebalancerRun` in `src/rebalancer/index.ts` after the sweeps and `updateRebalanceStatuses` loop completes and before the function returns. `loadCumulativeModeBalances` then reads fresh on-chain balances.
- Update `src/rebalancer/README.md` runtime entrypoints note to document the second refresh.

## Why

`initializeRebalancerRun` runs `tokenClient.update()` once at the top of the function in parallel with `updateSpokePoolClients`. Between that snapshot and `loadCumulativeModeBalances`, the adapter sweeps and `updateRebalanceStatuses` loop submit OFT/CCTP/Hypercore transactions that move funds across chains. The cached balance the cumulative sizing logic reads is therefore pre-burn / pre-deposit.

When that happens for the `zion-across-swap-rebalancer`, `CumulativeBalanceRebalancerClient.rebalanceInventory` sizes a new bridge from Optimism against the stale balance, the OFT messenger's `send` simulation reverts at `eth_estimateGas` with `ERC20: burn amount exceeds balance`, and the bot exits with code 1 (full diagnosis in [thread](https://app.slack.com/client/T90K0AL22/C0AFB0BP3SB/thread/C0AFB0BP3SB-1780451604.000599) and `master.relayer/src/rebalancer/adapters/hyperliquid.js:206`). The serverless Hub then retries with `RUN_IDENTIFIER + 'r'` and the same flow crashes again, producing duplicate-looking `🍻 Creating new order` log pairs in `#zion-across-swap-rebalancer`.

Reading on-chain truth directly after the status updates fixes the root sizing problem with one line of meaningful runtime work — no new interface methods, no Redis-side debit tracking, no adapter-specific preflight. Cost is one extra parallel balance fan-out across the swap-rebalancer's ~18 token/chain pairs (~1-2s).

Supersedes the earlier preflight-check and in-flight-debit-tracking iterations of this branch.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [ ] On next deploy, check that `zion-across-swap-rebalancer` runs no longer surface `Error: ... ERC20: burn amount exceeds balance` and that a `Refreshed TokenClient balances post-status-update` debug entry appears once per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)