### PR TITLE
chore(deps): bump @across-protocol/sdk to 4.3.167

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@across-protocol/constants": "^3.1.109",
-    "@across-protocol/contracts": "5.0.10",
-    "@across-protocol/sdk": "4.3.164",
+    "@across-protocol/contracts": "5.0.15",
+    "@across-protocol/sdk": "4.3.166",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",
@@ -132,7 +132,8 @@
   "resolutions": {
     "protobufjs": "^7.5.4",
     "fast-xml-parser": "^5.7.1",
-    "better-sqlite3": "^11.10.0"
+    "better-sqlite3": "^11.10.0",
+    "@across-protocol/contracts": "5.0.15"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.com/",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.109",
     "@across-protocol/contracts": "5.0.15",
-    "@across-protocol/sdk": "4.3.166",
+    "@across-protocol/sdk": "4.3.167",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -352,14 +352,20 @@ export const CONTRACT_ADDRESSES: {
       abi: CCTP_V2_TOKEN_MESSENGER_ABI,
     },
     sponsoredCCTPDstPeriphery: {
-      address: getDeployedAddress("SponsoredCCTPDstPeriphery", CHAIN_IDs.HYPEREVM),
+      // @across-protocol/contracts 5.0.11 split the HyperEVM periphery into
+      // per-token deployments. The USDC variant is the default destination
+      // periphery; USDH callers go through `dstUsdhHandler` instead.
+      address: getDeployedAddress("SponsoredCCTPDstPeriphery_CCTP_USDC", CHAIN_IDs.HYPEREVM),
       abi: SPONSORED_CCTP_DST_PERIPHERY_ABI,
     },
     dstCctpHandler: {
-      address: getDeployedAddress("SponsoredCCTPDstPeriphery", CHAIN_IDs.HYPEREVM),
+      address: getDeployedAddress("SponsoredCCTPDstPeriphery_CCTP_USDC", CHAIN_IDs.HYPEREVM),
+    },
+    dstUsdhHandler: {
+      address: getDeployedAddress("SponsoredCCTPDstPeriphery_CCTP_USDH", CHAIN_IDs.HYPEREVM),
     },
     dstOftHandler: {
-      address: getDeployedAddress("DstOFTHandler", CHAIN_IDs.HYPEREVM),
+      address: getDeployedAddress("DstOFTHandler_OFT_USDT", CHAIN_IDs.HYPEREVM),
     },
     hyperliquidDepositHandler: {
       address: getDeployedAddress("HyperliquidDepositHandler", CHAIN_IDs.HYPEREVM),

--- a/src/utils/ContractUtils.ts
+++ b/src/utils/ContractUtils.ts
@@ -112,7 +112,9 @@ export function getDeploymentBlockNumber(contractName: string, networkId: number
 
 // The DstOft/Cctp handler contracts only exist on HyperEVM.
 export function getDstOftHandler(): Contract {
-  const factoryName = "DstOFTHandler";
+  // @across-protocol/contracts 5.0.11 token-suffixed the HyperEVM destination
+  // handlers; the legacy "DstOFTHandler" key no longer resolves.
+  const factoryName = "DstOFTHandler_OFT_USDT";
   const artifact = typechain["HyperCoreFlowExecutor__factory"];
   const address = isDefined(process.env.DST_OFT_HANDLER)
     ? process.env.DST_OFT_HANDLER

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.3.166":
-  version "4.3.166"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.166.tgz#1bb1e6299dd71dffbd8725211a94c5928d68cff0"
-  integrity sha512-mXoGPYXDLCAWRU8OMDFC/XxljI5nEERySDcywdTomGxjfhY7Fz0rXbJbesubsKJZ2BBtJshuHvMfxZh44IgqRw==
+"@across-protocol/sdk@4.3.167":
+  version "4.3.167"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.167.tgz#b107b810dae49ad461236d6312990941d1685dc8"
+  integrity sha512-RH/W4rctUux2DKwftpxlMOgXOBj1Fwvcl3bosE7Bgg70Dzyr6+cHn1NX98VZw5oQ35Uc6+okCpCTvwrjc1NfTw==
   dependencies:
     "@across-protocol/constants" "^3.1.110"
     "@across-protocol/contracts" "5.0.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"@across-protocol/constants@^3.1.107":
-  version "3.1.108"
-  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.108.tgz#982e230c0193f3b4124e3cb880eb6cb481f76a7e"
-  integrity sha512-uYcIw6VjWhSRal9+xv5aTgk3cK1qVH/8SkpSCpa6KMQUXmCKZ3eGGaVMl7Nogl6S0Cj/D76LnMgM3jUP6NK9ag==
-
 "@across-protocol/constants@^3.1.109":
   version "3.1.109"
   resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.109.tgz#3a7e9f7581405cd09dbbdc480800d4a775051c46"
@@ -17,12 +12,17 @@
   resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.110.tgz#8db121beb440187295874476ad05b1a8d4729acf"
   integrity sha512-4GfJed7zziPBW4ywsaQaqtT5kSnIo0xthMcAJYqVcDm37e1oIv5lHFNoyGT8bOUNa0T1ZeEGcHLTOzbz+mfTnw==
 
-"@across-protocol/contracts@5.0.10":
-  version "5.0.10"
-  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-5.0.10.tgz#c6eb6a88ef83b51fe019829668e928794b73b4d6"
-  integrity sha512-W1AAXzYjNmRsSQ8sckvrcI0gYOpBjPdJ01VseGLUxAoSqn2w2xPH65ZOsXyUVZrLdzoYNpYeJVYFgcaIEgVd0g==
+"@across-protocol/constants@^3.1.111":
+  version "3.1.111"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.111.tgz#bad4718e4d6179a2012a6d66d3440e1a8c1b2cb5"
+  integrity sha512-z1ly6ROzCHE6G66wYaARFtYDRLii9LWBL1HhBiHnzi2ukLA5Qg62MipFXN5Ux5aS62xLyvBcgtCB8HKUvGzhrA==
+
+"@across-protocol/contracts@5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-5.0.15.tgz#439687558b75054f8268b138422f2cf956226c54"
+  integrity sha512-yEotmTHSM5gs9SuHkUFaY+K2E4ZgenFve5Wwa7+i5cumh/ZpdRYdsp4U0pvQcdC3ccq8xeGGRLqkh58qpzjrDQ==
   dependencies:
-    "@across-protocol/constants" "^3.1.107"
+    "@across-protocol/constants" "^3.1.111"
     "@coral-xyz/anchor" "^0.31.1"
     "@eth-optimism/contracts" "^0.5.40"
     "@ethersproject/bignumber" "5.7.0"
@@ -39,13 +39,13 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.3.164":
-  version "4.3.164"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.164.tgz#c8a91564d60f7afc3b332d7fe45b44fb1318c904"
-  integrity sha512-Zz3GksBHekq2KjlIM+24sG281onM/3au94ly8kwknq7aKsy1kxfeH62mq3cpeCGXq7UbFB14BMiE0nSb2WcqbQ==
+"@across-protocol/sdk@4.3.166":
+  version "4.3.166"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.166.tgz#1bb1e6299dd71dffbd8725211a94c5928d68cff0"
+  integrity sha512-mXoGPYXDLCAWRU8OMDFC/XxljI5nEERySDcywdTomGxjfhY7Fz0rXbJbesubsKJZ2BBtJshuHvMfxZh44IgqRw==
   dependencies:
     "@across-protocol/constants" "^3.1.110"
-    "@across-protocol/contracts" "5.0.10"
+    "@across-protocol/contracts" "5.0.15"
     "@coral-xyz/anchor" "^0.30.1"
     "@eth-optimism/sdk" "^3.3.1"
     "@ethersproject/bignumber" "^5.7.0"


### PR DESCRIPTION
## Summary

Bumps \`@across-protocol/sdk\` from 4.3.164 → [4.3.167](https://github.com/across-protocol/sdk/releases/tag/v4.3.167), covering two PRs that ship together:

- across-protocol/sdk#1459 (4.3.166) — Tron bandwidth accounting in \`getAuxiliaryNativeTokenCost\`. Closes the ~6.5% under-estimate observed on Mainnet → Tron multicall fills (e.g. deposit 3984372) that was flipping marginal routes to "unprofitable" on the primary bot for ~3 minutes before the sweeper picked them up.
- across-protocol/sdk#1460 (4.3.167) — \`relayerFeeDetails\` minDeposit fix; keeps the value finite for chains with non-zero auxiliary cost. Not consumed by the relayer directly (relayer uses \`QueryBase__factory\` / \`QueryInterface\`, not \`relayerFeeDetails\`), but bundled because it shipped alongside.

## Why the contracts pin also moves

SDK 4.3.165+ bumped its \`@across-protocol/contracts\` pin from 5.0.10 → 5.0.15. The relayer needs the same version at the top level, otherwise yarn keeps a nested duplicate copy under \`node_modules/@across-protocol/sdk\` and TypeScript treats \`MerkleTree<PoolRebalanceLeaf>\` as two distinct classes (private \`elements\` field on each) — which broke \`scripts/constructEmergencyRoot.ts\` and \`src/dataworker/Dataworker.ts\` at typecheck time.

Two changes pull them back in line:
- \`@across-protocol/contracts\`: \`5.0.10\` → \`5.0.15\` (matches SDK transitive pin).
- New \`resolutions\` entry for \`@across-protocol/contracts: 5.0.15\` to keep yarn from re-introducing the duplicate.

## Test plan

- [x] \`yarn install\` clean
- [x] \`yarn typecheck\` clean
- [ ] CI green
- [ ] Reviewer: smoke-check in zion shadow / sandbox before promoting to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)