### PR TITLE
improve(AdapterManager): wrap excess native ETH on Robinhood

### DIFF
--- a/src/clients/bridges/AdapterManager.ts
+++ b/src/clients/bridges/AdapterManager.ts
@@ -39,9 +39,15 @@ export class AdapterManager {
 
   // Some L2's canonical bridges send ETH, not WETH, over the canonical bridges, resulting in recipient addresses
   // receiving ETH that needs to be wrapped on the L2. This array contains the chainIds of the chains that this
-  // manager will attempt to wrap ETH on into WETH. This list also includes chains like Arbitrum where the relayer is
-  // expected to receive ETH as a gas refund from an L1 to L2 deposit that was intended to rebalance inventory.
-  private chainsToWrapEtherOn = [...spokesThatHoldNativeTokens, CHAIN_IDs.ARBITRUM, CHAIN_IDs.MAINNET];
+  // manager will attempt to wrap ETH on into WETH. This list also includes Orbit chains (Arbitrum, Robinhood)
+  // where the relayer is expected to receive ETH as a retryable-ticket gas refund from an L1 to L2 deposit that
+  // was intended to rebalance inventory.
+  private chainsToWrapEtherOn = [
+    ...spokesThatHoldNativeTokens,
+    CHAIN_IDs.ARBITRUM,
+    CHAIN_IDs.ROBINHOOD,
+    CHAIN_IDs.MAINNET,
+  ];
   private _spokePoolManager?: SpokePoolManager;
   // spokePoolManager is populated by the constructor unless `spokePoolClients` is missing, in which case the
   // adapter manager is constructed in a partial state. Reads pre-init throw, writes go through the setter.


### PR DESCRIPTION
## Motivation

The relayer EOA (`0x07aE…E67`) has accumulated **~5.5 ETH of unwrapped native ETH on Robinhood (4663)** since chain launch (2026-06-25). Source: retryable-ticket gas refunds — every canonical-bridge inventory rebalance to Robinhood over-provisions submission cost + L2 gas, and the excess (~0.013 ETH/ticket, type-105 `submitRetryable`) refunds to the relayer EOA on the child chain. This is the exact mechanism described for Arbitrum in the comment above `wrapNativeTokenIfAboveThreshold`.

Robinhood is Orbit-family, so it isn't in `spokesThatHoldNativeTokens` (OP/ZK-stack only) and — unlike Arbitrum — wasn't appended to `chainsToWrapEtherOn`. The wrap loop therefore never touches 4663 and the refunds pile up as idle native ETH (fill gas there is only 2–6 µETH/tx).

## Change

Add `CHAIN_IDs.ROBINHOOD` to `chainsToWrapEtherOn`, alongside Arbitrum. No config change needed:
- The prod inventory config's global `wrapEtherThreshold: 0.3` / `wrapEtherTarget: 0.2` will apply to 4663 (no per-chain override required; gas cost on the chain makes 0.2 ETH ample float).
- Unwrap config already exists: `tokenConfig.WETH.4663.unwrapWethThreshold: 0.1 / unwrapWethTarget: 0.2`.
- `BaseChainAdapter.wrapNativeTokenIfAboveThreshold` works generically: WETH is deployed on 4663 (`0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73`, symbol `WETH`), so the symbol safety-check passes.

First run after deploy should wrap ~5.35 ETH into WETH inventory.

Related: UMAprotocol/bot-configs#4134 (adds 4663 balance monitoring). Requested by Paul in Slack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)