### PR TITLE
feat(deposit-address): add v3 refund-withdrawals for misrouted transfers

### DIFF
--- a/docs/deposit-address-withdraw-pubsub.md
+++ b/docs/deposit-address-withdraw-pubsub.md
@@ -63,10 +63,10 @@ The publisher serializes the envelope as a UTF-8 JSON string and sends it as the
 
 ### Producer mechanics (this repo)
 
-`DepositAddressHandler._publishWithdrawExecuted` in `src/deposit-address/DepositAddressHandler.ts`:
+`DepositAddressHandler._publishWithdrawExecuted` in `src/deposit-address/DepositAddressHandler.ts` (shared by the v1 `initiateWithdraw` and v3 `initiateWithdrawV3` paths — the payload is version-agnostic, only the refund-address field location differs):
 
 1. Runs only after a refund withdraw has been confirmed on-chain **and** the depositKey has been persisted to Redis. Ordering matters: we never publish without first committing to "this depositKey is done", which prevents handover from racing the publish into a duplicate withdraw.
-2. Filters `receipt.logs` for ERC-20 `Transfer(address,address,uint256)` events whose `address` matches the token contract, whose `from` topic matches the deposit address, AND whose `to` topic matches `routeParams.refundAddress`. The `to` match disambiguates fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address in one tx. Picks the **last** match as a final tiebreaker (handles Multicall3-bundled withdraws where intermediate transfers to the same refund address may also appear). Zero matches → warn + skip the publish (do not raise).
+2. Filters `receipt.logs` for ERC-20 `Transfer(address,address,uint256)` events whose `address` matches the token contract, whose `from` topic matches the deposit address, AND whose `to` topic matches the refund address (`routeParams.refundAddress` for v1, `refundAddress.address` for v3). The `to` match disambiguates fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address in one tx. Picks the **last** match as a final tiebreaker (handles Multicall3-bundled withdraws where intermediate transfers to the same refund address may also appear). Zero matches → warn + skip the publish (do not raise).
 3. Builds the payload above and calls `GcpPubSubPublisher.publishJson`.
 4. Wraps the call in try/catch; on failure, logs at `error` level with `notificationPath: "across-bot-error"` and continues. The withdraw is on-chain and Redis-persisted — there is no rollback and no in-process retry.
 

--- a/src/clients/AcrossApiBaseClient.ts
+++ b/src/clients/AcrossApiBaseClient.ts
@@ -97,4 +97,29 @@ export abstract class BaseAcrossApiClient {
       return;
     }
   }
+
+  /**
+   * Like `_post`, but **rethrows** instead of collapsing failures to `undefined`. Callers that
+   * must classify the failure (e.g. distinguish a terminal 4xx from a retryable transient error)
+   * use this and inspect the thrown error — `postWithTimeout` throws a typed `HttpError` carrying
+   * the HTTP `status` on non-2xx responses. Still logs at warn for observability parity with `_post`.
+   */
+  protected async _postOrThrow<T>(endpoint: string, body: unknown): Promise<T> {
+    try {
+      const headers: Record<string, string> = { "Content-Type": "application/json", Accept: "application/json" };
+      if (this.apiKey) {
+        headers.Authorization = `Bearer ${this.apiKey}`;
+      }
+
+      return await postWithTimeout<T>(`${this.urlBase}/${endpoint}`, body, {}, headers, this.apiResponseTimeout);
+    } catch (err) {
+      this.logger.warn({
+        at: this.logContext,
+        message: `Failed to post to ${this.urlBase}`,
+        endpoint,
+        error: (err as Error).message,
+      });
+      throw err;
+    }
+  }
 }

