### PR TITLE
fix(hyperliquid): wake waitForNextTask on abort so handover actually terminates the process

### DIFF
--- a/src/hyperliquid/HyperliquidExecutor.ts
+++ b/src/hyperliquid/HyperliquidExecutor.ts
@@ -605,10 +605,22 @@ export class HyperliquidExecutor {
 
   // Task utilities
   private async waitForNextTask(): Promise<void> {
-    if (this.tasks.length > 0) {
+    if (this.tasks.length > 0 || this.abortController.signal.aborted) {
       return;
     }
-    await new Promise<void>((resolve) => (this.taskResolver = resolve));
+    // Park here until a new task is queued OR a handover request fires the
+    // AbortController. Without the abort listener, an idle executor whose
+    // upstream event source has stalled (e.g. dropped websocket) would never
+    // wake up, processTasks() would never exit, and the bot process would
+    // hang well past handover until the hub's 720s spoke timeout.
+    await new Promise<void>((resolve) => {
+      const onAbort = () => resolve();
+      this.abortController.signal.addEventListener("abort", onAbort, { once: true });
+      this.taskResolver = () => {
+        this.abortController.signal.removeEventListener("abort", onAbort);
+        resolve();
+      };
+    });
   }
 
   private dstHandler(tokenSymbol: string): Contract {


### PR DESCRIPTION
## Summary

`HyperliquidExecutor.waitForNextTask()` parks `processTasks()` on a Promise that only `updateTasks()` resolves. When `waitForDisconnect()` fires `abortController.abort()` on handover, an executor that is idle inside `waitForNextTask()` is **not** woken. `processTasks()` never returns, `Promise.allSettled([processTasks, waitForHandover])` never settles, `runHyperliquidExecutor()` never returns, and the bot process never exits.

The hub's HTTP call to the spoke runner then hangs until the 720s spoke timeout, and `serverless-hub-across-mainnet` posts the `Some spoke calls returned errors` alert.

## What happened on 2026-06-12 04:10 UTC

Trigger: Chainstack's HyperEVM websocket (`wss://hyperliquid-mainnet.core.chainstack.com/…/nanoreth`) started dropping subscriptions with `The socket has been closed.` — `EventListener::onEvents` logged it as a warning but had no path back to a live subscription, so `handleNewBlock` stopped firing → `updateTasks` was never called → `taskResolver` was never invoked.

Timeline for hub run `b91fdde6-7267-408a-88be-d8333fb3ea1d`, spoke run `b097744b-…`:

| Time (UTC) | Event |
|---|---|
| `04:10:03` | Hub dispatches the spoke call. |
| `04:10:17` | Last `Finished processing task` log. Executor drained startup batch, parked in `waitForNextTask()`. |
| `04:10:24 → 04:12:25` | Continuous `Caught HyperEVM SwapFlowInitialized provider error: The socket has been closed.` warnings. |
| `04:12:13` | Next instance `18f3105b-…r` calls `Coordinator::initiateHandover`. |
| `04:12:14` | Outgoing instance detects the new run-id in Redis and calls `abortController.abort()`. **Process should exit here.** |
| `04:12:14` | New instance starts `Reviewing active orders` / `Finished processing task` — handover at the coordinator layer is clean. |
| `04:12:25` → `04:22:02` | **Silence from `b097744b-…`.** No `Time to run` log → `runHyperliquidExecutor` never returned. |
| `04:22:02` | Hub gives up the initial call (720s budget exhausted) and retries with `b097744b-…r`. |
| `04:34:02` | Retry also hits the 720s timeout; alert posted to `#across-error`. |

The new bot instance was processing orders normally the entire time. There was no data-plane gap. The hub's 720s timeout is the *outgoing* bot's HTTP shutdown leak, not a Hyperliquid-side incident.

## Fix

```diff
   private async waitForNextTask(): Promise<void> {
-    if (this.tasks.length > 0) {
+    if (this.tasks.length > 0 || this.abortController.signal.aborted) {
       return;
     }
-    await new Promise<void>((resolve) => (this.taskResolver = resolve));
+    await new Promise<void>((resolve) => {
+      const onAbort = () => resolve();
+      this.abortController.signal.addEventListener("abort", onAbort, { once: true });
+      this.taskResolver = () => {
+        this.abortController.signal.removeEventListener("abort", onAbort);
+        resolve();
+      };
+    });
   }
```

`waitForNextTask` now wakes on either a new task **or** abort. The abort listener is detached when a task resolves first, so listeners don't accumulate over long-lived runs.

After this, the abort path on handover is:

1. `subscribe()` returns → `waitForDisconnect` calls `abort()`.
2. `waitForNextTask` resolves immediately.
3. `resolveNextTask` loop sees `signal.aborted=true` and returns.
4. `processTasks` returns; `Promise.allSettled` settles.
5. `runHyperliquidExecutor` reaches `finally`, returns, and `index.ts`'s `process.exit(0)` runs.

## Out of scope

- Re-establishing dropped subscriptions mid-run (the underlying provider flakiness): separate problem. This PR only fixes the graceful-shutdown leak so the next hub tick gets a fresh process with a fresh connection.
- `EventListener` (`src/clients/EventListener.ts`) discards viem `watchBlocks` / `watchEvent` unsubscribe handles. With this fix in place `process.exit(0)` terminates the process regardless, so it isn't load-bearing — left for a follow-up if we want explicit teardown.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [ ] Deploy and watch the next `zion-across-hyperliquid-executor` handover — the `HyperliquidExecutor#index` `Time to run` log should appear within a few seconds of the incoming instance's `initiateHandover`, and the spoke call should return to the hub in <10s instead of hanging until 720s.
- [ ] Optional unit test: drive `HyperliquidExecutor` past `startListeners()`, await one cycle of `processTasks`, then call `abortController.abort()` and assert `processTasks` resolves under a small timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)