### PR TITLE
fix(rebalancer): measure swap spread against oracle fair price, not par

### DIFF
--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -68,6 +68,23 @@ Implemented production swap adapters:
 Pending-status Redis sets are keyed by adapter status and signer address, so callers can request pending rebalance
 accounting for a specific EVM account while keeping independently operated accounts isolated from one another.
 
+#### Estimated cost: spread vs oracle fair price
+
+`getEstimatedCost` on the Binance and Hyperliquid adapters includes a spread-cost component that compares the worst-fill price an order would cross on the venue's order book against the oracle-derived fair cross-token price `P_base_usd / P_quote_usd`. For dollar-pegged pairs (e.g. `USDC/USDT`) the ratio is ≈ 1 and the formula reduces to the prior par-based form; for non-par markets (e.g. `WETH/USDC`, `WETH/USDT`) the same formula correctly compares the worst-fill price to the true cross-token rate without producing nonsense estimates.
+
+Oracle wiring:
+
+- `BaseAdapter._getTokenPriceUsd(symbol)` resolves a token's USD price via the same hub-chain-address lookup `CumulativeBalanceRebalancerClient` uses, with results cached per adapter instance for the rebalancer cycle.
+- Operators can override a token's USD price with the `RELAYER_TOKEN_PRICE_FIXED_<address>` env var (where `<address>` is the hex hub-chain ERC-20 address), matching the existing override the cumulative client honors. Use for incident response when the upstream oracle is degraded.
+- `BaseAdapter._getFairCrossPrice(baseToken, quoteToken)` is the helper both adapters call; it returns the quote-per-base ratio so it can be compared directly to the order book's `latestPrice`.
+
+Fallback behavior on oracle failure:
+
+- Binance falls back to depth-only order-book slippage (the prior `slippagePct` measure) — a conservative lower bound that under-estimates real cost when a stablecoin pair trades off par.
+- Hyperliquid falls back to the legacy `1 - latestPrice` par-based formula, which preserves current behavior for the stablecoin pairs HL routes today.
+- Both adapters emit a `warn` log on oracle failure (`Oracle fair price unresolved for <base>/<quote>; falling back to ...`) so operators can detect degraded estimates.
+- Both adapters clamp negative spread to zero, so a favorably-priced book does not surface as a negative cost or fail the downstream `toBNWei` parse.
+
 Binance account assumption:
 
 - `relayer-v2` currently assumes all bots and clients that interact with the Binance rebalancer adapter share the same

