### PR TITLE
feat(profitability): allow per-chain RELAYER_GAS_PADDING overrides

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -132,6 +132,10 @@ export class ProfitClient {
   // resolveGasMultiplier / minRelayerFeePct don't re-parse env vars on every call.
   private readonly policies: RelayerPolicy[];
 
+  // Per-destination-chain gas-padding multipliers (already `1 + padding`, mirroring `gasPadding`).
+  // Empty entry falls back to the global `gasPadding`.
+  protected readonly chainGasPadding: { [chainId: number]: BigNumber };
+
   // @todo: Consolidate this set of args before it grows legs and runs away from us.
   constructor(
     readonly logger: winston.Logger,
@@ -148,7 +152,11 @@ export class ProfitClient {
     readonly additionalL1Tokens: EvmAddress[] = [],
     // Sets of token symbols that should be treated equivalently, for example [ "USDC": [USDT, USDH ].
     readonly peggedTokens: { [pegTokenSymbol: string]: Set<string> } = {},
-    readonly l1TokensOverride: string[] = []
+    readonly l1TokensOverride: string[] = [],
+    // Per-destination-chain gas padding overrides. Values are raw padding fractions
+    // (e.g. `toBNWei("0.015")` for 1.5%); the constructor folds in the leading 1×.
+    // Falls back to `gasPadding` when a destination chain has no entry.
+    chainGasPaddingOverrides: { [chainId: number]: BigNumber } = {}
   ) {
     // Require 0% <= gasPadding <= 200%
     assert(
@@ -156,6 +164,15 @@ export class ProfitClient {
       `Gas padding out of range (${this.gasPadding})`
     );
     this.gasPadding = toBNWei("1").add(gasPadding);
+    this.chainGasPadding = Object.fromEntries(
+      Object.entries(chainGasPaddingOverrides).map(([chainId, padding]) => {
+        assert(
+          padding.gte(bnZero) && padding.lte(toBNWei(2)),
+          `Gas padding override out of range (chainId=${chainId}, padding=${padding})`
+        );
+        return [Number(chainId), toBNWei("1").add(padding)];
+      })
+    );
 
     // Require 0% <= gasMultiplier <= 400%
     assert(
@@ -188,6 +205,14 @@ export class ProfitClient {
     this.isTestnet = this.hubPoolClient.chainId !== CHAIN_IDs.MAINNET;
 
     this.policies = this.decodePolicies();
+  }
+
+  // Resolve the gas-padding multiplier for `chainId`. Falls back to the global
+  // `gasPadding` if no per-chain override was configured. Both forms are already
+  // `1 + padding`, so the result can be applied directly to a cost without further
+  // adjustment.
+  resolveGasPadding(chainId: number): BigNumber {
+    return this.chainGasPadding[chainId] ?? this.gasPadding;
   }
 
   resolveGasMultiplier(deposit: Deposit): BigNumber {
@@ -381,8 +406,9 @@ export class ProfitClient {
 
     // Fills with messages have arbitrary execution and therefore lower certainty about the simulated execution cost.
     // Pad these estimates before computing profitability to allow execution headroom and reduce the chance of an OoG.
-    nativeGasCost = nativeGasCost.mul(this.gasPadding).div(fixedPoint);
-    tokenGasCost = tokenGasCost.mul(this.gasPadding).div(fixedPoint);
+    const gasPadding = this.resolveGasPadding(chainId);
+    nativeGasCost = nativeGasCost.mul(gasPadding).div(fixedPoint);
+    tokenGasCost = tokenGasCost.mul(gasPadding).div(fixedPoint);
 
     // Gas estimates for token-only fills are stable and reliable. Allow these to be scaled up or down via the
     // configured gasMultiplier. Do not scale the nativeGasCost, since it might be used to set the transaction gasLimit.
@@ -548,7 +574,7 @@ export class ProfitClient {
       nativeGasCost,
       tokenGasCost,
       gasPrice,
-      gasPadding: this.gasPadding,
+      gasPadding: this.resolveGasPadding(deposit.destinationChainId),
       gasMultiplier: this.resolveGasMultiplier(deposit),
       gasTokenPriceUsd,
       gasCostUsd,
@@ -698,7 +724,7 @@ export class ProfitClient {
         nativeGasCost: fill.nativeGasCost,
         tokenGasCost: formatEther(fill.tokenGasCost),
         gasPrice: formatGwei(fill.gasPrice.toString()),
-        gasPadding: this.gasPadding,
+        gasPadding: this.resolveGasPadding(deposit.destinationChainId),
         gasMultiplier: formatEther(this.resolveGasMultiplier(deposit)),
         gasTokenPriceUsd: formatEther(fill.gasTokenPriceUsd),
         grossRelayerFeeUsd: formatEther(fill.grossRelayerFeeUsd),
@@ -936,16 +962,17 @@ export class ProfitClient {
           exclusiveRelayer,
         };
         const gasCosts = await this._getTotalGasCost(deposit, toAddressType(relayer, destinationChainId));
+        const gasPadding = this.resolveGasPadding(destinationChainId);
 
         // The scaledNativeGasCost is approximately what the relayer will set as the `gasLimit` when submitting
         // fills on the destination chain.
-        const scaledNativeGasCost = gasCosts.nativeGasCost.mul(this.gasPadding).div(fixedPointAdjustment);
+        const scaledNativeGasCost = gasCosts.nativeGasCost.mul(gasPadding).div(fixedPointAdjustment);
         // The scaledTokenGasCost is the estimated gas cost of submitting a fill on the destination chain and is used
         // in the this.estimateFillCost function to determine whether a deposit is profitable to fill. Therefore,
         // the scaledTokenGasCost should be safely lower than the quote API's tokenGasCosts in order for the relayer
         // to consider a deposit is profitable.
         const scaledTokenGasCost = gasCosts.tokenGasCost
-          .mul(this.gasPadding)
+          .mul(gasPadding)
           .div(fixedPointAdjustment)
           .mul(this.gasMultiplier)
           .div(fixedPointAdjustment);
@@ -956,7 +983,7 @@ export class ProfitClient {
             ...gasCosts,
             scaledNativeGasCost,
             scaledTokenGasCost,
-            gasPadding: formatEther(this.gasPadding),
+            gasPadding: formatEther(gasPadding),
             gasMultiplier: formatEther(this.gasMultiplier),
           },
         ];

--- a/src/clients/README.md
+++ b/src/clients/README.md
@@ -67,6 +67,20 @@ The Profit Client estimates what the gas cost would be to fill the deposit (i.e.
 
 Importantly, the Profit CLient exposes certain configuration objects that the user can use to set profitability thresholds.
 
+### Per-destination-chain gas padding
+
+`RELAYER_GAS_PADDING` is the fractional cushion the Profit Client adds on top of every estimated destination-chain gas cost before checking profitability (default `0.15` = 15%, set in `src/common/Constants.ts`). It exists to absorb estimator drift on EVM destinations where the actual fill can consume more gas than the simulator predicts.
+
+`RELAYER_GAS_PADDING_<chainId>` overrides the padding for a single destination chain. Values are raw padding fractions (e.g. `0.015` for 1.5%) and must satisfy `0 <= padding <= 2` (0%–200%) per entry; out-of-range overrides throw at construct time. Override the global default per chain when the destination's gas-side input is essentially exact and the blanket cushion is just margin the relayer never spends — for example Tron, where energy price is governance-fixed and bandwidth scales with already-modeled serialized bytes.
+
+`ProfitClient.resolveGasPadding(chainId)` returns the per-chain multiplier if configured, otherwise the global `gasPadding`. Both forms are stored as `1 + padding` and applied to a cost without further adjustment. All padding application sites (per-fill `estimateFillCost`, the gas-cost cache built in `update`, and the two profitability log emissions) route through `resolveGasPadding`, so no chain without an override sees a behavior change.
+
+Example: drop the cushion on Tron (chain `728126428`) to 1.5% while leaving every other destination on the 15% default:
+
+```
+RELAYER_GAS_PADDING_728126428=0.015
+```
+
 ### Per-token-pair policy overrides
 
 The Profit Client supports a registry of named "policies" that can short-circuit the standard `MIN_RELAYER_FEE_PCT_*` and `RELAYER_GAS_MULTIPLIER_*` lookups. The policies in `RELAYER_POLICIES` (comma-separated) are decoded once at construct time and evaluated in order; the first whose predicate matches the deposit wins. Env mutations after construction are ignored — operators should set policy env vars before the relayer starts.

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -193,7 +193,8 @@ export async function constructRelayerClients(
     config.relayerGasPadding,
     relayerTokens,
     config.peggedTokenPrices,
-    config.l1TokensOverride
+    config.l1TokensOverride,
+    config.relayerGasPaddingOverrides
   );
   await profitClient.update();
 

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -52,6 +52,10 @@ export class RelayerConfig extends CommonConfig {
   readonly relayerOriginChains: number[] = [];
   readonly relayerDestinationChains: number[] = [];
   readonly relayerGasPadding: BigNumber;
+  // Per-chain `RELAYER_GAS_PADDING_<chainId>` overrides applied in ProfitClient on top
+  // of the global `RELAYER_GAS_PADDING`. Stored as raw padding fractions (e.g. `0.015`
+  // for 1.5%) — ProfitClient adds the leading `1` when constructing the multiplier.
+  readonly relayerGasPaddingOverrides: { [chainId: number]: BigNumber } = {};
   readonly relayerGasMultiplier: BigNumber;
   readonly relayerMessageGasMultiplier: BigNumber;
   readonly minRelayerFeePct: BigNumber;
@@ -463,6 +467,11 @@ export class RelayerConfig extends CommonConfig {
         ? sendMessageRelaysChain === "true"
         : process.env["SEND_MESSAGE_RELAYS"] === "true";
       this.sendingMessageRelaysEnabled[chainId] = sendMessageRelays;
+
+      const gasPaddingOverride = process.env[`RELAYER_GAS_PADDING_${chainId}`];
+      if (isDefined(gasPaddingOverride)) {
+        this.relayerGasPaddingOverrides[chainId] = toBNWei(gasPaddingOverride);
+      }
     });
 
     // Only validate config for chains that the relayer cares about.


### PR DESCRIPTION
## Summary

Adds a \`RELAYER_GAS_PADDING_<chainId>\` env override pattern so we can scale the relayer's gas-cost padding per destination chain, rather than carrying the same blanket cushion (currently 2.5%) for every route.

The global default exists to absorb estimation noise on EVM destinations where the actual fill can consume more gas than the simulator predicts. On Tron the simulator is essentially exact (energy is governance-fixed and bandwidth scales with serialized bytes, which we already model in sdk#1459) — the 2.5% cushion just adds margin the relayer never spends. That cushion is also the line item flipping borderline Mainnet → Tron multicall fills to "unprofitable" in the primary bot's check, even after the bandwidth fix landed (cross-ref: deposit \`3986569\` analysis in #devops).

## Approach

Mirror the existing per-chain env conventions (\`RELAYER_MIN_FILL_TIME_<chainId>\`, \`SEND_MESSAGE_RELAYS_<chainId>\`):

- \`RelayerConfig.relayerGasPaddingOverrides\`: parsed inside the existing \`chainIds.forEach\` block from \`RELAYER_GAS_PADDING_<chainId>\` env vars. Stored as raw padding fractions.
- \`ProfitClient.chainGasPadding\`: holds the already-folded \`1 + padding\` form, validated 0%–200% per entry.
- \`ProfitClient.resolveGasPadding(chainId)\` returns the per-chain multiplier if configured, otherwise the global \`gasPadding\`. All four padding application sites (\`estimateFillCost\` per-fill, \`update\` gas-cost cache, the two log emissions) route through it.

No behavior change for chains without an override — every existing call resolves through \`resolveGasPadding\` to the same \`this.gasPadding\` value as before.

## Followups (not in this PR)

- Configurama: add \`RELAYER_GAS_PADDING_728126428: \"0.015\"\` to the prod inputs for \`zion-across-relayer-primary\`, \`-secondary\`, \`-sweeper\` once this lands.
- Companion change in across-protocol/quote-api so the quote-api budgets a slightly higher gas cushion than the relayer evaluates, ensuring the quote stays comfortably above breakeven.

## Test plan

- [x] \`yarn typecheck\` clean
- [x] \`yarn lint\` clean
- [ ] Smoke-check in zion shadow / sandbox before promoting to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)