### PR TITLE
improve(dataworker): More robust on executor collisions

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1808,10 +1808,27 @@ export class Dataworker {
     poolLeaves: PoolRebalanceLeaf[],
     balanceAllocator: BalanceAllocator
   ): Promise<PoolRebalanceLeaf[]> {
+    // A coincident executor's claim depletes the HubPool balance, which would otherwise read as a
+    // spurious shortfall below. Drop already-claimed leaves so balance checks only flag real shortfalls.
+    const claimedBitMap = await this._readPoolRebalanceClaimedBitMap();
+    const unclaimedLeaves = poolLeaves.filter((leaf) => {
+      const claimed = isDefined(claimedBitMap) && claimedBitMap.shr(leaf.leafId).and(1).eq(1);
+      if (claimed) {
+        const network = getNetworkName(leaf.chainId);
+        this.logger.debug({
+          at: "Dataworker#_getExecutablePoolRebalanceLeaves",
+          message: `Skipping pool rebalance leaf ${leaf.leafId} for ${network}: already claimed.`,
+          leafId: leaf.leafId,
+          chainId: leaf.chainId,
+        });
+      }
+      return !claimed;
+    });
+
     // We evaluate these leaves iteratively rather than in parallel so we can keep track
     // of the used balances after "executing" each leaf.
     const executableLeaves: PoolRebalanceLeaf[] = [];
-    for (const leaf of poolLeaves) {
+    for (const leaf of unclaimedLeaves) {
       // We can evaluate the l1 tokens within the leaf in parallel because we can assume
       // that there are not duplicate L1 tokens within the leaf.
       const isExecutable = await sdkUtils.everyAsync(leaf.l1Tokens, async (l1Token, i) => {
@@ -2003,22 +2020,29 @@ export class Dataworker {
     return leavesToBroadcast.length;
   }
 
+  // Pending root bundle's claimed bitmap; undefined if the read fails.
+  async _readPoolRebalanceClaimedBitMap(): Promise<BigNumber | undefined> {
+    try {
+      const { claimedBitMap } = await this.clients.hubPoolClient.hubPool.rootBundleProposal();
+      return BigNumber.from(claimedBitMap);
+    } catch (err) {
+      this.logger.warn({
+        at: "Dataworker#_readPoolRebalanceClaimedBitMap",
+        message: "Failed to read rootBundleProposal.claimedBitMap.",
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return undefined;
+    }
+  }
+
   async _filterAlreadyClaimedPoolRebalanceLeaves(leaves: PoolRebalanceLeaf[]): Promise<PoolRebalanceLeaf[]> {
     if (leaves.length === 0) {
       return leaves;
     }
 
-    let claimedBitMap: BigNumber;
-    try {
-      const rootBundle = await this.clients.hubPoolClient.hubPool.rootBundleProposal();
-      claimedBitMap = BigNumber.from(rootBundle.claimedBitMap);
-    } catch (err) {
-      // If this read fails we can't filter — defer to the existing simulation path and keep all leaves.
-      this.logger.warn({
-        at: "Dataworker#_filterAlreadyClaimedPoolRebalanceLeaves",
-        message: "Failed to re-read rootBundleProposal.claimedBitMap; skipping pre-broadcast filter.",
-        error: err instanceof Error ? err.message : String(err),
-      });
+    // If this read fails we can't filter — defer to the existing simulation path and keep all leaves.
+    const claimedBitMap = await this._readPoolRebalanceClaimedBitMap();
+    if (!isDefined(claimedBitMap)) {
       return leaves;
     }
 

--- a/test/Dataworker.executePoolRebalanceUtils.ts
+++ b/test/Dataworker.executePoolRebalanceUtils.ts
@@ -771,10 +771,15 @@ describe("Dataworker: Utilities to execute pool rebalance leaves", function () {
   });
   describe("_getExecutablePoolRebalanceLeaves", function () {
     let token1: EvmAddress, token2: EvmAddress, balanceAllocator: BalanceAllocator;
+    let claimedBitMapStub: sinon.SinonStub | undefined;
     beforeEach(function () {
       token1 = EvmAddress.from(randomAddress());
       token2 = EvmAddress.from(randomAddress());
       balanceAllocator = getNewBalanceAllocator();
+    });
+    afterEach(function () {
+      claimedBitMapStub?.restore();
+      claimedBitMapStub = undefined;
     });
     it("All l1 tokens on single leaf are executable", async function () {
       balanceAllocator.testSetBalance(
@@ -919,6 +924,86 @@ describe("Dataworker: Utilities to execute pool rebalance leaves", function () {
       expect(leaves[0].chainId).to.equal(10);
       const errorLogs = spy.getCalls().filter((call) => call.lastArg.level === "error");
       expect(errorLogs.length).to.equal(1);
+    });
+    it("Skips a leaf already claimed on chain by a competing executor, without erroring", async function () {
+      // Fund the leaf, so the only reason to drop it is the claimed bit.
+      balanceAllocator.testSetBalance(
+        hubPoolClient.chainId,
+        token1,
+        EvmAddress.from(hubPoolClient.hubPool.address),
+        toBNWei("1")
+      );
+      balanceAllocator.testSetBalance(
+        hubPoolClient.chainId,
+        token2,
+        EvmAddress.from(hubPoolClient.hubPool.address),
+        toBNWei("1")
+      );
+      // leafId 0 already claimed (bit 0 set).
+      claimedBitMapStub = sinon
+        .stub(dataworkerInstance, "_readPoolRebalanceClaimedBitMap")
+        .resolves(ethers.BigNumber.from(1));
+      const leaves = await dataworkerInstance._getExecutablePoolRebalanceLeaves(
+        [
+          {
+            chainId: 10,
+            groupIndex: 0,
+            bundleLpFees: [toBNWei("1"), toBNWei("1")],
+            netSendAmounts: [toBNWei("1"), toBNWei("1")],
+            runningBalances: [toBNWei("1"), toBNWei("1")],
+            leafId: 0,
+            l1Tokens: [token1, token2],
+          },
+        ],
+        balanceAllocator
+      );
+      expect(leaves.length).to.equal(0);
+      expect(spy.getCalls().filter((call) => call.lastArg.level === "error").length).to.equal(0);
+      expect(lastSpyLogIncludes(spy, "already claimed")).to.be.true;
+    });
+    it("Skips only the claimed leaf and keeps the unclaimed leaf", async function () {
+      balanceAllocator.testSetBalance(
+        hubPoolClient.chainId,
+        token1,
+        EvmAddress.from(hubPoolClient.hubPool.address),
+        toBNWei("2")
+      );
+      balanceAllocator.testSetBalance(
+        hubPoolClient.chainId,
+        token2,
+        EvmAddress.from(hubPoolClient.hubPool.address),
+        toBNWei("2")
+      );
+      // Only leafId 0 is claimed (bit 0 set).
+      claimedBitMapStub = sinon
+        .stub(dataworkerInstance, "_readPoolRebalanceClaimedBitMap")
+        .resolves(ethers.BigNumber.from(1));
+      const leaves = await dataworkerInstance._getExecutablePoolRebalanceLeaves(
+        [
+          {
+            chainId: 10,
+            groupIndex: 0,
+            bundleLpFees: [toBNWei("1"), toBNWei("1")],
+            netSendAmounts: [toBNWei("1"), toBNWei("1")],
+            runningBalances: [toBNWei("1"), toBNWei("1")],
+            leafId: 0,
+            l1Tokens: [token1, token2],
+          },
+          {
+            chainId: 42161,
+            groupIndex: 0,
+            bundleLpFees: [toBNWei("1"), toBNWei("1")],
+            netSendAmounts: [toBNWei("1"), toBNWei("1")],
+            runningBalances: [toBNWei("1"), toBNWei("1")],
+            leafId: 1,
+            l1Tokens: [token1, token2],
+          },
+        ],
+        balanceAllocator
+      );
+      expect(leaves.length).to.equal(1);
+      expect(leaves[0].leafId).to.equal(1);
+      expect(spy.getCalls().filter((call) => call.lastArg.level === "error").length).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
Rather than loudly complaining about insufficient funds to execute a pool rebalance leaf, check first whether the leaf has already been claimed. This is the leading cause of these alerts lately, and is a result of concurrent executor runs.