--- a/src/rebalancer/adapters/baseAdapter.ts
+++ b/src/rebalancer/adapters/baseAdapter.ts
@@ -5,6 +5,7 @@ import {
   Address,
   assert,
   BigNumber,
+  bnZero,
   CHAIN_IDs,
   coingecko,
   Contract,
@@ -15,6 +16,7 @@ import {
   EventSearchConfig,
   EvmAddress,
   forEachAsync,
+  fromWei,
   getBlockForTimestamp,
   getProvider,
   getTokenInfo,
@@ -24,6 +26,7 @@ import {
   PriceClient,
   Signer,
   submitTransaction,
+  toBNWei,
   winston,
 } from "../../utils";
 import { RedisCache } from "../../cache/Redis";
@@ -67,6 +70,12 @@ export abstract class BaseAdapter implements RebalancerAdapter {
   protected allDestinationChains: Set<number> = new Set();
   protected allSourceChains: Set<number> = new Set();
   protected allSourceTokens: Set<string> = new Set();
+
+  // Per-instance USD price cache for spread-cost estimation. The rebalancer is short-lived
+  // (one cycle per invocation), so we don't apply a TTL here; matches the cache scope used
+  // in CumulativeBalanceRebalancerClient._getTokenPriceUsd. If the adapter ever runs in a
+  // long-lived process, revisit this with a time-based eviction.
+  private readonly tokenPriceUsdCache = new Map<string, BigNumber>();
 
   protected abstract REDIS_PREFIX: string;
 
@@ -404,5 +413,46 @@ export abstract class BaseAdapter implements RebalancerAdapter {
 
   protected async _submitTransaction(transaction: AugmentedTransaction): Promise<string> {
     return (await submitTransaction(transaction, this.transactionClient)).hash;
+  }
+
+  /**
+   * Resolve the USD price for a token symbol, using the same lookup pattern as
+   * CumulativeBalanceRebalancerClient: the hub-chain address is used as the cache key and the
+   * oracle key, and a `RELAYER_TOKEN_PRICE_FIXED_<address>` env var can override the oracle
+   * value. Returns an 18-decimal BigNumber USD price.
+   */
+  protected async _getTokenPriceUsd(token: string): Promise<BigNumber> {
+    const cached = this.tokenPriceUsdCache.get(token);
+    if (isDefined(cached)) {
+      return cached;
+    }
+    const hubTokenAddress = getTokenInfoFromSymbol(token, this.config.hubPoolChainId).address.toNative();
+    const fixedPriceEnv = process.env[`RELAYER_TOKEN_PRICE_FIXED_${hubTokenAddress}`];
+    const priceUsd = isDefined(fixedPriceEnv)
+      ? toBNWei(fixedPriceEnv)
+      : toBNWei((await this.priceClient.getPriceByAddress(hubTokenAddress)).price);
+    assert(priceUsd.gt(bnZero), `Unable to resolve positive USD price for ${token}`);
+    this.tokenPriceUsdCache.set(token, priceUsd);
+    return priceUsd;
+  }
+
+  /**
+   * Oracle-derived fair cross-token price for a spot market, expressed as quote-per-base
+   * (so `latestPrice` from an order book can be compared directly to it). The ratio is
+   * dimensionless — both USD prices cancel out. Returns a plain number; callers handle the
+   * percent-vs-decimal scaling appropriate for their downstream math.
+   *
+   * Use this in place of hardcoded `1` references for spread-vs-par calculations so non-par
+   * markets (e.g. ETH/USDC) measure slippage correctly. For stablecoin pairs the ratio is
+   * ≈ 1 and the formula reduces to the prior par-based form.
+   */
+  protected async _getFairCrossPrice(baseToken: string, quoteToken: string): Promise<number> {
+    const [basePriceUsd, quotePriceUsd] = await Promise.all([
+      this._getTokenPriceUsd(baseToken),
+      this._getTokenPriceUsd(quoteToken),
+    ]);
+    // Both prices are 18-decimal BigNumbers; we expand the numerator by 1e18 before dividing
+    // so integer division preserves precision, then convert back to a float via fromWei.
+    return Number(fromWei(basePriceUsd.mul(toBNWei(1, 18)).div(quotePriceUsd), 18));
   }
 }

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -63,6 +63,11 @@ import { CctpAdapter } from "./cctpAdapter";
 import { OftAdapter, getOftPreDepositOrderTtlOverride } from "./oftAdapter";
 import WETH_ABI from "../../common/abi/Weth.json";
 
+// Symbols treated as $1-pegged for spread-cost estimation in getEstimatedCost. Only routes
+// where both sides of the swap are dollar-pegged use the par-based spread measure; non-par
+// markets fall back to depth-only slippage to avoid producing nonsense fee estimates.
+const STABLECOIN_SYMBOLS = new Set(["USDC", "USDT", "DAI"]);
+
 export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   private _binanceApiClient?: Binance;
   private exchangeInfoPromise?: ReturnType<Binance["exchangeInfo"]>;
@@ -915,16 +920,28 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       toBNWei(truncate(Number(withdrawFee), destinationTokenInfo.decimals), destinationTokenInfo.decimals)
     );
 
-    // Spread cost vs $1 par for the worst-fill price the order would cross. The previous
-    // implementation used only depth-induced slippage (price impact vs bestPx), which misses
-    // the bid-ask gap when the underlying pair trades off par on Binance (e.g. USDCUSDT asks
-    // sitting at ~$1.001 means a market BUY pays ~10 bps vs par even when it fills entirely
-    // at the top of book and slippagePct ≈ 0). Mirrors the par-based spread calculation in
-    // HyperliquidStablecoinSwapAdapter.getEstimatedCost. spreadPct is kept in percent units
-    // (consistent with the prior slippagePct path) so the downstream toBNWei(1, 20) divisor
-    // scales percent → decimal.
-    let spreadPct = 0;
-    if (routeRequiresSwap && isDefined(spotMarketMeta)) {
+    // Spread cost for the worst-fill price the order would cross. The prior implementation
+    // used only depth-induced slippage (price impact vs bestPx), which misses the bid-ask gap
+    // when a dollar-pegged pair trades off par on Binance — e.g. USDCUSDT asks sitting at
+    // ~$1.001 means a market BUY pays ~10 bps vs par even when it fills entirely at the top
+    // of book and slippagePct ≈ 0.
+    //
+    // For dollar-pegged pairs (both source and destination are recognized stablecoin symbols)
+    // we measure spread vs $1 par, mirroring HyperliquidStablecoinSwapAdapter.getEstimatedCost.
+    // For non-par markets (e.g. ETH/USDC where latestPrice is on the order of thousands), a
+    // par-based formula would produce nonsense, so we retain the depth-only measure as a
+    // safe lower bound. A future change can introduce an oracle-priced reference for those
+    // markets if the rebalancer ever routes them through Binance.
+    //
+    // spreadPct is kept in percent units (consistent with the prior slippagePct path) so the
+    // downstream toBNWei(1, 20) divisor scales percent → decimal.
+    let spreadPct = latestPrice.slippagePct;
+    if (
+      routeRequiresSwap &&
+      isDefined(spotMarketMeta) &&
+      STABLECOIN_SYMBOLS.has(sourceToken) &&
+      STABLECOIN_SYMBOLS.has(destinationToken)
+    ) {
       const parSpreadDecimal = spotMarketMeta.isBuy ? latestPrice.latestPrice - 1 : 1 - latestPrice.latestPrice;
       spreadPct = Math.max(0, parSpreadDecimal * 100);
     }

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -915,8 +915,19 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       toBNWei(truncate(Number(withdrawFee), destinationTokenInfo.decimals), destinationTokenInfo.decimals)
     );
 
-    const spreadPct = latestPrice.slippagePct; // slippage is a percentage so we need to divide it by an additional
-    // 100 to get it to a decimal.
+    // Spread cost vs $1 par for the worst-fill price the order would cross. The previous
+    // implementation used only depth-induced slippage (price impact vs bestPx), which misses
+    // the bid-ask gap when the underlying pair trades off par on Binance (e.g. USDCUSDT asks
+    // sitting at ~$1.001 means a market BUY pays ~10 bps vs par even when it fills entirely
+    // at the top of book and slippagePct ≈ 0). Mirrors the par-based spread calculation in
+    // HyperliquidStablecoinSwapAdapter.getEstimatedCost. spreadPct is kept in percent units
+    // (consistent with the prior slippagePct path) so the downstream toBNWei(1, 20) divisor
+    // scales percent → decimal.
+    let spreadPct = 0;
+    if (routeRequiresSwap && isDefined(spotMarketMeta)) {
+      const parSpreadDecimal = spotMarketMeta.isBuy ? latestPrice.latestPrice - 1 : 1 - latestPrice.latestPrice;
+      spreadPct = Math.max(0, parSpreadDecimal * 100);
+    }
     const spreadFee = toBNWei(truncate(spreadPct, 18), 18).mul(amountToTransfer).div(toBNWei(1, 20));
 
     // Bridge to Binance deposit network Fee:

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -63,11 +63,6 @@ import { CctpAdapter } from "./cctpAdapter";
 import { OftAdapter, getOftPreDepositOrderTtlOverride } from "./oftAdapter";
 import WETH_ABI from "../../common/abi/Weth.json";
 
-// Symbols treated as $1-pegged for spread-cost estimation in getEstimatedCost. Only routes
-// where both sides of the swap are dollar-pegged use the par-based spread measure; non-par
-// markets fall back to depth-only slippage to avoid producing nonsense fee estimates.
-const STABLECOIN_SYMBOLS = new Set(["USDC", "USDT", "DAI"]);
-
 export class BinanceStablecoinSwapAdapter extends BaseAdapter {
   private _binanceApiClient?: Binance;
   private exchangeInfoPromise?: ReturnType<Binance["exchangeInfo"]>;
@@ -921,29 +916,37 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     );
 
     // Spread cost for the worst-fill price the order would cross. The prior implementation
-    // used only depth-induced slippage (price impact vs bestPx), which misses the bid-ask gap
-    // when a dollar-pegged pair trades off par on Binance — e.g. USDCUSDT asks sitting at
-    // ~$1.001 means a market BUY pays ~10 bps vs par even when it fills entirely at the top
-    // of book and slippagePct ≈ 0.
+    // used only depth-induced slippage (price impact vs bestPx), which misses the bid-ask
+    // gap when the underlying pair trades off the oracle-implied fair rate — e.g. USDCUSDT
+    // asks sitting at ~$1.001 means a market BUY pays ~10 bps vs par even when it fills
+    // entirely at the top of book and slippagePct ≈ 0.
     //
-    // For dollar-pegged pairs (both source and destination are recognized stablecoin symbols)
-    // we measure spread vs $1 par, mirroring HyperliquidStablecoinSwapAdapter.getEstimatedCost.
-    // For non-par markets (e.g. ETH/USDC where latestPrice is on the order of thousands), a
-    // par-based formula would produce nonsense, so we retain the depth-only measure as a
-    // safe lower bound. A future change can introduce an oracle-priced reference for those
-    // markets if the rebalancer ever routes them through Binance.
+    // Measure spread against the oracle-derived fair cross-token price (P_base_usd /
+    // P_quote_usd), which generalizes to any market: for stablecoin pairs the fair price is
+    // ≈ 1 and the formula reduces to the prior par-based form; for non-par pairs like
+    // ETH/USDC it correctly compares latestPrice (~3500) to the fair cross-token rate.
+    //
+    // If the oracle fails to resolve either side, fall back to the depth-only slippage as
+    // a safe lower bound and log a warn so operators can monitor.
     //
     // spreadPct is kept in percent units (consistent with the prior slippagePct path) so the
     // downstream toBNWei(1, 20) divisor scales percent → decimal.
     let spreadPct = latestPrice.slippagePct;
-    if (
-      routeRequiresSwap &&
-      isDefined(spotMarketMeta) &&
-      STABLECOIN_SYMBOLS.has(sourceToken) &&
-      STABLECOIN_SYMBOLS.has(destinationToken)
-    ) {
-      const parSpreadDecimal = spotMarketMeta.isBuy ? latestPrice.latestPrice - 1 : 1 - latestPrice.latestPrice;
-      spreadPct = Math.max(0, parSpreadDecimal * 100);
+    if (routeRequiresSwap && isDefined(spotMarketMeta)) {
+      try {
+        const fairPrice = await this._getFairCrossPrice(spotMarketMeta.baseAssetName, spotMarketMeta.quoteAssetName);
+        const slippageDecimal = spotMarketMeta.isBuy
+          ? (latestPrice.latestPrice - fairPrice) / fairPrice
+          : (fairPrice - latestPrice.latestPrice) / fairPrice;
+        spreadPct = Math.max(0, slippageDecimal * 100);
+      } catch (err) {
+        this.logger.warn({
+          at: "BinanceStablecoinSwapAdapter.getEstimatedCost",
+          message: `Oracle fair price unresolved for ${spotMarketMeta.baseAssetName}/${spotMarketMeta.quoteAssetName}; falling back to depth-only slippage`,
+          err: String(err),
+        });
+        // spreadPct already initialized to latestPrice.slippagePct above.
+      }
     }
     const spreadFee = toBNWei(truncate(spreadPct, 18), 18).mul(amountToTransfer).div(toBNWei(1, 20));
 

--- a/src/rebalancer/adapters/hyperliquid.ts
+++ b/src/rebalancer/adapters/hyperliquid.ts
@@ -567,13 +567,25 @@ export class HyperliquidStablecoinSwapAdapter extends BaseAdapter {
     );
     const latestPrice = Number(px);
 
-    const isBuy = spotMarketMeta.isBuy;
+    // Measure spread against the oracle-derived fair cross-token price (P_base_usd /
+    // P_quote_usd) rather than the hardcoded `1` par assumption. For dollar-pegged pairs
+    // this reduces to the prior par-based form; for non-par markets it generalizes
+    // correctly. If the oracle is unavailable, fall back to the par-based form as a safe
+    // default for the stablecoin pairs this adapter routes today.
     let spreadPct = 0;
-    if (isBuy) {
-      // if is buy, the fee is positive if the price is over 1
-      spreadPct = latestPrice - 1;
-    } else {
-      spreadPct = 1 - latestPrice;
+    try {
+      const fairPrice = await this._getFairCrossPrice(spotMarketMeta.baseAssetName, spotMarketMeta.quoteAssetName);
+      const slippageDecimal = spotMarketMeta.isBuy
+        ? (latestPrice - fairPrice) / fairPrice
+        : (fairPrice - latestPrice) / fairPrice;
+      spreadPct = Math.max(0, slippageDecimal);
+    } catch (err) {
+      this.logger.warn({
+        at: "HyperliquidStablecoinSwapAdapter.getEstimatedCost",
+        message: `Oracle fair price unresolved for ${spotMarketMeta.baseAssetName}/${spotMarketMeta.quoteAssetName}; falling back to par-based assumption`,
+        err: String(err),
+      });
+      spreadPct = Math.max(0, spotMarketMeta.isBuy ? latestPrice - 1 : 1 - latestPrice);
     }
     const spreadFee = toBNWei(spreadPct.toFixed(18), 18).mul(amountToTransfer).div(toBNWei(1, 18));
 


### PR DESCRIPTION
## Summary

Generalizes the spread-vs-par formula used inside `getEstimatedCost` on both `BinanceStablecoinSwapAdapter` and `HyperliquidStablecoinSwapAdapter` so it works for any spot market, not just dollar-pegged pairs. The HL adapter previously did `1 − latestPrice`, and BN was originally depth-only (and then in earlier commits on this branch, gated to stablecoin symbols). Both forms hardcoded $1 as the fair price, which:

1. **Missed real cost on stablecoin pairs.** USDCUSDT asks on Binance sit around ~$1.001; a market BUY pays the ~10 bps gap vs $1 even when slippage-vs-bestPx is ~0. BN's depth-only estimator reported ~0 bps on $200k+ swaps that actually cost 10-11 bps round-trip.
2. **Made the par assumption non-reusable.** A naive `latestPrice − 1` for ETH/USDC (`latestPrice ≈ 3500`) would report ~3500 bps of "spread" and dominate the cost-estimator's route selection.

## Approach

Measure the spread against an oracle-derived fair cross-token price `P_base_usd / P_quote_usd`. The ratio is dimensionless: for dollar-pegged pairs it ≈ 1 and the formula reduces to the prior par-based form; for non-par markets it correctly compares the order book's worst-fill price to the true cross-token rate.

```ts
const fairPrice = await this._getFairCrossPrice(
  spotMarketMeta.baseAssetName,
  spotMarketMeta.quoteAssetName
);
const slippageDecimal = spotMarketMeta.isBuy
  ? (latestPrice - fairPrice) / fairPrice
  : (fairPrice - latestPrice) / fairPrice;
spreadPct = Math.max(0, slippageDecimal /* × 100 for BN's percent units */);
```

## Infrastructure

Added two helpers on `BaseAdapter` (already holds the shared `PriceClient`):

- `_getTokenPriceUsd(symbol)` — mirrors `CumulativeBalanceRebalancerClient._getTokenPriceUsd`: resolves the hub-chain token address, supports `RELAYER_TOKEN_PRICE_FIXED_<address>` env override, returns an 18-decimal BigNumber USD price. Cached per-instance.
- `_getFairCrossPrice(baseToken, quoteToken)` — returns the dimensionless ratio `P_base / P_quote` as a plain number, ready for `latestPrice` comparison.

The cache scope matches the cumulative client (per-instance, no TTL) because the rebalancer is short-lived per cycle. Flagged in the source comment so a future long-lived runtime can add eviction.

## Adapter changes

- **BN**: removes the `STABLECOIN_SYMBOLS` gate (added in an earlier commit on this branch), now queries `_getFairCrossPrice` directly. Falls back to depth-only slippage if the oracle fails, with a warn log.
- **HL**: replaces the `1 − latestPrice` block with the same oracle-based form. Falls back to the original par-based formula on oracle failure (preserves current behavior for the stablecoin pairs HL routes today).
- Both adapters now clamp `spreadPct` to `≥ 0` so a favorably-priced book doesn't surface as a negative cost or crash `toBNWei`.

## Production evidence (from prior commits on this branch)

The BN cost estimator was reporting `expectedFees` ≈ 0 on $200k+ same-chain USDCUSDT swaps that realized ~10-11 bps cost. After this change, BN's `expectedFees` should land in the right ballpark when comparing against realized round-trip cost on USDCUSDT, USDC/DAI, and any future non-stable routing.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn lint` + prettier clean on the three modified files
- [x] `test/BinanceAdapter.quotes.ts` — 4/4 existing tests pass
- [x] `test/RebalancerClient.cumulativeRebalancing.ts` — 17/17 existing tests pass (this exercises `getEstimatedCost` via the cheapest-route selection logic)
- [ ] Post-deploy: `RebalanceClient.rebalanceCumulativeInventory` logs should show `expectedFees` values in the ~10-15 bps range for BN-routed USDCUSDT swaps, matching realized cost
- [ ] Post-deploy: HL `expectedFees` should remain roughly stable (USDC/USDT pair fair price ≈ 1 so formula yields the same result)

## Doc updates

No `README.md` or `AGENTS.md` updates — the change is implementation-level and the public interface (`getEstimatedCost`) signature is unchanged. The `RebalancerAdapter` interface and `src/rebalancer/README.md` adapter-interface section stay accurate. If reviewers want a comment in `docs/rebalancer-mode-adapter-architecture.md` calling out the oracle-priced reference, happy to add it.

## Branch history note

This PR's commit history shows the evolution discussed in-thread:
1. `d2c1edd` — initial par-based fix for BN (correct for stables, but unsafe for non-stables)
2. `d4d53cf` — gated the par-based logic on a stablecoin symbol allowlist (review feedback)
3. `a0bf620` — generalizes via oracle fair price, removes the stablecoin gate, and applies the same treatment to the HL adapter

Happy to squash on merge.