### PR TITLE
chore(deps): bump @across-protocol/sdk to 4.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "node": ">=22.18.0"
   },
   "dependencies": {
-    "@across-protocol/constants": "^3.1.114",
-    "@across-protocol/contracts": "5.0.18",
-    "@across-protocol/sdk": "4.4.0",
+    "@across-protocol/constants": "^3.1.116",
+    "@across-protocol/contracts": "5.0.20",
+    "@across-protocol/sdk": "4.4.4",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",
@@ -133,7 +133,7 @@
     "protobufjs": "^7.5.4",
     "fast-xml-parser": "^5.7.1",
     "better-sqlite3": "^11.10.0",
-    "@across-protocol/contracts": "5.0.18"
+    "@across-protocol/contracts": "5.0.20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.com/",

--- a/package.json
+++ b/package.json
@@ -132,8 +132,7 @@
   "resolutions": {
     "protobufjs": "^7.5.4",
     "fast-xml-parser": "^5.7.1",
-    "better-sqlite3": "^11.10.0",
-    "@across-protocol/contracts": "5.0.20"
+    "better-sqlite3": "^11.10.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.com/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,22 +2,17 @@
 # yarn lockfile v1
 
 
-"@across-protocol/constants@^3.1.112":
-  version "3.1.113"
-  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.113.tgz#af823dd81e25f10aa0c06d573b6237edb33fcd00"
-  integrity sha512-4bRz+a97nvdHhiVf9F3eQ2TlhdGWDOnS+Pvf8/rZNNTrEngWRmixWsibmxB35BcfhkhG+xPIHVsXNWiAFqDcXQ==
+"@across-protocol/constants@^3.1.115", "@across-protocol/constants@^3.1.116":
+  version "3.1.116"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.116.tgz#077da9ad06d8eb17c90ed474221cd4673fb7bec7"
+  integrity sha512-w7xvQI63r5lpQ9aj36tJdnyoW5Bhg+J6L86uOn14ApHLuE2bxJkwdKZN0c8bM90TCO65q1u0YqeLnUOjg1cH1g==
 
-"@across-protocol/constants@^3.1.114":
-  version "3.1.115"
-  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.115.tgz#09a0fcd7fe156e2af8dab8808c02d9a75b77cdf2"
-  integrity sha512-TMnMO6XI0yk2GGiz0pS7Jq2i7iaHSegGI/MVEYZPAwbRFE0IsrPCO60JHf3d/Pab7WEMgq8r+eShnw1Gh4Y0wQ==
-
-"@across-protocol/contracts@5.0.18":
-  version "5.0.18"
-  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-5.0.18.tgz#03ee00a580b43bc239856a8a7441a482e22de443"
-  integrity sha512-SZfUEct6GRBx7n1cgmcQh7378eHuna4nls2Cb6usodMpA8rUmesN925ahkcQ1QBzAGKho8sqAUi/j998MxA8Zg==
+"@across-protocol/contracts@5.0.20":
+  version "5.0.20"
+  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-5.0.20.tgz#5ab39360991bd347a60962a5a6361a1fd741e15b"
+  integrity sha512-V7DxmPqqRS1dSxc0t1heyl57ausitG1ZHAzgIkebQZ+Mmj3q4At73upUFayc5vHHcB1EI+72L+RcQFPgidJ/bw==
   dependencies:
-    "@across-protocol/constants" "^3.1.112"
+    "@across-protocol/constants" "^3.1.115"
     "@coral-xyz/anchor" "^0.31.1"
     "@eth-optimism/contracts" "^0.5.40"
     "@ethersproject/bignumber" "5.7.0"
@@ -34,13 +29,13 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.4.0.tgz#4b78299bc710d817e0ecd6b01c4cdb8f41b64dc0"
-  integrity sha512-FGvC6uB3x3KOuH2R91Svly/E9/2lmPwZCqI/E1UJTtiAL+TAJa1uxR2EdjsTSPBdysG/ipOI36wHakLnNQRIgg==
+"@across-protocol/sdk@4.4.4":
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.4.4.tgz#c50ba83d2fbf37f14dc27ca4d95b3618f57c32b8"
+  integrity sha512-msQqhABBctUEj+SIKWmiqxaruhQTButUetK3MuzneyZSOzIWfPdssU9Q060UHCLXQVdUK+Fan3ghheOH3fxdTg==
   dependencies:
-    "@across-protocol/constants" "^3.1.114"
-    "@across-protocol/contracts" "5.0.18"
+    "@across-protocol/constants" "^3.1.116"
+    "@across-protocol/contracts" "5.0.20"
     "@coral-xyz/anchor" "^0.30.1"
     "@eth-optimism/sdk" "^3.3.1"
     "@ethersproject/bignumber" "^5.7.0"


### PR DESCRIPTION
Bumps `@across-protocol/sdk` `4.4.0` → `4.4.4`, keeping `@across-protocol/contracts` and `@across-protocol/constants` in sync with the versions SDK 4.4.4 resolves — **without** using `resolutions` for any `@across-protocol/*` package.

| package | before | after |
|---|---|---|
| `@across-protocol/sdk` | `4.4.0` | `4.4.4` |
| `@across-protocol/contracts` | `5.0.18` | `5.0.20` |
| `@across-protocol/constants` | `^3.1.114` | `^3.1.116` |

Sync is achieved purely through the dependency declarations + yarn dedup, mirroring each package's own specifier style:
- `contracts` is pinned exact `5.0.20` (the SDK pins it exact too) → single resolved version.
- `constants` uses `^3.1.116` (the SDK's own range) → floats in lockstep with the SDK and dedups to one version.

This PR also **removes** the pre-existing `@across-protocol/contracts` entry from the `resolutions` block; with both the relayer and the SDK declaring `contracts@5.0.20`, it's redundant.

`yarn.lock` resolves a single version each — `contracts@5.0.20`, `constants@3.1.116`, `sdk@4.4.4` — with no duplicate trees. `tsc --build` passes with no source changes.

Requested by Paul (<@U03MNG527GQ>) via Slack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)