### PR TITLE
fix(dataworker): skip orbit gas pre-funding for Universal SpokePool chains

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -948,9 +948,13 @@ export const ARBITRUM_ORBIT_L1L2_MESSAGE_FEE_DATA: {
     amountWei: 0.02,
     amountMultipleToFund: 1,
   },
-  // @TODO: How to calculate this for Robinhood?
-  // Do we even need this for Robinhood? We are using Universal SpokePool.
-  // This was Aleph Zero's fee data.
+  // Robinhood and the other UNIVERSAL_CHAINS are Orbit by chain family but receive HubPool messages
+  // via the Universal (SP1) adapter rather than the native Arbitrum inbox, so they need no L1->L2
+  // message gas pre-funding and intentionally have no entry here. Dataworker._executePoolRebalanceLeaves
+  // skips them via the UNIVERSAL_CHAINS check.
+  //
+  // Kept below as a reference for a true native-inbox Orbit chain with a custom gas token
+  // (Aleph Zero, since removed):
   // [CHAIN_IDs.ALEPH_ZERO]: {
   //   amountWei: 0.49,
   //   amountMultipleToFund: 50,

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -96,6 +96,7 @@ import {
   getContractEntry,
   IOFT_ABI_FULL,
   spokePoolClientsToProviders,
+  UNIVERSAL_CHAINS,
 } from "../common";
 import * as OFT from "../utils/OFTUtils";
 import * as sdk from "@across-protocol/sdk";
@@ -1885,7 +1886,14 @@ export class Dataworker {
     const executableLeaves: PoolRebalanceLeaf[] = [];
     for (const leaf of fundedLeaves) {
       // For orbit leaves we need to check if we have enough gas tokens to pay for the L1 to L2 message.
-      if (!sdkUtils.chainIsArbitrum(leaf.chainId) && !sdkUtils.chainIsOrbit(leaf.chainId)) {
+      // Universal SpokePool chains (e.g. Robinhood) are Orbit by chain family but receive HubPool
+      // messages via the Succinct/Helios SP1 (Universal) adapter rather than the native Arbitrum inbox,
+      // so they require no L1->L2 message gas pre-funding and have no entry in
+      // ARBITRUM_ORBIT_L1L2_MESSAGE_FEE_DATA. Treat them like any other non-orbit leaf.
+      const requiresOrbitGasFunding =
+        (sdkUtils.chainIsArbitrum(leaf.chainId) || sdkUtils.chainIsOrbit(leaf.chainId)) &&
+        !UNIVERSAL_CHAINS.includes(leaf.chainId);
+      if (!requiresOrbitGasFunding) {
         executableLeaves.push(leaf);
         continue;
       }

--- a/test/Dataworker.executePoolRebalanceUtils.ts
+++ b/test/Dataworker.executePoolRebalanceUtils.ts
@@ -731,6 +731,35 @@ describe("Dataworker: Utilities to execute pool rebalance leaves", function () {
       expect(queuedTransactions[2].method).to.equal("executeRootBundle");
       expect(queuedTransactions[3].method).to.equal("executeRootBundle");
     });
+    it("does not fund Universal SpokePool Orbit leaf (e.g. Robinhood)", async function () {
+      // Robinhood is Orbit by chain family but uses the Universal SpokePool, so it receives HubPool
+      // messages via the SP1 adapter rather than the native Arbitrum inbox. The dataworker must not
+      // attempt to pre-fund L1->L2 message gas for it: there is no ARBITRUM_ORBIT_L1L2_MESSAGE_FEE_DATA
+      // entry, which previously caused a destructuring TypeError that aborted the whole execution.
+      const leaves: PoolRebalanceLeaf[] = [
+        {
+          chainId: CHAIN_IDs.ROBINHOOD,
+          groupIndex: 0,
+          bundleLpFees: [toBNWei("1")],
+          netSendAmounts: [toBNWei("1")],
+          runningBalances: [toBNWei("1")],
+          leafId: 0,
+          l1Tokens: [token1],
+        },
+      ];
+      const result = await dataworkerInstance._executePoolRebalanceLeaves(
+        spokePoolClients,
+        leaves,
+        balanceAllocator,
+        buildPoolRebalanceLeafTree(leaves)
+      );
+      expect(result).to.equal(1);
+
+      // Only the root-bundle execution should be queued — no loadEthForL2Calls gas pre-funding.
+      const queuedTransactions = multiCallerClient.getQueuedTransactions(hubPoolClient.chainId);
+      expect(queuedTransactions.every((txn) => txn.method !== "loadEthForL2Calls")).to.equal(true);
+      expect(queuedTransactions.filter((txn) => txn.method === "executeRootBundle").length).to.equal(1);
+    });
     it("Ignores leaves without sufficient reserves to execute", async function () {
       // Should only be able to execute the first leaf
       balanceAllocator.testSetBalance(


### PR DESCRIPTION
## Problem

The `zion-across-l1-executor` (dataworker) was crashing with:

```
TypeError: Cannot destructure property 'amountWei' of
'common_1.ARBITRUM_ORBIT_L1L2_MESSAGE_FEE_DATA[leaf.chainId]' as it is undefined.
    at Dataworker._getRequiredEthForOrbitPoolRebalanceLeaf
    at Dataworker._executePoolRebalanceLeaves
```

Root cause: **Robinhood** (chainId `4663`) is declared with `family: ORBIT` in `@across-protocol/constants`, so `sdkUtils.chainIsOrbit(4663)` returns `true`. The guard in `_executePoolRebalanceLeaves` only bypassed the orbit gas-funding path for chains that are *neither* Arbitrum *nor* Orbit, so Robinhood fell through into `_getRequiredEthForOrbitPoolRebalanceLeaf`, which destructures `ARBITRUM_ORBIT_L1L2_MESSAGE_FEE_DATA[leaf.chainId]`. That map only contains an entry for Arbitrum, so the lookup was `undefined` and the destructure threw.

Because the exception propagates up through `_executePoolLeavesAndSyncL1Tokens` → `runDataworker` → `run`, a single Robinhood leaf in a bundle aborts the **entire** pool-rebalance-leaf execution, not just its own leaf.

## Why skipping is correct

Robinhood is in `UNIVERSAL_CHAINS` — it receives HubPool messages via the Succinct/Helios SP1 (Universal) adapter rather than the native Arbitrum inbox. The orbit gas-funding logic exists solely to pre-fund the HubPool with ETH for native Arbitrum retryable-ticket fees; with the Universal adapter there are no such L1→L2 message fees to pay. So Robinhood is "Orbit" by chain *family* but "Universal" by *messaging*, and must not go down the orbit funding path (there is intentionally no fee-data entry for it). A pre-existing TODO in `ARBITRUM_ORBIT_L1L2_MESSAGE_FEE_DATA` already flagged this exact question.

## Change

- `_executePoolRebalanceLeaves` now only requires orbit gas funding when the chain is Arbitrum/Orbit **and not** in `UNIVERSAL_CHAINS`; Universal chains are treated like any other non-orbit leaf.
- Refreshed the stale TODO comment in `ARBITRUM_ORBIT_L1L2_MESSAGE_FEE_DATA`.
- Added a regression test asserting a Robinhood leaf executes (queues `executeRootBundle`) without queuing any `loadEthForL2Calls` gas pre-funding transaction.

## Testing

- `test/Dataworker.executePoolRebalanceUtils.ts` — 28 passing, including the new `does not fund Universal SpokePool Orbit leaf (e.g. Robinhood)` case.
- `yarn typecheck` and prettier/eslint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)