### PR TITLE
chore(deps): bump @across-protocol/sdk to 4.3.168

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.109",
     "@across-protocol/contracts": "5.0.15",
-    "@across-protocol/sdk": "4.3.167",
+    "@across-protocol/sdk": "4.3.168",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.3.167":
-  version "4.3.167"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.167.tgz#b107b810dae49ad461236d6312990941d1685dc8"
-  integrity sha512-RH/W4rctUux2DKwftpxlMOgXOBj1Fwvcl3bosE7Bgg70Dzyr6+cHn1NX98VZw5oQ35Uc6+okCpCTvwrjc1NfTw==
+"@across-protocol/sdk@4.3.168":
+  version "4.3.168"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.3.168.tgz#6e82f211b223d4579c71cf096dbd290bec2ddc89"
+  integrity sha512-UuopfctY/V2cPJTidG8Xl4uJHPwkPOODjaPo5K7t8RX7I+dD7mKsLgo9WpoeMpz4KeIgwEPF+xg3SfO+6rIG5Q==
   dependencies:
     "@across-protocol/constants" "^3.1.110"
     "@across-protocol/contracts" "5.0.15"


### PR DESCRIPTION
## Summary

Bumps `@across-protocol/sdk` from `4.3.167` → `4.3.168` to pick up [across-protocol/sdk#1461](https://github.com/across-protocol/sdk/pull/1461).

That release threads `SpokePoolClient.eventSearchConfig` (`from = deploymentBlock`, `maxLookBack`) through the TVM helpers (`relayFillStatus`, `findFillBlock`, `findFillEvent`, `findDepositBlock`, `getMaxFillDeadlineInRange`) and through `get1967Upgrades`. Before the fix, each of those called `paginatedEventQuery` without `maxLookBack`, so the helper degraded to a single open-ended `eth_getLogs` from block 0 — which Chainstack Tron rejected with `exceed max block range: 5000`. The relayer's `CHAIN_MAX_BLOCK_LOOKBACK[TRON] = 5_000` cap from #3480 only reached the SpokePoolClient event-ingestion path and missed the dataworker's pre-fill detection (`BundleDataClient._getFillStatusForDeposit` → `relayFillStatus` with a numeric `atHeight`).

## Test plan

- [x] `yarn typecheck` clean against 4.3.168.
- [ ] Watch the next dataworker run — the `eth_getLogs` against the Tron SpokePool (`0xc148af9b50bc03cc0c616cd85c66aae9bd90cd80`) should chunk into 5,000-block requests instead of one open-ended call.
- [ ] Confirm no new `exceed max block range: 5000` errors against `tron-mainnet.core.chainstack.com` after the bump rolls out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)