### PR TITLE
improve(InventoryClient): Broaden repayment eligibility for hub-origin deposits

### DIFF
--- a/docs/repayment-eligibility.md
+++ b/docs/repayment-eligibility.md
@@ -69,6 +69,7 @@ This is an LP-fee precomputation helper, not final selection. It may include:
 
 - origin chain (always)
 - destination chain (if allowed)
+- for a hub-origin deposit, every chain with both inventory token config and a pool rebalance route for the deposit's L1 token (via `getRepaymentChainsForL1Token()`)
 - config override chain
 - hub chain
 
@@ -88,7 +89,7 @@ In code order:
 6. resolve canonical L1 token and normalize input amount decimals
 7. apply repayment chain override (non-forced path)
 8. compute refund-aware virtual balance context
-9. build `chainsToEvaluate` in priority order
+9. build `chainsToEvaluate` in priority order (origin/destination standard candidates, plus — for a hub-origin deposit — every other pool-rebalance-route chain for the L1 token; see hub-origin broadening below)
 10. assert compatibility with `getPossibleRepaymentChainIds()`
 11. evaluate each chain against expected post-relay allocation vs effective target
 12. if forced origin and result is not exactly `[origin]`, return `[]`
@@ -104,6 +105,7 @@ Returned order is intentional and consumed by relayer selection.
 - forced-origin deposits can return `[]` when eligibility constraints reject origin.
 - `possible` and `eligible` are different sets by design: `possible` exists to guarantee LP-fee coverage, while `eligible` enforces policy/allocation admissibility.
 - post-relay virtual balance math is intentionally asymmetric for equivalence edge cases (for example USDC vs USDC.e-style mappings): destination output subtraction is only applied when tokens are considered equivalent by `areTokensEquivalent(...)`.
