### PR TITLE
fix(rebalancer/hyperliquid): truncate aggregated sz/fee before toBNWei

### DIFF
--- a/src/rebalancer/adapters/hyperliquid.ts
+++ b/src/rebalancer/adapters/hyperliquid.ts
@@ -983,21 +983,29 @@ export class HyperliquidStablecoinSwapAdapter extends BaseAdapter {
     const destinationTokenMeta = this._getTokenMeta(destinationToken);
     const destinationTokenInfo = getTokenInfoFromSymbol(destinationToken, destinationChain);
 
+    // Because we request fills with aggregateByTime=true, matchingFill.sz / .fee can carry more
+    // fractional digits than the token's coreDecimals (averaged across consolidated partial fills),
+    // which makes ethers `parseUnits` throw NUMERIC_FAULT (underflow) inside toBNWei. Truncate to
+    // coreDecimals first — the same mitigation pattern used at the end of this function. `px` is
+    // already toWei'd at 18 decimals below for the same reason.
+    const fillSz = truncate(Number(matchingFill.sz), destinationTokenMeta.coreDecimals);
+    const fillFee = truncate(Number(matchingFill.fee), destinationTokenMeta.coreDecimals);
+
     // If fill was a buy, then received amount is denominated in base asset, same as sz.
     // If fill was a sell, then received amount is denominated in quote asset, so receivedAmount = px * sz.
     let amountToWithdraw: BigNumber;
     if (matchingFill.dir === "Buy") {
-      amountToWithdraw = toBNWei(matchingFill.sz, destinationTokenMeta.coreDecimals);
+      amountToWithdraw = toBNWei(fillSz, destinationTokenMeta.coreDecimals);
     } else {
       // matchingFill.px might be an averagePx of all the partial fills so it can exceed pxDecimals so to be safe,
       // we toWei it to 18 decimals.
-      amountToWithdraw = toBNWei(matchingFill.sz, destinationTokenMeta.coreDecimals)
+      amountToWithdraw = toBNWei(fillSz, destinationTokenMeta.coreDecimals)
         .mul(toBNWei(matchingFill.px, 18))
         .div(toBNWei(1));
     }
 
     // Subtract the fee:
-    amountToWithdraw = amountToWithdraw.sub(toBNWei(matchingFill.fee, destinationTokenMeta.coreDecimals));
+    amountToWithdraw = amountToWithdraw.sub(toBNWei(fillFee, destinationTokenMeta.coreDecimals));
 
     // We need to make sure there are not more than evmDecimals decimals for the amount to withdraw or the HL
     // spotSend/sendAsset transaction will fail "Invalid number of decimals".


### PR DESCRIPTION
## Summary

- Every `zion-across-swap-rebalancer` run in prod is currently aborting with `Error: fractional component exceeds decimals (fault="underflow", parseFixed, code=NUMERIC_FAULT)` inside `HyperliquidStablecoinSwapAdapter._getMatchingFillForCloid`, which crashes `updateRebalanceStatuses` and consequently stalls every pending Hyperliquid order (e.g. the open `USDT0-USDC` ~$24.5k withdrawal currently flagged by `Monitor#reportOpenHyperliquidOrders`).
- Root cause: we request fills with `aggregateByTime=true`, so consolidated `matchingFill.sz` and `matchingFill.fee` strings can carry more fractional digits than the destination token's `coreDecimals`. Passing them straight into `toBNWei` makes ethers `parseUnits` underflow.
- Fix: truncate `sz` and `fee` to `coreDecimals` before calling `toBNWei`, mirroring the same defensive pattern already used at the bottom of this function and the existing 18-decimal mitigation for `px` (called out in the comment immediately above the broken line).

## Observability

- 9 incidents in the past hour on the `ACX infrastructure incidents` PagerDuty service:
  - 7 × ServerlessHub “Some spoke calls returned errors”, all naming `zion-across-swap-rebalancer` as the rejected spoke.
  - 2 × `Monitor#reportOpenHyperliquidOrders` for the same stuck `USDT0-USDC` order (age 1178s → 2052s between alerts).
- Cloud Run logs (`bots-across-3839` / `across-spoke-2c-8g`) confirm the stack trace lands inside `_getMatchingFillForCloid` → `updateRebalanceStatuses` → `initializeRebalancerRun`.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn lint` passes
- [ ] After merge: watch `ACX infrastructure incidents` for the next ~3 swap-rebalancer cycles (~15 minutes) and confirm the recurring `ServerlessHub` alert clears and the open `USDT0-USDC` order progresses past `PENDING_WITHDRAWAL_FROM_HYPERCORE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)