### PR TITLE
feat(DepositAddressHandler): Periodically kick env-defined watchdog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -294,7 +294,7 @@ ARWEAVE_GATEWAYS='[{"host":"arweave.org", "port": 443, "protocol":"https"}]'
 
 # Interval in seconds for the handler's recurring watchdog task (currently a
 # placeholder). Defaults to 60.
-# DEPOSIT_ADDRESS_WATCHDOG_INTERVAL=60
+# WATCHDOG_INTERVAL=60
 
 # Swap API base URL used for fetching deposit-execute and signed-withdraw quotes.
 # API_ENDPOINT=

--- a/.env.example
+++ b/.env.example
@@ -292,6 +292,10 @@ ARWEAVE_GATEWAYS='[{"host":"arweave.org", "port": 443, "protocol":"https"}]'
 # Polling interval in seconds for the indexer endpoint above. Defaults to 1.
 # INDEXER_API_POLLING_INTERVAL=1
 
+# Interval in seconds for the handler's recurring background task (currently a
+# placeholder). Defaults to 60.
+# DEPOSIT_ADDRESS_PERIODIC_TASK_INTERVAL=60
+
 # Swap API base URL used for fetching deposit-execute and signed-withdraw quotes.
 # API_ENDPOINT=
 

--- a/.env.example
+++ b/.env.example
@@ -292,9 +292,9 @@ ARWEAVE_GATEWAYS='[{"host":"arweave.org", "port": 443, "protocol":"https"}]'
 # Polling interval in seconds for the indexer endpoint above. Defaults to 1.
 # INDEXER_API_POLLING_INTERVAL=1
 
-# Interval in seconds for the handler's recurring background task (currently a
+# Interval in seconds for the handler's recurring watchdog task (currently a
 # placeholder). Defaults to 60.
-# DEPOSIT_ADDRESS_PERIODIC_TASK_INTERVAL=60
+# DEPOSIT_ADDRESS_WATCHDOG_INTERVAL=60
 
 # Swap API base URL used for fetching deposit-execute and signed-withdraw quotes.
 # API_ENDPOINT=

--- a/.env.example
+++ b/.env.example
@@ -292,9 +292,14 @@ ARWEAVE_GATEWAYS='[{"host":"arweave.org", "port": 443, "protocol":"https"}]'
 # Polling interval in seconds for the indexer endpoint above. Defaults to 1.
 # INDEXER_API_POLLING_INTERVAL=1
 
-# Interval in seconds for the handler's recurring watchdog task (currently a
-# placeholder). Defaults to 60.
-# WATCHDOG_INTERVAL=60
+# Interval in seconds for the watchdog heartbeat (dead-man's switch). Defaults
+# to 15. Keep well under the Checkly period + grace (30s + 30s) so a single
+# dropped ping doesn't trip the alert.
+# WATCHDOG_INTERVAL=15
+
+# Checkly heartbeat URL pinged (best-effort GET) every WATCHDOG_INTERVAL
+# seconds. Unset disables the heartbeat.
+# DEPOSIT_BOT_HEARTBEAT_URL=
 
 # Swap API base URL used for fetching deposit-execute and signed-withdraw quotes.
 # API_ENDPOINT=

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -309,6 +309,20 @@ export class DepositAddressHandler {
       this.config.indexerPollingInterval,
       this.abortController.signal
     );