+- hub-origin broadening: for a deposit originating on the hub chain, repayment candidates are broadened beyond origin/destination to every chain with inventory token config and a pool rebalance route for the deposit's L1 token. Because the deposited liquidity is already on the hub (the rebalancing center), repaying the relayer on an under-allocated route chain doubles as a cheap rebalance. The per-chain allocation check still applies, so broadening can only *add* under-allocated targets; LP-fee differences (the cost of rebalancing to a third chain) are priced into downstream profitability selection. `getPossibleRepaymentChainIds()` mirrors the same broadened set so LP fees are precomputed for every candidate. The destination is intentionally left to the standard path (the broadened set reuses the same config + pool-rebalance-route predicate that governs destination eligibility), and the gate is simply `originChainId === hubChainId` — a hub origin is always an unmetered fast-rebalance source, so the forced-origin path short-circuits earlier.
 
 ## Operator knobs
 

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -527,7 +527,7 @@ export class InventoryClient {
 
   getPossibleRepaymentChainIds(deposit: Deposit): number[] {
     // Origin chain is always included in the repayment chain list.
-    const { originChainId, destinationChainId } = deposit;
+    const { originChainId, destinationChainId, inputToken } = deposit;
     const chainIds = new Set<number>();
     chainIds.add(originChainId);
 
@@ -542,6 +542,17 @@ export class InventoryClient {
       chainIds.add(destinationChainId);
     }
 
+    // For a hub-origin deposit the input liquidity lands on the hub, so the relayer can be repaid on any chain with
+    // a pool rebalance route for this token and have the hub source the rebalance cheaply. Surface them all here so
+    // their LP fees are precomputed; determineRefundChainId() applies the allocation check. forceOriginRepayment is
+    // necessarily false at this point (it returns above).
+    if (originChainId === this.hubPoolClient.chainId) {
+      const l1Token = this.getL1TokenAddress(inputToken, originChainId);
+      if (isDefined(l1Token)) {
+        this.getRepaymentChainsForL1Token(l1Token).forEach((chainId) => chainIds.add(chainId));
+      }
+    }
+
     // Check per-chain override first, then global override
     const chainOverride = this.getRepaymentChainOverride(originChainId);
     if (isDefined(chainOverride)) {
@@ -550,6 +561,23 @@ export class InventoryClient {
 
     chainIds.add(this.hubPoolClient.chainId);
     return [...chainIds];
+  }
+
+  /**
+   * @notice Returns every enabled L2 chain that has both inventory token config and a pool rebalance route for the
+   * given L1 token. Used to broaden repayment eligibility for hub-origin deposits: because the deposited liquidity
+   * is already on the hub, repaying the relayer on any of these chains doubles as a low-cost rebalance.
+   * @param l1Token L1 token to enumerate repayment routes for.
+   * @returns list of eligible L2 chain IDs.
+   */
+  getRepaymentChainsForL1Token(l1Token: EvmAddress): number[] {
+    return this.getEnabledL2Chains().filter((chainId) => {
+      if (!this._l1TokenEnabledForChain(l1Token, chainId)) {
+        return false;
+      }
+      const repaymentToken = this.getRemoteTokenForL1Token(l1Token, chainId);
+      return isDefined(repaymentToken) && this.hubPoolClient.l2TokenHasPoolRebalanceRoute(repaymentToken, chainId);
+    });
   }
 
   /**
@@ -716,7 +744,7 @@ export class InventoryClient {
     // To correctly compute destination-chain allocation, add upcoming refunds for all equivalents of this L1 token.
     const cumulativeVirtualBalancePostRefunds = this.getCumulativeBalanceWithApproximateUpcomingRefunds(l1Token);
 
-    // Repayment is evaluated on the origin and destination chains only.
+    // Standard repayment candidates are the origin and destination chains.
     const prioritizeOrigin = deposit.toLiteChain || originQuickRebalance;
     const standardChainOrder = prioritizeOrigin
       ? [originChainId, destinationChainId]
@@ -728,7 +756,18 @@ export class InventoryClient {
     const standardCandidateChains = [...standardChainOrder].filter((chainId) =>
       chainId === originChainId ? canEvaluateOrigin : canEvaluateDestination
     );
-    const rankedChains = dedupArray(standardCandidateChains);
+
+    // For a hub-origin deposit, also evaluate every other chain with a pool rebalance route for this token. The
+    // deposited liquidity is already on the hub, so repaying the relayer on an under-allocated chain is a cheap
+    // rebalance; the allocation check below keeps only under-allocated chains, and LP fee differences are priced
+    // into downstream profitability selection. Destination is handled by the standard path above. No
+    // forceOriginRepayment guard is needed: a hub origin is always an unmetered fast-rebalance source, so the
+    // forced-origin path has already returned above.
+    const broadenedCandidateChains =
+      originChainId === hubChainId
+        ? this.getRepaymentChainsForL1Token(l1Token).filter((chainId) => chainId !== destinationChainId)
+        : [];
+    const rankedChains = dedupArray([...standardCandidateChains, ...broadenedCandidateChains]);
 
     const eligibleChains: number[] = [];
     // At this point, all ranked chains have defined token configs or are destination chains that can be accepted

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -848,7 +848,8 @@ export class Relayer {
 
   /**
    * For an array of unfilled deposits, compute the applicable LP fee for each. Fees are computed for all possible
-   * repayment chains which include origin, destination, all slow-withdrawal chains and mainnet.
+   * repayment chains returned by InventoryClient.getPossibleRepaymentChainIds(): origin, destination, the hub, any
+   * configured override, and — for hub-origin deposits — every chain with a pool rebalance route for the token.
    * @param deposits An array of deposits.
    * @returns A BatchLPFees object uniquely identifying LP fees per unique input deposit.
    */

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -590,6 +590,65 @@ describe("InventoryClient: Refund chain selection", function () {
     });
   });
 
+  describe("hub-origin repayment broadening", function () {
+    let hubDeposit: Deposit;
+    beforeEach(function () {
+      const inputAmount = toWei(1);
+      hubDeposit = {
+        depositId: bnZero,
+        fromLiteChain: false,
+        toLiteChain: false,
+        originChainId: MAINNET,
+        destinationChainId: OPTIMISM,
+        depositor: toAddressType(owner.address, MAINNET),
+        recipient: toAddressType(owner.address, MAINNET),
+        inputToken: toAddressType(l2TokensForWeth[MAINNET], MAINNET),
+        inputAmount,
+        outputToken: toAddressType(l2TokensForWeth[OPTIMISM], OPTIMISM),
+        outputAmount: inputAmount,
+        message: "0x",
+        messageHash: "0x",
+        quoteTimestamp: hubPoolClient.currentTime ?? 0,
+        fillDeadline: 0,
+        exclusivityDeadline: 0,
+        exclusiveRelayer: toAddressType(ZERO_ADDRESS, MAINNET),
+      };
+    });
+
+    it("includes every pool-rebalance-route chain in the possible repayment list for a hub-origin deposit", function () {
+      const possible = inventoryClient.getPossibleRepaymentChainIds(hubDeposit);
+      // Origin (== hub), destination, and the broadened routes (Optimism, Polygon, Arbitrum) are all present.
+      [MAINNET, OPTIMISM, POLYGON, ARBITRUM].forEach((chainId) => expect(possible).to.include(chainId));
+      // BSC has token config but no seeded pool rebalance route, so it is excluded.
+      expect(possible).to.not.include(BSC);
+    });
+
+    it("does not broaden the possible repayment list for a non-hub origin deposit", function () {
+      const l2Deposit = {
+        ...hubDeposit,
+        originChainId: POLYGON,
+        inputToken: toAddressType(l2TokensForWeth[POLYGON], POLYGON),
+      };
+      const possible = inventoryClient.getPossibleRepaymentChainIds(l2Deposit);
+      expect(possible).to.have.members([POLYGON, OPTIMISM, MAINNET]);
+      expect(possible).to.not.include(ARBITRUM);
+    });
+
+    it("refunds on under-allocated route chains that are neither origin nor destination", async function () {
+      // Drive Optimism (destination) over target and Polygon/Arbitrum well under target.
+      tokenClient.setTokenData(OPTIMISM, toAddressType(l2TokensForWeth[OPTIMISM], OPTIMISM), toWei(30));
+      tokenClient.setTokenData(POLYGON, toAddressType(l2TokensForWeth[POLYGON], POLYGON), toWei(0));
+      tokenClient.setTokenData(ARBITRUM, toAddressType(l2TokensForWeth[ARBITRUM], ARBITRUM), toWei(0));
+      await inventoryClient.update();
+
+      // Cumulative WETH balance = 100 (hub) + 30 + 0 + 0 = 130.
+      // Optimism (destination): 30/130 = 23% > 12% target -> excluded.
+      // Polygon / Arbitrum: (0+1)/130 = 0.77% < 7% target -> eligible (only reachable via broadening).
+      // Origin == hub is appended as the quick-rebalance fallback.
+      expect(await inventoryClient.determineRefundChainId(hubDeposit)).to.deep.equal([POLYGON, ARBITRUM, MAINNET]);
+    });
+  });
+
   describe("origin chain is a lite chain", function () {
     beforeEach(async function () {
       const inputAmount = toBNWei(1);


### PR DESCRIPTION
## Motivation

For a deposit originating on the **hub chain**, the input liquidity lands on the hub — the rebalancing center. The relayer can therefore be repaid on *any* chain with a pool rebalance route for the token and have the hub source that rebalance cheaply. Today, hub-origin deposits are only evaluated for repayment on the **origin (hub)** and **destination** chains.

This surfaced on a USDT (Mainnet) → USDC (Base) deposit that went unfilled: the destination (Base) was over-allocated and the hub hit origin-commitment limits, so there was no acceptable repayment chain — even though the relayer was under-allocated on other chains it could have rebalanced into.

## Change

- `InventoryClient.getRepaymentChainsForL1Token()` — new helper enumerating every enabled L2 chain that has **both** inventory token config and a pool rebalance route for the L1 token.
- `determineRefundChainId()` — for hub-origin deposits, append those chains to the candidate set. The existing per-chain allocation check (`expectedPostRelayAllocation <= effectiveTargetPct`) keeps only under-allocated chains, so broadening can only *add* safe targets. Destination stays on the standard path; the hub remains the fallback.
- `getPossibleRepaymentChainIds()` — mirror the broadened set so `batchComputeLpFees` precomputes an LP fee per candidate. LP-fee differences (i.e. the cost of rebalancing to a third chain) are therefore priced into downstream profitability selection — an unprofitable third-chain repayment is filtered out.
- Token-agnostic: keyed on the deposit's L1 token, not any specific token.

### Notes
- **Cheap by construction.** This reuses the in-memory allocation check only; it does *not* reintroduce the running-balance computation removed in #3520.
- **Guard simplification.** The gate is just `originChainId === hubChainId`. `forceOriginRepayment` cannot be set at that point — a hub origin is always an unmetered fast-rebalance source, so `isUnmeteredFastRebalance()` is true and the forced-origin path short-circuits earlier in `determineRefundChainId()`.
- Fixes a stale `batchComputeLpFees` comment that still referenced the removed slow-withdrawal chains.
- **Interaction with the fast-rebalance short-circuit:** broadening engages for hub-origin deposits not already short-circuited to origin by the `canFastRebalanceFill` rule. Since the hub is typically absent from `tokenConfig`, that short-circuit doesn't fire and broadening runs (the real-world case here). If we later want broadening to also override an explicit hub token config, that's a follow-up.

## Testing

`yarn build` + lint clean. New cases in `test/InventoryClient.RefundChain.ts` (all 46 in the file pass, no regressions):
- hub-origin deposit surfaces every pool-rebalance-route chain in the possible list (and excludes a config-but-no-route chain);
- non-hub origin is unaffected (no broadening);
- a hub-origin fill refunds on under-allocated route chains that are neither origin nor destination.

Worth a sanity check on utilisation after enabling, in the same spirit as #3520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)