### PR TITLE
fix(tx-utils): surface dispatchTransaction empty-response failures

### DIFF
--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -293,7 +293,19 @@ export async function dispatchTransaction(
     throw new Error(`${message} (${reason})`);
   }
 
-  return dispatcher.dispatch(transaction, transaction.contract, transaction.contract.provider);
+  const response = await dispatcher.dispatch(transaction, transaction.contract, transaction.contract.provider);
+  // `dispatcher.dispatch` resolves to `(await submit(...))[0]`, which is `undefined` when `submit`
+  // returns an empty array (i.e. the underlying `_submit` threw and `submit` swallowed it). Mirror
+  // the explicit guard in `submitTransaction` so callers see a thrown error instead of `undefined`
+  // — otherwise `sendAndConfirmTransaction` silently treats the failure as a no-op.
+  if (!response) {
+    throw new Error(
+      `Transaction succeeded simulation but failed to submit onchain via dispatch to ${
+        targetContract.address
+      }.${method}(${txnRequestData.args.join(", ")}) on ${txnRequest.chainId}`
+    );
+  }
+  return response;
 }
 
 /**

--- a/test/TransactionClient.ts
+++ b/test/TransactionClient.ts
@@ -1,6 +1,7 @@
 import { AugmentedTransaction } from "../src/clients";
 import {
   BigNumber,
+  dispatchTransaction,
   ethers,
   isDefined,
   TransactionReceipt,
@@ -236,6 +237,42 @@ describe("TransactionClient", function () {
       expect(txnResponses.length).to.equal(1);
       // wait() was called maxTries times (default is 10).
       expect(waitCalls).to.equal(10);
+    });
+  });
+
+  describe("dispatchTransaction empty-response guard", function () {
+    function makeTxn(chainId: number, result: string): AugmentedTransaction {
+      return {
+        chainId,
+        contract: { address, signer } as Contract,
+        method,
+        args: [{ result }],
+        message: "",
+        mrkdwn: "",
+      };
+    }
+
+    // `TransactionClient.dispatch` returns `(await submit(...))[0]` which is `undefined` when
+    // submit swallows a thrown error from `_submit`. Without the guard in `dispatchTransaction`,
+    // that `undefined` propagates up to callers as a false "skipped" result. Verify the guard
+    // converts it into a thrown error so callers can distinguish real failures.
+    it("throws when dispatch returns undefined (mirroring submitTransaction)", async function () {
+      const chainId = chainIds[0];
+      const original = txnClient.dispatch.bind(txnClient);
+      (txnClient as unknown as { dispatch: typeof original }).dispatch = async () =>
+        undefined as unknown as TransactionResponse;
+      try {
+        let caught: Error | undefined;
+        try {
+          await dispatchTransaction(makeTxn(chainId, txnClientPassResult), txnClient);
+        } catch (e) {
+          caught = e as Error;
+        }
+        expect(caught, "dispatchTransaction should have thrown").to.exist;
+        expect(caught?.message).to.include("failed to submit onchain via dispatch");
+      } finally {
+        (txnClient as unknown as { dispatch: typeof original }).dispatch = original;
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Slack discussion: continuation of the gasless stuck-queue reporting thread (PR #3464).

`TransactionClient.dispatch` resolves to `(await submit(...))[0]`, which evaluates to `undefined` whenever the inner `_submit` throws and `submit` swallows the error (its standard behavior — it returns the partial array of responses and logs at `info` with `notificationPath: across-error`). `dispatchTransaction` was forwarding that `undefined` verbatim, so callers like `sendAndConfirmTransaction` could not distinguish a real stuck-queue submission failure from a no-op return.

This PR mirrors the existing guard `submitTransaction` already applies on the same shape: after `dispatcher.dispatch(...)` returns, check for `undefined` and throw a descriptive `Error` instead. The dispatch-path now fails loudly, matching the non-dispatch path. No other behavior changes.

## Scope

- One-file production change in `src/utils/TransactionUtils.ts`; one targeted regression test in `test/TransactionClient.ts`.
- Independent of PR #3464 (the gasless typed-outcome work). #3464's `TransactionSubmissionFailedError` path will subsume this `new Error(...)` once that lands — straightforward conflict to resolve.

## Doc updates considered

No `AGENTS.md` / `README.md` shifts needed: this is a behavior-preserving bug fix; the module map and runtime flow stay the same.

## Test plan

- [x] `yarn typecheck` — clean.
- [x] `yarn lint` — clean.
- [x] `yarn hardhat test test/TransactionClient.ts` — 11/11 passing, including the new "throws when dispatch returns undefined (mirroring submitTransaction)" case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)