+    scheduleTask(() => this.runPeriodicTask(), this.config.periodicTaskInterval, this.abortController.signal);
+  }
+
+  /**
+   * Placeholder for a recurring background task, fired every `periodicTaskInterval` seconds
+   * alongside the indexer poll (same pattern as the relayer's periodic address-filter refresh).
+   * Runs until the handler's abortController fires on handover/shutdown.
+   */
+  private async runPeriodicTask(): Promise<void> {
+    this.logger.debug({
+      at: "DepositAddressHandler#runPeriodicTask",
+      message: "Periodic task fired (placeholder).",
+      intervalSeconds: this.config.periodicTaskInterval,
+    });
   }
 
   /*

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -66,6 +66,13 @@ const INTEGRATOR_ID_REGEX = /^0x[0-9a-fA-F]{4}$/;
 const SUPPORTED_INDEXER_MESSAGE_VERSIONS = new Set([1, 3]);
 
 /**
+ * Cap on each watchdog heartbeat request. `fetch` has no default timeout, and the scheduler
+ * fires every ping fire-and-forget — without a cap, a hung heartbeat endpoint would stack
+ * pending requests indefinitely.
+ */
+const HEARTBEAT_TIMEOUT_MS = 5_000;
+
+/**
  * Independent relayer bot which processes EIP-3009 signatures into deposits and corresponding fills.
  */
 export class DepositAddressHandler {
@@ -313,16 +320,22 @@ export class DepositAddressHandler {
   }
 
   /**
-   * Placeholder for a recurring background task, fired every `watchdogInterval` seconds
-   * alongside the indexer poll (same pattern as the relayer's periodic address-filter refresh).
-   * Runs until the handler's abortController fires on handover/shutdown.
+   * Dead-man's-switch heartbeat, kicked externally by the `watchdogInterval` scheduler in
+   * pollAndExecute() (default 15s) until the handler's abortController fires on
+   * handover/shutdown. With a Checkly period of 30s + grace of 30s, a dead bot trips the alert
+   * within ~60s; cadence << period, so a dropped ping is fine. Best-effort: a heartbeat failure
+   * must never disrupt the bot.
    */
   private async kickWatchdog(): Promise<void> {
-    this.logger.debug({
-      at: "DepositAddressHandler#kickWatchdog",
-      message: "Watchdog task fired (placeholder).",
-      intervalSeconds: this.config.watchdogInterval,
-    });
+    const url = this.config.heartbeatUrl;
+    if (!url) {
+      return;
+    }
+    try {
+      await fetch(url, { method: "GET", signal: AbortSignal.timeout(HEARTBEAT_TIMEOUT_MS) });
+    } catch {
+      /* best-effort: never let a heartbeat failure disrupt the bot */
+    }
   }
 
   /*

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -309,19 +309,19 @@ export class DepositAddressHandler {
       this.config.indexerPollingInterval,
       this.abortController.signal
     );
-    scheduleTask(() => this.kickWatchdog(), this.config.periodicTaskInterval, this.abortController.signal);
+    scheduleTask(() => this.kickWatchdog(), this.config.watchdogInterval, this.abortController.signal);
   }
 
   /**
-   * Placeholder for a recurring background task, fired every `periodicTaskInterval` seconds
+   * Placeholder for a recurring background task, fired every `watchdogInterval` seconds
    * alongside the indexer poll (same pattern as the relayer's periodic address-filter refresh).
    * Runs until the handler's abortController fires on handover/shutdown.
    */
   private async kickWatchdog(): Promise<void> {
     this.logger.debug({
       at: "DepositAddressHandler#kickWatchdog",
-      message: "Periodic task fired (placeholder).",
-      intervalSeconds: this.config.periodicTaskInterval,
+      message: "Watchdog task fired (placeholder).",
+      intervalSeconds: this.config.watchdogInterval,
     });
   }
 

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -309,7 +309,7 @@ export class DepositAddressHandler {
       this.config.indexerPollingInterval,
       this.abortController.signal
     );
-    scheduleTask(() => this.runPeriodicTask(), this.config.periodicTaskInterval, this.abortController.signal);
+    scheduleTask(() => this.kickWatchdog(), this.config.periodicTaskInterval, this.abortController.signal);
   }
 
   /**
@@ -317,9 +317,9 @@ export class DepositAddressHandler {
    * alongside the indexer poll (same pattern as the relayer's periodic address-filter refresh).
    * Runs until the handler's abortController fires on handover/shutdown.
    */
