### PR TITLE
improve(monitor): demote PDA/ALT close success logs to debug

### DIFF
--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -932,7 +932,7 @@ export class Monitor {
           .sendTransaction(encodedTransaction, { preflightCommitment: "confirmed", encoding: "base64" })
           .send();
 
-        this.logger.info({
+        this.logger.debug({
           at: "Monitor#closePDAs",
           message: `Closed PDA ${fillStatusPda} for fill ${fill.txnRef}`,
         });
@@ -1024,7 +1024,7 @@ export class Monitor {
         if (!this.monitorConfig.sendingTransactionsEnabled) {
           try {
             await simulateSolanaTransaction(txMessage, svmRpc);
-            this.logger.info({
+            this.logger.debug({
               at: "Monitor#closeALTs",
               message: `Simulated closing ALT ${pubkey} (deactivated at slot ${deactivationSlot})`,
             });
@@ -1041,7 +1041,7 @@ export class Monitor {
         try {
           const signature = await sendAndConfirmSolanaTransaction(txMessage, svmRpc);
           closedCount++;
-          this.logger.info({
+          this.logger.debug({
             at: "Monitor#closeALTs",
             message: `Closed ALT ${pubkey} (deactivated at slot ${deactivationSlot})`,
             signature,


### PR DESCRIPTION
## Motivation

The `Monitor#closePDAs` / `Monitor#closeALTs` per-item success messages (`Closed PDA …`, `Closed ALT …`) are routine Solana housekeeping, but at `info` level they post to Slack and were flooding `#zbot-across-monitor` (~80 messages per 4 hours), burying the low-balance warnings that channel exists to surface. Requested by Paul in Slack ([thread](https://umaproject.slack.com/archives/C02SXLDUYFQ/p1782972268347689)).

## Change

Demote the three per-item success logs (closed PDA, closed ALT, simulated ALT close) from `info` to `debug`. The `@risk-labs/logger` Slack transport only forwards `info` and above (`createSlackTransport` hardcodes `level: "info"`), so at `debug` these remain fully visible in GCP logs while no longer posting to Slack.

- Failure paths (`Failed to close PDA/ALT …`) stay at `warn` and still reach Slack.
- Matches the existing idiom in these methods, where aggregate/housekeeping logs are already `debug`.

No README/AGENTS.md updates needed — no behavior, configuration, or interface change; log-level only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)