### PR TITLE
fix: Wait for CCTP Solana mint confirmation before acking

### DIFF
--- a/src/cctp-finalizer/utils/svmUtils.ts
+++ b/src/cctp-finalizer/utils/svmUtils.ts
@@ -18,8 +18,9 @@ import { fetchAddressLookupTable } from "@solana-program/address-lookup-table";
 import {
   winston,
   SvmAddress,
-  sendAndConfirmSolanaTransaction,
+  sendAndConfirmSolanaTransactionWithSlot,
   SVMProvider,
+  SolanaTransaction,
   TOKEN_SYMBOLS_MAP,
   getAssociatedTokenAddress,
 } from "../../utils";
@@ -177,6 +178,36 @@ export function getSvmProvider(rpcUrl: string): SVMProvider {
   return createSolanaRpcFromTransport(transport);
 }
 
+/**
+ * Sends a mint tx and only returns once it is confirmed on-chain. The shared
+ * `sendAndConfirmSolanaTransaction*` helpers return the (locally-derived)
+ * signature even when the tx was never confirmed (e.g. dropped after blockhash
+ * expiry). In the finalizer that silently acks the Pub/Sub message for a mint
+ * that never landed, so treat an unconfirmed result (`confirmedSlot` undefined,
+ * which the poller only leaves unset when it never observed confirmed/finalized)
+ * as a hard failure and let Pub/Sub redeliver for a retry.
+ */
+// ponytail: covers dropped/unconfirmed only. A landed-but-reverted tx (entry.err
+// set with confirmationStatus "confirmed") still reads as success — add an err
+// check in the shared poller if that failure mode surfaces.
+export async function sendAndConfirmMintOrThrow(
+  tx: Parameters<typeof sendAndConfirmSolanaTransactionWithSlot>[0],
+  provider: SVMProvider,
+  cycles?: number,
+  pollingDelay?: number
+): Promise<string> {
+  const { signature, confirmedSlot } = await sendAndConfirmSolanaTransactionWithSlot(
+    tx,
+    provider,
+    cycles,
+    pollingDelay
+  );
+  if (confirmedSlot === undefined) {
+    throw new Error(`Solana mint transaction ${signature} was not confirmed on-chain (likely dropped)`);
+  }
+  return signature;
+}
+
 async function hasCCTPV2MessageBeenProcessed(message: string, provider: SVMProvider): Promise<boolean> {
   const parsedMessage = parseCctpV2Message(message);
   const { usedNonce } = await getMessageTransmitterAccounts(parsedMessage.nonceSeed);
@@ -184,7 +215,7 @@ async function hasCCTPV2MessageBeenProcessed(message: string, provider: SVMProvi
   return Boolean(nonceInfo.value);
 }
 
-async function sendAndConfirmCCTPV2ReceiveMessageTx(params: {
+export async function buildCctpV2ReceiveMessageTx(params: {
   provider: SVMProvider;
   signer: KeyPairSigner;
   attestation: string;
@@ -192,10 +223,8 @@ async function sendAndConfirmCCTPV2ReceiveMessageTx(params: {
   destinationChainId: number;
   originChainId: number;
   addressLookupTable: SolanaAddress;
-  logger: winston.Logger;
-}): Promise<string> {
-  const { provider, signer, attestation, message, destinationChainId, originChainId, addressLookupTable, logger } =
-    params;
+}): Promise<SolanaTransaction> {
+  const { provider, signer, attestation, message, destinationChainId, originChainId, addressLookupTable } = params;
 
   const parsedMessage = parseCctpV2Message(message);
   const [messageTransmitterAccounts, tokenMessengerAccounts] = await Promise.all([
@@ -224,7 +253,7 @@ async function sendAndConfirmCCTPV2ReceiveMessageTx(params: {
   const altAccount = await fetchAddressLookupTable(provider, addressLookupTable);
   const lookupTableMap = { [addressLookupTable]: altAccount.data.addresses };
 
-  const tx = updateOrAppendSetComputeUnitLimitInstruction(
+  return updateOrAppendSetComputeUnitLimitInstruction(
     300_000,
     pipe(
       await sdk.arch.svm.createDefaultTransaction(provider, signer),
@@ -232,8 +261,22 @@ async function sendAndConfirmCCTPV2ReceiveMessageTx(params: {
       (tx) => compressTransactionMessageUsingAddressLookupTables(tx, lookupTableMap)
     )
   );
+}
 
-  const signature = await sendAndConfirmSolanaTransaction(tx, provider);
+async function sendAndConfirmCCTPV2ReceiveMessageTx(params: {
+  provider: SVMProvider;
+  signer: KeyPairSigner;
+  attestation: string;
+  message: string;
+  destinationChainId: number;
+  originChainId: number;
+  addressLookupTable: SolanaAddress;
+  logger: winston.Logger;
+}): Promise<string> {
+  const { provider, destinationChainId, originChainId, logger } = params;
+  const tx = await buildCctpV2ReceiveMessageTx(params);
+
+  const signature = await sendAndConfirmMintOrThrow(tx, provider);
   logger.info({
     at: "svmUtils#getCCTPV2ReceiveMessageTx",
     message: "Mint transaction completed on Solana V2",
@@ -337,7 +380,7 @@ export async function processMintSvm(
       1, // hubChainId
       SvmAddress.from(recipient)
     );
-    txSignature = await sendAndConfirmSolanaTransaction(receiveMessageTx, svmProvider);
+    txSignature = await sendAndConfirmMintOrThrow(receiveMessageTx, svmProvider);
   } else {
     logger.info({
       at: "svmUtils#processMintSvm",

--- a/test/cctpFinalizerSvm.confirm.ts
+++ b/test/cctpFinalizerSvm.confirm.ts
@@ -1,0 +1,67 @@
+import { expect } from "./utils";
+import {
+  createTransactionMessage,
+  generateKeyPairSigner,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  type Blockhash,
+} from "@solana/kit";
+import { sendAndConfirmSolanaTransaction } from "../src/utils/TransactionUtils";
+import { sendAndConfirmMintOrThrow } from "../src/cctp-finalizer/utils/svmUtils";
+
+// A 32-byte all-zero base58 string is a valid Blockhash shape for offline signing.
+const FAKE_BLOCKHASH = "11111111111111111111111111111111" as Blockhash;
+
+const buildSignableTx = async () => {
+  const signer = await generateKeyPairSigner();
+  return pipe(createTransactionMessage({ version: 0 }), (tx) => setTransactionMessageFeePayerSigner(signer, tx));
+};
+
+// Fake provider whose getSignatureStatuses always yields `statusValue` — used to
+// simulate a dropped tx (status stays null / never reaches confirmed).
+const makeFakeProvider = (statusValue: unknown) => {
+  const fakeSignature = "5tkH59X6n7zVJ4r3z2hG5L9rA1bC2dE4fG6h8jK0mN1pQ3sT5uV7wY9aB1cD3eF6";
+  return {
+    provider: {
+      getLatestBlockhash: () => ({
+        send: async () => ({ value: { blockhash: FAKE_BLOCKHASH, lastValidBlockHeight: 1_000n } }),
+      }),
+      sendTransaction: () => ({ send: async () => fakeSignature }),
+      getSignatureStatuses: () => ({ send: async () => ({ context: { slot: 0n }, value: [statusValue] }) }),
+    },
+    fakeSignature,
+  };
+};
+
+describe("cctp-finalizer svmUtils — mint confirmation guard", function () {
+  // Documents the root cause: the shared helper resolves with a signature even
+  // when the tx never confirmed (a dropped tx), which is what caused the
+  // finalizer to ack the Pub/Sub message prematurely.
+  it("root cause: sendAndConfirmSolanaTransaction resolves even when the tx is never confirmed", async function () {
+    const tx = await buildSignableTx();
+    const { provider, fakeSignature } = makeFakeProvider(null); // dropped: status is always null
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sig = await sendAndConfirmSolanaTransaction(tx as any, provider as any, 2, 1);
+    expect(sig).to.equal(fakeSignature);
+  });
+
+  it("throws when the mint tx is never confirmed (dropped)", async function () {
+    const tx = await buildSignableTx();
+    const { provider } = makeFakeProvider(null); // dropped: status is always null
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(sendAndConfirmMintOrThrow(tx as any, provider as any, 2, 1)).to.be.rejectedWith(/not confirmed/);
+  });
+
+  it("returns the signature when the mint tx confirms", async function () {
+    const tx = await buildSignableTx();
+    const { provider, fakeSignature } = makeFakeProvider({
+      confirmationStatus: "confirmed",
+      slot: 123n,
+      err: null,
+      confirmations: 1n,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sig = await sendAndConfirmMintOrThrow(tx as any, provider as any, 2, 1);
+    expect(sig).to.equal(fakeSignature);
+  });
+});


### PR DESCRIPTION
## Problem

The CCTP finalizer acks the Pub/Sub burn message even when the Solana mint transaction was **dropped** and never landed on-chain.

Observed in prod — the finalizer logged a solscan URL for a tx that never confirmed, then reported success:
```
Processing burn transaction        13:31:09.737
Burn transaction processed successfully   13:31:25.779   (~16s later)
```

## Root cause

`_sendAndPoll` (`src/utils/TransactionUtils.ts`) exits its poll loop on *either* confirmation *or* timeout, and returns the (locally-derived) signature in both cases. A dropped tx never confirms, so the loop burns all 25 × 600ms ≈ 15s (matching the log gap) and then hands back the signature with no error. The finalizer logs success → returns `{ success: true }` → `app.ts` returns `204` → Pub/Sub acks → **no retry**.

Solana signatures are known before submission, which is why the exact signature shows up in the log for a tx that never landed.

## Fix (scoped to cctp-finalizer)

New `sendAndConfirmMintOrThrow` guard routes both the V1 and V2 mint sends through `sendAndConfirmSolanaTransactionWithSlot` and throws when the tx is never confirmed (`confirmedSlot === undefined`). The throw surfaces as a retryable `MintTransactionFailedError` → app returns `500` → Pub/Sub redelivers. `checkIfAlreadyProcessed` guards against a double-mint if the original was merely slow rather than dropped.

The shared `_sendAndPoll` is intentionally left untouched to keep the blast radius to the finalizer.

### Known limitation
Covers dropped/unconfirmed only. A landed-but-reverted tx (`entry.err` set with `confirmationStatus: "confirmed"`) still reads as success — flagged in a `ponytail:` comment; add an `err` check in the shared poller if that failure mode surfaces.

## Test

`test/cctpFinalizerSvm.confirm.ts` (3 passing):
- documents the root cause (shared helper resolves even when never confirmed)
- guard throws on a dropped tx
- guard returns the signature on confirmation

typecheck, eslint, prettier all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)