### PR TITLE
feat(deposit-address): publish deposit_executed for v3 executions

### DIFF
--- a/docs/deposit-address-withdraw-pubsub.md
+++ b/docs/deposit-address-withdraw-pubsub.md
@@ -53,9 +53,25 @@ type WithdrawFailedPayload = {
     reason: string;
   };
 };
+
+type DepositExecutedPayload = {
+  type: "deposit_executed";
+  data: {
+    chainId: number;       // execute tx chain (= origin chain)
+    blockNumber: number;   // execute tx block
+    txHash: string;        // execute tx hash, lowercase hex
+    logIndex: number;      // logIndex of the input-token Transfer leaving the deposit address
+    erc20Transfer: {       // inbound funding transfer (lookup key) — same block as withdraw_executed
+      chainId: number;
+      blockNumber: number;
+      txHash: string;
+      logIndex: number;
+    };
+  };
+};
 ```
 
-The bot currently emits **only `withdraw_executed`**. `withdraw_failed` is reserved by the contract but not produced — the bot retries internally on most failure paths and does not track a "retries exhausted" terminal state.
+The bot emits **`withdraw_executed`** (refund-withdraw paths) and **`deposit_executed`** (successful v3 correct-transfer executions). `deposit_executed` shares the exact `data` shape of `withdraw_executed`; only the `type` discriminator differs. `withdraw_failed` is reserved by the contract but not produced — the bot retries internally on most failure paths and does not track a "retries exhausted" terminal state.
 
 The `data.erc20Transfer` block is the lookup key the consumer uses to find the row (`(chainId, blockNumber, transactionHash, logIndex)` on the `deposit_address_transfer` table); the sibling fields under `data` populate the withdraw-tx columns on the row being transitioned.
 
@@ -69,6 +85,15 @@ The publisher serializes the envelope as a UTF-8 JSON string and sends it as the
 2. Filters `receipt.logs` for ERC-20 `Transfer(address,address,uint256)` events whose `address` matches the token contract, whose `from` topic matches the deposit address, AND whose `to` topic matches the refund address (`routeParams.refundAddress` for v1, `refundAddress.address` for v3). The `to` match disambiguates fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address in one tx. Picks the **last** match as a final tiebreaker (handles Multicall3-bundled withdraws where intermediate transfers to the same refund address may also appear). Zero matches → warn + skip the publish (do not raise).
 3. Builds the payload above and calls `GcpPubSubPublisher.publishJson`.
 4. Wraps the call in try/catch; on failure, logs at `error` level with `notificationPath: "across-bot-error"` and continues. The withdraw is on-chain and Redis-persisted — there is no rollback and no in-process retry.
+
+`DepositAddressHandler._publishDepositExecuted` (called from `initiateDepositV3` only — v1 and the failure paths are out of scope) mirrors the above:
+
+1. Runs only after a v3 deposit execute has confirmed on-chain **and** the refTxHash has been persisted to Redis.
+2. Filters `receipt.logs` for the input-token (`erc20Transfer.contractAddress`) ERC-20 `Transfer` whose `from` topic matches the deposit address. Unlike the withdraw path there is **no `to` filter** — the input token leaves the deposit address into the SpokePool / CCTP, with no fixed recipient — so any outgoing transfer of the input token qualifies. Picks the **last** match. Zero matches → warn + skip the publish.
+3. Builds the `deposit_executed` payload and publishes to the **same topic** as `withdraw_executed`.
+4. Same best-effort posture: on failure, log at `error` level and continue; no rollback, no retry.
+
+A single `GcpPubSubPublisher` client serves both event types (same project + topic); it is constructed when **either** gate (`ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER` / `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER`) is on, and each publish path checks its own flag so the two events toggle independently.
 
 ### Consumer mechanics (sibling `indexer` repo)
 

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -44,7 +44,7 @@ import {
 } from "../clients";
 import { AcrossIndexerApiClient } from "../clients/AcrossIndexerApiClient";
 import { GcpPubSubPublisher, getGcpPubSubPublisher } from "../messaging/gcp";
-import { buildWithdrawExecutedPayload } from "./withdrawPayload";
+import { buildDepositExecutedPayload, buildWithdrawExecutedPayload } from "./withdrawPayload";
 import ERC20_ABI from "../common/abi/MinimalERC20.json";
 
 /**
@@ -127,7 +127,9 @@ export class DepositAddressHandler {
 
   private transactionClient;
   private redisCache: RedisCacheInterface | undefined;
-  private withdrawPublisher: GcpPubSubPublisher | undefined;
+  // Single client shared by both lifecycle events (withdraw_executed / deposit_executed); they
+  // publish to the same topic and project. Per-event emission is gated by the respective config flag.
+  private executionPublisher: GcpPubSubPublisher | undefined;
 
   public constructor(
     readonly logger: winston.Logger,
@@ -154,8 +156,8 @@ export class DepositAddressHandler {
     this.redisCache = await getRedisCache(this.logger);
     assert(isDefined(this.redisCache), "DepositAddressHandler: requires a Redis cache for handover state");
 
-    if (this.config.enableDepositAddressWithdrawPublisher) {
-      this.withdrawPublisher = getGcpPubSubPublisher(this.logger, this.config.pubSubGcpProjectId);
+    if (this.config.enableDepositAddressWithdrawPublisher || this.config.enableDepositAddressDepositPublisher) {
+      this.executionPublisher = getGcpPubSubPublisher(this.logger, this.config.pubSubGcpProjectId);
     }
 
     // Exit if OS instructs us to do so.
@@ -640,7 +642,8 @@ export class DepositAddressHandler {
     receipt: TransactionReceipt,
     depositMessage: AnyDepositAddressMessage
   ): Promise<void> {
-    if (!isDefined(this.withdrawPublisher)) {
+    // The client may exist because the deposit gate is on; keep withdraw publishing independent.
+    if (!this.config.enableDepositAddressWithdrawPublisher || !isDefined(this.executionPublisher)) {
       return;
     }
     const payload = buildWithdrawExecutedPayload(receipt, depositMessage);
@@ -660,7 +663,7 @@ export class DepositAddressHandler {
     }
 
     try {
-      const messageId = await this.withdrawPublisher.publishJson(
+      const messageId = await this.executionPublisher.publishJson(
         this.config.pubSubDepositAddressWithdrawTopic,
         payload
       );
@@ -682,11 +685,61 @@ export class DepositAddressHandler {
     }
   }
 
+  /**
+   * Best-effort publish of a `deposit_executed` lifecycle event to GCP Pub/Sub after a successful
+   * v3 deposit (correct-transfer) execution. Mirrors {@link _publishWithdrawExecuted}: the deposit
+   * is already on-chain and Redis-persisted by the time we get here, so a publish failure never
+   * rolls back state and never throws to the caller — a dropped publish leaves the indexer row
+   * pending until ops reconciles. Shares the topic with `withdraw_executed`; gated independently by
+   * config.enableDepositAddressDepositPublisher.
+   */
+  private async _publishDepositExecuted(
+    receipt: TransactionReceipt,
+    depositMessage: DepositAddressMessageV3
+  ): Promise<void> {
+    if (!this.config.enableDepositAddressDepositPublisher || !isDefined(this.executionPublisher)) {
+      return;
+    }
+    const payload = buildDepositExecutedPayload(receipt, depositMessage);
+    if (!isDefined(payload)) {
+      this.logger.warn({
+        at: "DepositAddressHandler#_publishDepositExecuted",
+        message: "Skipping publish: no ERC20 Transfer of the input token leaving the deposit address found in receipt",
+        depositAddress: depositMessage.depositAddress,
+        token: depositMessage.erc20Transfer.contractAddress,
+        txHash: receipt.transactionHash,
+      });
+      return;
+    }
+
+    try {
+      const messageId = await this.executionPublisher.publishJson(
+        this.config.pubSubDepositAddressWithdrawTopic,
+        payload
+      );
+      this.logger.debug({
+        at: "DepositAddressHandler#_publishDepositExecuted",
+        message: "Published deposit_executed",
+        messageId,
+        payload,
+      });
+    } catch (err) {
+      this.logger.error({
+        at: "DepositAddressHandler#_publishDepositExecuted",
+        message: "Failed to publish deposit_executed to GCP Pub/Sub",
+        topic: this.config.pubSubDepositAddressWithdrawTopic,
+        payload,
+        err: err instanceof Error ? err.message : String(err),
+        notificationPath: "across-bot-error",
+      });
+    }
+  }
+
   /** Releases the Pub/Sub client. Idempotent. Safe to call when the publisher is not configured. */
   public async disconnect(): Promise<void> {
-    if (isDefined(this.withdrawPublisher)) {
-      await this.withdrawPublisher.close();
-      this.withdrawPublisher = undefined;
+    if (isDefined(this.executionPublisher)) {
+      await this.executionPublisher.close();
+      this.executionPublisher = undefined;
     }
   }
 
@@ -987,6 +1040,7 @@ export class DepositAddressHandler {
       this.executedDepositTxHashes.add(refTxHash);
       executeCommitted = true;
       await this._persistExecutedDepositsRedis();
+      await this._publishDepositExecuted(depositReceipt, depositMessage);
     } finally {
       if (!executeCommitted) {
         this.observedExecutedDeposits[originChainId].delete(depositKey);

--- a/src/deposit-address/DepositAddressHandlerConfig.ts
+++ b/src/deposit-address/DepositAddressHandlerConfig.ts
@@ -16,9 +16,11 @@ export class DepositAddressHandlerConfig extends CommonConfig {
 
   /** Gate for publishing `withdraw_executed` events to GCP Pub/Sub. */
   enableDepositAddressWithdrawPublisher: boolean;
-  /** GCP project that hosts the withdraw-lifecycle topic. Required when the publisher gate is on. */
+  /** Gate for publishing `deposit_executed` events (v3 correct-transfer executions). Independent of the withdraw gate; shares the topic. */
+  enableDepositAddressDepositPublisher: boolean;
+  /** GCP project that hosts the execution-lifecycle topic. Required when a publisher gate is on. */
   pubSubGcpProjectId: string;
-  /** Short topic name (e.g. `topic-deposit-address-withdraw`). Required when the publisher gate is on. */
+  /** Short topic name (e.g. `topic-deposit-address-execution`); shared by both events. Required when a publisher gate is on. */
   pubSubDepositAddressWithdrawTopic: string;
 
   constructor(env: ProcessEnv) {
@@ -35,6 +37,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
       WITHDRAW_ENABLED,
       ENABLE_V3_WITHDRAWALS,
       ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER,
+      ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER,
       PUBSUB_GCP_PROJECT_ID,
       PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC,
     } = env;
@@ -56,15 +59,16 @@ export class DepositAddressHandlerConfig extends CommonConfig {
     this.enableV3Withdrawals = ENABLE_V3_WITHDRAWALS === "true";
 
     this.enableDepositAddressWithdrawPublisher = ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER === "true";
+    this.enableDepositAddressDepositPublisher = ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER === "true";
     this.pubSubGcpProjectId = PUBSUB_GCP_PROJECT_ID?.trim() ?? "";
     this.pubSubDepositAddressWithdrawTopic = PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC?.trim() ?? "";
-    if (this.enableDepositAddressWithdrawPublisher) {
+    if (this.enableDepositAddressWithdrawPublisher || this.enableDepositAddressDepositPublisher) {
       if (!this.pubSubGcpProjectId) {
-        throw new Error("PUBSUB_GCP_PROJECT_ID is required when ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER=true");
+        throw new Error("PUBSUB_GCP_PROJECT_ID is required when a deposit-address publisher gate is enabled");
       }
       if (!this.pubSubDepositAddressWithdrawTopic) {
         throw new Error(
-          "PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC is required when ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER=true"
+          "PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC is required when a deposit-address publisher gate is enabled"
         );
       }
     }

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -70,6 +70,7 @@ The flow (`initiateDepositV3`):
    any failure the next poll **re-requests fresh calldata; stale payloads are never patched**.
 7. Sign and submit via `TransactionClient` (gas, nonce, rebroadcast), then persist the tx hash to
    Redis exactly like v1.
+8. Publish a `deposit_executed` lifecycle event to GCP Pub/Sub (if `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER=true`).
 
 The v3 message's `counterfactualMaterials`/`initialRoot`/`salt` are relayed by the indexer but not
 read by the execute path — the API re-derives them, so they are carried for diagnostics only.
@@ -151,31 +152,37 @@ On each poll, entries whose source messages are no longer returned by the indexe
 6. Persist the depositKey to Redis.
 7. Publish a `withdraw_executed` lifecycle event to GCP Pub/Sub (if the publisher gate is on).
 
-## Withdraw lifecycle Pub/Sub publish
+## Execution lifecycle Pub/Sub publish
 
-When `ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER=true`, every confirmed refund withdraw produces one message on the configured GCP Pub/Sub topic. The consumer lives at `indexer/packages/indexer/src/pubsub/DepositAddressWithdrawConsumer.ts` (sibling repo) and transitions the corresponding `deposit_address_transfer_withdraw` row from `auto_pending` to `executed`.
+The bot publishes two lifecycle events to one shared GCP Pub/Sub topic so the consumer can transition indexer rows out of `auto_pending`:
+
+- `withdraw_executed` — when `ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER=true`, every confirmed refund withdraw (v1 + v3).
+- `deposit_executed` — when `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER=true`, every successful **v3** correct-transfer execution (`initiateDepositV3`). v1 deposits and failure events are out of scope.
+
+The consumer lives at `indexer/packages/indexer/src/pubsub/DepositAddressWithdrawConsumer.ts` (sibling repo). A single Pub/Sub client serves both events (same project + topic); it is constructed when **either** gate is on, and each publish path checks its own flag so the two events toggle independently.
 
 ### Env
 
 | Name | Required | Description |
 | --- | --- | --- |
-| `ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER` | No (default `false`) | Master gate. When false, no Pub/Sub client is constructed. |
-| `PUBSUB_GCP_PROJECT_ID` | When gate is on | GCP project that **hosts the topic** (may differ from the bot's runtime project — cross-project publish is supported when the runtime SA holds `roles/pubsub.publisher` on the topic in the host project). |
-| `PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC` | When gate is on | Short topic name (e.g. `topic-deposit-address-execution` in prod, `…-sandbox` in non-prod). |
+| `ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER` | No (default `false`) | Gate for `withdraw_executed`. |
+| `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER` | No (default `false`) | Gate for `deposit_executed` (v3 executions). Independent of the withdraw gate. |
+| `PUBSUB_GCP_PROJECT_ID` | When either gate is on | GCP project that **hosts the topic** (may differ from the bot's runtime project — cross-project publish is supported when the runtime SA holds `roles/pubsub.publisher` on the topic in the host project). |
+| `PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC` | When either gate is on | Short topic name (e.g. `topic-deposit-address-execution` in prod, `…-sandbox` in non-prod). Shared by both events. |
 
 Auth uses Application Default Credentials. In Cloud Run / GKE the workload SA provides them; locally set `GOOGLE_APPLICATION_CREDENTIALS`.
 
 ### Payload (locked by the consumer)
 
-Every Pub/Sub message uses an envelope: `{ "type": "<message_type>", "data": <type-specific body> }`. The envelope shape is shared by all current and future message types so the consumer can dispatch on `type` and validate `data` against the matching schema. Today only one type is emitted:
+Every Pub/Sub message uses an envelope: `{ "type": "<message_type>", "data": <type-specific body> }`. The envelope shape is shared by all message types so the consumer can dispatch on `type` and validate `data` against the matching schema. `withdraw_executed` and `deposit_executed` share the exact `data` shape; only `type` differs:
 
 ```jsonc
 {
-  "type": "withdraw_executed",
+  "type": "withdraw_executed", // or "deposit_executed"
   "data": {
-    "chainId":     <withdraw tx chain>,
-    "blockNumber": <withdraw tx block number>,
-    "txHash":      "<withdraw tx hash>",
+    "chainId":     <execution tx chain>,
+    "blockNumber": <execution tx block number>,
+    "txHash":      "<execution tx hash>",
     "logIndex":    <logIndex of the ERC20 Transfer leaving the deposit address>,
     "erc20Transfer": {
       "chainId":     <inbound transfer chain>,
@@ -187,11 +194,16 @@ Every Pub/Sub message uses an envelope: `{ "type": "<message_type>", "data": <ty
 }
 ```
 
-All integer fields are `number`; tx hashes are lowercase hex strings. The `erc20Transfer` block identifies the original user transfer (the indexer keys rows on it); the sibling fields identify the withdraw transaction the bot just sent. The `logIndex` of the withdraw is the index of the ERC-20 `Transfer(address,address,uint256)` event whose `address` matches `erc20Transfer.contractAddress`, whose `from` is the deposit address, and whose `to` is the user's `routeParams.refundAddress`. Matching on `to` is necessary to disambiguate fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address in one tx (one to the user, one to a fee recipient). If multiple Transfer logs still satisfy all three filters (e.g. a Multicall3-bundled withdraw with intermediate hops to the same refund address), the **last** match is used.
+All integer fields are `number`; tx hashes are lowercase hex strings. The `erc20Transfer` block identifies the original user transfer (the indexer keys rows on it); the sibling fields identify the execution transaction the bot just sent. The `logIndex` is the index of the ERC-20 `Transfer(address,address,uint256)` event whose `address` matches `erc20Transfer.contractAddress` and whose `from` is the deposit address; the **last** such log is used.
+
+- **`withdraw_executed`** additionally requires `to` to equal the user's `routeParams.refundAddress`. Matching on `to` disambiguates fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address in one tx (one to the user, one to a fee recipient), and the last match handles Multicall3-bundled withdraws with intermediate hops to the same refund address.
+- **`deposit_executed`** omits the `to` filter — the input token leaves the deposit address into the SpokePool / CCTP with no fixed recipient — so any outgoing transfer of the input token qualifies.
+
+Zero matches → warn + skip the publish.
 
 ### Failure semantics
 
-Publish is best-effort. The withdraw is already on-chain and persisted in Redis before we publish; if the GCP client throws (after its own internal retries), we log at error level with `notificationPath: "across-bot-error"` and return — we do **not** roll back state, retry, or raise.
+Publish is best-effort. The withdraw or deposit execute is already on-chain and persisted in Redis before we publish; if the GCP client throws (after its own internal retries), we log at error level with `notificationPath: "across-bot-error"` and return — we do **not** roll back state, retry, or raise.
 
 The intentional trade-off: a dropped publish leaves the indexer row in `auto_pending` until ops reconciles. We do **not** replay executed-but-unpublished withdraws on startup (Redis does not persist per-key publish state). Both are accepted for v1; revisit if dropouts become an ops pain point.
 

--- a/src/deposit-address/withdrawPayload.ts
+++ b/src/deposit-address/withdrawPayload.ts
@@ -1,12 +1,13 @@
-import { AnyDepositAddressMessage, isDepositAddressMessageV3 } from "../interfaces";
-import { TransactionReceipt, utils } from "../utils";
+import { AnyDepositAddressMessage, DepositAddressMessageV3, isDepositAddressMessageV3 } from "../interfaces";
+import { isDefined, TransactionReceipt, utils } from "../utils";
 
 export const ERC20_TRANSFER_TOPIC = utils.id("Transfer(address,address,uint256)");
 
 /**
- * Body of a `withdraw_executed` lifecycle event. Carried in the `data` field of the
- * outer envelope so future message types can attach their own `data` shape under the
- * same `{ type, data }` skeleton.
+ * Body of a deposit-address execution lifecycle event (`withdraw_executed` / `deposit_executed`).
+ * Carried in the `data` field of the outer envelope so future message types can attach their own
+ * `data` shape under the same `{ type, data }` skeleton. Both event types share this shape; only
+ * the `type` discriminator differs.
  */
 export type WithdrawExecutedData = {
   chainId: number;
@@ -25,6 +26,42 @@ export type WithdrawExecutedPayload = {
   type: "withdraw_executed";
   data: WithdrawExecutedData;
 };
+
+/** Shares `WithdrawExecutedData`'s shape; emitted for successful v3 deposit (correct-transfer) executions. */
+export type DepositExecutedData = WithdrawExecutedData;
+
+export type DepositExecutedPayload = {
+  type: "deposit_executed";
+  data: DepositExecutedData;
+};
+
+/**
+ * Returns the last ERC20 `Transfer(address,address,uint256)` log in `receipt` whose `address`
+ * matches `token` and whose `from` topic matches `depositAddress`. When `to` is provided, the
+ * `to` topic must match as well — used by the withdraw path to disambiguate fee-on-transfer /
+ * tax / burn tokens that emit several Transfer events from the deposit address in one tx. The
+ * deposit-execute path omits `to`: funds leave the deposit address to the SpokePool / CCTP
+ * (no fixed recipient), so any outgoing transfer of the input token qualifies. The **last** match
+ * is returned in both cases — the final settlement out of the deposit address (handles
+ * Multicall3-bundled txs with intermediate hops). Returns `undefined` when no log matches.
+ */
+function findLastTransferFromDepositAddress(
+  receipt: TransactionReceipt,
+  token: string,
+  depositAddress: string,
+  to?: string
+): TransactionReceipt["logs"][number] | undefined {
+  const paddedFrom = utils.hexZeroPad(depositAddress.toLowerCase(), 32);
+  const paddedTo = isDefined(to) ? utils.hexZeroPad(to.toLowerCase(), 32) : undefined;
+  const transferLogs = receipt.logs.filter(
+    (log) =>
+      log.address.toLowerCase() === token.toLowerCase() &&
+      log.topics[0] === ERC20_TRANSFER_TOPIC &&
+      log.topics[1]?.toLowerCase() === paddedFrom &&
+      (!isDefined(paddedTo) || log.topics[2]?.toLowerCase() === paddedTo)
+  );
+  return transferLogs.length === 0 ? undefined : transferLogs[transferLogs.length - 1];
+}
 
 /**
  * Builds the `withdraw_executed` payload published to GCP Pub/Sub. Returns `undefined` when
@@ -53,22 +90,55 @@ export function buildWithdrawExecutedPayload(
     ? depositMessage.refundAddress.address
     : depositMessage.routeParams.refundAddress;
 
-  const paddedFrom = utils.hexZeroPad(depositAddress.toLowerCase(), 32);
-  const paddedTo = utils.hexZeroPad(refundAddress.toLowerCase(), 32);
-  const transferLogs = receipt.logs.filter(
-    (log) =>
-      log.address.toLowerCase() === token.toLowerCase() &&
-      log.topics[0] === ERC20_TRANSFER_TOPIC &&
-      log.topics[1]?.toLowerCase() === paddedFrom &&
-      log.topics[2]?.toLowerCase() === paddedTo
-  );
-  if (transferLogs.length === 0) {
+  const transferLog = findLastTransferFromDepositAddress(receipt, token, depositAddress, refundAddress);
+  if (!isDefined(transferLog)) {
     return undefined;
   }
-  const transferLog = transferLogs[transferLogs.length - 1];
 
   return {
     type: "withdraw_executed",
+    data: {
+      chainId: Number(erc20Transfer.chainId),
+      blockNumber: receipt.blockNumber,
+      txHash: receipt.transactionHash.toLowerCase(),
+      logIndex: transferLog.logIndex,
+      erc20Transfer: {
+        chainId: Number(erc20Transfer.chainId),
+        blockNumber: erc20Transfer.blockNumber,
+        txHash: erc20Transfer.transactionHash.toLowerCase(),
+        logIndex: erc20Transfer.logIndex,
+      },
+    },
+  };
+}
+
+/**
+ * Builds the `deposit_executed` payload published to GCP Pub/Sub after a successful v3 deposit
+ * (correct-transfer) execution. Returns `undefined` when the receipt contains no ERC20 `Transfer`
+ * of the input token leaving the deposit address — caller should warn and skip.
+ *
+ * Unlike the withdraw path there is no fixed recipient to match on: the execute moves the input
+ * token out of the deposit address into the SpokePool / CCTP, so any outgoing transfer of the
+ * input token qualifies and the **last** match is used (final settlement out of the deposit
+ * address). The inner `data.erc20Transfer` block is the inbound funding transfer from the indexer
+ * (the consumer's row-lookup key); the sibling fields identify the execute transaction.
+ *
+ * The envelope shape `{ type, data }` is shared with `withdraw_executed`; only the `type` differs.
+ */
+export function buildDepositExecutedPayload(
+  receipt: TransactionReceipt,
+  depositMessage: DepositAddressMessageV3
+): DepositExecutedPayload | undefined {
+  const { erc20Transfer, depositAddress } = depositMessage;
+  const token = erc20Transfer.contractAddress;
+
+  const transferLog = findLastTransferFromDepositAddress(receipt, token, depositAddress);
+  if (!isDefined(transferLog)) {
+    return undefined;
+  }
+
+  return {
+    type: "deposit_executed",
     data: {
       chainId: Number(erc20Transfer.chainId),
       blockNumber: receipt.blockNumber,

--- a/test/DepositAddressHandler.publish.ts
+++ b/test/DepositAddressHandler.publish.ts
@@ -1,7 +1,11 @@
 import { expect } from "chai";
 import { utils, TransactionReceipt } from "../src/utils";
-import { DepositAddressMessage } from "../src/interfaces/DepositAddress";
-import { buildWithdrawExecutedPayload, ERC20_TRANSFER_TOPIC } from "../src/deposit-address/withdrawPayload";
+import { DepositAddressMessage, DepositAddressMessageV3 } from "../src/interfaces/DepositAddress";
+import {
+  buildDepositExecutedPayload,
+  buildWithdrawExecutedPayload,
+  ERC20_TRANSFER_TOPIC,
+} from "../src/deposit-address/withdrawPayload";
 import { getGcpPubSubPublisher } from "../src/messaging/gcp";
 
 const DEPOSIT_ADDRESS = "0x000000000000000000000000000000000000C0DE";
@@ -11,6 +15,8 @@ const TOKEN = "0x000000000000000000000000000000000000DEAD";
 const OTHER_TOKEN = "0x0000000000000000000000000000000000005678";
 const REFUND_TX = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefABCD";
 const INBOUND_TX = "0x1111111111111111111111111111111111111111111111111111111111111111";
+// Sink the input token leaves the deposit address to on a deposit execute (SpokePool / CCTP).
+const SPOKE_POOL = "0x0000000000000000000000000000000000005900";
 
 function topicAddress(address: string): string {
   return utils.hexZeroPad(address.toLowerCase(), 32);
@@ -51,6 +57,38 @@ function depositMessage(): DepositAddressMessage {
       contractAddress: TOKEN,
       transactionHash: INBOUND_TX,
       transferClassification: "intent_refund",
+    },
+  };
+}
+
+function depositMessageV3(): DepositAddressMessageV3 {
+  return {
+    depositAddress: DEPOSIT_ADDRESS,
+    version: 3,
+    salt: "0x" + "0".repeat(64),
+    initialRoot: "0x" + "0".repeat(64),
+    counterfactualBeaconContractAddress: "0x000000000000000000000000000000000000B1B1",
+    counterfactualFactoryContractAddress: "0x000000000000000000000000000000000000B2B2",
+    adminWithdrawManagerContractAddress: "0x000000000000000000000000000000000000B3B3",
+    shouldSponsorAccountCreation: false,
+    counterfactualMaterials: [],
+    routeParams: {
+      outputToken: TOKEN,
+      destinationChainId: "10",
+      recipient: { namespace: "evm", address: "0x0000000000000000000000000000000000001111" },
+    },
+    refundAddress: { namespace: "evm", address: REFUND_ADDRESS },
+    depositAddressNamespace: "evm",
+    erc20Transfer: {
+      chainId: "1",
+      blockNumber: 1_000_000,
+      logIndex: 4,
+      from: "0x0000000000000000000000000000000000009999",
+      to: DEPOSIT_ADDRESS,
+      amount: "5000",
+      contractAddress: TOKEN,
+      transactionHash: INBOUND_TX,
+      transferClassification: "correct_transfer",
     },
   };
 }
@@ -164,6 +202,75 @@ describe("buildWithdrawExecutedPayload", function () {
       { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(REFUND_ADDRESS)] },
     ]);
     const payload = buildWithdrawExecutedPayload(receipt, depositMessage());
+    expect(payload?.data.logIndex).to.equal(2);
+  });
+});
+
+describe("buildDepositExecutedPayload", function () {
+  it("picks the input-token Transfer log leaving the deposit address (any recipient)", function () {
+    const receipt = fakeReceipt([
+      // Unrelated event from the same token contract — wrong topic[0].
+      { address: TOKEN, topics: ["0x" + "f".repeat(64), topicAddress(DEPOSIT_ADDRESS), topicAddress(SPOKE_POOL)] },
+      // Transfer from another address — wrong topic[1].
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(FEE_RECIPIENT), topicAddress(SPOKE_POOL)] },
+      // Transfer of a different token leaving the deposit address — wrong contract address.
+      { address: OTHER_TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(SPOKE_POOL)] },
+      // The match: input token leaving the deposit address to the SpokePool (recipient not constrained).
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(SPOKE_POOL)] },
+    ]);
+
+    const payload = buildDepositExecutedPayload(receipt, depositMessageV3());
+    expect(payload).to.not.be.undefined;
+    expect(payload).to.deep.equal({
+      type: "deposit_executed",
+      data: {
+        chainId: 1,
+        blockNumber: 1_234_567,
+        txHash: REFUND_TX.toLowerCase(),
+        logIndex: 3,
+        erc20Transfer: {
+          chainId: 1,
+          blockNumber: 1_000_000,
+          txHash: INBOUND_TX,
+          logIndex: 4,
+        },
+      },
+    });
+  });
+
+  it("matches case-insensitively on token and depositAddress", function () {
+    const message = depositMessageV3();
+    message.erc20Transfer.contractAddress = TOKEN.toUpperCase().replace("0X", "0x");
+    const receipt = fakeReceipt([
+      {
+        address: TOKEN.toLowerCase(),
+        topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(SPOKE_POOL)],
+      },
+    ]);
+    const payload = buildDepositExecutedPayload(receipt, message);
+    expect(payload?.data.logIndex).to.equal(0);
+  });
+
+  it("returns undefined when no input-token Transfer leaves the deposit address", function () {
+    const receipt = fakeReceipt([
+      // Right shape but wrong token.
+      { address: OTHER_TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(SPOKE_POOL)] },
+      // Inbound transfer (to = depositAddress) — wrong direction.
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(FEE_RECIPIENT), topicAddress(DEPOSIT_ADDRESS)] },
+    ]);
+    expect(buildDepositExecutedPayload(receipt, depositMessageV3())).to.be.undefined;
+  });
+
+  it("picks the LAST input-token Transfer leaving the deposit address when multiple exist", function () {
+    const receipt = fakeReceipt([
+      // Intermediate transfer from the deposit address.
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(FEE_RECIPIENT)] },
+      // Unrelated log between the two matches.
+      { address: OTHER_TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(SPOKE_POOL)] },
+      // Final settlement transfer from the deposit address — this is the one we want.
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(SPOKE_POOL)] },
+    ]);
+    const payload = buildDepositExecutedPayload(receipt, depositMessageV3());
     expect(payload?.data.logIndex).to.equal(2);
   });
 });


### PR DESCRIPTION
Emit a `deposit_executed` Pub/Sub event after a successful v3 deposit execution (`initiateDepositV3`), mirroring the existing `withdraw_executed` flow — same envelope and topic, only the `type` differs. Gated by a new independent `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)