### PR TITLE
chore: bump SDK to 4.3.164

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.109",
     "@across-protocol/contracts": "5.0.10",
-    "@across-protocol/sdk": "4.3.163",
+    "@across-protocol/sdk": "4.3.164",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.3.163":
-  version "4.3.163"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.163.tgz#5a9ca6afb40cf20d6e771a813f45b56355a8a9d5"
-  integrity sha512-lerUqx8dwhAcov6tDislEAYUMXUeQlOgsYJ/dwR+qt+Cy5gOE4ObM1bRbYFLZvapil+UywHdruGEAelkbuxadQ==
+"@across-protocol/sdk@4.3.164":
+  version "4.3.164"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.164.tgz#c8a91564d60f7afc3b332d7fe45b44fb1318c904"
+  integrity sha512-Zz3GksBHekq2KjlIM+24sG281onM/3au94ly8kwknq7aKsy1kxfeH62mq3cpeCGXq7UbFB14BMiE0nSb2WcqbQ==
   dependencies:
     "@across-protocol/constants" "^3.1.110"
     "@across-protocol/contracts" "5.0.10"


### PR DESCRIPTION
## Summary
- Updates `@across-protocol/sdk` from `4.3.163` to `4.3.164`.
- Refreshes the Yarn lockfile entry for the new SDK tarball.

## Context
- Requested SDK release: https://github.com/across-protocol/sdk/releases/tag/v4.3.164
- Release notes include SVM QuorumFallback error/fallback handling changes.

## Validation
- `yarn install --ignore-scripts --frozen-lockfile`
- `yarn build`