### PR TITLE
feat(deposit-address): relay integratorId into v3 execute request

### DIFF
--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -62,6 +62,12 @@ export interface DepositAddressExecuteRequest {
   executionFeeRecipient: string;
   /** Bot-priced payout, deducted from the bridged amount. Omitted => 0. */
   executionFee?: string;
+  /**
+   * Integrator attribution (2-byte hex, `^0x[0-9a-fA-F]{4}$`). Sourced from the indexer message's
+   * `integrator` projection, NOT the bot's auth key (the bot sweeps addresses owned by many
+   * integrators); drives the CREATE2 salt + on-chain integrator tag. Required by the endpoint.
+   */
+  integratorId: string;
 }
 
 export interface DepositAddressExecuteResponse {

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -51,6 +51,9 @@ import ERC20_ABI from "../common/abi/MinimalERC20.json";
  */
 const V3_SIGNATURE_DEADLINE_BUFFER = 60;
 
+/** Quote-api execute requires a 2-byte-hex integratorId; mirror its schema regex. */
+const INTEGRATOR_ID_REGEX = /^0x[0-9a-fA-F]{4}$/;
+
 /**
  * Indexer message versions the bot knows how to execute. Anything else (e.g. v2, or a future
  * version shipped on the indexer before the bot supports it) is dropped before normalization —
@@ -837,6 +840,23 @@ export class DepositAddressHandler {
         return;
       }
 
+      // The execute endpoint requires the integratorId (2-byte hex) that the deposit address was
+      // derived with — it folds into the CREATE2 salt server-side. No funded v3 addresses exist
+      // pre-integrator, so a missing/malformed value is a data anomaly: skip rather than guess one,
+      // which would only derive (and execute at) a different, unfunded address.
+      const integratorId = depositMessage.integrator?.integratorId;
+      if (!isDefined(integratorId) || !INTEGRATOR_ID_REGEX.test(integratorId)) {
+        this.logger.warn({
+          at: "DepositAddressHandler#initiateDepositV3",
+          message: "Skipping v3 deposit: missing or malformed integratorId",
+          integratorId: integratorId ?? "absent",
+          depositAddress,
+          refTxHash,
+          chainId: originChainId,
+        });
+        return;
+      }
+
       // Defensive on-chain balance check — guards against reorged indexer messages and against
       // acting on a deposit-address that has already been executed through another path.
       const inputTokenContract = new Contract(inputToken, ERC20_ABI, this.providersByChain[originChainId]);
@@ -971,8 +991,15 @@ export class DepositAddressHandler {
   ): Promise<DepositAddressExecuteResponse | undefined> {
     const { routeParams, refundAddress, erc20Transfer } = depositMessage;
     // The API re-derives the deposit address and merkle materials from this identity; the bot
-    // sends funding context only (relaying ≠ building calldata). executionFee is omitted for now:
-    // the API defaults it to 0 and bot-side fee pricing is deferred to a follow-up task.
+    // relays funding context plus the integratorId the address was derived with (≠ building
+    // calldata). executionFee is omitted for now: the API defaults it to 0 and bot-side fee pricing
+    // is deferred to a follow-up task. The integratorId is validated by initiateDepositV3's guard
+    // before we reach here; re-assert so the required request field narrows to a string.
+    const integratorId = depositMessage.integrator?.integratorId;
+    assert(
+      isDefined(integratorId) && INTEGRATOR_ID_REGEX.test(integratorId),
+      "DepositAddressHandler: _getExecuteTx requires a validated integratorId"
+    );
     const request = {
       destination: {
         token: {
@@ -985,6 +1012,7 @@ export class DepositAddressHandler {
       userAddress: refundAddress.address,
       amount: erc20Transfer.amount,
       executionFeeRecipient: this.signerAddress.toNative(),
+      integratorId,
     };
     // `_post` swallows errors and returns undefined, so retry on both throw and falsy return.
     try {

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -42,8 +42,13 @@ execute endpoint (`POST /deposit-addresses/execute`, bearer-authed with the same
 re-derives the deposit address and all counterfactual merkle materials server-side from the
 identity (`destination.token`, `destination.recipient`, `userAddress`); the bot relays funding
 context only — origin chain, amount, destination route, refund identity — plus its own
-`executionFeeRecipient`. `executionFee` is currently omitted (the API defaults it to 0); bot-side
-fee pricing is a follow-up task.
+`executionFeeRecipient` and the `integratorId` the address was derived with. `executionFee` is
+currently omitted (the API defaults it to 0); bot-side fee pricing is a follow-up task.
+
+The `integratorId` (2-byte hex) is sourced from the indexer message's `integrator` projection (a
+property of the deposit address, not the bot's auth key) and is **required** by the execute
+endpoint — it folds into the CREATE2 salt + on-chain integrator tag, so the address is derived
+per-integrator. The bot relays it verbatim.
 
 The flow (`initiateDepositV3`):
 
@@ -51,16 +56,19 @@ The flow (`initiateDepositV3`):
    scheme is keyed on `erc20Transfer.transactionHash` / `depositKey`, shared across versions).
 2. Skip non-`evm` `depositAddressNamespace` / `refundAddress.namespace` (the execute identity must
    be an EVM address).
-3. Defensive on-chain balance check, as on the other paths.
-4. Fetch `{ executeTx: { to, data, value }, ... }` from the execute endpoint. The calldata wraps
+3. Skip when the `integrator.integratorId` is absent or not 2-byte hex (warned, no API call) —
+   mirrors the namespace guard. No funded v3 addresses exist pre-integrator, so a missing/malformed
+   id is a data anomaly; sending it would only derive a different, unfunded address.
+4. Defensive on-chain balance check, as on the other paths.
+5. Fetch `{ executeTx: { to, data, value }, ... }` from the execute endpoint. The calldata wraps
    `factory.deployIfNeededAndExecute`, so there is **no bot-side deploy step** and the bot needn't
    know deploy state.
-5. Validate the response before submitting: the API-derived `depositAddress` must match the funded
+6. Validate the response before submitting: the API-derived `depositAddress` must match the funded
    address from the indexer (mismatch would execute at a different address), `executeTx.chainId`
    must match the origin chain, `isPlaceholder` must be false, and `signatureDeadline` must have
    ≥60s of headroom. The calldata embeds a deadline-bounded signature — it is perishable, and on
    any failure the next poll **re-requests fresh calldata; stale payloads are never patched**.
-6. Sign and submit via `TransactionClient` (gas, nonce, rebroadcast), then persist the tx hash to
+7. Sign and submit via `TransactionClient` (gas, nonce, rebroadcast), then persist the tx hash to
    Redis exactly like v1.
 
 The v3 message's `counterfactualMaterials`/`initialRoot`/`salt` are relayed by the indexer but not

--- a/src/interfaces/DepositAddress.ts
+++ b/src/interfaces/DepositAddress.ts
@@ -44,6 +44,17 @@ export interface CounterfactualMaterials {
   spokePoolLeaf?: ExecutionFeeLeaf;
 }
 
+/**
+ * Integrator attribution projected from the deposit address's CDA `integrator` jsonb. The indexer
+ * surfaces this on every `/deposit-address-transfers` item (v1 and v3); `apiKeyHash` is
+ * intentionally omitted (sensitive). `integratorId` is a 2-byte hex string (or null when the
+ * deposit address has no integrator recorded).
+ */
+export interface DepositAddressIntegrator {
+  name: string;
+  integratorId: string | null;
+}
+
 export interface DepositAddressMessage {
   depositAddress: string;
   paramsHash: string;
@@ -57,6 +68,8 @@ export interface DepositAddressMessage {
   shouldSponsorAccountCreation: boolean;
   /** Indexer message version. v1 (or absent = legacy v1) and v3 are processed; v2 is ignored. */
   version?: number;
+  /** Optional during rollout: pre-integrator indexer messages omit it. */
+  integrator?: DepositAddressIntegrator | null;
 }
 
 /**
@@ -110,6 +123,8 @@ export interface DepositAddressMessageV3 {
   refundAddress: NamespacedAccount;
   depositAddressNamespace: string;
   erc20Transfer: Erc20Transfer;
+  /** Optional during rollout: pre-integrator indexer messages omit it. Relayed to the execute endpoint. */
+  integrator?: DepositAddressIntegrator | null;
 }
 
 /** A `/deposit-address-transfers` item, discriminated on `version`. */

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -97,6 +97,7 @@ function depositMessageV3(overrides: Partial<DepositAddressMessageV3> = {}): Dep
     },
     refundAddress: { namespace: "evm", address: REFUND_ADDRESS },
     depositAddressNamespace: "evm",
