### PR TITLE
improve(tx-client): typed error when broadcast tx cannot be confirmed

### DIFF
--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -7,6 +7,7 @@ import {
   BigNumber,
   blockExplorerLink,
   toBNWei,
+  TransactionConfirmationFailedError,
   TransactionReceipt,
   TransactionResponse,
   TransactionSimulationResult,
@@ -177,6 +178,14 @@ export class TransactionClient {
 
       if (!txnReceipt) {
         this.logger.warn({ at, message: `Unable to confirm ${chain} transaction.`, txnRef });
+        // Previously this code path silently returned the broadcast response; callers couldn't
+        // distinguish a confirmed tx from an unconfirmed stuck-in-mempool one. Surface a typed
+        // error so `submit()` can let it propagate (rather than swallowing as a generic submit
+        // failure) and downstream consumers can branch on `instanceof`.
+        throw new TransactionConfirmationFailedError(
+          `Transaction broadcast on ${chain} could not be confirmed after ${maxTries} attempts.`,
+          txnResponse
+        );
       }
     }
 
@@ -230,6 +239,19 @@ export class TransactionClient {
         response = await this._submit(txn, { nonce: nonce ?? null });
       } catch (error) {
         delete chainNonceMap[signerAddr];
+        // Confirmation failures (broadcast OK but receipt never observed) are re-thrown so callers
+        // can distinguish them from generic pre-broadcast errors. All other errors continue to be
+        // logged and swallowed in line with the pre-existing contract of `submit`.
+        if (error instanceof TransactionConfirmationFailedError) {
+          this.logger.warn({
+            at: "TransactionClient#submit",
+            message: `Transaction ${idx + 1} on ${networkName} broadcast but never confirmed.`,
+            mrkdwn,
+            errorMessage: error.message,
+            notificationPath: "across-error",
+          });
+          throw error;
+        }
         this.logger.info({
           at: "TransactionClient#submit",
           message: `Transaction ${idx + 1} submission on ${networkName} failed or timed out.`,

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -256,6 +256,29 @@ export function getTarget(targetAddress: string):
   }
 }
 
+/**
+ * Thrown by `TransactionClient._submit` when a transaction was broadcast successfully but the
+ * client could not confirm its receipt after `maxTries` attempts. Previously this condition was
+ * masked: `_submit` warned and returned the underlying `TransactionResponse` as if everything was
+ * fine, which let callers (e.g. `sendAndConfirmTransaction`) end up calling `.wait()` again
+ * against an RPC that may retry forever. The typed error lets `TransactionClient.submit` re-throw
+ * this specific case (instead of swallowing it like other submission errors) so consumers can
+ * react to a real "stuck unconfirmed" outcome.
+ *
+ * Attaches the submitted `TransactionResponse` (when one exists) so callers can still correlate
+ * the failure to the broadcast tx hash for diagnostics.
+ */
+export class TransactionConfirmationFailedError extends Error {
+  readonly kind = "confirmation_failed" as const;
+  constructor(
+    message: string,
+    readonly response: TransactionResponse | undefined
+  ) {
+    super(message);
+    this.name = "TransactionConfirmationFailedError";
+  }
+}
+
 export async function submitTransaction(
   transaction: AugmentedTransaction,
   transactionClient: TransactionClient

--- a/test/TransactionClient.ts
+++ b/test/TransactionClient.ts
@@ -3,6 +3,7 @@ import {
   BigNumber,
   ethers,
   isDefined,
+  TransactionConfirmationFailedError,
   TransactionReceipt,
   TransactionResponse,
   TransactionSimulationResult,
@@ -223,7 +224,7 @@ describe("TransactionClient", function () {
       expect(waitCalls).to.equal(2);
     });
 
-    it("Gives up after maxTries exhausted", async function () {
+    it("Throws TransactionConfirmationFailedError when maxTries is exhausted", async function () {
       const chainId = chainIds[0];
       let waitCalls = 0;
       txnClient.waitOverride = () => {
@@ -231,11 +232,28 @@ describe("TransactionClient", function () {
         return Promise.reject(makeEthersError(ethers.errors.SERVER_ERROR));
       };
 
-      const txnResponses = await txnClient.submit(chainId, [makeConfirmationTxn(chainId)]);
-      // The transaction still returns because _submit returns txnPromise even when confirmation fails.
-      expect(txnResponses.length).to.equal(1);
+      let caught: unknown;
+      try {
+        await txnClient.submit(chainId, [makeConfirmationTxn(chainId)]);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught, "submit should have thrown after maxTries").to.be.instanceOf(TransactionConfirmationFailedError);
       // wait() was called maxTries times (default is 10).
       expect(waitCalls).to.equal(10);
+      // The submitted response should be attached so callers can correlate to the broadcast tx.
+      expect((caught as TransactionConfirmationFailedError).response).to.exist;
+    });
+
+    it("Generic submit errors are still swallowed (no regression)", async function () {
+      const chainId = chainIds[0];
+      // Force the underlying tx promise to reject pre-confirmation. _submit re-throws, submit
+      // logs and returns an empty array — same as the existing "Handles submission success &
+      // failure" case but exercised here against the ensureConfirmation surface.
+      const txnResponses = await txnClient.submit(chainId, [
+        { ...makeConfirmationTxn(chainId), args: [{ result: "Forced submission failure" }] },
+      ]);
+      expect(txnResponses.length).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

Slack discussion: continuation of the gasless stuck-queue reporting thread (PRs #3464, #3465, #3466). Opening as a **draft** because this changes `TransactionClient.submit`'s contract slightly — worth a sanity check before merging.

`TransactionClient._submit`'s confirmation loop previously warned and returned the broadcast `TransactionResponse` when `wait()` never produced a receipt within `maxTries` retries. Two problems flow from that:

1. **Callers couldn't tell broadcast-only from confirmed.** `sendAndConfirmTransaction` would call `.wait()` again on the same response, potentially polling indefinitely against the RPC. The bot's state machine treated the tx as confirmed.
2. **No signal for the gasless stuck-queue counter** (PR #3464). A tx that broadcasts but never confirms is precisely the "stuck queue" the user wants to count, but today it looks like a success internally.

## Change

- New `TransactionConfirmationFailedError` (in `src/utils/TransactionUtils.ts`) — extends `Error`, carries the submitted `TransactionResponse` so callers can correlate to the broadcast tx hash, and exposes a `kind: "confirmation_failed"` literal for future discriminated unions.
- `_submit` throws it after the `maxTries` loop completes without a receipt, in addition to the existing warn-level log.
- `TransactionClient.submit` whitelists it in the catch and re-throws (with its own warn log), so it propagates out rather than being swallowed alongside generic submission errors. All other error categories continue to be logged at `info` and swallowed at submit's existing surface — no regression for the ~15 direct callers that depend on submit's lenient contract.

## Behavior change worth noting

Today: `_submit` with `ensureConfirmation: true` and a `wait()` that keeps failing eventually returns the broadcast response — `sendAndConfirmTransaction`'s outer `txResponse.wait()` then potentially retries forever or returns late, and the caller proceeds as if confirmed.

After this change: the same scenario throws → `sendAndConfirmTransaction` (which catches all errors and returns `undefined`) treats it as a failure → caller's existing `!isDefined(receipt)` branch fires and logs "Failed to submit X tx". For the DepositAddressHandler and (post-#3464) GaslessRelayer callers, this is the desired behavior — silent give-up becomes loud failure.

Only callers that set `ensureConfirmation: true` are affected. In production today, only `sendAndConfirmTransaction` sets it (`DepositAddressHandler` × 3 sites + gasless × 2 sites).

## Doc updates considered

No `AGENTS.md` / `README.md` shifts. The error class is a new export but the module map and runtime flow stay the same.

## Test plan

- [x] `yarn typecheck` — clean.
- [x] `yarn lint` — clean.
- [x] `yarn hardhat test test/TransactionClient.ts` — 11/11 passing.
  - Replaced the existing "Gives up after maxTries exhausted" test (which asserted the silent-fall-through) with "Throws TransactionConfirmationFailedError when maxTries is exhausted".
  - Added "Generic submit errors are still swallowed (no regression)" to lock in the contract for non-confirmation errors.
- [x] `yarn hardhat test test/TransactionClient.ts test/DepositAddressHandler.ts test/MultiCallerClient.ts test/TryMulticallClient.ts` — 40/40 passing (broader sanity check on adjacent surfaces).
- [ ] Reviewer sanity-check: any non-test caller relying on the old "broadcast-but-unconfirmed treated as success" semantics? Best place to look is anywhere setting `ensureConfirmation: true` outside of `sendAndConfirmTransaction`.

## Stacking

- Sits on master; independent of #3464, #3465, #3466. When #3464 lands, the gasless counter will naturally see this as a `submission_failed` outcome (via `sendAndConfirmTransaction`'s existing try/catch). Adding a fourth `TransactionOutcome` variant for `confirmation_failed` specifically is a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)