### PR TITLE
fix(TransactionClient): don't resubmit repriced (already-mined) replacements

### DIFF
--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -159,12 +159,30 @@ export class TransactionClient {
               // Call failed
               this.logger.warn({ ...common, message: `Transaction on ${chain} failed during execution...` });
               throw error;
-            case ethers.errors.TRANSACTION_REPLACED:
+            case ethers.errors.TRANSACTION_REPLACED: {
+              // ethers throws TRANSACTION_REPLACED when a same-nonce transaction took our slot. A
+              // "repriced" replacement (cancelled === false) is a speed-up of the *same* logical
+              // transaction: it has already mined under a new hash, so resubmitting here would
+              // double-send (e.g. duplicate an inventory rebalance transfer). Treat it as success
+              // by returning the mined replacement. Only a genuine cancellation/replacement
+              // (cancelled === true) means our transaction did not take effect and must be resent.
+              const { cancelled, replacement } = error as unknown as {
+                cancelled?: boolean;
+                replacement?: TransactionResponse;
+              };
+              if (cancelled === false && isDefined(replacement)) {
+                this.logger.warn({
+                  ...common,
+                  message: `Transaction on ${chain} was repriced and already mined; using replacement.`,
+                });
+                return replacement;
+              }
               this.logger.warn({
                 ...common,
                 message: `Transaction submission on ${chain} replaced at nonce ${nonce}, resubmitting...`,
               });
               return this._submit(txn, { nonce: null, maxTries: maxTries - 1 });
+            }
             default:
               this.logger.warn({
                 ...common,

--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -166,11 +166,23 @@ export class TransactionClient {
               // double-send (e.g. duplicate an inventory rebalance transfer). Treat it as success
               // by returning the mined replacement. Only a genuine cancellation/replacement
               // (cancelled === true) means our transaction did not take effect and must be resent.
-              const { cancelled, replacement } = error as unknown as {
+              const { cancelled, replacement, receipt } = error as unknown as {
                 cancelled?: boolean;
                 replacement?: TransactionResponse;
+                receipt?: TransactionReceipt;
               };
               if (cancelled === false && isDefined(replacement)) {
+                // The repriced replacement is itself an on-chain execution. ethers includes its mined
+                // receipt here; a status === 0 receipt means the replacement reverted. Surface that as
+                // a failure (mirroring the CALL_EXCEPTION path above) so callers don't record a reverted
+                // rebalance/finalization as confirmed.
+                if (receipt?.status === 0) {
+                  this.logger.warn({
+                    ...common,
+                    message: `Transaction on ${chain} was repriced but the replacement reverted.`,
+                  });
+                  throw error;
+                }
                 this.logger.warn({
                   ...common,
                   message: `Transaction on ${chain} was repriced and already mined; using replacement.`,

--- a/test/TransactionClient.ts
+++ b/test/TransactionClient.ts
@@ -208,6 +208,30 @@ describe("TransactionClient", function () {
       expect(waitCalls).to.equal(2);
     });
 
+    it("Does not resubmit a repriced (already-mined) replacement", async function () {
+      const chainId = chainIds[0];
+      const replacementHash = ethers.utils.id("repriced-replacement");
+      let waitCalls = 0;
+      txnClient.waitOverride = () => {
+        ++waitCalls;
+        // ethers reports a same-nonce speed-up of the *same* logical transaction as
+        // TRANSACTION_REPLACED with cancelled === false; the replacement has already mined.
+        return Promise.reject(
+          makeEthersError(ethers.errors.TRANSACTION_REPLACED, {
+            cancelled: false,
+            replacement: { nonce: 1, hash: replacementHash } as TransactionResponse,
+          })
+        );
+      };
+
+      const txnResponses = await txnClient.submit(chainId, [makeConfirmationTxn(chainId)]);
+      expect(txnResponses.length).to.equal(1);
+      // wait() was called exactly once: a repriced replacement is treated as success, never resubmitted.
+      expect(waitCalls).to.equal(1);
+      // The mined replacement is returned rather than the original (now-replaced) transaction.
+      expect(txnResponses[0].hash).to.equal(replacementHash);
+    });
+
     it("Retries on transient error then succeeds", async function () {
       const chainId = chainIds[0];
       let waitCalls = 0;

--- a/test/TransactionClient.ts
+++ b/test/TransactionClient.ts
@@ -220,6 +220,7 @@ describe("TransactionClient", function () {
           makeEthersError(ethers.errors.TRANSACTION_REPLACED, {
             cancelled: false,
             replacement: { nonce: 1, hash: replacementHash } as TransactionResponse,
+            receipt: { status: 1 } as TransactionReceipt,
           })
         );
       };
@@ -230,6 +231,30 @@ describe("TransactionClient", function () {
       expect(waitCalls).to.equal(1);
       // The mined replacement is returned rather than the original (now-replaced) transaction.
       expect(txnResponses[0].hash).to.equal(replacementHash);
+    });
+
+    it("Treats a reverted repriced replacement as a failure", async function () {
+      const chainId = chainIds[0];
+      const replacementHash = ethers.utils.id("reverted-repriced-replacement");
+      let waitCalls = 0;
+      txnClient.waitOverride = () => {
+        ++waitCalls;
+        // A repriced replacement that mined but reverted: ethers reports cancelled === false and
+        // attaches the replacement's receipt with status === 0.
+        return Promise.reject(
+          makeEthersError(ethers.errors.TRANSACTION_REPLACED, {
+            cancelled: false,
+            replacement: { nonce: 1, hash: replacementHash } as TransactionResponse,
+            receipt: { status: 0 } as TransactionReceipt,
+          })
+        );
+      };
+
+      const txnResponses = await txnClient.submit(chainId, [makeConfirmationTxn(chainId)]);
+      // A reverted replacement is surfaced as a failure (like CALL_EXCEPTION), so it is excluded.
+      expect(txnResponses.length).to.equal(0);
+      // wait() was called exactly once: a reverted replacement is never resubmitted.
+      expect(waitCalls).to.equal(1);
     });
 
     it("Retries on transient error then succeeds", async function () {


### PR DESCRIPTION
## Problem

Follow-up to #3503, addressing the Codex P1 raised on that PR (which had already merged ~2 minutes before the review landed).

#3503 opted inventory rebalance transfers into `TransactionClient._submit`'s confirmation loop (`ensureConfirmation: true`). That loop's `TRANSACTION_REPLACED` handler resubmits under a **fresh nonce on *any* replacement**:

```ts
case ethers.errors.TRANSACTION_REPLACED:
  ...
  return this._submit(txn, { nonce: null, maxTries: maxTries - 1 });
```

ethers (v5) classifies a same-nonce replacement via `error.cancelled`:
- `reason: "repriced"` → `cancelled === false` — a gas speed-up of the **same logical transaction**. The transfer has **already mined** under a new hash.
- `reason: "cancelled"` / `"replaced"` → `cancelled === true` — the original did **not** take effect.

In the `repriced` case the current code resubmits a transfer that already landed → **double-send** (e.g. a duplicated inventory rebalance). This affects every `ensureConfirmation` caller (rebalancer, refiller, finalizers, dataworker), not just the inventory path.

## Fix

In the `TRANSACTION_REPLACED` branch, return the mined `replacement` when `cancelled === false`; only resubmit on genuine cancellations/replacements (`cancelled === true`). Returning `error.replacement` also hands the caller the *actual* mined tx (correct hash) rather than the original, now-replaced one.

A repriced replacement can still mine **and revert**. ethers attaches the replacement's mined receipt to the error, and `waitForTransaction` does not throw on revert, so `receipt.status === 0` would otherwise be reported as a confirmed success. The `cancelled === false` branch now checks `error.receipt.status` and, on a reverted replacement, throws (mirroring the existing `CALL_EXCEPTION` failure path) so callers don't record a reverted rebalance/finalization as confirmed. (Codex P2.)

## Testing

- `tsc --noEmit`, eslint, prettier: clean
- `test/TransactionClient.ts` — 12 passing, including:
  - existing **Resubmits on TRANSACTION_REPLACED** (genuine replacement → still resubmits),
  - **Does not resubmit a repriced (already-mined) replacement** (regression guard: `wait()` called once, mined replacement returned, no resubmit), and
  - new **Treats a reverted repriced replacement as a failure** (replacement receipt `status === 0` → surfaced as a failure, no resubmit).

## Docs

No README/AGENTS updates needed — this behavior is documented only in the in-code comment, which is updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
