### PR TITLE
fix(finalizer): finalize shared root bundle message on all executed Universal chains

### DIFF
--- a/src/finalizer/utils/helios.ts
+++ b/src/finalizer/utils/helios.ts
@@ -461,7 +461,7 @@ async function getRelevantL1Events(
   return relevantStoredCallDataEvents;
 }
 
-function filterRequiredActions(
+export function filterRequiredActions(
   hubPoolClient: HubPoolClient,
   l2SpokePoolClient: SpokePoolClient,
   l2ChainId: number,
@@ -471,16 +471,37 @@ function filterRequiredActions(
     if (action.type !== "UpdateAndExecute") {
       return true;
     }
-    let observedExecutedRoot = false;
-    for (const leaf of hubPoolClient.getExecutedRootBundles()) {
-      if (leaf.txnRef === action.l1Event.txnRef) {
-        if (leaf.chainId === l2ChainId) {
-          return true;
-        }
-        observedExecutedRoot = true;
-      }
+    // Admin function messages are stored against a specific target spoke pool and are not tied to a
+    // pool rebalance leaf, so they are never gated here. Only the shared `relayRootBundle` message --
+    // which the HubPoolStore stores with `target == address(0)` so that it is reused by every
+    // Universal chain in the bundle -- must wait for this chain's leaf to be executed on the HubPool.
+    if (!compareAddressesSimple(action.l1Event.target, ethers.constants.AddressZero)) {
+      return true;
     }
-    return !observedExecutedRoot;
+    // The shared `relayRootBundle` message is written to the HubPoolStore exactly once per bundle --
+    // by whichever Universal chain's `executeRootBundle()` runs first -- and is keyed by a nonce equal
+    // to the bundle's `challengePeriodEndTimestamp`. We must only finalize it on this L2 once THIS
+    // chain's pool rebalance leaf for that bundle has been executed on the HubPool; otherwise the
+    // refund root (and the funds backing it) is not yet ready on this chain.
+    //
+    // We therefore look the bundle up by its `challengePeriodEndTimestamp` and check whether a leaf
+    // for `l2ChainId` has executed. We intentionally do NOT require the leaf to have executed in the
+    // same L1 transaction that stored the message: the dataworker frequently splits leaf execution
+    // across multiple `executeRootBundle()` transactions, in which case every Universal chain whose
+    // leaf landed outside the storing transaction would otherwise be skipped forever.
+    const challengePeriodEndTimestamp = action.l1Event.nonce.toNumber();
+    const proposedRootBundle = hubPoolClient
+      .getProposedRootBundles()
+      .find((bundle) => bundle.challengePeriodEndTimestamp === challengePeriodEndTimestamp);
+    if (!isDefined(proposedRootBundle)) {
+      // The proposal predates our lookback window; its leaves were necessarily executed long ago, so
+      // there is nothing left to wait for.
+      return true;
+    }
+    const followingBlockNumber =
+      hubPoolClient.getFollowingRootBundle(proposedRootBundle)?.blockNumber ?? hubPoolClient.latestHeightSearched;
+    const executedLeaves = hubPoolClient.getExecutedLeavesForRootBundle(proposedRootBundle, followingBlockNumber);
+    return executedLeaves.some((leaf) => leaf.chainId === l2ChainId);
   });
 }
 

--- a/test/Finalizer.HeliosFilterRequiredActions.test.ts
+++ b/test/Finalizer.HeliosFilterRequiredActions.test.ts
@@ -1,0 +1,99 @@
+import { expect } from "chai";
+import { filterRequiredActions, type HeliosAction } from "../src/finalizer/utils/helios";
+import type { HubPoolClient, SpokePoolClient } from "../src/clients";
+import type { StoredCallDataEvent } from "../src/interfaces/Universal";
+import { toBN, ZERO_ADDRESS } from "../src/utils";
+
+// Plasma. Stands in for "a Universal chain whose pool rebalance leaf was executed in a different
+// `executeRootBundle()` transaction than the one that stored the shared relayRootBundle message".
+const L2_CHAIN_ID = 9745;
+const CHALLENGE_PERIOD_END_TIMESTAMP = 1782213311;
+
+function storedCallDataEvent(overrides: Partial<StoredCallDataEvent> = {}): StoredCallDataEvent {
+  return {
+    // The HubPoolStore stores the shared relayRootBundle message with `target == address(0)` and
+    // `nonce == challengePeriodEndTimestamp`.
+    target: ZERO_ADDRESS,
+    data: "0x",
+    nonce: toBN(CHALLENGE_PERIOD_END_TIMESTAMP),
+    blockNumber: 100,
+    txnIndex: 0,
+    logIndex: 0,
+    txnRef: "0xstore",
+    ...overrides,
+  } as unknown as StoredCallDataEvent;
+}
+
+function updateAndExecuteAction(l1Event: StoredCallDataEvent): HeliosAction {
+  return { type: "UpdateAndExecute", l1Event } as HeliosAction;
+}
+
+function makeHubPoolClient(opts: {
+  proposals: { challengePeriodEndTimestamp: number; blockNumber: number }[];
+  executedLeafChainIds: number[];
+}): HubPoolClient {
+  return {
+    latestHeightSearched: 1_000_000,
+    getProposedRootBundles: () => opts.proposals,
+    getFollowingRootBundle: () => undefined,
+    getExecutedLeavesForRootBundle: () => opts.executedLeafChainIds.map((chainId) => ({ chainId })),
+  } as unknown as HubPoolClient;
+}
+
+const dummySpokePoolClient = {} as unknown as SpokePoolClient;
+
+describe("Helios finalizer: filterRequiredActions", function () {
+  it("keeps the shared relayRootBundle action once this chain's leaf has executed, even when it executed in a different transaction than the one that stored the message", function () {
+    // Regression test: the message was stored in tx 0xstore (by some other Universal chain's
+    // executeRootBundle), but this chain's leaf executed in a separate batch. The action must still
+    // be kept -- gating is on whether this chain's leaf for the bundle executed, not on tx equality.
+    const action = updateAndExecuteAction(storedCallDataEvent({ txnRef: "0xstore" }));
+    const hubPoolClient = makeHubPoolClient({
+      proposals: [{ challengePeriodEndTimestamp: CHALLENGE_PERIOD_END_TIMESTAMP, blockNumber: 50 }],
+      executedLeafChainIds: [1, L2_CHAIN_ID],
+    });
+
+    const result = filterRequiredActions(hubPoolClient, dummySpokePoolClient, L2_CHAIN_ID, [action]);
+    expect(result).to.have.length(1);
+  });
+
+  it("filters out the shared relayRootBundle action while this chain's leaf has not executed yet", function () {
+    const action = updateAndExecuteAction(storedCallDataEvent());
+    const hubPoolClient = makeHubPoolClient({
+      proposals: [{ challengePeriodEndTimestamp: CHALLENGE_PERIOD_END_TIMESTAMP, blockNumber: 50 }],
+      executedLeafChainIds: [1, 143], // other chains executed, but not L2_CHAIN_ID
+    });
+
+    const result = filterRequiredActions(hubPoolClient, dummySpokePoolClient, L2_CHAIN_ID, [action]);
+    expect(result).to.have.length(0);
+  });
+
+  it("keeps the shared relayRootBundle action when the bundle proposal predates the lookback window", function () {
+    const action = updateAndExecuteAction(storedCallDataEvent());
+    const hubPoolClient = makeHubPoolClient({ proposals: [], executedLeafChainIds: [] });
+
+    const result = filterRequiredActions(hubPoolClient, dummySpokePoolClient, L2_CHAIN_ID, [action]);
+    expect(result).to.have.length(1);
+  });
+
+  it("keeps admin function actions (non-zero target) without gating on leaf execution", function () {
+    const adminTarget = "0x000000000000000000000000000000000000dEaD";
+    const action = updateAndExecuteAction(storedCallDataEvent({ target: adminTarget }));
+    // No executed leaves for this chain at all -- an admin message must still pass.
+    const hubPoolClient = makeHubPoolClient({
+      proposals: [{ challengePeriodEndTimestamp: CHALLENGE_PERIOD_END_TIMESTAMP, blockNumber: 50 }],
+      executedLeafChainIds: [],
+    });
+
+    const result = filterRequiredActions(hubPoolClient, dummySpokePoolClient, L2_CHAIN_ID, [action]);
+    expect(result).to.have.length(1);
+  });
+
+  it("keeps non-UpdateAndExecute actions untouched", function () {
+    const action = { type: "UpdateOnly" } as HeliosAction;
+    const hubPoolClient = makeHubPoolClient({ proposals: [], executedLeafChainIds: [] });
+
+    const result = filterRequiredActions(hubPoolClient, dummySpokePoolClient, L2_CHAIN_ID, [action]);
+    expect(result).to.have.length(1);
+  });
+});


### PR DESCRIPTION
## Problem

The Helios (Universal) finalizer can permanently skip relaying a bundle's `relayRootBundle` message to a Universal chain, stranding that chain's relayer refunds for the bundle.

For Universal chains, `executeRootBundle()` doesn't send `relayRootBundle(refundRoot, slowRoot)` per-chain. Instead `HubPoolStore` stores it **once per bundle**, globally (`target == address(0)`, keyed by `nonce == challengePeriodEndTimestamp`), emitted by whichever Universal chain's `executeRootBundle()` runs first — `_storeData` dedupes the rest.

`filterRequiredActions()` then only generated a finalization for a chain whose pool-rebalance leaf executed in the **same L1 transaction** that emitted the `StoredCallData`:

```ts
for (const leaf of hubPoolClient.getExecutedRootBundles()) {
  if (leaf.txnRef === action.l1Event.txnRef) {
    if (leaf.chainId === l2ChainId) return true;
    observedExecutedRoot = true;
  }
}
return !observedExecutedRoot;
```

The dataworker frequently splits leaf execution across **multiple** `executeRootBundle()` transactions (gas-driven). Any Universal chain whose leaf lands outside the storing transaction hits `observedExecutedRoot` and is filtered out — and never re-tried, because the `StoredCallData` rolls out of the finalizer's (halved) L1 lookback before the blocking executed-root does.

### Observed incident

Bundle proposed in mainnet tx `0xb588…d1e2` (relayerRefundRoot `0x6833acff…`). Its 18 pool-rebalance leaves were executed in two batches:

- batch 1 `0x24a6…6897c` → `[1,10,56,130,137,143,324,480,999,1868]` — contains Monad (143), BSC (56), HyperEVM (999); **wrote the `StoredCallData`** (nonce `1782213311` = the bundle's `challengePeriodEndTimestamp`).
- batch 2 `0x9098…0ba4a` → `[8453,9745,34443,42161,57073,59144,7777777,…]` — contains **Plasma (9745)**, which hit the dedupe and emitted nothing.

Plasma was the only Helios chain in batch 2 (the rest use native bridges), so it was uniquely filtered out: the indexer shows the refund root relayed to 17 chains incl. 56/143/999, but **no** `RelayedRootBundle` on Plasma.

## Fix

Gate on whether **this chain's** pool-rebalance leaf for the bundle has executed — matching the bundle by its `challengePeriodEndTimestamp` (which equals the message nonce) — instead of requiring the leaf to share the storing transaction:

```ts
const proposedRootBundle = hubPoolClient
  .getProposedRootBundles()
  .find((bundle) => bundle.challengePeriodEndTimestamp === action.l1Event.nonce.toNumber());
...
const executedLeaves = hubPoolClient.getExecutedLeavesForRootBundle(proposedRootBundle, followingBlockNumber);
return executedLeaves.some((leaf) => leaf.chainId === l2ChainId);
```

This preserves the original intent of #3279 (don't relay a root to a chain before that chain's leaf is executed) while no longer assuming all Universal leaves are executed atomically with the store write. Admin-function messages (non-zero `target`) remain ungated, as before.

## Testing

- `yarn build` ✓
- New unit test `test/Finalizer.HeliosFilterRequiredActions.test.ts` (5 cases, all passing), incl. the regression: leaf executed in a different tx than the store → action kept; leaf not yet executed → filtered; proposal aged out → kept; admin message → kept; non-`UpdateAndExecute` → kept.
- `eslint` + `prettier` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)