### PR TITLE
feat(deposit-address): forward integratorId to v1 counterfactual quote

### DIFF
--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -1092,6 +1092,10 @@ export class DepositAddressHandler {
     // Only the route-relevant leaf is nonzero; the swap-api selects which one applies by strategy.
     const cctpExecutionFee = counterfactualMaterials?.cctpLeaf?.params?.executionFee;
     const spokePoolExecutionFee = counterfactualMaterials?.spokePoolLeaf?.params?.executionFee;
+    // Integrator attribution from the indexer message, forwarded verbatim for tagging. `?? undefined`
+    // collapses both a missing `integrator` and an explicit null id, so absent integrators contribute
+    // no query param (stripped at serialization) and the request keeps its legacy shape.
+    const integratorId = depositMessage.integrator?.integratorId ?? undefined;
     // Swap API expects Tron origin fields in base58; on-chain paths keep ethers `0x` via normalizeDepositAddressMessage.
     // refundAddress must match what was committed in the withdraw leaf at PDA creation time so the
     // swap-api rebuilds the same merkle root the on-chain factory derives the deposit address from.
@@ -1110,6 +1114,7 @@ export class DepositAddressHandler {
       shouldSponsorAccountCreation: String(depositMessage.shouldSponsorAccountCreation),
       cctpExecutionFee,
       spokePoolExecutionFee,
+      integratorId,
     };
     try {
       return await this.api.getCounterfactualDepositQuote(params);

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -92,6 +92,12 @@ subtracts the fee before bridging). `executionFeeRecipient` is the bot signer, s
 the committed fee. The forwarded values are logged on the execute success and swap-quote failure
 lines for diagnosability. The withdraw path is unaffected — `withdrawLeaf` carries no fee.
 
+`_getSwapApiQuote` also forwards the indexer message's `integrator.integratorId` (when present) as an
+`integratorId` query param — **verbatim**, for integrator attribution — and omits it when the message
+carries no integrator (or a null id), preserving the legacy request shape. Unlike the v3 execute path
+(which validates the id and skips on mismatch because it folds into the CREATE2 salt), the v1 path
+neither validates nor skips: the deposit address is already deployed from explicit salt/paramsHash.
+
 ## Redis persistence
 
 Two sets persist across runs so handover does not double-spend or double-refund:

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -30,9 +30,16 @@ const BASE_PARAM_KEYS = [
   "shouldSponsorAccountCreation",
 ];
 
-/** EVM-origin correct_transfer message; `materials` overrides the counterfactualMaterials leaves. */
-function depositMessage(materials: DepositAddressMessage["counterfactualMaterials"]): DepositAddressMessage {
+/**
+ * EVM-origin correct_transfer message; `materials` overrides the counterfactualMaterials leaves and
+ * `integrator` overrides the optional integrator projection (omitted entirely when not provided).
+ */
+function depositMessage(
+  materials: DepositAddressMessage["counterfactualMaterials"],
+  integrator?: DepositAddressMessage["integrator"]
+): DepositAddressMessage {
   return {
+    ...(integrator !== undefined ? { integrator } : {}),
     depositAddress: DEPOSIT_ADDRESS,
     paramsHash: "0x" + "0".repeat(64),
     salt: "0x" + "0".repeat(64),
@@ -113,7 +120,7 @@ function depositMessageV3(overrides: Partial<DepositAddressMessageV3> = {}): Dep
   };
 }
 
-describe("DepositAddressHandler._getSwapApiQuote execution-fee params", function () {
+describe("DepositAddressHandler._getSwapApiQuote params", function () {
   let handler: DepositAddressHandler;
   let getStub: sinon.SinonStub;
 
@@ -166,6 +173,27 @@ describe("DepositAddressHandler._getSwapApiQuote execution-fee params", function
     expect(params.cctpExecutionFee).to.equal(undefined);
     expect(params.spokePoolExecutionFee).to.equal(undefined);
     expect(BASE_PARAM_KEYS.every((key) => key in params)).to.equal(true);
+  });
+
+  it("forwards integratorId verbatim when the message carries one", async function () {
+    const params = await capturedParams(
+      depositMessage({ withdrawLeaf }, { name: "test-integrator", integratorId: "0x1234" })
+    );
+    expect(params.integratorId).to.equal("0x1234");
+  });
+
+  it("leaves integratorId undefined when the message has no integrator", async function () {
+    const params = await capturedParams(depositMessage({ withdrawLeaf }));
+    // Undefined is dropped at query-string serialization, so the request keeps its legacy shape.
+    expect(params.integratorId).to.equal(undefined);
+  });
+
+  it("leaves integratorId undefined when the integrator id is null", async function () {
+    const params = await capturedParams(
+      depositMessage({ withdrawLeaf }, { name: "test-integrator", integratorId: null })
+    );
+    // `?? undefined` collapses an explicit null id so it too is dropped at serialization.
+    expect(params.integratorId).to.equal(undefined);
   });
 });
 


### PR DESCRIPTION
## Summary

The v1 deposit-execute quote path (`_getSwapApiQuote` → `GET swap/counterfactual`) now forwards the indexer message's `integrator.integratorId` as an `integratorId` query param when present, mirroring what the v3 execute path already does. This lets the swap-api attribute/tag v1 executions to the originating integrator.

- Forwarded **verbatim** for attribution; **omitted** when the message carries no integrator (or a null id), so legacy (pre-integrator) addresses keep their exact previous request shape. Omission relies on the same `undefined`-stripping the existing `cctpExecutionFee` / `spokePoolExecutionFee` params use.
- **No validation, never skips** — unlike the v3 execute path (which validates the id with `INTEGRATOR_ID_REGEX` and skips on mismatch, because the id folds into the CREATE2 salt server-side). The v1 deposit address is already deployed by the bot from explicit `salt`/`paramsHash`, so a missing or malformed integratorId cannot derive a different/unfunded address or strand funds.

## Changes

- `src/deposit-address/DepositAddressHandler.ts` — add `integratorId` to the v1 quote params.
- `test/DepositAddressHandler.ts` — extend the `depositMessage` helper with an optional `integrator`; add cases for present / absent / null id. (Describe block renamed `_getSwapApiQuote params`.)
- `src/deposit-address/README.md` — document the forwarding behavior alongside the fee-echo section.

## Verification

- `yarn test test/DepositAddressHandler.ts` — 23 passing (incl. 3 new integratorId cases).
- `yarn typecheck` and `prettier --check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)