### PR TITLE
fix(Binance): Filter rebalances on sender side from L2 to L1 via Binance adapter

### DIFF
--- a/src/adapter/l2Bridges/BinanceCEXBridge.ts
+++ b/src/adapter/l2Bridges/BinanceCEXBridge.ts
@@ -120,7 +120,20 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
       );
     });
 
-    const unmatchedDeposits = getOutstandingBinanceDeposits(depositHistory, withdrawHistory, this.depositNetwork);
+    // FilterMap to remove all deposits which originated from another EOA.
+    const filteredDepositHistory = await filterAsync(depositHistory, async (deposit) => {
+      const txnReceipt = await this.getL1Bridge().provider.getTransactionReceipt(deposit.txId);
+      if (!compareAddressesSimple(txnReceipt.from, fromAddress.toNative())) {
+        return false;
+      }
+      return true;
+    });
+
+    const unmatchedDeposits = getOutstandingBinanceDeposits(
+      filteredDepositHistory,
+      withdrawHistory,
+      this.depositNetwork
+    );
     return unmatchedDeposits.reduce((sum, deposit) => sum.add(floatToBN(deposit.amount, l2TokenInfo.decimals)), bnZero);
   }
 

--- a/src/adapter/l2Bridges/BinanceCEXBridge.ts
+++ b/src/adapter/l2Bridges/BinanceCEXBridge.ts
@@ -108,7 +108,11 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
     // Remove any deposits and withdrawals that are marked as related to a swap.
     const depositHistory = await filterAsync(_depositHistory, async (deposit) => {
       const depositType = await getBinanceDepositType(deposit);
-      return deposit.coin === this.l1TokenInfo.symbol && depositType !== BinanceTransactionType.SWAP;
+      return (
+        deposit.network === this.depositNetwork &&
+        deposit.coin === this.l1TokenInfo.symbol &&
+        depositType !== BinanceTransactionType.SWAP
+      );
     });
     const withdrawHistory = await filterAsync(_withdrawHistory, async (withdrawal) => {
       const withdrawalType = await getBinanceWithdrawalType(withdrawal);
@@ -120,9 +124,9 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
       );
     });
 
-    // FilterMap to remove all deposits which originated from another EOA.
+    // FilterMap to remove all deposits from this L2 which originated from another EOA.
     const filteredDepositHistory = await filterAsync(depositHistory, async (deposit) => {
-      const txnReceipt = await this.getL1Bridge().provider.getTransactionReceipt(deposit.txId);
+      const txnReceipt = await this.getL2Bridge().provider.getTransactionReceipt(deposit.txId);
       if (!compareAddressesSimple(txnReceipt.from, fromAddress.toNative())) {
         return false;
       }

--- a/src/adapter/l2Bridges/BinanceCEXBridge.ts
+++ b/src/adapter/l2Bridges/BinanceCEXBridge.ts
@@ -25,6 +25,7 @@ import {
   getBinanceWithdrawalType,
   isCompletedBinanceWithdrawal,
   getOutstandingBinanceDeposits,
+  isDefined,
 } from "../../utils";
 import { L1Token } from "../../interfaces";
 import { BaseL2BridgeAdapter } from "./BaseL2BridgeAdapter";
@@ -127,7 +128,7 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
     // FilterMap to remove all deposits from this L2 which originated from another EOA.
     const filteredDepositHistory = await filterAsync(depositHistory, async (deposit) => {
       const txnReceipt = await this.getL2Bridge().provider.getTransactionReceipt(deposit.txId);
-      if (!compareAddressesSimple(txnReceipt.from, fromAddress.toNative())) {
+      if (!isDefined(txnReceipt) || !compareAddressesSimple(txnReceipt.from, fromAddress.toNative())) {
         return false;
       }
       return true;

--- a/src/adapter/l2Bridges/BinanceCEXBridge.ts
+++ b/src/adapter/l2Bridges/BinanceCEXBridge.ts
@@ -128,10 +128,7 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
     // FilterMap to remove all deposits from this L2 which originated from another EOA.
     const filteredDepositHistory = await filterAsync(depositHistory, async (deposit) => {
       const txnReceipt = await this.getL2Bridge().provider.getTransactionReceipt(deposit.txId);
-      if (!isDefined(txnReceipt) || !compareAddressesSimple(txnReceipt.from, fromAddress.toNative())) {
-        return false;
-      }
-      return true;
+      return isDefined(txnReceipt) && compareAddressesSimple(txnReceipt.from, fromAddress.toNative());
     });
 
     const unmatchedDeposits = getOutstandingBinanceDeposits(


### PR DESCRIPTION
We don't currently filter out outstanding deposits in the L2ToL1 Binance adapter by sender address in the same way that we do for L1ToL2
