### PR TITLE
feat(deposit-address): v3 deposit-execute path (thin submitter)

### DIFF
--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -41,6 +41,46 @@ export interface SignedWithdrawResponse {
   deadline: number;
 }
 
+/**
+ * Request body for the v3 deposit-address execute endpoint. The API re-derives the deposit
+ * address and all counterfactual materials from the identity (`destination`, `userAddress`);
+ * the bot only supplies funding context and its payout address.
+ */
+export interface DepositAddressExecuteRequest {
+  destination: {
+    token: {
+      chainId: number;
+      address: string;
+    };
+    recipient: string;
+  };
+  originChainId: number;
+  /** The withdraw "user" identity committed at deposit-address creation (the refund address). */
+  userAddress: string;
+  /** Input amount as a decimal (or 0x-hex) bigint string. */
+  amount: string;
+  executionFeeRecipient: string;
+  /** Bot-priced payout, deducted from the bridged amount. Omitted => 0. */
+  executionFee?: string;
+}
+
+export interface DepositAddressExecuteResponse {
+  /** The API's re-derived deposit address; must match the funded address from the indexer. */
+  depositAddress: string;
+  executeTx: {
+    ecosystem: "evm";
+    chainId: number;
+    to: string;
+    data: string;
+    value: string;
+  };
+  signer: string;
+  /** Unix-seconds deadline on the embedded counterfactual signature; calldata is perishable. */
+  signatureDeadline: number;
+  /** True when the address derivation used placeholder creation code; never submit if set. */
+  isPlaceholder: boolean;
+}
+
 interface SwapData {
   approval?: {
     target: EvmAddress;
@@ -148,6 +188,10 @@ export class AcrossSwapApiClient extends BaseAcrossApiClient {
 
   async signedWithdraw(req: SignedWithdrawRequest): Promise<SignedWithdrawResponse | undefined> {
     return this._post<SignedWithdrawResponse>("/swap/counterfactual/sign-withdraw", req);
+  }
+
+  async executeDepositAddress(req: DepositAddressExecuteRequest): Promise<DepositAddressExecuteResponse | undefined> {
+    return this._post<DepositAddressExecuteResponse>("deposit-addresses/execute", req);
   }
 
   private _isRouteSupported(route: SwapRoute): boolean {

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -23,14 +23,33 @@ import {
   normalizeDepositAddressMessage,
   toAddressType,
   TransactionReceipt,
+  getCurrentTime,
 } from "../utils";
 import { getRedisCache, RedisCacheInterface } from "../cache/Redis";
-import { DepositAddressMessage } from "../interfaces";
-import { AcrossSwapApiClient, TransactionClient, SwapApiResponse, SignedWithdrawResponse } from "../clients";
+import {
+  AnyDepositAddressMessage,
+  DepositAddressMessage,
+  DepositAddressMessageV3,
+  isDepositAddressMessageV3,
+} from "../interfaces";
+import {
+  AcrossSwapApiClient,
+  TransactionClient,
+  SwapApiResponse,
+  SignedWithdrawResponse,
+  DepositAddressExecuteResponse,
+} from "../clients";
 import { AcrossIndexerApiClient } from "../clients/AcrossIndexerApiClient";
 import { GcpPubSubPublisher, getGcpPubSubPublisher } from "../messaging/gcp";
 import { buildWithdrawExecutedPayload } from "./withdrawPayload";
 import ERC20_ABI from "../common/abi/MinimalERC20.json";
+
+/**
+ * Minimum seconds that must remain on a v3 execute response's signatureDeadline at submission
+ * time — headroom for simulation, broadcast and confirmation. Responses closer to expiry are
+ * dropped and re-requested fresh on the next poll.
+ */
+const V3_SIGNATURE_DEADLINE_BUFFER = 60;
 
 /**
  * Independent relayer bot which processes EIP-3009 signatures into deposits and corresponding fills.
@@ -268,13 +287,30 @@ export class DepositAddressHandler {
   }
 
   /**
-   * Dispatches an indexer message to the deposit or refund-withdraw path based on its classification:
-   *   - correct_transfer: forward deposit/execute path.
-   *   - mis_route / intent_refund: refund-withdraw path.
+   * Dispatches an indexer message to the deposit or refund-withdraw path based on its version and
+   * classification:
+   *   - v3 correct_transfer: thin-submitter execute path (initiateDepositV3).
+   *   - v3 anything else: dropped — the v3 refund-withdraw flow is not yet supported.
+   *   - v1 correct_transfer: forward deposit/execute path.
+   *   - v1 mis_route / intent_refund: refund-withdraw path.
    *   - anything else: dropped (forward-compat) until explicitly supported.
    */
-  private async processExecution(depositMessage: DepositAddressMessage): Promise<void> {
+  private async processExecution(depositMessage: AnyDepositAddressMessage): Promise<void> {
     const classification = depositMessage.erc20Transfer.transferClassification;
+    if (isDepositAddressMessageV3(depositMessage)) {
+      if (classification === "correct_transfer") {
+        return this.initiateDepositV3(depositMessage);
+      }
+      this.logger.debug({
+        at: "DepositAddressHandler#processExecution",
+        message: "deposit-address transfer skipped: v3 refund-withdraw not yet supported",
+        classification,
+        depositAddress: depositMessage.depositAddress,
+        txHash: depositMessage.erc20Transfer.transactionHash,
+        chainId: depositMessage.erc20Transfer.chainId,
+      });
+      return;
+    }
     if (classification === "correct_transfer") {
       return this.initiateDeposit(depositMessage);
     }
@@ -739,6 +775,221 @@ export class DepositAddressHandler {
     await this._persistExecutedDepositsRedis();
   }
 
+  /**
+   * v3 (upgradeable-counterfactual) deposit-execute path. The bot is a thin submitter: it relays
+   * funding context to the quote-api execute endpoint, which re-derives the deposit address and
+   * merkle materials server-side and returns ready-to-sign factory calldata wrapping
+   * `deployIfNeededAndExecute` — so unlike v1 there is no bot-side deploy step. The returned
+   * calldata embeds a deadline-bounded signature: it is perishable and is re-requested fresh on
+   * the next poll after any failure, never patched.
+   */
+  private async initiateDepositV3(depositMessage: DepositAddressMessageV3): Promise<void> {
+    const { depositAddress, routeParams, refundAddress, erc20Transfer, depositAddressNamespace } = depositMessage;
+    const { amount, transactionHash: refTxHash, contractAddress: inputToken } = erc20Transfer;
+    const originChainId = Number(erc20Transfer.chainId);
+    const destinationChainId = Number(routeParams.destinationChainId);
+    const depositKey = getDepositKey(depositMessage);
+
+    if (!this.config.relayerOriginChains.includes(originChainId)) {
+      return;
+    }
+
+    // Skip if a previous instance (or this one) already executed this deposit (persisted in Redis).
+    if (this.executedDepositTxHashes.has(refTxHash)) {
+      this.logger.debug({
+        at: "DepositAddressHandler#initiateDepositV3",
+        message: "Skipping already executed deposit (found in Redis)",
+        refTxHash,
+        depositKey,
+      });
+      return;
+    }
+
+    if (this.observedExecutedDeposits[originChainId]?.has(depositKey)) {
+      return;
+    }
+
+    this.observedExecutedDeposits[originChainId].add(depositKey);
+    // Release the in-flight lock on every exit path except a confirmed on-chain execute; an
+    // unexpected throw must not strand the depositKey, since the next poll would silently skip it.
+    let executeCommitted = false;
+    try {
+      // The execute endpoint identity (userAddress) must be an EVM address; non-EVM identities
+      // cannot be executed through this path.
+      if (depositAddressNamespace !== "evm" || refundAddress.namespace !== "evm") {
+        this.logger.warn({
+          at: "DepositAddressHandler#initiateDepositV3",
+          message: "Skipping v3 deposit: unsupported account namespace",
+          depositAddressNamespace,
+          refundAddressNamespace: refundAddress.namespace,
+          depositAddress,
+          refTxHash,
+          chainId: originChainId,
+        });
+        return;
+      }
+
+      // Defensive on-chain balance check — guards against reorged indexer messages and against
+      // acting on a deposit-address that has already been executed through another path.
+      const inputTokenContract = new Contract(inputToken, ERC20_ABI, this.providersByChain[originChainId]);
+      const onchainBalance: BigNumber = await inputTokenContract.balanceOf(depositAddress);
+      if (onchainBalance.lt(toBN(amount))) {
+        this.logger.debug({
+          at: "DepositAddressHandler#initiateDepositV3",
+          message: "Deposit address does not have sufficient input token balance to initiate deposit.",
+          depositKey,
+          depositAddress,
+          inputToken,
+          amount,
+          onchainBalance: onchainBalance.toString(),
+        });
+        return;
+      }
+
+      const executeResponse = await this._getExecuteTx(depositMessage);
+      if (!isDefined(executeResponse)) {
+        this.logger.warn({
+          at: "DepositAddressHandler#initiateDepositV3",
+          message: "Failed to fetch execute tx from swap API",
+          depositKey,
+          depositAddress,
+          chainId: originChainId,
+        });
+        return;
+      }
+      if (!this._validateExecuteResponse(executeResponse, depositMessage, originChainId, depositKey)) {
+        return;
+      }
+
+      const { executeTx: apiExecuteTx } = executeResponse;
+      const useDispatcher = this.depositAddressSigners.length > 0;
+      const executeTx = {
+        contract: this.getExecuteContract(apiExecuteTx.to, originChainId, useDispatcher),
+        method: "",
+        args: [apiExecuteTx.data],
+        value: toBN(apiExecuteTx.value),
+        chainId: originChainId,
+        message: "Completed Deposit Execution Successfully 🎯",
+        mrkdwn: `Completed execution of v3 Deposit on ${getNetworkName(originChainId)} to ${getNetworkName(
+          destinationChainId
+        )}, using deposit address ${blockExplorerLink(depositAddress, originChainId)}`,
+      };
+
+      const depositReceipt = await sendAndConfirmTransaction(executeTx, this.transactionClient, useDispatcher);
+      if (!isDefined(depositReceipt)) {
+        this.logger.warn({
+          at: "DepositAddressHandler#initiateDepositV3",
+          message: "Failed to submit execute tx",
+          depositKey,
+          executeTx: {
+            ...executeTx,
+            contract: executeTx.contract.address,
+          },
+        });
+        return;
+      }
+
+      // The execute is on-chain; keep the in-flight lock and persist to Redis immediately so
+      // handover cannot miss this execute.
+      this.executedDepositTxHashes.add(refTxHash);
+      executeCommitted = true;
+      await this._persistExecutedDepositsRedis();
+    } finally {
+      if (!executeCommitted) {
+        this.observedExecutedDeposits[originChainId].delete(depositKey);
+      }
+    }
+  }
+
+  /**
+   * Sanity-checks an execute response before submission. Most importantly, the API's re-derived
+   * deposit address must match the funded address from the indexer — a mismatch means the API
+   * would deploy/execute at a different address than the one holding the user's funds.
+   */
+  private _validateExecuteResponse(
+    executeResponse: DepositAddressExecuteResponse,
+    depositMessage: DepositAddressMessageV3,
+    originChainId: number,
+    depositKey: string
+  ): boolean {
+    const { depositAddress } = depositMessage;
+    const { executeTx, isPlaceholder, signatureDeadline } = executeResponse;
+    const logContext = {
+      at: "DepositAddressHandler#initiateDepositV3",
+      depositKey,
+      depositAddress,
+      chainId: originChainId,
+    };
+
+    if (executeResponse.depositAddress.toLowerCase() !== depositAddress.toLowerCase()) {
+      this.logger.warn({
+        ...logContext,
+        message: "Skipping execute: API-derived deposit address does not match funded deposit address",
+        apiDepositAddress: executeResponse.depositAddress,
+      });
+      return false;
+    }
+    if (executeTx.chainId !== originChainId) {
+      this.logger.warn({
+        ...logContext,
+        message: "Skipping execute: execute tx chainId does not match origin chainId",
+        executeTxChainId: executeTx.chainId,
+      });
+      return false;
+    }
+    if (isPlaceholder) {
+      this.logger.warn({
+        ...logContext,
+        message: "Skipping execute: API derivation used placeholder creation code",
+      });
+      return false;
+    }
+    // The embedded signature is deadline-bounded; leave headroom for simulation + broadcast +
+    // confirmation. A stale response is dropped and re-requested fresh on the next poll.
+    if (signatureDeadline < getCurrentTime() + V3_SIGNATURE_DEADLINE_BUFFER) {
+      this.logger.warn({
+        ...logContext,
+        message: "Skipping execute: signature deadline too close to expiry",
+        signatureDeadline,
+      });
+      return false;
+    }
+    return true;
+  }
+
+  private async _getExecuteTx(
+    depositMessage: DepositAddressMessageV3,
+    retriesRemaining = 3
+  ): Promise<DepositAddressExecuteResponse | undefined> {
+    const { routeParams, refundAddress, erc20Transfer } = depositMessage;
+    // The API re-derives the deposit address and merkle materials from this identity; the bot
+    // sends funding context only (relaying ≠ building calldata). executionFee is omitted for now:
+    // the API defaults it to 0 and bot-side fee pricing is deferred to a follow-up task.
+    const request = {
+      destination: {
+        token: {
+          chainId: Number(routeParams.destinationChainId),
+          address: routeParams.outputToken,
+        },
+        recipient: routeParams.recipient.address,
+      },
+      originChainId: Number(erc20Transfer.chainId),
+      userAddress: refundAddress.address,
+      amount: erc20Transfer.amount,
+      executionFeeRecipient: this.signerAddress.toNative(),
+    };
+    // `_post` swallows errors and returns undefined, so retry on both throw and falsy return.
+    try {
+      const result = await this.api.executeDepositAddress(request);
+      if (result) {
+        return result;
+      }
+    } catch {
+      // Logging is handled in AcrossSwapApiClient.
+    }
+    return retriesRemaining > 0 ? this._getExecuteTx(depositMessage, --retriesRemaining) : undefined;
+  }
+
   private getExecuteContract(address: string, originChainId: number, useDispatcher: boolean): Contract {
     const contract = new Contract(address, []);
     return useDispatcher ? contract : contract.connect(this.baseSigner.connect(this.providersByChain[originChainId]));
@@ -757,36 +1008,37 @@ export class DepositAddressHandler {
   /*
    * @notice Queries the Indexer API for all pending deposit addresses transactions. By default, do not retry since this endpoing is being polled.
    */
-  private async _queryIndexerApi(retriesRemaining = 3): Promise<DepositAddressMessage[]> {
-    let apiResponseData: DepositAddressMessage[] | undefined = undefined;
+  private async _queryIndexerApi(retriesRemaining = 3): Promise<AnyDepositAddressMessage[]> {
+    let apiResponseData: AnyDepositAddressMessage[] | undefined = undefined;
     try {
-      apiResponseData = await this.indexerApi.get<DepositAddressMessage[]>(this.config.indexerApiEndpoint, {});
+      apiResponseData = await this.indexerApi.get<AnyDepositAddressMessage[]>(this.config.indexerApiEndpoint, {});
     } catch {
       // Error log should have been emitted in IndexerApiClient.
     }
     if (!isDefined(apiResponseData)) {
       return retriesRemaining > 0 ? this._queryIndexerApi(--retriesRemaining) : [];
     }
-    // Drop unsupported v2/v3 messages BEFORE normalization. v2/v3 payloads may not carry the v1
-    // shape (routeParams/erc20Transfer/counterfactualMaterials), and normalizeDepositAddressMessage
-    // dereferences those unconditionally — a single bad message would throw and sink the whole batch,
-    // starving supported v1 messages in the same response. Only top-level fields are safe to read here.
+    // Drop unsupported message versions BEFORE normalization. Unsupported payloads (e.g. v2) may
+    // not carry the v1 shape (routeParams/erc20Transfer/counterfactualMaterials), and
+    // normalizeDepositAddressMessage dereferences those unconditionally — a single bad message
+    // would throw and sink the whole batch, starving supported messages in the same response.
+    // Only top-level fields are safe to read here. v3 items keep their own shape and are passed
+    // through un-normalized (the v3 execute path is EVM-only and guards namespaces itself).
     return apiResponseData
       .filter((message) => {
         const { version } = message;
-        if (version === 2 || version === 3) {
+        if (isDefined(version) && version !== 1 && version !== 3) {
           this.logger.debug({
             at: "DepositAddressHandler#_queryIndexerApi",
             message: "deposit-address transfer skipped: unsupported message version",
             version,
             depositAddress: message.depositAddress,
-            paramsHash: message.paramsHash,
           });
           return false;
         }
         return true;
       })
-      .map(normalizeDepositAddressMessage);
+      .map((message) => (isDepositAddressMessageV3(message) ? message : normalizeDepositAddressMessage(message)));
   }
 
   private async _getSwapApiQuote(

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -52,6 +52,14 @@ import ERC20_ABI from "../common/abi/MinimalERC20.json";
 const V3_SIGNATURE_DEADLINE_BUFFER = 60;
 
 /**
+ * Indexer message versions the bot knows how to execute. Anything else (e.g. v2, or a future
+ * version shipped on the indexer before the bot supports it) is dropped before normalization —
+ * an allowlist, not a v2 denylist, so an unknown shape can never reach normalizeDepositAddressMessage
+ * and sink the whole poll batch.
+ */
+const SUPPORTED_INDEXER_MESSAGE_VERSIONS = new Set([1, 3]);
+
+/**
  * Independent relayer bot which processes EIP-3009 signatures into deposits and corresponding fills.
  */
 export class DepositAddressHandler {
@@ -1027,7 +1035,7 @@ export class DepositAddressHandler {
     return apiResponseData
       .filter((message) => {
         const { version } = message;
-        if (isDefined(version) && version !== 1 && version !== 3) {
+        if (isDefined(version) && !SUPPORTED_INDEXER_MESSAGE_VERSIONS.has(version)) {
           this.logger.debug({
             at: "DepositAddressHandler#_queryIndexerApi",
             message: "deposit-address transfer skipped: unsupported message version",

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -27,9 +27,44 @@ The indexer tags each ERC-20 transfer with a `transferClassification`:
 
 The deposit path is always active. The refund-withdraw path is gated by `WITHDRAW_ENABLED`.
 
-`_queryIndexerApi` drops any message whose top-level `version` is `2` or `3` (debug-logged) before
-normalization, since v2/v3 payloads may not carry the v1 shape that `normalizeDepositAddressMessage`
-dereferences. Only v1 — and legacy messages with no `version` field — are processed.
+Each message also carries a top-level `version` that selects the execution scheme:
+
+| Version | Path |
+| --- | --- |
+| absent / `1` | Legacy v1 scheme — normalized via `normalizeDepositAddressMessage`, then dispatched on classification as above. |
+| `3` | Upgradeable-counterfactual scheme — `correct_transfer` goes to the v3 execute path (below); refund classifications are dropped (v3 refund-withdraw is not yet supported). |
+| anything else (e.g. `2`) | Dropped (debug-logged) before normalization, since unsupported payloads may not carry a shape the normalizer can dereference. |
+
+## v3 execute flow (thin submitter)
+
+For `version: 3` messages the bot is a **thin submitter** of API-built calldata. The quote-api
+execute endpoint (`POST /deposit-addresses/execute`, bearer-authed with the same `SWAP_API_KEY`)
+re-derives the deposit address and all counterfactual merkle materials server-side from the
+identity (`destination.token`, `destination.recipient`, `userAddress`); the bot relays funding
+context only — origin chain, amount, destination route, refund identity — plus its own
+`executionFeeRecipient`. `executionFee` is currently omitted (the API defaults it to 0); bot-side
+fee pricing is a follow-up task.
+
+The flow (`initiateDepositV3`):
+
+1. Filter on `relayerOriginChains` and dedup against the same Redis/in-memory sets as v1 (the dedup
+   scheme is keyed on `erc20Transfer.transactionHash` / `depositKey`, shared across versions).
+2. Skip non-`evm` `depositAddressNamespace` / `refundAddress.namespace` (the execute identity must
+   be an EVM address).
+3. Defensive on-chain balance check, as on the other paths.
+4. Fetch `{ executeTx: { to, data, value }, ... }` from the execute endpoint. The calldata wraps
+   `factory.deployIfNeededAndExecute`, so there is **no bot-side deploy step** and the bot needn't
+   know deploy state.
+5. Validate the response before submitting: the API-derived `depositAddress` must match the funded
+   address from the indexer (mismatch would execute at a different address), `executeTx.chainId`
+   must match the origin chain, `isPlaceholder` must be false, and `signatureDeadline` must have
+   ≥60s of headroom. The calldata embeds a deadline-bounded signature — it is perishable, and on
+   any failure the next poll **re-requests fresh calldata; stale payloads are never patched**.
+6. Sign and submit via `TransactionClient` (gas, nonce, rebroadcast), then persist the tx hash to
+   Redis exactly like v1.
+
+The v3 message's `counterfactualMaterials`/`initialRoot`/`salt` are relayed by the indexer but not
+read by the execute path — the API re-derives them, so they are carried for diagnostics only.
 
 ## Execution fee (deposit-execute path)
 

--- a/src/interfaces/DepositAddress.ts
+++ b/src/interfaces/DepositAddress.ts
@@ -55,8 +55,69 @@ export interface DepositAddressMessage {
   adminWithdrawManagerContractAddress: string;
   counterfactualMaterials: CounterfactualMaterials;
   shouldSponsorAccountCreation: boolean;
-  /** Indexer message version. Bot only processes v1 (or absent = legacy v1); v2/v3 are ignored. */
+  /** Indexer message version. v1 (or absent = legacy v1) and v3 are processed; v2 is ignored. */
   version?: number;
+}
+
+/**
+ * Account in the Across namespace vocabulary (`evm`, `zksync`, `tron`, `solana`; kept open for
+ * forward-compat). Deliberately not CAIP-2: `eip155` cannot distinguish zkSync-stack chains
+ * (different CREATE2 derivation) from standard EVM, so `evm`/`zksync` are split by derivation
+ * class, not VM family.
+ */
+export interface NamespacedAccount {
+  namespace: string;
+  address: string;
+}
+
+/**
+ * v3 route leaf, relayed verbatim from the indexer. The bot never reads these for execution —
+ * the quote-api re-derives the full merkle set server-side — they are carried for
+ * forward-compat and diagnostics only.
+ */
+export interface CounterfactualMaterialV3 {
+  kind: string;
+  implementationAddress: string;
+  encodedParams: string;
+  leafHash: string;
+  merkleProof: string[];
+}
+
+/** v3 route params. Funding context (origin chain, input token, amount) lives in `erc20Transfer`. */
+export interface RouteParamsV3 {
+  outputToken: string;
+  destinationChainId: string;
+  recipient: NamespacedAccount;
+}
+
+/**
+ * v3 (upgradeable-counterfactual) `/deposit-address-transfers` item. Mirrors the indexer's
+ * `DepositAddressTransferItemV3` projection: durable identity + relayed merkle materials, with
+ * the shared `erc20Transfer` funding envelope. No `paramsHash` or
+ * `counterfactualDepositContractAddress` — those are v1-only.
+ */
+export interface DepositAddressMessageV3 {
+  depositAddress: string;
+  version: 3;
+  salt: string;
+  initialRoot: string;
+  counterfactualBeaconContractAddress: string;
+  counterfactualFactoryContractAddress: string;
+  adminWithdrawManagerContractAddress: string;
+  shouldSponsorAccountCreation: boolean;
+  counterfactualMaterials: CounterfactualMaterialV3[];
+  routeParams: RouteParamsV3;
+  refundAddress: NamespacedAccount;
+  depositAddressNamespace: string;
+  erc20Transfer: Erc20Transfer;
+}
+
+/** A `/deposit-address-transfers` item, discriminated on `version`. */
+export type AnyDepositAddressMessage = DepositAddressMessage | DepositAddressMessageV3;
+
+/** Type guard discriminating v3 items from v1/legacy. */
+export function isDepositAddressMessageV3(message: AnyDepositAddressMessage): message is DepositAddressMessageV3 {
+  return message.version === 3;
 }
 
 // TODO: Add schema for SwapAPI response.

--- a/src/utils/DepositAddressUtils.ts
+++ b/src/utils/DepositAddressUtils.ts
@@ -1,6 +1,6 @@
 import { Contract } from "ethers";
 import { AugmentedTransaction } from "../clients";
-import { DepositAddressMessage } from "../interfaces/DepositAddress";
+import { AnyDepositAddressMessage, DepositAddressMessage } from "../interfaces/DepositAddress";
 import { getEthersCompatibleAddress } from "./ContractUtils";
 
 /**
@@ -76,8 +76,9 @@ export function normalizeDepositAddressMessage(message: DepositAddressMessage): 
 
 /**
  * Returns a unique key for a deposit so we can track if it was already executed (e.g. in observedExecutedDeposits).
+ * Accepts any message version — the key only depends on the shared deposit-address/transfer envelope.
  */
-export function getDepositKey(depositMessage: DepositAddressMessage): string {
+export function getDepositKey(depositMessage: AnyDepositAddressMessage): string {
   return `${depositMessage.depositAddress}:${depositMessage.erc20Transfer.transactionHash}`;
 }
 

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -1,7 +1,8 @@
 import sinon from "sinon";
 import { expect } from "chai";
-import { EvmAddress, Signer, winston } from "../src/utils";
-import { DepositAddressMessage } from "../src/interfaces/DepositAddress";
+import { EvmAddress, getCurrentTime, Signer, winston } from "../src/utils";
+import { DepositAddressMessage, DepositAddressMessageV3 } from "../src/interfaces/DepositAddress";
+import { DepositAddressExecuteResponse } from "../src/clients";
 import { DepositAddressHandler } from "../src/deposit-address/DepositAddressHandler";
 import { DepositAddressHandlerConfig } from "../src/deposit-address/DepositAddressHandlerConfig";
 
@@ -68,6 +69,48 @@ const withdrawLeaf = {
   encodedParams: "0x",
   implementationAddress: IMPL,
 };
+
+/** v3 correct_transfer message mirroring the indexer's DepositAddressTransferItemV3 projection. */
+function depositMessageV3(overrides: Partial<DepositAddressMessageV3> = {}): DepositAddressMessageV3 {
+  return {
+    depositAddress: DEPOSIT_ADDRESS,
+    version: 3,
+    salt: "0x" + "0".repeat(64),
+    initialRoot: "0x" + "2".repeat(64),
+    counterfactualBeaconContractAddress: "0x000000000000000000000000000000000000B1B1",
+    counterfactualFactoryContractAddress: "0x000000000000000000000000000000000000B2B2",
+    adminWithdrawManagerContractAddress: "0x000000000000000000000000000000000000B3B3",
+    shouldSponsorAccountCreation: false,
+    counterfactualMaterials: [
+      {
+        kind: "vanilla-cctp",
+        implementationAddress: IMPL,
+        encodedParams: "0x",
+        leafHash: "0x" + "0".repeat(64),
+        merkleProof: [],
+      },
+    ],
+    routeParams: {
+      outputToken: OUTPUT_TOKEN,
+      destinationChainId: "1337",
+      recipient: { namespace: "evm", address: RECIPIENT },
+    },
+    refundAddress: { namespace: "evm", address: REFUND_ADDRESS },
+    depositAddressNamespace: "evm",
+    erc20Transfer: {
+      chainId: "42161",
+      blockNumber: 1_000_000,
+      logIndex: 4,
+      from: REFUND_ADDRESS,
+      to: DEPOSIT_ADDRESS,
+      amount: "5000",
+      contractAddress: TOKEN,
+      transactionHash: "0x" + "3".repeat(64),
+      transferClassification: "correct_transfer",
+    },
+    ...overrides,
+  };
+}
 
 describe("DepositAddressHandler._getSwapApiQuote execution-fee params", function () {
   let handler: DepositAddressHandler;
@@ -144,24 +187,196 @@ describe("DepositAddressHandler._queryIndexerApi version filtering", function ()
     return (handler as unknown as Internals)._queryIndexerApi();
   }
 
-  it("drops v2/v3 messages and keeps v1 + legacy in the same batch", async function () {
+  it("drops v2 messages and keeps v1 + legacy + v3 in the same batch", async function () {
     const v1 = { ...depositMessage({ withdrawLeaf }), version: 1 };
     const legacy = depositMessage({ withdrawLeaf });
-    // v2/v3 payloads that do NOT carry the v1 shape — only normalized v1/legacy messages should
-    // ever reach normalizeDepositAddressMessage, so these must be filtered out before the map.
+    // v2 payloads do NOT carry the v1 shape — only v1/legacy messages should ever reach
+    // normalizeDepositAddressMessage, so v2 must be filtered out before the map.
     const v2 = { version: 2, depositAddress: DEPOSIT_ADDRESS, paramsHash: "0x" + "0".repeat(64) };
-    const v3 = { version: 3, depositAddress: DEPOSIT_ADDRESS, paramsHash: "0x" + "0".repeat(64) };
+    const v3 = depositMessageV3();
 
     const result = await query([v2, v1, v3, legacy]);
 
-    expect(result).to.have.length(2);
-    expect(result.map((m) => m.version)).to.deep.equal([1, undefined]);
+    expect(result).to.have.length(3);
+    expect(result.map((m) => m.version)).to.deep.equal([1, 3, undefined]);
   });
 
-  it("does not throw when a v2/v3 message lacks the v1 shape", async function () {
+  it("passes v3 messages through un-normalized", async function () {
+    // normalizeDepositAddressMessage dereferences v1-only fields; a v3 item reaching it would
+    // throw. The v3 shape must be returned verbatim.
+    const v3 = depositMessageV3();
+    const result = await query([v3]);
+    expect(result).to.deep.equal([v3]);
+  });
+
+  it("does not throw when a v2 message lacks the v1 shape", async function () {
     // A bare v2 payload would make normalizeDepositAddressMessage throw if it reached the map;
     // filtering before normalization must keep the poll alive.
     const result = await query([{ version: 2 }]);
     expect(result).to.deep.equal([]);
+  });
+});
+
+describe("DepositAddressHandler.processExecution v3 routing", function () {
+  let handler: DepositAddressHandler;
+  let v3Stub: sinon.SinonStub;
+  let v1Stub: sinon.SinonStub;
+  let withdrawStub: sinon.SinonStub;
+  let logger: winston.Logger;
+
+  type Internals = { processExecution: (m: unknown) => Promise<void> };
+
+  beforeEach(function () {
+    const config = {} as unknown as DepositAddressHandlerConfig;
+    logger = { debug: sinon.stub() } as unknown as winston.Logger;
+    handler = new DepositAddressHandler(logger, config, {} as unknown as Signer, []);
+    v3Stub = sinon.stub().resolves();
+    v1Stub = sinon.stub().resolves();
+    withdrawStub = sinon.stub().resolves();
+    Object.assign(handler, { initiateDepositV3: v3Stub, initiateDeposit: v1Stub, initiateWithdraw: withdrawStub });
+  });
+
+  afterEach(() => sinon.restore());
+
+  it("routes v3 correct_transfer to the v3 execute path", async function () {
+    const message = depositMessageV3();
+    await (handler as unknown as Internals).processExecution(message);
+    expect(v3Stub.calledOnceWithExactly(message)).to.equal(true);
+    expect(v1Stub.notCalled).to.equal(true);
+    expect(withdrawStub.notCalled).to.equal(true);
+  });
+
+  it("skips v3 refund classifications (withdraw flow not yet supported)", async function () {
+    for (const transferClassification of ["mis_route", "intent_refund"] as const) {
+      const message = depositMessageV3();
+      message.erc20Transfer.transferClassification = transferClassification;
+      await (handler as unknown as Internals).processExecution(message);
+    }
+    expect(v3Stub.notCalled).to.equal(true);
+    expect(v1Stub.notCalled).to.equal(true);
+    expect(withdrawStub.notCalled).to.equal(true);
+  });
+
+  it("keeps routing v1 messages to the v1 paths", async function () {
+    const deposit = depositMessage({ withdrawLeaf });
+    await (handler as unknown as Internals).processExecution(deposit);
+    expect(v1Stub.calledOnceWithExactly(deposit)).to.equal(true);
+
+    const refund = depositMessage({ withdrawLeaf });
+    refund.erc20Transfer.transferClassification = "mis_route";
+    await (handler as unknown as Internals).processExecution(refund);
+    expect(withdrawStub.calledOnceWithExactly(refund)).to.equal(true);
+    expect(v3Stub.notCalled).to.equal(true);
+  });
+});
+
+describe("DepositAddressHandler._getExecuteTx request mapping", function () {
+  let handler: DepositAddressHandler;
+  let executeStub: sinon.SinonStub;
+
+  type Internals = {
+    _getExecuteTx: (m: DepositAddressMessageV3) => Promise<DepositAddressExecuteResponse | undefined>;
+  };
+
+  beforeEach(function () {
+    const config = {} as unknown as DepositAddressHandlerConfig;
+    handler = new DepositAddressHandler(undefined as unknown as winston.Logger, config, {} as unknown as Signer, []);
+    // _signerAddress is normally set by initialize(); set it directly for this unit test.
+    (handler as unknown as { _signerAddress: EvmAddress })._signerAddress = EvmAddress.from(SIGNER);
+    executeStub = sinon.stub().resolves({ depositAddress: DEPOSIT_ADDRESS });
+    (handler as unknown as { api: { executeDepositAddress: sinon.SinonStub } }).api = {
+      executeDepositAddress: executeStub,
+    };
+  });
+
+  afterEach(() => sinon.restore());
+
+  it("relays funding context only, with executionFee omitted", async function () {
+    await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());
+    expect(executeStub.calledOnce).to.equal(true);
+    // Exact request body: the execute endpoint re-derives the address/materials from this
+    // identity, and its superstruct schema rejects unknown or missing keys.
+    expect(executeStub.firstCall.args[0]).to.deep.equal({
+      destination: {
+        token: { chainId: 1337, address: OUTPUT_TOKEN },
+        recipient: RECIPIENT,
+      },
+      originChainId: 42161,
+      userAddress: REFUND_ADDRESS,
+      amount: "5000",
+      executionFeeRecipient: SIGNER,
+    });
+  });
+
+  it("retries on undefined responses and gives up after exhausting retries", async function () {
+    executeStub.resolves(undefined);
+    const result = await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());
+    expect(result).to.equal(undefined);
+    expect(executeStub.callCount).to.equal(4); // initial attempt + 3 retries
+  });
+});
+
+describe("DepositAddressHandler._validateExecuteResponse guards", function () {
+  let handler: DepositAddressHandler;
+  let warnStub: sinon.SinonStub;
+
+  type Internals = {
+    _validateExecuteResponse: (
+      r: DepositAddressExecuteResponse,
+      m: DepositAddressMessageV3,
+      originChainId: number,
+      depositKey: string
+    ) => boolean;
+  };
+
+  const message = depositMessageV3();
+  const originChainId = Number(message.erc20Transfer.chainId);
+
+  function executeResponse(overrides: Partial<DepositAddressExecuteResponse> = {}): DepositAddressExecuteResponse {
+    return {
+      depositAddress: DEPOSIT_ADDRESS,
+      executeTx: { ecosystem: "evm", chainId: originChainId, to: TOKEN, data: "0x", value: "0" },
+      signer: SIGNER,
+      signatureDeadline: getCurrentTime() + 600,
+      isPlaceholder: false,
+      ...overrides,
+    };
+  }
+
+  function validate(response: DepositAddressExecuteResponse): boolean {
+    return (handler as unknown as Internals)._validateExecuteResponse(response, message, originChainId, "key");
+  }
+
+  beforeEach(function () {
+    const config = {} as unknown as DepositAddressHandlerConfig;
+    warnStub = sinon.stub();
+    const logger = { warn: warnStub } as unknown as winston.Logger;
+    handler = new DepositAddressHandler(logger, config, {} as unknown as Signer, []);
+  });
+
+  afterEach(() => sinon.restore());
+
+  it("accepts a well-formed response (case-insensitive address match)", function () {
+    expect(validate(executeResponse({ depositAddress: DEPOSIT_ADDRESS.toLowerCase() }))).to.equal(true);
+    expect(warnStub.notCalled).to.equal(true);
+  });
+
+  it("rejects when the API-derived deposit address does not match the funded address", function () {
+    expect(validate(executeResponse({ depositAddress: RECIPIENT }))).to.equal(false);
+    expect(warnStub.calledOnce).to.equal(true);
+  });
+
+  it("rejects when the execute tx targets the wrong chain", function () {
+    const response = executeResponse();
+    response.executeTx.chainId = 1;
+    expect(validate(response)).to.equal(false);
+  });
+
+  it("rejects placeholder derivations", function () {
+    expect(validate(executeResponse({ isPlaceholder: true }))).to.equal(false);
+  });
+
+  it("rejects responses whose signature deadline is too close to expiry", function () {
+    expect(validate(executeResponse({ signatureDeadline: getCurrentTime() + 30 }))).to.equal(false);
   });
 });


### PR DESCRIPTION
## Summary

Wires the v3 (upgradeable-counterfactual) **deposit-execute** path into the deposit-address bot as a **thin submitter**, running concurrently with v1. Implements the execution half of [ACB-509](https://linear.app/uma/issue/ACB-509/bot-phase-2-v3-execute-withdraw-thin-submitter); the v3 refund-withdraw path is out of scope and v3 refund classifications are skipped with a debug log.

Pairs with:
- across-protocol/indexer#1036 — `/deposit-address-transfers` now serves `version: 3` items in their own shape.
- across-protocol/quote-api#2773 — `POST /deposit-addresses/execute` builds the calldata.

**Design note:** the implemented execute endpoint **re-derives** the deposit address and merkle materials server-side from the identity (`destination.token`, `destination.recipient`, `userAddress`), so unlike the ticket's original relay-materials sketch the bot does **not** forward `counterfactualMaterials`/`initialRoot`/`salt` — it relays funding context only and submits the returned `deployIfNeededAndExecute` calldata. Justified bot-side work stays bot-side: signing, nonce, gas, rebroadcast, dedup, scheduling.

## Changes

- **`src/interfaces/DepositAddress.ts`** — `DepositAddressMessageV3` mirroring the indexer v3 projection, `NamespacedAccount`, `CounterfactualMaterialV3`, `AnyDepositAddressMessage` union + `isDepositAddressMessageV3` guard. v1 types untouched.
- **`src/clients/AcrossSwapApiClient.ts`** — `executeDepositAddress()` (`POST deposit-addresses/execute`, bearer-authed with the existing `SWAP_API_KEY`) with request/response types matching the endpoint schema.
- **`src/deposit-address/DepositAddressHandler.ts`**
  - `_queryIndexerApi` keeps v3 items (passed through un-normalized); unknown versions (e.g. v2) are still dropped before normalization.
  - `processExecution` routes v3 `correct_transfer` → new `initiateDepositV3`; v3 refund classifications are skipped.
  - `initiateDepositV3`: chain filter → scheme-agnostic dedup (same Redis/in-memory sets as v1) → EVM-namespace guard → defensive on-chain balance check → fetch calldata → validate → submit via `TransactionClient` → persist to Redis. **No bot-side deploy step** (the calldata wraps `factory.deployIfNeededAndExecute`).
  - Response guards before submission: API-derived `depositAddress` must equal the funded address from the indexer, `executeTx.chainId` must match the origin chain, `isPlaceholder` must be false, and the perishable `signatureDeadline` must have ≥60s headroom — stale calldata is dropped and re-requested fresh on the next poll, never patched.
  - `executionFee` is omitted for now (API defaults to 0); bot-side fee pricing is a follow-up task.
- **`src/utils/DepositAddressUtils.ts`** — `getDepositKey` widened to the version union (reads only the shared envelope).
- **`test/DepositAddressHandler.ts`** — v3 fixture factory; updated version-filtering suite (v3 kept un-normalized, v2 dropped); new suites for v3 routing, execute request mapping (exact body — the endpoint's superstruct schema rejects unknown/missing keys), retry exhaustion, and all four response guards.
- **`src/deposit-address/README.md`** — version-routing table and a "v3 execute flow (thin submitter)" section.

No new config: no feature flag (v3 is live once deployed) and no changes to `DepositAddressHandlerConfig`/`index.ts`. `withdrawPayload.ts` untouched (refund-only).

## Test plan

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `RELAYER_TEST=true yarn hardhat test test/DepositAddressHandler.ts` — 16 passing (3 pre-existing suites green, 13 new/updated v3 tests)
- [ ] Staging sanity: point `INDEXER_API_ENDPOINT` at an indexer serving a v3 item and `API_ENDPOINT`/`SWAP_API_KEY` at the quote-api preview (PR #2773; key needs the `deposit-address` permission); confirm calldata fetch, address-match guard, and on-chain execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)