### PR TITLE
fix(svm): re-broadcast Solana tx during confirmation polling

### DIFF
--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -20,7 +20,9 @@ import {
   getBase64EncodedWireTransaction,
   setTransactionMessageLifetimeUsingBlockhash,
   signTransactionMessageWithSigners,
+  type Base64EncodedWireTransaction,
   type MicroLamports,
+  type Signature,
 } from "@solana/kit";
 import { updateOrAppendSetComputeUnitPriceInstruction } from "@solana-program/compute-budget";
 
@@ -58,11 +60,29 @@ export async function withFreshBlockhash<T extends SolanaUnsignedTransaction>(pr
 // https://solana.com/docs/rpc/http/sendtransaction.
 export type SolanaSendOptions = { minContextSlot?: bigint };
 
-export async function signAndSendTransaction(
+// Re-broadcast the same signed wire tx every N polling cycles while waiting
+// for confirmation. Solana leaders can drop or skip txs that aren't picked up
+// in their assigned slot — under congestion or with an uncompetitive priority
+// fee, the original `sendTransaction` may sit in mempool for many slots until
+// some later leader happens to ingest it. Re-broadcasting the same serialized
+// tx is idempotent (signature is deterministic from body+sigs) and gives
+// successive leaders new chances to land it before our polling budget runs
+// out. ~1.8s cadence (3 × 600ms polling delay) matches a few Solana slots.
+const SOLANA_REBROADCAST_EVERY_CYCLES = 3;
+
+// Internal helper that prepares, signs, and broadcasts a Solana transaction.
+// Returns the signature plus the serialized wire tx and the send options used,
+// so a polling loop above can re-broadcast the same tx (with `skipPreflight`)
+// when a leader has dropped it.
+async function _prepareAndSendSolanaTransaction(
   provider: SVMProvider,
   _unsignedTxn: SolanaUnsignedTransaction,
-  opts: SolanaSendOptions = {}
-) {
+  opts: SolanaSendOptions
+): Promise<{
+  signature: Signature;
+  serializedTx: Base64EncodedWireTransaction;
+  baseSendOpts: SolanaInternalSendOptions;
+}> {
   const priorityFeeOverride = process.env["SVM_PRIORITY_FEE_OVERRIDE"];
   const unsignedTxn = isDefined(priorityFeeOverride)
     ? updateOrAppendSetComputeUnitPriceInstruction(BigInt(priorityFeeOverride) as MicroLamports, _unsignedTxn)
@@ -70,14 +90,30 @@ export async function signAndSendTransaction(
   const txWithFreshBlockhash = await withFreshBlockhash(provider, unsignedTxn);
   const signedTransaction = await signTransactionMessageWithSigners(txWithFreshBlockhash);
   const serializedTx = getBase64EncodedWireTransaction(signedTransaction);
-  return provider
-    .sendTransaction(serializedTx, {
-      preflightCommitment: "confirmed",
-      skipPreflight: false,
-      encoding: "base64",
-      ...(isDefined(opts.minContextSlot) ? { minContextSlot: opts.minContextSlot } : {}),
-    })
-    .send();
+  const baseSendOpts: SolanaInternalSendOptions = {
+    preflightCommitment: "confirmed",
+    skipPreflight: false,
+    encoding: "base64",
+    ...(isDefined(opts.minContextSlot) ? { minContextSlot: opts.minContextSlot } : {}),
+  };
+  const signature = await provider.sendTransaction(serializedTx, baseSendOpts).send();
+  return { signature, serializedTx, baseSendOpts };
+}
+
+type SolanaInternalSendOptions = {
+  preflightCommitment: "confirmed";
+  skipPreflight: boolean;
+  encoding: "base64";
+  minContextSlot?: bigint;
+};
+
+export async function signAndSendTransaction(
+  provider: SVMProvider,
+  _unsignedTxn: SolanaUnsignedTransaction,
+  opts: SolanaSendOptions = {}
+) {
+  const { signature } = await _prepareAndSendSolanaTransaction(provider, _unsignedTxn, opts);
+  return signature;
 }
 
 // Internal helper: send + poll. Returns the signature and (when reached) the
@@ -93,7 +129,11 @@ async function _sendAndPoll(
   const delay = (ms: number) => {
     return new Promise((resolve) => setTimeout(resolve, ms));
   };
-  const txSignature = await signAndSendTransaction(provider, unsignedTransaction, opts);
+  const {
+    signature: txSignature,
+    serializedTx,
+    baseSendOpts,
+  } = await _prepareAndSendSolanaTransaction(provider, unsignedTransaction, opts);
   let confirmed = false;
   let confirmedSlot: bigint | undefined;
   let _cycles = 0;
@@ -117,6 +157,20 @@ async function _sendAndPoll(
     if (!confirmed) {
       await delay(pollingDelay);
       _cycles++;
+      // Re-broadcast the same signed wire tx every few cycles so a leader
+      // that dropped/skipped the original send gets new attempts to land it.
+      // Preflight already passed on the initial send, so skip it here to keep
+      // the RPC roundtrip cheap. Any errors thrown by the RPC on rebroadcast
+      // (e.g. AlreadyProcessed once the tx has landed, transient provider
+      // failures) are benign — the polling above remains the source of truth
+      // for confirmation status.
+      if (_cycles % SOLANA_REBROADCAST_EVERY_CYCLES === 0) {
+        try {
+          await provider.sendTransaction(serializedTx, { ...baseSendOpts, skipPreflight: true }).send();
+        } catch {
+          // intentionally swallowed; see comment above
+        }
+      }
     }
   }
   return { signature: txSignature, confirmedSlot };

--- a/test/TransactionUtils.svm.ts
+++ b/test/TransactionUtils.svm.ts
@@ -26,7 +26,17 @@ const buildSignableTx = async () => {
   return txMessage;
 };
 
-const makeFakeProvider = (statusValueByPollCall: Array<unknown>, contextSlotByPollCall: Array<bigint> = []) => {
+type FakeProviderOpts = {
+  // If set, the Nth call to sendTransaction (1-indexed) throws instead of
+  // returning a signature. Used to verify rebroadcast errors are swallowed.
+  throwOnSendInvocation?: number;
+};
+
+const makeFakeProvider = (
+  statusValueByPollCall: Array<unknown>,
+  contextSlotByPollCall: Array<bigint> = [],
+  providerOpts: FakeProviderOpts = {}
+) => {
   const fakeSignature = "5tkH59X6n7zVJ4r3z2hG5L9rA1bC2dE4fG6h8jK0mN1pQ3sT5uV7wY9aB1cD3eF6";
   const sendInvocations: Array<CapturedSendOptions> = [];
   let pollIndex = 0;
@@ -36,7 +46,15 @@ const makeFakeProvider = (statusValueByPollCall: Array<unknown>, contextSlotByPo
     }),
     sendTransaction: (_serializedTx: string, opts: CapturedSendOptions) => {
       sendInvocations.push(opts);
-      return { send: async () => fakeSignature };
+      const thisCall = sendInvocations.length;
+      return {
+        send: async () => {
+          if (providerOpts.throwOnSendInvocation === thisCall) {
+            throw new Error("simulated RPC failure on rebroadcast");
+          }
+          return fakeSignature;
+        },
+      };
     },
     getSignatureStatuses: (_sigs: string[]) => ({
       send: async () => {
@@ -107,6 +125,72 @@ describe("TransactionUtils — SVM send pinning", function () {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await sendAndConfirmSolanaTransactionWithSlot(txMessage as any, provider as any, 2, 1);
       expect(result.confirmedSlot).to.equal(undefined);
+    });
+  });
+
+  describe("rebroadcast during polling", function () {
+    it("does not rebroadcast when the tx confirms on the first poll", async function () {
+      const txMessage = await buildSignableTx();
+      const { provider, sendInvocations } = makeFakeProvider([
+        { confirmationStatus: "confirmed", slot: 10n, err: null, confirmations: 1n },
+      ]);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await sendAndConfirmSolanaTransactionWithSlot(txMessage as any, provider as any, 10, 1);
+
+      expect(sendInvocations).to.have.lengthOf(1);
+      expect(sendInvocations[0].skipPreflight).to.equal(false);
+    });
+
+    it("rebroadcasts the same wire tx with skipPreflight=true every 3 polling cycles", async function () {
+      const txMessage = await buildSignableTx();
+      // 7 unconfirmed polls — cycle index after each poll is 1..7, so
+      // rebroadcasts fire at cycle 3 and cycle 6 → 1 initial send + 2
+      // rebroadcasts = 3 total sendTransaction invocations.
+      const unconfirmed = Array.from({ length: 7 }, () => ({
+        confirmationStatus: "processed",
+        slot: 1n,
+        err: null,
+        confirmations: 0n,
+      }));
+      const { provider, sendInvocations } = makeFakeProvider(unconfirmed);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await sendAndConfirmSolanaTransactionWithSlot(txMessage as any, provider as any, 7, 1, {
+        minContextSlot: 500n,
+      });
+      expect(result.confirmedSlot).to.equal(undefined);
+      expect(sendInvocations).to.have.lengthOf(3);
+      // Initial send keeps preflight on; rebroadcasts skip it.
+      expect(sendInvocations[0].skipPreflight).to.equal(false);
+      expect(sendInvocations[1].skipPreflight).to.equal(true);
+      expect(sendInvocations[2].skipPreflight).to.equal(true);
+      // Rebroadcasts preserve the same `minContextSlot` pin as the initial send.
+      expect(sendInvocations[0].minContextSlot).to.equal(500n);
+      expect(sendInvocations[1].minContextSlot).to.equal(500n);
+      expect(sendInvocations[2].minContextSlot).to.equal(500n);
+    });
+
+    it("swallows errors thrown by the rebroadcast sendTransaction and keeps polling", async function () {
+      const txMessage = await buildSignableTx();
+      // Unconfirmed for cycles 1..3 then confirmed on poll 4 — exactly one
+      // rebroadcast fires at cycle 3 and it throws.
+      const statuses = [
+        { confirmationStatus: "processed", slot: 1n, err: null, confirmations: 0n },
+        { confirmationStatus: "processed", slot: 1n, err: null, confirmations: 0n },
+        { confirmationStatus: "processed", slot: 1n, err: null, confirmations: 0n },
+        { confirmationStatus: "confirmed", slot: 99n, err: null, confirmations: 1n },
+      ];
+      const { provider, sendInvocations } = makeFakeProvider(statuses, [], { throwOnSendInvocation: 2 });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await sendAndConfirmSolanaTransactionWithSlot(txMessage as any, provider as any, 10, 1);
+
+      // 1 initial + 1 (failing) rebroadcast = 2 send invocations; the
+      // rebroadcast error must not propagate, and polling must still observe
+      // the eventual confirmation.
+      expect(sendInvocations).to.have.lengthOf(2);
+      expect(result.confirmedSlot).to.equal(99n);
     });
   });
 


### PR DESCRIPTION
## Summary

`_sendAndPoll` (`src/utils/TransactionUtils.ts`) broadcasts a Solana tx exactly once via `signAndSendTransaction`, then polls `getSignatureStatuses` for the full budget (25 cycles × 600ms = 15s). If the first-targeted leader skips or drops the tx — common under congestion or with an uncompetitive priority fee — the tx sits in mempool until some later leader happens to ingest it, often beyond our polling budget. That's the failure mode that's been firing as

> `Solana tx <sig> did not confirm within 15000ms; cannot advance minContextSlot for dependent sends`

at `Dataworker.ts:3088` (introduced by #3469) on `zion-across-l2-executor-solana`.

### Evidence the tx is landing late, not the RPC lagging

Lined up the on-chain `blockTime` against the Slack error timestamp for 7 recent failures:

| Tx | Slack error ts | On-chain blockTime | Δ |
|---|---|---|---|
| `2pDsTZYW…` | 1781500623.67 | 1781500622 | **+1.7s** |
| `2TwxY6pM…` | 1781496122.19 | 1781496120 | **+2.2s** |
| `5XzGj7ob…` | 1781488017.42 | 1781488013 | **+4.4s** |
| `4i8oPkEJ…` | 1781484417.95 | 1781484420 | **−2.0s** |
| `4cz5sHCJ…` | 1781464621.15 | 1781464619 | **+2.2s** |
| `2rLphv2d…` | 1781453816.29 | 1781453814 | **+2.3s** |
| `4UzFw7kD…` | 1781447532.05 | 1781447529 | **+3.0s** |

Every signature finalised on chain within ±5s of our timeout firing, one of them ~2s *after* the timeout — so the tx had landed; we just gave up before observing it. RPC lag isn't the culprit.

Frequency on `zion-across-l2-executor-solana`: 31 of these errors since 2026-06-01 (~2/day). No funds at risk — the next dataworker run sees the leaf as already executed and skips — but it's a steady page-equivalent and a real liveness gap on a heavily-watched bot.

## Change

In `_sendAndPoll`, re-broadcast the same signed wire tx every `SOLANA_REBROADCAST_EVERY_CYCLES = 3` polling cycles (~1.8s, a few Solana slots) with `skipPreflight: true`. The signature is deterministic from the tx body + sigs, so re-broadcasts are idempotent — the polling loop remains the source of truth for confirmation. Errors thrown by re-broadcast (e.g. `AlreadyProcessed` once the tx has landed, transient provider failures) are intentionally swallowed.

Implementation detail: extracted the prepare/sign/broadcast steps from `signAndSendTransaction` into a private `_prepareAndSendSolanaTransaction` helper that returns the signature plus the serialized wire tx and the send options used, so `_sendAndPoll` can re-broadcast the same tx without re-signing or re-fetching the blockhash. Public `signAndSendTransaction` signature is unchanged.

## Trade-offs considered

- **Why not just bump `SVM_REFUND_LEAF_SEND_POLL_CYCLES`?** Extending the budget would mask the symptom (some txs would happen to land within the wider window) but every send pays the wall-clock cost on every failure, and the actual problem — leader skipping our send and no resend ever happening — would persist. Re-broadcasting is what the standard Solana `send-and-confirm` loop does.
- **Why `skipPreflight: true` on re-broadcasts?** Preflight already ran on the initial send and either passed (so subsequent state-based rejections on a no-op re-broadcast are spurious) or failed (in which case we wouldn't be here). Skipping it keeps the RPC roundtrip cheap.
- **Why swallow re-broadcast errors?** Once the tx has actually landed, the RPC will reject `sendTransaction` with `AlreadyProcessed` — that's fine, it means the next poll will see `confirmed`. Other transient errors are equally non-fatal because the polling loop is what decides success/failure.
- **Why cadence 3 cycles, not e.g. every cycle?** Solana slot time is ~400ms; re-broadcasting every poll (600ms) would create unnecessary RPC pressure with little benefit, since the leader assignment changes every 4 slots (~1.6s). 3 × 600ms = 1.8s lands the re-broadcast on a fresh leader window.
- **Why a constant instead of an env knob?** Keeping the patch minimal; the cadence is meaningful in terms of Solana's slot/leader cycle and shouldn't need per-deployment tuning. Easy to promote to env-configurable later.
- **Blockhash expiration?** Solana keeps the last 150 blockhashes (~60s); within the 15s budget the original blockhash stays valid. If the budget is later widened past ~50s we'd need to refresh, but that's out of scope here.

## Out of scope / follow-ups

- Independent: check what `SVM_PRIORITY_FEE_OVERRIDE` the executor bot is running with. Even with rebroadcast, an uncompetitive priority fee will keep us in the tail of leader queues — would be worth bumping if it's at default.
- An SDK-side equivalent fix in `@across-protocol/sdk` if any downstream consumers use a similar send-and-poll pattern.

## Doc updates

No `README.md` / `AGENTS.md` updates needed — internal hardening of an existing private code path with no operator-facing contract change.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `npx hardhat test test/TransactionUtils.svm.ts` — 8 passing, including 3 new tests:
  - does not rebroadcast when the tx confirms on the first poll
  - rebroadcasts the same wire tx with `skipPreflight=true` every 3 polling cycles
  - swallows errors thrown by the rebroadcast `sendTransaction` and keeps polling
- [ ] Deploy to `zion-across-l2-executor-solana` and watch for the next ~48h. Win condition: zero new `did not confirm within 15000ms` pages, or — if any do fire — the on-chain landing time is now well past our polling window rather than within ±5s of it (which would indicate priority fee, not send-side, as the remaining gap).

## Threads

- [#zbot-across-error 1781500623.674929](https://risklabs.slack.com/archives/C03GHT4RV42/p1781500623674929?thread_ts=1781500623.674929) — triage thread that motivated this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)