### PR TITLE
fix: do not lock deposits which fail in simulation

### DIFF
--- a/src/gasless/GaslessRelayer.ts
+++ b/src/gasless/GaslessRelayer.ts
@@ -685,6 +685,9 @@ export class GaslessRelayer {
                 fillImmediate = false;
                 // Drop synthetic (or any in-memory) deposit so DEPOSIT_CONFIRM's standard branch must re-resolve from receipt / chain.
                 deposit = undefined;
+		// It's possible the deposit will always fail in simulation (e.g. insufficient balance). In this
+		// case, drop the lock on the deposit in case there were follow-up requests we need to unblock.
+		delete this.fillLock[fillKey];
               }
             }
 

--- a/src/gasless/GaslessRelayer.ts
+++ b/src/gasless/GaslessRelayer.ts
@@ -685,9 +685,9 @@ export class GaslessRelayer {
                 fillImmediate = false;
                 // Drop synthetic (or any in-memory) deposit so DEPOSIT_CONFIRM's standard branch must re-resolve from receipt / chain.
                 deposit = undefined;
-		// It's possible the deposit will always fail in simulation (e.g. insufficient balance). In this
-		// case, drop the lock on the deposit in case there were follow-up requests we need to unblock.
-		delete this.fillLock[fillKey];
+                // It's possible the deposit will always fail in simulation (e.g. insufficient balance). In this
+                // case, drop the lock on the deposit in case there were follow-up requests we need to unblock.
+                delete this.fillLock[fillKey];
               }
             }
 

--- a/src/gasless/GaslessRelayer.ts
+++ b/src/gasless/GaslessRelayer.ts
@@ -685,9 +685,6 @@ export class GaslessRelayer {
                 fillImmediate = false;
                 // Drop synthetic (or any in-memory) deposit so DEPOSIT_CONFIRM's standard branch must re-resolve from receipt / chain.
                 deposit = undefined;
-                // It's possible the deposit will always fail in simulation (e.g. insufficient balance). In this
-                // case, drop the lock on the deposit in case there were follow-up requests we need to unblock.
-                delete this.fillLock[fillKey];
               }
             }
 
@@ -769,8 +766,11 @@ export class GaslessRelayer {
                 nextState = MessageState.FILL_PENDING;
               } else {
                 log("info", `Could not locate deposit on ${origin}.`);
-                await delay(1);
+                // It's possible the deposit will always fail in simulation (e.g. insufficient balance). In this
+                // case, drop the lock on the deposit in case there were follow-up requests we need to unblock.
+                delete this.fillLock[fillKey];
                 nextState = MessageState.DEPOSIT_SUBMIT;
+                await delay(1);
               }
             }
             setState(nextState);


### PR DESCRIPTION
We do not want to block on a deposit which fails in simulation.