+    integrator: { name: "test-integrator", integratorId: "0xdead" },
     erc20Transfer: {
       chainId: "42161",
       blockNumber: 1_000_000,
@@ -293,7 +294,7 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
 
   afterEach(() => sinon.restore());
 
-  it("relays funding context only, with executionFee omitted", async function () {
+  it("relays funding context and integratorId, with executionFee omitted", async function () {
     await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());
     expect(executeStub.calledOnce).to.equal(true);
     // Exact request body: the execute endpoint re-derives the address/materials from this
@@ -307,6 +308,7 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
       userAddress: REFUND_ADDRESS,
       amount: "5000",
       executionFeeRecipient: SIGNER,
+      integratorId: "0xdead",
     });
   });
 
@@ -315,6 +317,50 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
     const result = await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());
     expect(result).to.equal(undefined);
     expect(executeStub.callCount).to.equal(4); // initial attempt + 3 retries
+  });
+});
+
+describe("DepositAddressHandler.initiateDepositV3 integratorId guard", function () {
+  let handler: DepositAddressHandler;
+  let executeStub: sinon.SinonStub;
+  let warnStub: sinon.SinonStub;
+  const originChainId = 42161;
+
+  type Internals = { initiateDepositV3: (m: DepositAddressMessageV3) => Promise<void> };
+
+  beforeEach(function () {
+    const config = { relayerOriginChains: [originChainId] } as unknown as DepositAddressHandlerConfig;
+    warnStub = sinon.stub();
+    const logger = { warn: warnStub, debug: sinon.stub() } as unknown as winston.Logger;
+    handler = new DepositAddressHandler(logger, config, {} as unknown as Signer, []);
+    executeStub = sinon.stub().resolves({ depositAddress: DEPOSIT_ADDRESS });
+    (handler as unknown as { api: { executeDepositAddress: sinon.SinonStub } }).api = {
+      executeDepositAddress: executeStub,
+    };
+    // initiateDepositV3 adds/removes the depositKey from this set; seed it so the path runs.
+    (handler as unknown as { observedExecutedDeposits: Record<number, Set<string>> }).observedExecutedDeposits = {
+      [originChainId]: new Set<string>(),
+    };
+  });
+
+  afterEach(() => sinon.restore());
+
+  // Each case reaches the guard (evm namespace, origin chain allowed, not yet executed) and must
+  // skip before calling the execute endpoint, since a missing/malformed integratorId would only
+  // derive a different, unfunded address.
+  const skipCases: { name: string; integrator: DepositAddressMessageV3["integrator"] }[] = [
+    { name: "integrator is null", integrator: null },
+    { name: "integratorId is null", integrator: { name: "x", integratorId: null } },
+    { name: "integratorId is non-hex", integrator: { name: "x", integratorId: "0xZZZZ" } },
+    { name: "integratorId is wrong length", integrator: { name: "x", integratorId: "0xdeadbeef" } },
+  ];
+
+  skipCases.forEach(({ name, integrator }) => {
+    it(`skips without calling the execute endpoint when ${name}`, async function () {
+      await (handler as unknown as Internals).initiateDepositV3(depositMessageV3({ integrator }));
+      expect(executeStub.notCalled).to.equal(true);
+      expect(warnStub.calledOnce).to.equal(true);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

The indexer now exposes integrator attribution on each `/deposit-address-transfers` item (`across-protocol/indexer#1055`), and the quote-api v3 execute endpoint `POST /deposit-addresses/execute` now takes a **required** `integratorId` (2-byte hex, `^0x[0-9a-fA-F]{4}$`) that folds into the CREATE2 salt + on-chain integrator tag — so v3 deposit addresses are derived **per-integrator** (`across-protocol/quote-api#2807`).

This PR pulls `integrator.integratorId` from the indexer message and relays it verbatim to the execute endpoint.

## Behavior

- **Relay verbatim:** the bot sends the indexer-sourced `integratorId` (not its own auth key — it sweeps addresses owned by many integrators).
- **Missing/malformed → skip + warn, no API call:** there are no funded/final v3 addresses pre-integrator (sponsored leaf still placeholder), so every real future v3 transfer carries a valid id. A missing one is a data anomaly, and sending it would only derive a different, unfunded address — so we guard before calling the API, mirroring the existing namespace guard.

## Changes

- **`src/interfaces/DepositAddress.ts`** — new `DepositAddressIntegrator` type mirroring the indexer DTO; optional `integrator` field on both v1 and v3 message interfaces (optional for rollout safety).
- **`src/clients/AcrossSwapApiClient.ts`** — required `integratorId` on `DepositAddressExecuteRequest`.
- **`src/deposit-address/DepositAddressHandler.ts`** — `INTEGRATOR_ID_REGEX` constant; skip+warn guard in `initiateDepositV3`; validated `integratorId` relayed from `_getExecuteTx` (with an `assert` safety net so the required field narrows to `string`).
- **`test/DepositAddressHandler.ts`** — extended the v3 fixture, asserted `integratorId` in the request-mapping test, and added 4 guard cases (integrator null, integratorId null, non-hex, wrong length).
- **`src/deposit-address/README.md`** — documented the relay + guard in the v3 execute flow.

## Testing

- `yarn build` — clean.
- `RELAYER_TEST=true yarn hardhat test test/DepositAddressHandler.ts` — 20 passing, including the updated mapping test and the 4 new guard cases.
- ESLint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)