--- a/src/clients/AcrossApiBaseClient.ts
+++ b/src/clients/AcrossApiBaseClient.ts
@@ -105,12 +105,11 @@ export abstract class BaseAcrossApiClient {
    * the HTTP `status` on non-2xx responses. Still logs at warn for observability parity with `_post`.
    */
   protected async _postOrThrow<T>(endpoint: string, body: unknown): Promise<T> {
+    const headers: Record<string, string> = { "Content-Type": "application/json", Accept: "application/json" };
+    if (this.apiKey) {
+      headers.Authorization = `Bearer ${this.apiKey}`;
+    }
     try {
-      const headers: Record<string, string> = { "Content-Type": "application/json", Accept: "application/json" };
-      if (this.apiKey) {
-        headers.Authorization = `Bearer ${this.apiKey}`;
-      }
-
       return await postWithTimeout<T>(`${this.urlBase}/${endpoint}`, body, {}, headers, this.apiResponseTimeout);
     } catch (err) {
       this.logger.warn({

--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -42,6 +42,49 @@ export interface SignedWithdrawResponse {
 }
 
 /**
+ * Request body for the v3 (upgradeable-counterfactual) deposit-address sign-withdraw endpoint.
+ * The server **verifies** (never re-derives) the deposit address from these persisted CDA
+ * materials, so every contract address is mandatory and the withdraw merkle `proof` is supplied
+ * by the caller (the leaf itself is rebuilt server-side).
+ */
+export interface DepositAddressSignWithdrawRequest {
+  chainId: number;
+  depositAddress: string;
+  initialRoot: string;
+  salt: string;
+  token: string;
+  /** uint256 refund amount as a decimal (or 0x-hex) string. */
+  amount: string;
+  /** Refund recipient committed on-chain at deposit-address creation (not redirectable). */
+  user: string;
+  /** bytes32[] merkle proof for the withdraw leaf. */
+  proof: string[];
+  counterfactualDepositFactory: string;
+  counterfactualBeacon: string;
+  adminWithdrawManager: string;
+  withdrawImplementation: string;
+  /** When true, the estimated execution cost is converted to refund-token units and subtracted. */
+  deductGasFromRefund?: boolean;
+}
+
+export interface DepositAddressSignWithdrawResponse {
+  signedWithdrawTx: {
+    ecosystem: "evm";
+    chainId: number;
+    to: string;
+    data: string;
+    value: string;
+  };
+  bundledDeploy: boolean;
+  signer: string;
+  deadline: number;
+  /** Raw smallest-unit strings. With deduction off: appliedGasFee "0", netAmount === requestedAmount. */
+  requestedAmount: string;
+  appliedGasFee: string;
+  netAmount: string;
+}
+
+/**
  * Request body for the v3 deposit-address execute endpoint. The API re-derives the deposit
  * address and all counterfactual materials from the identity (`destination`, `userAddress`);
  * the bot only supplies funding context and its payout address.
@@ -199,6 +242,17 @@ export class AcrossSwapApiClient extends BaseAcrossApiClient {
 
   async signedWithdraw(req: SignedWithdrawRequest): Promise<SignedWithdrawResponse | undefined> {
     return this._post<SignedWithdrawResponse>("/swap/counterfactual/sign-withdraw", req);
+  }
+
+  /**
+   * v3 (upgradeable-counterfactual) sign-withdraw (POST). Rethrows on failure (via `_postOrThrow`)
+   * so the caller can classify the HTTP status — a 422 (`GAS_EXCEEDS_REFUND` /
+   * `UNPRICEABLE_REFUND_TOKEN`) is terminal, other failures are retryable.
+   */
+  async signWithdrawDepositAddressV3(
+    req: DepositAddressSignWithdrawRequest
+  ): Promise<DepositAddressSignWithdrawResponse> {
+    return this._postOrThrow<DepositAddressSignWithdrawResponse>("deposit-addresses/sign-withdraw", req);
   }
 
   /** v3 upgradeable-counterfactual deposit-execute quote (POST). */

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -24,10 +24,12 @@ import {
   toAddressType,
   TransactionReceipt,
   getCurrentTime,
+  isHttpError,
 } from "../utils";
 import { getRedisCache, RedisCacheInterface } from "../cache/Redis";
 import {
   AnyDepositAddressMessage,
+  CounterfactualMaterialV3,
   DepositAddressMessage,
   DepositAddressMessageV3,
   isDepositAddressMessageV3,
@@ -38,6 +40,7 @@ import {
   SwapApiResponse,
   SignedWithdrawResponse,
   DepositAddressExecuteResponse,
+  DepositAddressSignWithdrawResponse,
 } from "../clients";
 import { AcrossIndexerApiClient } from "../clients/AcrossIndexerApiClient";
 import { GcpPubSubPublisher, getGcpPubSubPublisher } from "../messaging/gcp";
@@ -92,6 +95,14 @@ export class DepositAddressHandler {
 
   /** Set of depositKeys for refund withdraws successfully executed (persisted in Redis for handover). */
   private executedWithdrawKeys: Set<string> = new Set();
+
+  /**
+   * Set of depositKeys for v3 refund withdraws the quote-api rejected with a terminal 422
+   * (`GAS_EXCEEDS_REFUND` / `UNPRICEABLE_REFUND_TOKEN`). Persisted in Redis so the skip survives
+   * handover and is not re-attempted on later polls. Pruned alongside the other sets once the
+   * indexer stops returning the source message.
+   */
+  private terminallySkippedWithdrawKeys: Set<string> = new Set();
 
   /**
    * Per chainId (refund chain = erc20Transfer.chainId): set of depositKeys for withdraws currently
@@ -183,6 +194,7 @@ export class DepositAddressHandler {
 
     await this._loadExecutedDepositsFromRedis();
     await this._loadWithdrawnKeysFromRedis();
+    await this._loadSkippedWithdrawKeysFromRedis();
 
     this.initialized = true;
   }
@@ -193,6 +205,10 @@ export class DepositAddressHandler {
 
   private getWithdrawnKeysRedisKey(): string {
     return `deposit-address:withdrawn-deposit-keys:${this.config.botIdentifier}`;
+  }
+
+  private getSkippedWithdrawKeysRedisKey(): string {
+    return `deposit-address:skipped-withdraw-keys:${this.config.botIdentifier}`;
   }
 
   /** Loads executed deposit tx hashes from Redis (e.g. after handover). */
@@ -253,6 +269,35 @@ export class DepositAddressHandler {
     });
   }
 
+  /** Loads terminally-skipped (422) refund-withdraw depositKeys from Redis (e.g. after handover). */
+  private async _loadSkippedWithdrawKeysFromRedis(): Promise<void> {
+    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    const { redisCache } = this;
+    const redisKey = this.getSkippedWithdrawKeysRedisKey();
+    const raw = await redisCache.get<string>(redisKey);
+    let arr: string[] = [];
+    try {
+      if (raw) {
+        arr = parseJson.stringArray(raw);
+      }
+    } catch (err) {
+      this.logger.error({
+        at: "DepositAddressHandler#_loadSkippedWithdrawKeysFromRedis",
+        message: "Failed to parse skipped withdraw keys from Redis, using empty set",
+        redisKey,
+        err: err instanceof Error ? err.message : String(err),
+      });
+
+      throw err;
+    }
+    this.terminallySkippedWithdrawKeys = new Set(arr);
+    this.logger.debug({
+      at: "DepositAddressHandler#_loadSkippedWithdrawKeysFromRedis",
+      message: "Loaded terminally-skipped withdraw deposit keys from Redis",
+      count: this.terminallySkippedWithdrawKeys.size,
+    });
+  }
+
   /*
    * @notice Polls the Across indexer API and starts background tasks.
    */
@@ -291,6 +336,11 @@ export class DepositAddressHandler {
         this.executedWithdrawKeys.delete(key);
       }
     }
+    for (const key of [...this.terminallySkippedWithdrawKeys]) {
+      if (!depositKeysFromIndexer.has(key)) {
+        this.terminallySkippedWithdrawKeys.delete(key);
+      }
+    }
 
     await forEachAsync(depositMessages, async (depositMessage) => {
       await this.processExecution(depositMessage);
@@ -301,7 +351,8 @@ export class DepositAddressHandler {
    * Dispatches an indexer message to the deposit or refund-withdraw path based on its version and
    * classification:
    *   - v3 correct_transfer: thin-submitter execute path (initiateDepositV3).
-   *   - v3 anything else: dropped — the v3 refund-withdraw flow is not yet supported.
+   *   - v3 mis_route: refund-withdraw path (initiateWithdrawV3), gated behind config.enableV3Withdrawals.
+   *   - v3 anything else (incl. intent_refund): dropped — not yet supported on v3.
    *   - v1 correct_transfer: forward deposit/execute path.
    *   - v1 mis_route / intent_refund: refund-withdraw path.
    *   - anything else: dropped (forward-compat) until explicitly supported.
@@ -312,9 +363,12 @@ export class DepositAddressHandler {
       if (classification === "correct_transfer") {
         return this.initiateDepositV3(depositMessage);
       }
+      if (classification === "mis_route") {
+        return this.initiateWithdrawV3(depositMessage);
+      }
       this.logger.debug({
         at: "DepositAddressHandler#processExecution",
-        message: "deposit-address transfer skipped: v3 refund-withdraw not yet supported",
+        message: "deposit-address transfer skipped: v3 refund-withdraw not supported for classification",
         classification,
         depositAddress: depositMessage.depositAddress,
         txHash: depositMessage.erc20Transfer.transactionHash,
@@ -565,6 +619,14 @@ export class DepositAddressHandler {
     await redisCache.set(redisKey, JSON.stringify([...this.executedWithdrawKeys]));
   }
 
+  /** Same pattern as `_persistWithdrawnKeysRedis` but for terminally-skipped (422) withdraw keys. */
+  private async _persistSkippedWithdrawKeysRedis(): Promise<void> {
+    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    const { redisCache } = this;
+    const redisKey = this.getSkippedWithdrawKeysRedisKey();
+    await redisCache.set(redisKey, JSON.stringify([...this.terminallySkippedWithdrawKeys]));
+  }
+
   /**
    * Best-effort publish of a `withdraw_executed` lifecycle event to GCP Pub/Sub. Payload shape
    * is locked by the consumer (`isDepositAddressWithdrawPayload` in
@@ -576,18 +638,21 @@ export class DepositAddressHandler {
    */
   private async _publishWithdrawExecuted(
     receipt: TransactionReceipt,
-    depositMessage: DepositAddressMessage
+    depositMessage: AnyDepositAddressMessage
   ): Promise<void> {
     if (!isDefined(this.withdrawPublisher)) {
       return;
     }
     const payload = buildWithdrawExecutedPayload(receipt, depositMessage);
     if (!isDefined(payload)) {
+      const refundAddress = isDepositAddressMessageV3(depositMessage)
+        ? depositMessage.refundAddress.address
+        : depositMessage.routeParams.refundAddress;
       this.logger.warn({
         at: "DepositAddressHandler#_publishWithdrawExecuted",
         message: "Skipping publish: no ERC20 Transfer (deposit address → refund address) found in receipt",
         depositAddress: depositMessage.depositAddress,
-        refundAddress: depositMessage.routeParams.refundAddress,
+        refundAddress,
         token: depositMessage.erc20Transfer.contractAddress,
         txHash: receipt.transactionHash,
       });
@@ -1024,6 +1089,262 @@ export class DepositAddressHandler {
       // Logging is handled in AcrossSwapApiClient.
     }
     return retriesRemaining > 0 ? this._getExecuteTx(depositMessage, --retriesRemaining) : undefined;
+  }
+
+  /**
+   * v3 refund-withdraw path entry point. Gated behind config.enableV3Withdrawals and only reached
+   * for `mis_route` classifications (see processExecution). Refunds funds stranded on a v3
+   * (upgradeable-counterfactual) deposit address back to the committed refund address via the
+   * quote-api v3 sign-withdraw endpoint, which bundles the BeaconProxy deploy + signedWithdrawToUser
+   * into a single Multicall3 call when the proxy is not yet on-chain. Gas is deducted from the
+   * refund (`deductGasFromRefund: true`) so refunds are not operated at a loss; a terminal 422
+   * (fee ≥ refund / unpriceable token) is persisted and never retried.
+   */
+  private async initiateWithdrawV3(depositMessage: DepositAddressMessageV3): Promise<void> {
+    const { depositAddress, refundAddress, erc20Transfer, depositAddressNamespace } = depositMessage;
+    const { amount, transactionHash: refTxHash, contractAddress: token } = erc20Transfer;
+    // Refund chain is where the funds landed.
+    const chainId = Number(erc20Transfer.chainId);
+    const depositKey = getDepositKey(depositMessage);
+
+    if (!this.config.enableV3Withdrawals) {
+      this.logger.debug({
+        at: "DepositAddressHandler#initiateWithdrawV3",
+        message: "deposit-address transfer skipped: v3 withdraw flow disabled",
+        depositAddress,
+        txHash: refTxHash,
+        chainId,
+      });
+      return;
+    }
+
+    if (!this.config.relayerOriginChains.includes(chainId)) {
+      return;
+    }
+
+    // Skip if a previous instance (or this one) already executed this withdraw (persisted in Redis).
+    if (this.executedWithdrawKeys.has(depositKey)) {
+      this.logger.debug({
+        at: "DepositAddressHandler#initiateWithdrawV3",
+        message: "Skipping already executed withdraw (found in Redis)",
+        refTxHash,
+        depositKey,
+      });
+      return;
+    }
+
+    // Skip if a previous attempt hit a terminal 422 (persisted in Redis); never re-attempt.
+    if (this.terminallySkippedWithdrawKeys.has(depositKey)) {
+      this.logger.debug({
+        at: "DepositAddressHandler#initiateWithdrawV3",
+        message: "Skipping terminally-skipped withdraw (found in Redis)",
+        refTxHash,
+        depositKey,
+      });
+      return;
+    }
+
+    if (this.observedExecutedWithdraws[chainId]?.has(depositKey)) {
+      return;
+    }
+
+    this.observedExecutedWithdraws[chainId].add(depositKey);
+    // Release the in-flight lock on every exit path except a confirmed on-chain withdraw; an
+    // unexpected throw must not strand the depositKey, since the next poll would silently skip it.
+    let withdrawCommitted = false;
+    try {
+      // The withdraw user identity and deposit address must be EVM addresses for this path.
+      if (depositAddressNamespace !== "evm" || refundAddress.namespace !== "evm") {
+        this.logger.warn({
+          at: "DepositAddressHandler#initiateWithdrawV3",
+          message: "Skipping v3 withdraw: unsupported account namespace",
+          depositAddressNamespace,
+          refundAddressNamespace: refundAddress.namespace,
+          depositAddress,
+          refTxHash,
+          chainId,
+        });
+        return;
+      }
+
+      const withdrawLeaf = depositMessage.counterfactualMaterials.find((leaf) => leaf.kind === "withdraw");
+      if (
+        !isDefined(withdrawLeaf) ||
+        !isDefined(withdrawLeaf.merkleProof) ||
+        !isDefined(withdrawLeaf.implementationAddress)
+      ) {
+        this.logger.warn({
+          at: "DepositAddressHandler#initiateWithdrawV3",
+          message: "Skipping v3 withdraw: message missing withdraw leaf materials",
+          depositAddress,
+          refTxHash,
+          chainId,
+        });
+        return;
+      }
+
+      // Defensive on-chain balance check — guards against reorged indexer messages and against
+      // acting on a deposit-address already withdrawn through another path.
+      const tokenContract = new Contract(token, ERC20_ABI, this.providersByChain[chainId]);
+      let onchainBalance: BigNumber;
+      try {
+        onchainBalance = await tokenContract.balanceOf(depositAddress);
+      } catch (err) {
+        this.logger.warn({
+          at: "DepositAddressHandler#initiateWithdrawV3",
+          message: "Skipping withdraw: failed to fetch deposit address balance",
+          depositAddress,
+          token,
+          depositKey,
+          refTxHash,
+          chainId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+
+      if (onchainBalance.lt(toBN(amount))) {
+        this.logger.debug({
+          at: "DepositAddressHandler#initiateWithdrawV3",
+          message: "Skipping withdraw: deposit address balance below transfer amount",
+          depositAddress,
+          token,
+          amount,
+          onchainBalance: onchainBalance.toString(),
+          depositKey,
+          refTxHash,
+          chainId,
+        });
+        return;
+      }
+
+      const signed = await this._getSignedWithdrawV3(depositMessage, withdrawLeaf);
+      if (!isDefined(signed)) {
+        // _getSignedWithdrawV3 already logged (transient retry-exhausted or terminal 422 skip).
+        return;
+      }
+
+      if (signed.signedWithdrawTx.chainId !== chainId) {
+        this.logger.warn({
+          at: "DepositAddressHandler#initiateWithdrawV3",
+          message: "Skipping withdraw: signed payload chainId does not match refund chainId",
+          signedChainId: signed.signedWithdrawTx.chainId,
+          chainId,
+          depositKey,
+          refTxHash,
+          depositAddress,
+        });
+        return;
+      }
+
+      // The signature is deadline-bounded; leave headroom for simulation + broadcast + confirmation.
+      if (signed.deadline < getCurrentTime() + V3_SIGNATURE_DEADLINE_BUFFER) {
+        this.logger.warn({
+          at: "DepositAddressHandler#initiateWithdrawV3",
+          message: "Skipping withdraw: signature deadline too close to expiry",
+          deadline: signed.deadline,
+          depositKey,
+          refTxHash,
+          depositAddress,
+          chainId,
+        });
+        return;
+      }
+
+      const useDispatcher = this.depositAddressSigners.length > 0;
+      const withdrawTx = {
+        contract: this.getExecuteContract(signed.signedWithdrawTx.to, chainId, useDispatcher),
+        method: "",
+        args: [signed.signedWithdrawTx.data],
+        value: toBN(signed.signedWithdrawTx.value),
+        chainId,
+        message: "Completed Refund Withdraw 💸",
+        mrkdwn: `v3 refund withdraw on ${getNetworkName(chainId)} for deposit address ${blockExplorerLink(
+          depositAddress,
+          chainId
+        )} (requestedAmount: ${signed.requestedAmount}, appliedGasFee: ${signed.appliedGasFee}, netAmount: ${
+          signed.netAmount
+        }, bundledDeploy: ${signed.bundledDeploy})`,
+      };
+
+      const receipt = await sendAndConfirmTransaction(withdrawTx, this.transactionClient, useDispatcher);
+      if (!isDefined(receipt)) {
+        this.logger.warn({
+          at: "DepositAddressHandler#initiateWithdrawV3",
+          message: "Failed to submit withdraw tx",
+          depositKey,
+          refTxHash,
+          depositAddress,
+          chainId,
+        });
+        return;
+      }
+
+      // The withdraw is on-chain; keep the in-flight lock and never re-attempt this depositKey,
+      // even if the Redis persist below throws (handover may miss it, but a double-send is worse).
+      this.executedWithdrawKeys.add(depositKey);
+      withdrawCommitted = true;
+      await this._persistWithdrawnKeysRedis();
+      await this._publishWithdrawExecuted(receipt, depositMessage);
+    } finally {
+      if (!withdrawCommitted) {
+        this.observedExecutedWithdraws[chainId].delete(depositKey);
+      }
+    }
+  }
+
+  /**
+   * Fetches v3 signed-withdraw calldata from the quote-api. Classifies failures: a terminal 422
+   * (`GAS_EXCEEDS_REFUND` / `UNPRICEABLE_REFUND_TOKEN`) is persisted to the terminal-skip set and
+   * never retried; every other failure (network, timeout, 5xx, transient 400) is retried.
+   */
+  private async _getSignedWithdrawV3(
+    depositMessage: DepositAddressMessageV3,
+    withdrawLeaf: CounterfactualMaterialV3,
+    retriesRemaining = 3
+  ): Promise<DepositAddressSignWithdrawResponse | undefined> {
+    const { depositAddress, refundAddress, erc20Transfer, initialRoot, salt } = depositMessage;
+    const { contractAddress: token, amount, chainId } = erc20Transfer;
+    const depositKey = getDepositKey(depositMessage);
+    const request = {
+      chainId: Number(chainId),
+      depositAddress,
+      initialRoot,
+      salt,
+      token,
+      amount,
+      user: refundAddress.address,
+      proof: withdrawLeaf.merkleProof,
+      counterfactualDepositFactory: depositMessage.counterfactualFactoryContractAddress,
+      counterfactualBeacon: depositMessage.counterfactualBeaconContractAddress,
+      adminWithdrawManager: depositMessage.adminWithdrawManagerContractAddress,
+      withdrawImplementation: withdrawLeaf.implementationAddress,
+      deductGasFromRefund: true,
+    };
+    try {
+      return await this.api.signWithdrawDepositAddressV3(request);
+    } catch (err) {
+      // 422 is a terminal state per product decision: gas exceeds the refund or the refund token is
+      // unpriceable. Persist the skip so it survives handover and is not re-attempted on later polls.
+      if (isHttpError(err) && err.status === 422) {
+        this.terminallySkippedWithdrawKeys.add(depositKey);
+        await this._persistSkippedWithdrawKeysRedis();
+        this.logger.warn({
+          at: "DepositAddressHandler#_getSignedWithdrawV3",
+          message: "Skipping withdraw permanently: quote-api returned terminal 422",
+          status: err.status,
+          error: err.message,
+          depositKey,
+          depositAddress,
+          chainId: Number(chainId),
+        });
+        return undefined;
+      }
+      // Logging is handled in AcrossSwapApiClient/base client; retry transient failures.
+      return retriesRemaining > 0
+        ? this._getSignedWithdrawV3(depositMessage, withdrawLeaf, --retriesRemaining)
+        : undefined;
+    }
   }
 
   private getExecuteContract(address: string, originChainId: number, useDispatcher: boolean): Contract {

--- a/src/deposit-address/DepositAddressHandlerConfig.ts
+++ b/src/deposit-address/DepositAddressHandlerConfig.ts
@@ -11,6 +11,8 @@ export class DepositAddressHandlerConfig extends CommonConfig {
   initializationRetryAttempts: number;
   swapApiKey: string;
   withdrawEnabled: boolean;
+  /** Gate for the v3 (upgradeable-counterfactual) refund-withdraw path. Independent of withdrawEnabled. */
+  enableV3Withdrawals: boolean;
 
   /** Gate for publishing `withdraw_executed` events to GCP Pub/Sub. */
   enableDepositAddressWithdrawPublisher: boolean;
@@ -31,6 +33,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
       SWAP_API_KEY,
       INITIALIZATION_RETRY_ATTEMPTS,
       WITHDRAW_ENABLED,
+      ENABLE_V3_WITHDRAWALS,
       ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER,
       PUBSUB_GCP_PROJECT_ID,
       PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC,
@@ -50,6 +53,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
     this.apiTimeoutOverride = Number(API_TIMEOUT_OVERRIDE ?? 3000); // In ms
     this.initializationRetryAttempts = Number(INITIALIZATION_RETRY_ATTEMPTS ?? 3);
     this.withdrawEnabled = WITHDRAW_ENABLED === "true";
+    this.enableV3Withdrawals = ENABLE_V3_WITHDRAWALS === "true";
 
     this.enableDepositAddressWithdrawPublisher = ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER === "true";
     this.pubSubGcpProjectId = PUBSUB_GCP_PROJECT_ID?.trim() ?? "";

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -25,14 +25,14 @@ The indexer tags each ERC-20 transfer with a `transferClassification`:
 | `intent_refund` | Refund-withdraw path — same flow as `mis_route`. |
 | anything else | Dropped (forward-compat). |
 
-The deposit path is always active. The refund-withdraw path is gated by `WITHDRAW_ENABLED`.
+The deposit path is always active. The v1 refund-withdraw path is gated by `WITHDRAW_ENABLED`; the v3 refund-withdraw path is gated independently by `ENABLE_V3_WITHDRAWALS` (must be exactly `"true"`).
 
 Each message also carries a top-level `version` that selects the execution scheme:
 
 | Version | Path |
 | --- | --- |
 | absent / `1` | Legacy v1 scheme — normalized via `normalizeDepositAddressMessage`, then dispatched on classification as above. |
-| `3` | Upgradeable-counterfactual scheme — `correct_transfer` goes to the v3 execute path (below); refund classifications are dropped (v3 refund-withdraw is not yet supported). |
+| `3` | Upgradeable-counterfactual scheme — `correct_transfer` goes to the v3 execute path (below); `mis_route` goes to the v3 refund-withdraw path (below) when `ENABLE_V3_WITHDRAWALS=true`; `intent_refund` and other classifications are dropped (not yet supported on v3). |
 | anything else (e.g. `2`) | Dropped (debug-logged) before normalization, since unsupported payloads may not carry a shape the normalizer can dereference. |
 
 ## v3 execute flow (thin submitter)
@@ -74,6 +74,39 @@ The flow (`initiateDepositV3`):
 The v3 message's `counterfactualMaterials`/`initialRoot`/`salt` are relayed by the indexer but not
 read by the execute path — the API re-derives them, so they are carried for diagnostics only.
 
+## v3 refund-withdraw flow
+
+For `version: 3` `mis_route` messages, when `ENABLE_V3_WITHDRAWALS=true`, the bot refunds the
+stranded funds back to the committed refund address. `intent_refund` is **not** handled on v3 yet
+(dropped). The flow (`initiateWithdrawV3`) mirrors v1 `initiateWithdraw` with v3-specific guards:
+
+1. Gate on `enableV3Withdrawals`, filter on `relayerOriginChains` (refund chain = `erc20Transfer.chainId`),
+   and dedup against the shared withdraw sets (`executedWithdrawKeys`, in-flight `observedExecutedWithdraws`,
+   and the v3 terminal-skip set below).
+2. Skip non-`evm` `depositAddressNamespace` / `refundAddress.namespace` (the withdraw user must be EVM).
+3. Locate the withdraw leaf in `counterfactualMaterials` (`kind === "withdraw"`); skip if its
+   `merkleProof` / `implementationAddress` are missing.
+4. Defensive on-chain balance check, as on the other paths.
+5. Fetch `{ signedWithdrawTx: { to, data, value, chainId }, deadline, requestedAmount, appliedGasFee, netAmount, bundledDeploy }`
+   from `POST /deposit-addresses/sign-withdraw`. Unlike v1, **gas is deducted from the refund**
+   (`deductGasFromRefund: true`) so refunds are not operated at a loss. The endpoint **verifies** the
+   supplied CDA materials (never re-derives the address) and bundles the v3 BeaconProxy
+   `deploy(salt, initialRoot)` + `signedWithdrawToUser` into one Multicall3 call when the proxy is
+   not yet on-chain.
+6. Validate the response: `signedWithdrawTx.chainId` must match the refund chain and the embedded
+   signature's `deadline` must have ≥60s headroom (perishable; re-requested fresh on the next poll).
+7. Submit via `TransactionClient`, persist the depositKey, and publish `withdraw_executed` (same gate
+   + topic + payload as v1; the payload reads `refundAddress.address` for v3).
+
+**Terminal 422 handling.** The endpoint rejects with 422 when gas can't be deducted —
+`GAS_EXCEEDS_REFUND` (fee ≥ refund, typically dust) or `UNPRICEABLE_REFUND_TOKEN` (no market price).
+A 422 is treated as **terminal**: the bot does not submit and **does not retry on later polls**. The
+depositKey is persisted to a dedicated skip set (below) so the decision survives handover. Every
+other failure (network, timeout, 5xx, transient 400 incl. `GAS_FEE_TEMPORARILY_UNAVAILABLE`) is
+retried, then skipped for the current poll and re-attempted on the next. Surfacing the 422 status
+requires the non-swallowing `_postOrThrow` base-client method (`_post` collapses errors to
+`undefined`); the bot classifies on the `HttpError.status`.
+
 ## Execution fee (deposit-execute path)
 
 The swap API prices a worst-case `executionFee` at deposit-address creation time and commits it
@@ -94,10 +127,11 @@ lines for diagnosability. The withdraw path is unaffected — `withdrawLeaf` car
 
 ## Redis persistence
 
-Two sets persist across runs so handover does not double-spend or double-refund:
+Three sets persist across runs so handover does not double-spend, double-refund, or re-attempt a terminally-skipped refund:
 
 - `deposit-address:executed:<botIdentifier>` — set of `erc20Transfer.transactionHash` for successfully executed deposits.
 - `deposit-address:withdrawn-deposit-keys:<botIdentifier>` — set of `depositKey` (`depositAddress:transactionHash`) for successfully executed refund withdraws.
+- `deposit-address:skipped-withdraw-keys:<botIdentifier>` — set of `depositKey` for v3 refund withdraws the quote-api rejected with a terminal 422 (`GAS_EXCEEDS_REFUND` / `UNPRICEABLE_REFUND_TOKEN`); never re-attempted.
 
 On each poll, entries whose source messages are no longer returned by the indexer are pruned — the indexer has its own TTL and stops returning expired messages.
 

--- a/src/deposit-address/withdrawPayload.ts
+++ b/src/deposit-address/withdrawPayload.ts
@@ -1,4 +1,4 @@
-import { DepositAddressMessage } from "../interfaces";
+import { AnyDepositAddressMessage, isDepositAddressMessageV3 } from "../interfaces";
 import { TransactionReceipt, utils } from "../utils";
 
 export const ERC20_TRANSFER_TOPIC = utils.id("Transfer(address,address,uint256)");
@@ -44,13 +44,17 @@ export type WithdrawExecutedPayload = {
  */
 export function buildWithdrawExecutedPayload(
   receipt: TransactionReceipt,
-  depositMessage: DepositAddressMessage
+  depositMessage: AnyDepositAddressMessage
 ): WithdrawExecutedPayload | undefined {
-  const { erc20Transfer, depositAddress, routeParams } = depositMessage;
+  const { erc20Transfer, depositAddress } = depositMessage;
   const token = erc20Transfer.contractAddress;
+  // v3 carries the refund recipient as a namespaced account; v1 carries it on routeParams.
+  const refundAddress = isDepositAddressMessageV3(depositMessage)
+    ? depositMessage.refundAddress.address
+    : depositMessage.routeParams.refundAddress;
 
   const paddedFrom = utils.hexZeroPad(depositAddress.toLowerCase(), 32);
-  const paddedTo = utils.hexZeroPad(routeParams.refundAddress.toLowerCase(), 32);
+  const paddedTo = utils.hexZeroPad(refundAddress.toLowerCase(), 32);
   const transferLogs = receipt.logs.filter(
     (log) =>
       log.address.toLowerCase() === token.toLowerCase() &&

--- a/src/utils/SDKUtils.ts
+++ b/src/utils/SDKUtils.ts
@@ -122,6 +122,7 @@ export const {
   fetchWithTimeout,
   postWithTimeout,
   isHttpError,
+  HttpError,
 } = sdk.utils;
 
 export type FetchHeaders = sdk.utils.FetchHeaders;

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -1,8 +1,8 @@
 import sinon from "sinon";
 import { expect } from "chai";
-import { EvmAddress, getCurrentTime, Signer, winston } from "../src/utils";
+import { EvmAddress, getCurrentTime, HttpError, Signer, winston } from "../src/utils";
 import { DepositAddressMessage, DepositAddressMessageV3 } from "../src/interfaces/DepositAddress";
-import { DepositAddressExecuteResponse } from "../src/clients";
+import { DepositAddressExecuteResponse, DepositAddressSignWithdrawResponse } from "../src/clients";
 import { DepositAddressHandler } from "../src/deposit-address/DepositAddressHandler";
 import { DepositAddressHandlerConfig } from "../src/deposit-address/DepositAddressHandlerConfig";
 
@@ -69,6 +69,27 @@ const withdrawLeaf = {
   encodedParams: "0x",
   implementationAddress: IMPL,
 };
+
+const WITHDRAW_IMPL = "0x000000000000000000000000000000000000B4B4";
+
+/** v3 withdraw leaf as projected by the indexer (`kind === "withdraw"`). */
+const v3WithdrawLeaf = {
+  kind: "withdraw",
+  implementationAddress: WITHDRAW_IMPL,
+  encodedParams: "0x",
+  leafHash: "0x" + "4".repeat(64),
+  merkleProof: ["0x" + "5".repeat(64), "0x" + "6".repeat(64)],
+};
+
+/** v3 mis_route message carrying a withdraw leaf, ready for the refund-withdraw path. */
+function withdrawMessageV3(overrides: Partial<DepositAddressMessageV3> = {}): DepositAddressMessageV3 {
+  const message = depositMessageV3({
+    counterfactualMaterials: [v3WithdrawLeaf],
+    ...overrides,
+  });
+  message.erc20Transfer.transferClassification = "mis_route";
+  return message;
+}
 
 /** v3 correct_transfer message mirroring the indexer's DepositAddressTransferItemV3 projection. */
 function depositMessageV3(overrides: Partial<DepositAddressMessageV3> = {}): DepositAddressMessageV3 {
@@ -225,6 +246,7 @@ describe("DepositAddressHandler.processExecution v3 routing", function () {
   let v3Stub: sinon.SinonStub;
   let v1Stub: sinon.SinonStub;
   let withdrawStub: sinon.SinonStub;
+  let withdrawV3Stub: sinon.SinonStub;
   let logger: winston.Logger;
 
   type Internals = { processExecution: (m: unknown) => Promise<void> };
@@ -236,7 +258,13 @@ describe("DepositAddressHandler.processExecution v3 routing", function () {
     v3Stub = sinon.stub().resolves();
     v1Stub = sinon.stub().resolves();
     withdrawStub = sinon.stub().resolves();
-    Object.assign(handler, { initiateDepositV3: v3Stub, initiateDeposit: v1Stub, initiateWithdraw: withdrawStub });
+    withdrawV3Stub = sinon.stub().resolves();
+    Object.assign(handler, {
+      initiateDepositV3: v3Stub,
+      initiateDeposit: v1Stub,
+      initiateWithdraw: withdrawStub,
+      initiateWithdrawV3: withdrawV3Stub,
+    });
   });
 
   afterEach(() => sinon.restore());
@@ -247,17 +275,27 @@ describe("DepositAddressHandler.processExecution v3 routing", function () {
     expect(v3Stub.calledOnceWithExactly(message)).to.equal(true);
     expect(v1Stub.notCalled).to.equal(true);
     expect(withdrawStub.notCalled).to.equal(true);
+    expect(withdrawV3Stub.notCalled).to.equal(true);
   });
 
-  it("skips v3 refund classifications (withdraw flow not yet supported)", async function () {
-    for (const transferClassification of ["mis_route", "intent_refund"] as const) {
-      const message = depositMessageV3();
-      message.erc20Transfer.transferClassification = transferClassification;
-      await (handler as unknown as Internals).processExecution(message);
-    }
+  it("routes v3 mis_route to the v3 withdraw path", async function () {
+    const message = depositMessageV3();
+    message.erc20Transfer.transferClassification = "mis_route";
+    await (handler as unknown as Internals).processExecution(message);
+    expect(withdrawV3Stub.calledOnceWithExactly(message)).to.equal(true);
     expect(v3Stub.notCalled).to.equal(true);
     expect(v1Stub.notCalled).to.equal(true);
     expect(withdrawStub.notCalled).to.equal(true);
+  });
+
+  it("drops v3 intent_refund (not yet supported)", async function () {
+    const message = depositMessageV3();
+    message.erc20Transfer.transferClassification = "intent_refund";
+    await (handler as unknown as Internals).processExecution(message);
+    expect(v3Stub.notCalled).to.equal(true);
+    expect(v1Stub.notCalled).to.equal(true);
+    expect(withdrawStub.notCalled).to.equal(true);
+    expect(withdrawV3Stub.notCalled).to.equal(true);
   });
 
   it("keeps routing v1 messages to the v1 paths", async function () {
@@ -270,6 +308,7 @@ describe("DepositAddressHandler.processExecution v3 routing", function () {
     await (handler as unknown as Internals).processExecution(refund);
     expect(withdrawStub.calledOnceWithExactly(refund)).to.equal(true);
     expect(v3Stub.notCalled).to.equal(true);
+    expect(withdrawV3Stub.notCalled).to.equal(true);
   });
 });
 
@@ -426,5 +465,135 @@ describe("DepositAddressHandler._validateExecuteResponse guards", function () {
 
   it("rejects responses whose signature deadline is too close to expiry", function () {
     expect(validate(executeResponse({ signatureDeadline: getCurrentTime() + 30 }))).to.equal(false);
+  });
+});
+
+describe("DepositAddressHandler._getSignedWithdrawV3", function () {
+  let handler: DepositAddressHandler;
+  let signWithdrawStub: sinon.SinonStub;
+  let redisSetStub: sinon.SinonStub;
+
+  type Internals = {
+    _getSignedWithdrawV3: (
+      m: DepositAddressMessageV3,
+      leaf: typeof v3WithdrawLeaf,
+      retriesRemaining?: number
+    ) => Promise<DepositAddressSignWithdrawResponse | undefined>;
+    terminallySkippedWithdrawKeys: Set<string>;
+  };
+
+  function internals(): Internals {
+    return handler as unknown as Internals;
+  }
+
+  beforeEach(function () {
+    const config = {} as unknown as DepositAddressHandlerConfig;
+    const logger = { warn: sinon.stub(), debug: sinon.stub() } as unknown as winston.Logger;
+    handler = new DepositAddressHandler(logger, config, {} as unknown as Signer, []);
+    signWithdrawStub = sinon.stub();
+    (handler as unknown as { api: { signWithdrawDepositAddressV3: sinon.SinonStub } }).api = {
+      signWithdrawDepositAddressV3: signWithdrawStub,
+    };
+    redisSetStub = sinon.stub().resolves();
+    (handler as unknown as { redisCache: { set: sinon.SinonStub } }).redisCache = { set: redisSetStub };
+  });
+
+  afterEach(() => sinon.restore());
+
+  it("builds the sign-withdraw request from the message + withdraw leaf, with gas deduction on", async function () {
+    signWithdrawStub.resolves({ signedWithdrawTx: { chainId: 42161 } });
+    const message = withdrawMessageV3();
+    await internals()._getSignedWithdrawV3(message, v3WithdrawLeaf);
+    expect(signWithdrawStub.calledOnce).to.equal(true);
+    expect(signWithdrawStub.firstCall.args[0]).to.deep.equal({
+      chainId: 42161,
+      depositAddress: DEPOSIT_ADDRESS,
+      initialRoot: "0x" + "2".repeat(64),
+      salt: "0x" + "0".repeat(64),
+      token: TOKEN,
+      amount: "5000",
+      user: REFUND_ADDRESS,
+      proof: v3WithdrawLeaf.merkleProof,
+      counterfactualDepositFactory: "0x000000000000000000000000000000000000B2B2",
+      counterfactualBeacon: "0x000000000000000000000000000000000000B1B1",
+      adminWithdrawManager: "0x000000000000000000000000000000000000B3B3",
+      withdrawImplementation: WITHDRAW_IMPL,
+      deductGasFromRefund: true,
+    });
+  });
+
+  it("retries transient failures, then gives up without persisting a skip", async function () {
+    signWithdrawStub.rejects(new HttpError(400, "GAS_FEE_TEMPORARILY_UNAVAILABLE"));
+    const message = withdrawMessageV3();
+    const result = await internals()._getSignedWithdrawV3(message, v3WithdrawLeaf);
+    expect(result).to.equal(undefined);
+    expect(signWithdrawStub.callCount).to.equal(4); // initial attempt + 3 retries
+    expect(internals().terminallySkippedWithdrawKeys.size).to.equal(0);
+    expect(redisSetStub.notCalled).to.equal(true);
+  });
+
+  it("treats a 422 as terminal: no retry, persists the skip key", async function () {
+    signWithdrawStub.rejects(new HttpError(422, "GAS_EXCEEDS_REFUND"));
+    const message = withdrawMessageV3();
+    const result = await internals()._getSignedWithdrawV3(message, v3WithdrawLeaf);
+    expect(result).to.equal(undefined);
+    expect(signWithdrawStub.callCount).to.equal(1); // no retries on a terminal 422
+    const depositKey = `${DEPOSIT_ADDRESS}:${message.erc20Transfer.transactionHash}`;
+    expect(internals().terminallySkippedWithdrawKeys.has(depositKey)).to.equal(true);
+    expect(redisSetStub.calledOnce).to.equal(true);
+  });
+});
+
+describe("DepositAddressHandler.initiateWithdrawV3 guards", function () {
+  let handler: DepositAddressHandler;
+  let signWithdrawStub: sinon.SinonStub;
+  let warnStub: sinon.SinonStub;
+  let debugStub: sinon.SinonStub;
+  const chainId = 42161;
+
+  type Internals = {
+    initiateWithdrawV3: (m: DepositAddressMessageV3) => Promise<void>;
+    terminallySkippedWithdrawKeys: Set<string>;
+  };
+
+  function makeHandler(enableV3Withdrawals: boolean): void {
+    const config = { enableV3Withdrawals, relayerOriginChains: [chainId] } as unknown as DepositAddressHandlerConfig;
+    warnStub = sinon.stub();
+    debugStub = sinon.stub();
+    const logger = { warn: warnStub, debug: debugStub } as unknown as winston.Logger;
+    handler = new DepositAddressHandler(logger, config, {} as unknown as Signer, []);
+    signWithdrawStub = sinon.stub().resolves({ signedWithdrawTx: { chainId } });
+    (handler as unknown as { api: { signWithdrawDepositAddressV3: sinon.SinonStub } }).api = {
+      signWithdrawDepositAddressV3: signWithdrawStub,
+    };
+    (handler as unknown as { observedExecutedWithdraws: Record<number, Set<string>> }).observedExecutedWithdraws = {
+      [chainId]: new Set<string>(),
+    };
+    (handler as unknown as { redisCache: { set: sinon.SinonStub } }).redisCache = { set: sinon.stub().resolves() };
+  }
+
+  afterEach(() => sinon.restore());
+
+  it("skips without calling the API when the v3 withdraw gate is off", async function () {
+    makeHandler(false);
+    await (handler as unknown as Internals).initiateWithdrawV3(withdrawMessageV3());
+    expect(signWithdrawStub.notCalled).to.equal(true);
+    expect(debugStub.calledOnce).to.equal(true);
+  });
+
+  it("skips with a warning when the deposit-address namespace is not evm", async function () {
+    makeHandler(true);
+    await (handler as unknown as Internals).initiateWithdrawV3(withdrawMessageV3({ depositAddressNamespace: "svm" }));
+    expect(signWithdrawStub.notCalled).to.equal(true);
+    expect(warnStub.calledOnce).to.equal(true);
+  });
+
+  it("skips with a warning when the message carries no withdraw leaf", async function () {
+    makeHandler(true);
+    await (handler as unknown as Internals).initiateWithdrawV3(
+      withdrawMessageV3({ counterfactualMaterials: [{ ...v3WithdrawLeaf, kind: "vanilla-cctp" }] })
+    );
+    expect(signWithdrawStub.notCalled).to.equal(true);
+    expect(warnStub.calledOnce).to.equal(true);
   });
 });


### PR DESCRIPTION

<img width="864" height="145" alt="Screenshot 2026-06-17 at 17 02 23" src="https://github.com/user-attachments/assets/7a5c7eab-d8fe-46a2-ba19-44647767c09d" />
<img width="868" height="148" alt="Screenshot 2026-06-17 at 17 00 45" src="https://github.com/user-attachments/assets/bbbbdb02-6204-4119-8f74-37571b03e9ae" />

## Summary

Adds the bot-side **v3** (upgradeable-counterfactual) refund-withdraw flow. Previously `processExecution` dropped every non-`correct_transfer` v3 message ("v3 refund-withdraw not yet supported"), stranding funds that landed on a v3 deposit address but could not be forwarded. `mis_route` classifications now flow to a new `initiateWithdrawV3`, which calls the quote-api `POST /deposit-addresses/sign-withdraw` endpoint ([quote-api #2790](https://github.com/across-protocol/quote-api/pull/2790)) and submits the signed `AdminWithdrawManager.signedWithdrawToUser` calldata.

The v1 path (`WITHDRAW_ENABLED` / `initiateWithdraw`) and the v1 endpoint are untouched.

## Behavior

- **Gated** behind a new `ENABLE_V3_WITHDRAWALS` env (must be exactly `"true"`), independent of v1's `WITHDRAW_ENABLED`.
- **Scope**: only `mis_route` is handled; `intent_refund` stays dropped on v3 for now.
- **Gas deduction**: sends `deductGasFromRefund: true` so refunds aren't operated at a loss.
- **Terminal 422**: a `GAS_EXCEEDS_REFUND` / `UNPRICEABLE_REFUND_TOKEN` response is treated as terminal — persisted to a new `deposit-address:skipped-withdraw-keys:<botId>` Redis set and never retried (survives handover). Every other failure (network, timeout, 5xx, transient 400) is retried, then skipped for the current poll and re-attempted next poll.
- Surfacing the 422 status required a non-swallowing `_postOrThrow` base-client method (`_post` collapses errors to `undefined`); classification is by `HttpError.status`.
- **Pub/Sub**: confirmed v3 withdraws publish the same `withdraw_executed` lifecycle event as v1 under the existing `ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER` gate + topic. `buildWithdrawExecutedPayload` / `_publishWithdrawExecuted` generalized to `AnyDepositAddressMessage` (reads `refundAddress.address` for v3). When the publisher gate is off, publish is silently skipped — no pubsub env required for local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)