### PR TITLE
fix: cap Tron eth_getLogs lookback to 5,000 blocks

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -169,6 +169,7 @@ const resolveRpcConfig = () => {
     [CHAIN_IDs.MONAD]: 1_000, // Alchemy constraint
     [CHAIN_IDs.SOLANA]: 1_000,
     [CHAIN_IDs.SOLANA_DEVNET]: 1000,
+    [CHAIN_IDs.TRON]: 5_000, // Chainstack constraint.
   };
   return Object.fromEntries(Object.values(CHAIN_IDs).map((chainId) => [chainId, ranges[chainId] ?? defaultRange]));
 };


### PR DESCRIPTION
## Summary
- Add an explicit `CHAIN_IDs.TRON: 5_000` override in `CHAIN_MAX_BLOCK_LOOKBACK` (`src/common/Constants.ts`).
- Tron was falling through to the 10,000 default, but Chainstack's Tron RPC caps `eth_getLogs` at 5,000 blocks and returns `exceed max block range: 5000` — observed in the dataworker.

## Test plan
- [ ] Run the dataworker against Tron and confirm no more `exceed max block range` errors from `eth_getLogs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)