-  private async runPeriodicTask(): Promise<void> {
+  private async kickWatchdog(): Promise<void> {
     this.logger.debug({
-      at: "DepositAddressHandler#runPeriodicTask",
+      at: "DepositAddressHandler#kickWatchdog",
       message: "Periodic task fired (placeholder).",
       intervalSeconds: this.config.periodicTaskInterval,
     });

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -72,6 +72,10 @@ const SUPPORTED_INDEXER_MESSAGE_VERSIONS = new Set([1, 3]);
  */
 const HEARTBEAT_TIMEOUT_MS = 5_000;
 
+// Warn on every Nth consecutive heartbeat failure (i.e. once per N ticks during a sustained
+// outage, rather than once per tick or once ever).
+const HEARTBEAT_FAILURE_WARN_THRESHOLD = 10;
+
 /**
  * Independent relayer bot which processes EIP-3009 signatures into deposits and corresponding fills.
  */
@@ -79,6 +83,7 @@ export class DepositAddressHandler {
   private abortController = new AbortController();
   private _instanceCoordinator?: InstanceCoordinator;
   private initialized = false;
+  private consecutiveHeartbeatFailures = 0;
 
   // instanceCoordinator is populated by initialize(); reads pre-init throw, writes go through the setter.
   private get instanceCoordinator(): InstanceCoordinator {
@@ -324,17 +329,34 @@ export class DepositAddressHandler {
    * pollAndExecute() (default 15s) until the handler's abortController fires on
    * handover/shutdown. With a Checkly period of 30s + grace of 30s, a dead bot trips the alert
    * within ~60s; cadence << period, so a dropped ping is fine. Best-effort: a heartbeat failure
-   * must never disrupt the bot.
+   * must never disrupt the bot, but sustained failures are logged since the alert will fire and
+   * this log is the first place to look for the cause.
    */
   private async kickWatchdog(): Promise<void> {
     const url = this.config.heartbeatUrl;
     if (!url) {
       return;
     }
+
+    let failure: string;
     try {
-      await fetch(url, { method: "GET", signal: AbortSignal.timeout(HEARTBEAT_TIMEOUT_MS) });
-    } catch {
-      /* best-effort: never let a heartbeat failure disrupt the bot */
+      const response = await fetch(url, { method: "GET", signal: AbortSignal.timeout(HEARTBEAT_TIMEOUT_MS) });
+      if (response.ok) {
+        this.consecutiveHeartbeatFailures = 0;
+        return;
+      }
+      failure = `HTTP ${response.status}`;
+    } catch (err) {
+      failure = err instanceof Error ? err.message : String(err);
+    }
+
+    if (++this.consecutiveHeartbeatFailures % HEARTBEAT_FAILURE_WARN_THRESHOLD === 0) {
+      this.logger.warn({
+        at: "DepositAddressHandler#kickWatchdog",
+        message: "Sustained watchdog heartbeat failures",
+        consecutiveFailures: this.consecutiveHeartbeatFailures,
+        lastError: failure,
+      });
     }
   }
 

--- a/src/deposit-address/DepositAddressHandlerConfig.ts
+++ b/src/deposit-address/DepositAddressHandlerConfig.ts
@@ -4,6 +4,8 @@ import { parseJson } from "../utils";
 export class DepositAddressHandlerConfig extends CommonConfig {
   indexerApiEndpoint: string;
   indexerPollingInterval: number;
+  /** Interval in seconds for the background periodic task (placeholder today). */
+  periodicTaskInterval: number;
 
   relayerOriginChains: number[];
   depositLookback: number;
@@ -28,6 +30,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
 
     const {
       INDEXER_API_POLLING_INTERVAL,
+      DEPOSIT_ADDRESS_PERIODIC_TASK_INTERVAL,
       INDEXER_API_ENDPOINT,
       MAX_RELAYER_DEPOSIT_LOOKBACK,
       RELAYER_ORIGIN_CHAINS,
@@ -42,6 +45,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
       PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC,
     } = env;
     this.indexerPollingInterval = Number(INDEXER_API_POLLING_INTERVAL ?? 1); // Default to 1s
+    this.periodicTaskInterval = Number(DEPOSIT_ADDRESS_PERIODIC_TASK_INTERVAL ?? 60); // Default to 60s
     this.indexerApiEndpoint = String(INDEXER_API_ENDPOINT);
     this.swapApiKey = SWAP_API_KEY?.trim() ?? "";
     if (!this.swapApiKey) {

--- a/src/deposit-address/DepositAddressHandlerConfig.ts
+++ b/src/deposit-address/DepositAddressHandlerConfig.ts
@@ -30,7 +30,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
 
     const {
       INDEXER_API_POLLING_INTERVAL,
-      DEPOSIT_ADDRESS_WATCHDOG_INTERVAL,
+      DEPOSIT_ADDRESS_WATCHDOG_INTERVAL = "60",
       INDEXER_API_ENDPOINT,
       MAX_RELAYER_DEPOSIT_LOOKBACK,
       RELAYER_ORIGIN_CHAINS,
@@ -45,7 +45,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
       PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC,
     } = env;
     this.indexerPollingInterval = Number(INDEXER_API_POLLING_INTERVAL ?? 1); // Default to 1s
-    this.watchdogInterval = Number(DEPOSIT_ADDRESS_WATCHDOG_INTERVAL ?? 60); // Default to 60s
+    this.watchdogInterval = Number(DEPOSIT_ADDRESS_WATCHDOG_INTERVAL);
     this.indexerApiEndpoint = String(INDEXER_API_ENDPOINT);
     this.swapApiKey = SWAP_API_KEY?.trim() ?? "";
     if (!this.swapApiKey) {

--- a/src/deposit-address/DepositAddressHandlerConfig.ts
+++ b/src/deposit-address/DepositAddressHandlerConfig.ts
@@ -4,8 +4,11 @@ import { parseJson } from "../utils";
 export class DepositAddressHandlerConfig extends CommonConfig {
   indexerApiEndpoint: string;
   indexerPollingInterval: number;
-  /** Interval in seconds for the background watchdog task (placeholder today). */
+  /** Interval in seconds for the background watchdog heartbeat. Cadence must stay well under the
+   * Checkly period + grace so a dropped ping doesn't trip the alert. */
   watchdogInterval: number;
+  /** Checkly heartbeat URL for the dead-man's switch. Unset disables the heartbeat. */
+  heartbeatUrl: string;
 
   relayerOriginChains: number[];
   depositLookback: number;
@@ -30,7 +33,8 @@ export class DepositAddressHandlerConfig extends CommonConfig {
 
     const {
       INDEXER_API_POLLING_INTERVAL,
-      WATCHDOG_INTERVAL = "60",
+      WATCHDOG_INTERVAL = "15",
+      DEPOSIT_BOT_HEARTBEAT_URL,
       INDEXER_API_ENDPOINT,
       MAX_RELAYER_DEPOSIT_LOOKBACK,
       RELAYER_ORIGIN_CHAINS,
@@ -46,6 +50,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
     } = env;
     this.indexerPollingInterval = Number(INDEXER_API_POLLING_INTERVAL ?? 1); // Default to 1s
     this.watchdogInterval = Number(WATCHDOG_INTERVAL);
+    this.heartbeatUrl = DEPOSIT_BOT_HEARTBEAT_URL?.trim() ?? "";
     this.indexerApiEndpoint = String(INDEXER_API_ENDPOINT);
     this.swapApiKey = SWAP_API_KEY?.trim() ?? "";
     if (!this.swapApiKey) {

--- a/src/deposit-address/DepositAddressHandlerConfig.ts
+++ b/src/deposit-address/DepositAddressHandlerConfig.ts
@@ -30,7 +30,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
 
     const {
       INDEXER_API_POLLING_INTERVAL,
-      DEPOSIT_ADDRESS_WATCHDOG_INTERVAL = "60",
+      WATCHDOG_INTERVAL = "60",
       INDEXER_API_ENDPOINT,
       MAX_RELAYER_DEPOSIT_LOOKBACK,
       RELAYER_ORIGIN_CHAINS,
@@ -45,7 +45,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
       PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC,
     } = env;
     this.indexerPollingInterval = Number(INDEXER_API_POLLING_INTERVAL ?? 1); // Default to 1s
-    this.watchdogInterval = Number(DEPOSIT_ADDRESS_WATCHDOG_INTERVAL);
+    this.watchdogInterval = Number(WATCHDOG_INTERVAL);
     this.indexerApiEndpoint = String(INDEXER_API_ENDPOINT);
     this.swapApiKey = SWAP_API_KEY?.trim() ?? "";
     if (!this.swapApiKey) {

--- a/src/deposit-address/DepositAddressHandlerConfig.ts
+++ b/src/deposit-address/DepositAddressHandlerConfig.ts
@@ -4,8 +4,8 @@ import { parseJson } from "../utils";
 export class DepositAddressHandlerConfig extends CommonConfig {
   indexerApiEndpoint: string;
   indexerPollingInterval: number;
-  /** Interval in seconds for the background periodic task (placeholder today). */
-  periodicTaskInterval: number;
+  /** Interval in seconds for the background watchdog task (placeholder today). */
+  watchdogInterval: number;
 
   relayerOriginChains: number[];
   depositLookback: number;
@@ -30,7 +30,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
 
     const {
       INDEXER_API_POLLING_INTERVAL,
-      DEPOSIT_ADDRESS_PERIODIC_TASK_INTERVAL,
+      DEPOSIT_ADDRESS_WATCHDOG_INTERVAL,
       INDEXER_API_ENDPOINT,
       MAX_RELAYER_DEPOSIT_LOOKBACK,
       RELAYER_ORIGIN_CHAINS,
@@ -45,7 +45,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
       PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC,
     } = env;
     this.indexerPollingInterval = Number(INDEXER_API_POLLING_INTERVAL ?? 1); // Default to 1s
-    this.periodicTaskInterval = Number(DEPOSIT_ADDRESS_PERIODIC_TASK_INTERVAL ?? 60); // Default to 60s
+    this.watchdogInterval = Number(DEPOSIT_ADDRESS_WATCHDOG_INTERVAL ?? 60); // Default to 60s
     this.indexerApiEndpoint = String(INDEXER_API_ENDPOINT);
     this.swapApiKey = SWAP_API_KEY?.trim() ?? "";
     if (!this.swapApiKey) {

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -11,7 +11,7 @@ The deposit-address handler polls the across-indexer for ERC-20 transfers that h
 3. `DepositAddressHandler` instance, then `initialize()`.
 4. Background polling loop (`pollAndExecute`) on the configured interval. This also starts a
    recurring background task (`kickWatchdog`, placeholder today) on its own interval
-   (`DEPOSIT_ADDRESS_WATCHDOG_INTERVAL`, default 60s), scheduled via `scheduleTask` against
+   (`WATCHDOG_INTERVAL`, default 60s), scheduled via `scheduleTask` against
    the handler's abort signal — the same pattern the relayer uses for its periodic
    address-filter refresh.
 5. Handover via Redis (`InstanceCoordinator`) — exits cleanly when another instance takes over.

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -10,10 +10,12 @@ The deposit-address handler polls the across-indexer for ERC-20 transfers that h
 2. Dispatcher keys for transaction signing.
 3. `DepositAddressHandler` instance, then `initialize()`.
 4. Background polling loop (`pollAndExecute`) on the configured interval. This also starts a
-   recurring background task (`kickWatchdog`, placeholder today) on its own interval
-   (`WATCHDOG_INTERVAL`, default 60s), scheduled via `scheduleTask` against
-   the handler's abort signal — the same pattern the relayer uses for its periodic
-   address-filter refresh.
+   watchdog heartbeat (`kickWatchdog`) on its own interval (`WATCHDOG_INTERVAL`, default 15s),
+   scheduled via `scheduleTask` against the handler's abort signal — the same pattern the relayer
+   uses for its periodic address-filter refresh. Each tick GETs `DEPOSIT_BOT_HEARTBEAT_URL`
+   (unset = disabled) as a dead-man's switch: with a Checkly period of 30s + grace of 30s, a dead
+   bot trips the alert within ~60s. Pings are best-effort (failures swallowed, 5s cap per request)
+   and stop on handover/shutdown with the rest of the handler.
 5. Handover via Redis (`InstanceCoordinator`) — exits cleanly when another instance takes over.
 
 Cleanup in the `finally` block closes the Pub/Sub publisher and Redis clients.

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -14,8 +14,10 @@ The deposit-address handler polls the across-indexer for ERC-20 transfers that h
    scheduled via `scheduleTask` against the handler's abort signal — the same pattern the relayer
    uses for its periodic address-filter refresh. Each tick GETs `DEPOSIT_BOT_HEARTBEAT_URL`
    (unset = disabled) as a dead-man's switch: with a Checkly period of 30s + grace of 30s, a dead
-   bot trips the alert within ~60s. Pings are best-effort (failures swallowed, 5s cap per request)
-   and stop on handover/shutdown with the rest of the handler.
+   bot trips the alert within ~60s. Pings are best-effort (failures never disrupt the bot, 5s cap
+   per request), but every 10th consecutive failure — including non-2xx responses — emits a
+   warning log to aid diagnosis when the alert fires. Pings stop on handover/shutdown with the
+   rest of the handler.
 5. Handover via Redis (`InstanceCoordinator`) — exits cleanly when another instance takes over.
 
 Cleanup in the `finally` block closes the Pub/Sub publisher and Redis clients.

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -10,7 +10,7 @@ The deposit-address handler polls the across-indexer for ERC-20 transfers that h
 2. Dispatcher keys for transaction signing.
 3. `DepositAddressHandler` instance, then `initialize()`.
 4. Background polling loop (`pollAndExecute`) on the configured interval. This also starts a
-   recurring background task (`runPeriodicTask`, placeholder today) on its own interval
+   recurring background task (`kickWatchdog`, placeholder today) on its own interval
    (`DEPOSIT_ADDRESS_PERIODIC_TASK_INTERVAL`, default 60s), scheduled via `scheduleTask` against
    the handler's abort signal — the same pattern the relayer uses for its periodic
    address-filter refresh.

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -9,7 +9,11 @@ The deposit-address handler polls the across-indexer for ERC-20 transfers that h
 1. `DepositAddressHandlerConfig` from env.
 2. Dispatcher keys for transaction signing.
 3. `DepositAddressHandler` instance, then `initialize()`.
-4. Background polling loop (`pollAndExecute`) on the configured interval.
+4. Background polling loop (`pollAndExecute`) on the configured interval. This also starts a
+   recurring background task (`runPeriodicTask`, placeholder today) on its own interval
+   (`DEPOSIT_ADDRESS_PERIODIC_TASK_INTERVAL`, default 60s), scheduled via `scheduleTask` against
+   the handler's abort signal — the same pattern the relayer uses for its periodic
+   address-filter refresh.
 5. Handover via Redis (`InstanceCoordinator`) — exits cleanly when another instance takes over.
 
 Cleanup in the `finally` block closes the Pub/Sub publisher and Redis clients.

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -11,7 +11,7 @@ The deposit-address handler polls the across-indexer for ERC-20 transfers that h
 3. `DepositAddressHandler` instance, then `initialize()`.
 4. Background polling loop (`pollAndExecute`) on the configured interval. This also starts a
    recurring background task (`kickWatchdog`, placeholder today) on its own interval
-   (`DEPOSIT_ADDRESS_PERIODIC_TASK_INTERVAL`, default 60s), scheduled via `scheduleTask` against
+   (`DEPOSIT_ADDRESS_WATCHDOG_INTERVAL`, default 60s), scheduled via `scheduleTask` against
    the handler's abort signal — the same pattern the relayer uses for its periodic
    address-filter refresh.
 5. Handover via Redis (`InstanceCoordinator`) — exits cleanly when another instance takes over.


### PR DESCRIPTION
## Summary

Adds a watchdog heartbeat (dead-man's switch) to the deposit-address handler, as agreed in Slack.

- `kickWatchdog()` is scheduled via `scheduleTask` against the handler's `abortController` signal, firing every `WATCHDOG_INTERVAL` seconds (default 15) until handover/shutdown — same pattern as the relayer's periodic address-filter refresh in `src/relayer/index.ts`.
- Each tick GETs `DEPOSIT_BOT_HEARTBEAT_URL` (Checkly heartbeat). Unset disables the heartbeat entirely.
- Best-effort by design: fetch failures are swallowed so a heartbeat problem can never disrupt the bot, and each request is capped at 5s (`fetch` has no default timeout) so a hung endpoint can't stack pending requests.
- No internal throttle — cadence is owned by the scheduler (per Slack discussion). With a Checkly period of 30s + grace of 30s, a dead bot trips the alert within ~60s; cadence ≪ period, so a dropped ping is fine.
- Config/env documented in `.env.example` and `src/deposit-address/README.md`.

## Testing

- `tsc --noEmit` clean, eslint clean.
- `test/DepositAddressHandler.ts`: 30 passing. (1 pre-existing failure in `DepositAddressHandler.publish.ts` reproduces identically on unmodified `master` — unrelated.)
- Smoke-tested against a local HTTP server: ping lands on the endpoint; unset URL is a no-op; unreachable endpoint is swallowed without throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)