### PR TITLE
fix(rebalancer): wait for inventory rebalance tx confirmation

### DIFF
--- a/src/adapter/BaseChainAdapter.ts
+++ b/src/adapter/BaseChainAdapter.ts
@@ -453,6 +453,10 @@ export class BaseChainAdapter {
       value,
       message,
       mrkdwn: `Sent ${formatUnitsForToken(tokenSymbol, amount)} ${tokenSymbol} to chain ${dstChain}.`,
+      // Block until the rebalance is mined rather than returning a pending tx. TransactionClient's
+      // confirmation loop awaits the receipt and is robust to RPC errors like transaction replacement
+      // (TRANSACTION_REPLACED), resubmitting under a fresh nonce instead of throwing.
+      ensureConfirmation: true,
     };
     const { reason, succeed, transaction: txnRequest } = (await this.transactionClient.simulate([_txnRequest]))[0];
     const { contract: targetContract, ...txnRequestData } = txnRequest;


### PR DESCRIPTION
## Problem

The inventory rebalancer submits a cross-chain transfer and then immediately moves on **without waiting for the transaction to be mined**. The flagged Slack run ("Executed Inventory rebalances 📒") reported rebalances to BNB / zkSync / Base as done while the txs were still only *submitted*.

Trace:
`InventoryClient.rebalanceInventoryIfNeeded` → `sendTokenCrossChain` → `AdapterManager.sendTokenCrossChain` → `BaseChainAdapter.sendTokenToTargetChain` → `submitTransaction`.

In `sendTokenToTargetChain`, the `AugmentedTransaction` was built **without `ensureConfirmation`**. So `TransactionClient._submit` skips its entire `if (txn.ensureConfirmation)` block — the one that awaits `txnResponse.wait()` and handles `TRANSACTION_REPLACED` — and returns the *pending* tx. The caller then just reads `{ hash }` and returns.

## Fix

Set `ensureConfirmation: true` on the rebalance transaction. This routes it through the shared confirmation loop in `TransactionClient._submit`, which:

- awaits the receipt before returning (no more fire-and-forget), and
- is **robust to RPC errors like transaction replacement**: on `TRANSACTION_REPLACED` it resubmits under a fresh nonce instead of throwing; on `CALL_EXCEPTION` it surfaces the revert; otherwise it retries the wait up to `maxTries`.

This is the same idiom already used by the refiller, the standalone `src/rebalancer/adapters/*`, the dataworker, and the finalizers — this inventory path was the one place that omitted it.

## Scope

In production `sendTokenToTargetChain` is reached only via the inventory rebalancer (`AdapterManager.sendTokenCrossChain` ← `InventoryClient`), so this does not change behavior for other bots.

## Testing

- `tsc --noEmit`, eslint, prettier: clean
- `test/generic-adapters/AdapterManager.SendTokensCrossChain.ts` — 6 passing
- `test/generic-adapters/zkSync.ts` — 21 passing

## Note / possible follow-up

The shared `TRANSACTION_REPLACED` handler resubmits on *any* replacement. In the ethers `reason: "repriced"` case (a same-nonce speed-up of the *same* logical tx) the replacement was already mined, so a resubmit could double-send. That's pre-existing behavior in the shared handler (affects every `ensureConfirmation` caller), so I left it out of this targeted fix — happy to tighten it to inspect `error.cancelled` / `error.receipt` as a separate change if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)