### PR TITLE
feat(scripts): deposit + request slow fills across active pool rebalance routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ relayer-v2/
 
 - `scripts/` contains one-off and operator-facing tooling that reuses runtime clients/utilities without going through `index.ts`.
 - `scripts/swapOnBinance.ts` is an interactive CLI that deposits into the shared Binance account, optionally trades on Binance spot, and withdraws to a destination chain.
+- `scripts/depositAndRequestSlowFill.ts` is an interactive CLI that deposits + requests slow fills across every active pool rebalance route for a token being wound down, forcing pool rebalance leaves that return SpokePool balances to the HubPool (see `scripts/README_depositAndRequestSlowFill.md`).
 
 ## Memory/state model
 

--- a/scripts/README_depositAndRequestSlowFill.md
+++ b/scripts/README_depositAndRequestSlowFill.md
@@ -1,0 +1,70 @@
+# Deposit + Request Slow Fill Script
+
+## Overview
+
+`depositAndRequestSlowFill.ts` is an operator tool for winding down LP support for a token. For each requested
+token it:
+
+1. Resolves every chain with an active HubPool pool rebalance route for the token (excluding disabled and lite
+   chains, per the ConfigStore `DISABLED_CHAINS` / `LITE_CHAIN_ID_INDICES` global configs).
+2. Submits a deposit on the HubPool chain SpokePool to each destination chain, with
+   `outputAmount == inputAmount` (0 relayer fee, so a fast fill is unprofitable and the deposit remains unfilled),
+   no exclusivity and an empty message.
+3. Submits a corresponding `requestSlowFill()` on each destination chain SpokePool, reconstructing the relay data
+   from the emitted `FundsDeposited` event.
+
+The resulting deposit + slow fill request events force the next root bundle to emit a pool rebalance leaf for
+every (chain, token) pair, so that zeroed `spokeTargetBalances` take effect and all SpokePool balances are
+returned to the HubPool.
+
+## Sequencing
+
+This script is one step in a multi-transaction wind-down:
+
+1. Execute the ConfigStore `updateTokenConfig()` transaction that zeroes the token's rate model and
+   `spokeTargetBalances`. The script warns (and prompts) if this does not appear to have happened yet.
+2. **Run this script** to submit deposits + slow fill requests for all affected tokens.
+3. Wait for the subsequent root bundle (containing the pool rebalance leaves that pull tokens back to the hub)
+   to be proposed **and executed**.
+4. Only then execute the HubPool `setPoolRebalanceRoute()` transaction that removes the token's routes. Removing
+   routes earlier would prevent the bundle from creating the required leaves.
+
+## Prerequisites
+
+- RPC providers configured in `.env` (same convention as the main relayer configuration), for the hub chain and
+  every destination chain with an active route.
+- A funded wallet: the per-route deposit amount of each token on the hub chain, plus gas on the hub chain and
+  every destination chain (note: Lens gas is GHO). The dry run reports both.
+
+## Usage
+
+Dry run (default) — discovers routes and prints the plan, balances and warnings without sending anything:
+
+```bash
+yarn tsx ./scripts/depositAndRequestSlowFill --wallet privateKey
+```
+
+Execute (prompts for confirmation before each route):
+
+```bash
+yarn tsx ./scripts/depositAndRequestSlowFill --wallet privateKey --execute
+```
+
+Options:
+
+| Option        | Default        | Description                                                 |
+| ------------- | -------------- | ----------------------------------------------------------- |
+| `--tokens`    | `ACX,WGHO,UMA` | Comma-separated token symbols (hub chain symbols).          |
+| `--amount`    | `1`            | Deposit amount per route, in whole tokens.                  |
+| `--chainIds`  | (all routes)   | Restrict to a comma-separated list of destination chains.   |
+| `--recipient` | depositor      | Recipient of the slow fill on the destination chain.        |
+| `--execute`   | off            | Submit transactions; without it the script is a dry run.    |
+| `--wallet`    | `secret`       | Wallet type (`mnemonic`, `privateKey`, `gckms`).            |
+
+Note: the deposited tokens are paid out (less any LP fee — 0 once the rate model is zeroed) to the recipient on
+each destination chain when the slow fill leaf executes, i.e. the depositor is made whole on the destination
+chain.
+
+If a deposit is fast-filled before the slow fill request lands (unexpected, as the relayer fee is 0), the script
+reports it and marks the route as failed: an outright fill does not move the destination chain running balance,
+so that route should be re-run or investigated.

--- a/scripts/depositAndRequestSlowFill.ts
+++ b/scripts/depositAndRequestSlowFill.ts
@@ -65,16 +65,25 @@ async function getGlobalConfigArray(configStore: Contract, key: string): Promise
  * defeating the purpose of the exercise.
  */
 async function tokenConfigUpdated(configStore: Contract, l1Token: string): Promise<boolean> {
-  let tokenConfig: { rateModel?: Record<string, string>; spokeTargetBalances?: Record<string, unknown> };
+  let tokenConfig: {
+    rateModel?: Record<string, string>;
+    routeRateModel?: Record<string, Record<string, string>>;
+    spokeTargetBalances?: Record<string, unknown>;
+  };
   try {
     tokenConfig = JSON.parse(await configStore.l1TokenConfig(l1Token));
   } catch {
     return false;
   }
 
-  const rateModelZeroed = ["R0", "R1", "R2"].every((k) => tokenConfig.rateModel?.[k] === "0");
+  const rateModelZeroed = (rateModel?: Record<string, string>) =>
+    ["R0", "R1", "R2"].every((k) => rateModel?.[k] === "0");
+
+  // Route-specific rate models take precedence over the default rate model, so any surviving routeRateModel
+  // entries must be zeroed as well.
+  const routeRateModelsZeroed = Object.values(tokenConfig.routeRateModel ?? {}).every(rateModelZeroed);
   const spokeTargetsCleared = Object.keys(tokenConfig.spokeTargetBalances ?? {}).length === 0;
-  return rateModelZeroed && spokeTargetsCleared;
+  return rateModelZeroed(tokenConfig.rateModel) && routeRateModelsZeroed && spokeTargetsCleared;
 }
 
 /**
@@ -334,7 +343,7 @@ async function run(args: Record<string, string | boolean>, signer: Signer): Prom
     const { token } = tokenRoutes[0];
     if (!(await tokenConfigUpdated(configStore, token.address))) {
       console.log(
-        `WARNING: ${symbol} ConfigStore config still has a non-zero rate model and/or spokeTargetBalances.` +
+        `WARNING: ${symbol} ConfigStore config still has a non-zero (route) rate model and/or spokeTargetBalances.` +
           " Has the updateTokenConfig() transaction been executed?"
       );
       if (execute && !(await utils.askYesNoQuestion(`Proceed with ${symbol} anyway?`))) {

--- a/scripts/depositAndRequestSlowFill.ts
+++ b/scripts/depositAndRequestSlowFill.ts
@@ -1,0 +1,495 @@
+import minimist from "minimist";
+import { config } from "dotenv";
+import { Contract, ethers, Signer } from "ethers";
+import { CHAIN_IDs } from "@across-protocol/constants";
+import { constants as sdkConsts, utils as sdkUtils } from "@across-protocol/sdk";
+import { ExpandedERC20__factory as ERC20 } from "@across-protocol/sdk/typechain";
+import { FillStatus, RelayData } from "../src/interfaces";
+import { TransactionClient } from "../src/clients";
+import {
+  BigNumber,
+  blockExplorerLink,
+  bnZero,
+  chainIsEvm,
+  ConvertDecimals,
+  convertRelayDataParamsToBytes32,
+  disconnectRedisClients,
+  exit,
+  formatUnits,
+  getNetworkName,
+  getProvider,
+  getSigner,
+  isDefined,
+  Logger as logger,
+  toAddressType,
+} from "../src/utils";
+import * as utils from "./utils";
+
+const { NODE_SUCCESS, NODE_INPUT_ERR, NODE_APP_ERR } = utils;
+const { AddressZero } = ethers.constants;
+const { formatBytes32String } = ethers.utils;
+
+const DEPOSIT_EVENT = "FundsDeposited";
+
+/**
+ * For each requested token, deposit on the HubPool chain to every chain with an active pool rebalance route, then
+ * submit a corresponding slow fill request on each destination chain. This guarantees that the next root bundle
+ * emits a pool rebalance leaf for every (chain, token) pair, so that updated spokeTargetBalances (i.e. 0) take
+ * effect and all SpokePool balances are returned to the HubPool. Intended for winding down LP support for a token;
+ * run after the relevant ConfigStore updateTokenConfig() rate model & spoke target update has been executed, and
+ * before the corresponding pool rebalance routes are removed.
+ *
+ * Deposits are made with outputAmount == inputAmount (0 relayer fee), so a fast fill is unprofitable and the
+ * deposit should remain unfilled until the slow fill executes via the root bundle.
+ */
+
+type SlowFillRoute = {
+  token: utils.ERC20; // HubPool chain token.
+  destinationChainId: number;
+  destinationToken: string;
+  destinationDecimals: number;
+  inputAmount: BigNumber;
+  outputAmount: BigNumber;
+};
+
+async function getGlobalConfigArray(configStore: Contract, key: string): Promise<number[]> {
+  const raw: string = await configStore.globalConfig(formatBytes32String(key));
+  // Some historical values are string-quoted (e.g. '["10","137"]'), so strip quotes before parsing.
+  return raw.length > 0 ? JSON.parse(raw.replaceAll('"', "")).map(Number) : [];
+}
+
+/**
+ * Sanity-check that the token's ConfigStore config has already been updated to wind the token down (zeroed rate
+ * model, no spokeTargetBalances). If not, deposits made now would be bundled with the old LP fee and spoke targets,
+ * defeating the purpose of the exercise.
+ */
+async function tokenConfigUpdated(configStore: Contract, l1Token: string): Promise<boolean> {
+  let tokenConfig: { rateModel?: Record<string, string>; spokeTargetBalances?: Record<string, unknown> };
+  try {
+    tokenConfig = JSON.parse(await configStore.l1TokenConfig(l1Token));
+  } catch {
+    return false;
+  }
+
+  const rateModelZeroed = ["R0", "R1", "R2"].every((k) => tokenConfig.rateModel?.[k] === "0");
+  const spokeTargetsCleared = Object.keys(tokenConfig.spokeTargetBalances ?? {}).length === 0;
+  return rateModelZeroed && spokeTargetsCleared;
+}
+
+/**
+ * Resolve the set of chains with an active pool rebalance route for l1Token, excluding the hub chain itself and
+ * any chain that is disabled or lite (slow fills cannot be requested for lite chain destinations).
+ */
+async function getActiveRouteChainIds(
+  hubPool: Contract,
+  configStore: Contract,
+  hubChainId: number,
+  l1Token: string
+): Promise<{ chainId: number; destinationToken: string }[]> {
+  const [chainIds, disabledChainIds, liteChainIds] = await Promise.all(
+    ["CHAIN_ID_INDICES", "DISABLED_CHAINS", "LITE_CHAIN_ID_INDICES"].map((key) =>
+      getGlobalConfigArray(configStore, key)
+    )
+  );
+
+  const candidates = chainIds.filter(
+    (chainId) => chainId !== hubChainId && !disabledChainIds.includes(chainId) && !liteChainIds.includes(chainId)
+  );
+
+  const routes = await Promise.all(
+    candidates.map(async (chainId) => ({
+      chainId,
+      destinationToken: await hubPool.poolRebalanceRoute(chainId, l1Token),
+    }))
+  );
+
+  return routes
+    .filter(({ destinationToken }) => destinationToken !== AddressZero)
+    .filter(({ chainId }) => {
+      if (!chainIsEvm(chainId)) {
+        console.log(`Skipping non-EVM chain ${getNetworkName(chainId)} (${chainId}); not supported by this script.`);
+        return false;
+      }
+      return true;
+    });
+}
+
+async function resolveRoutes(
+  hubPool: Contract,
+  configStore: Contract,
+  hubChainId: number,
+  symbol: string,
+  amount: string,
+  destinationChainIds: number[]
+): Promise<SlowFillRoute[]> {
+  const token = utils.resolveToken(symbol, hubChainId);
+  const inputAmount = ethers.utils.parseUnits(amount, token.decimals);
+
+  let routes = await getActiveRouteChainIds(hubPool, configStore, hubChainId, token.address);
+  if (destinationChainIds.length > 0) {
+    routes = routes.filter(({ chainId }) => destinationChainIds.includes(chainId));
+  }
+
+  return Promise.all(
+    routes.map(async ({ chainId, destinationToken }) => {
+      const provider = await getProvider(chainId);
+      const erc20 = new Contract(destinationToken, ERC20.abi, provider);
+      const destinationDecimals = Number(await erc20.decimals());
+      return {
+        token,
+        destinationChainId: chainId,
+        destinationToken,
+        destinationDecimals,
+        inputAmount,
+        outputAmount: ConvertDecimals(token.decimals, destinationDecimals)(inputAmount),
+      };
+    })
+  );
+}
+
+function printRoute(route: SlowFillRoute, hubChainId: number): void {
+  const { token, destinationChainId, destinationToken, inputAmount } = route;
+  console.log(
+    `\t${token.symbol.padEnd(6)} ${getNetworkName(hubChainId)} -> ${getNetworkName(destinationChainId)}` +
+      ` (${destinationChainId})` +
+      `\n\t\tinputToken       : ${token.address}` +
+      `\n\t\tdestinationToken : ${destinationToken}` +
+      `\n\t\tamount           : ${formatUnits(inputAmount, token.decimals)} ${token.symbol}`
+  );
+}
+
+/**
+ * Submit a deposit on the hub chain SpokePool for the route, then submit the corresponding slow fill request on
+ * the destination chain SpokePool. Returns true on success (or if a slow fill request already exists).
+ */
+async function depositAndRequestSlowFill(
+  route: SlowFillRoute,
+  hubChainId: number,
+  signer: Signer,
+  recipientOverride?: string
+): Promise<boolean> {
+  const { token, destinationChainId, destinationToken, inputAmount, outputAmount } = route;
+  const [origin, destination] = [getNetworkName(hubChainId), getNetworkName(destinationChainId)];
+
+  const provider = await getProvider(hubChainId);
+  const originSigner = signer.connect(provider);
+  const depositor = toAddressType(await originSigner.getAddress(), hubChainId);
+  const recipient = toAddressType(recipientOverride ?? depositor.toEvmAddress(), destinationChainId);
+  if (!recipient.isValidOn(destinationChainId)) {
+    console.log(`Invalid recipient address for chain ${destinationChainId}: (${recipient}).`);
+    return false;
+  }
+
+  const spokePool = (await utils.getSpokePoolContract(hubChainId)).connect(originSigner);
+  const txnClient = new TransactionClient(logger, [signer]);
+
+  // Set quoteTimestamp to the current SpokePool time and take the maximum permissible fillDeadline. The slow fill
+  // request must land on the destination chain before the fillDeadline expires.
+  const [currentTime, fillDeadlineBuffer] = await Promise.all([
+    spokePool.getCurrentTime(),
+    spokePool.fillDeadlineBuffer(),
+  ]);
+  const quoteTimestamp = Number(currentTime);
+  const fillDeadline = quoteTimestamp + Number(fillDeadlineBuffer);
+
+  const inputToken = toAddressType(token.address, hubChainId);
+  const outputToken = toAddressType(destinationToken, destinationChainId);
+  const exclusiveRelayer = toAddressType(AddressZero, destinationChainId);
+
+  const [depositResponse] = await txnClient.submit(hubChainId, [
+    {
+      contract: spokePool,
+      chainId: hubChainId,
+      method: "deposit",
+      args: [
+        depositor.toBytes32(),
+        recipient.toBytes32(),
+        inputToken.toBytes32(),
+        outputToken.toBytes32(),
+        inputAmount,
+        outputAmount,
+        destinationChainId,
+        exclusiveRelayer.toBytes32(),
+        quoteTimestamp,
+        fillDeadline,
+        0, // exclusivityParameter
+        sdkConsts.EMPTY_MESSAGE,
+      ],
+      message: "SpokePool deposit",
+      mrkdwn: `Deposit ${formatUnits(inputAmount, token.decimals)} ${token.symbol} ${origin} -> ${destination}`,
+      ensureConfirmation: true,
+    },
+  ]);
+  if (!isDefined(depositResponse)) {
+    console.log(`Deposit submission for ${token.symbol} ${origin} -> ${destination} failed.`);
+    return false;
+  }
+  const receipt = await depositResponse.wait();
+  console.log(`Deposit confirmed: ${blockExplorerLink(receipt.transactionHash, hubChainId)}.`);
+
+  // Reconstruct the relay data from the emitted FundsDeposited event to guarantee that the slow fill request
+  // hashes to the on-chain deposit.
+  const fundsDeposited = spokePool.interface.getEventTopic(DEPOSIT_EVENT);
+  const depositLog = receipt.logs.find(
+    ({ address, topics }) => address === spokePool.address && topics[0] === fundsDeposited
+  );
+  if (!isDefined(depositLog)) {
+    console.log(`No ${DEPOSIT_EVENT} event found in txn ${receipt.transactionHash}.`);
+    return false;
+  }
+  const { args: depositArgs } = spokePool.interface.parseLog(depositLog);
+
+  const relayData: RelayData = {
+    originChainId: hubChainId,
+    depositor: toAddressType(depositArgs.depositor, hubChainId),
+    recipient: toAddressType(depositArgs.recipient, destinationChainId),
+    depositId: depositArgs.depositId,
+    inputToken: toAddressType(depositArgs.inputToken, hubChainId),
+    inputAmount: depositArgs.inputAmount,
+    outputToken: toAddressType(depositArgs.outputToken, destinationChainId),
+    outputAmount: depositArgs.outputAmount,
+    message: depositArgs.message,
+    fillDeadline: depositArgs.fillDeadline,
+    exclusiveRelayer: toAddressType(depositArgs.exclusiveRelayer, destinationChainId),
+    exclusivityDeadline: depositArgs.exclusivityDeadline,
+  };
+  const relayDataHash = sdkUtils.getRelayDataHash(relayData, destinationChainId);
+  console.log(`Deposit ${depositArgs.depositId} (relayDataHash ${relayDataHash}) confirmed on ${origin}.`);
+
+  const destProvider = await getProvider(destinationChainId);
+  const destSigner = signer.connect(destProvider);
+  const destSpokePool = (await utils.getSpokePoolContract(destinationChainId)).connect(destSigner);
+
+  const fillStatus = Number(await destSpokePool.fillStatuses(relayDataHash));
+  if (fillStatus !== FillStatus.Unfilled) {
+    const status = FillStatus[fillStatus];
+    console.log(`Deposit ${depositArgs.depositId} already has ${destination} fill status ${status}; skipping.`);
+    // An existing slow fill request still achieves the objective; an outright fill does not.
+    return fillStatus === FillStatus.RequestedSlowFill;
+  }
+
+  const [slowFillResponse] = await txnClient.submit(destinationChainId, [
+    {
+      contract: destSpokePool,
+      chainId: destinationChainId,
+      method: "requestSlowFill",
+      args: [convertRelayDataParamsToBytes32(relayData)],
+      message: "Requested slow fill for deposit.",
+      mrkdwn: `Requested ${destination} slow fill for ${origin} depositId ${depositArgs.depositId}.`,
+      ensureConfirmation: true,
+    },
+  ]);
+  if (!isDefined(slowFillResponse)) {
+    console.log(`Slow fill request for depositId ${depositArgs.depositId} on ${destination} failed.`);
+    return false;
+  }
+  const slowFillReceipt = await slowFillResponse.wait();
+  console.log(
+    `Slow fill request confirmed: ${blockExplorerLink(slowFillReceipt.transactionHash, destinationChainId)}.`
+  );
+
+  return true;
+}
+
+async function run(args: Record<string, string | boolean>, signer: Signer): Promise<boolean> {
+  const hubChainId = CHAIN_IDs.MAINNET;
+  const symbols = String(args.tokens)
+    .split(",")
+    .map((symbol) => symbol.trim().toUpperCase())
+    .filter((symbol) => symbol.length > 0);
+  const destinationChainIds = String(args.chainIds ?? "")
+    .split(",")
+    .filter((chainId) => chainId.length > 0)
+    .map(Number);
+  const amount = String(args.amount);
+  const execute = Boolean(args.execute);
+  const recipient = isDefined(args.recipient) ? String(args.recipient) : undefined;
+
+  if (destinationChainIds.length > 0 && !utils.validateChainIds(destinationChainIds)) {
+    console.log(`Invalid set of chain IDs (${destinationChainIds.join(", ")}).`);
+    return false;
+  }
+
+  const [hubPool, configStore] = await Promise.all([
+    utils.getContract(hubChainId, "HubPool"),
+    utils.getContract(hubChainId, "AcrossConfigStore"),
+  ]);
+
+  const signerAddr = await signer.getAddress();
+  const provider = await getProvider(hubChainId);
+
+  // Resolve all routes up-front and print the plan.
+  const routes: SlowFillRoute[] = [];
+  for (const symbol of symbols) {
+    const tokenRoutes = await resolveRoutes(hubPool, configStore, hubChainId, symbol, amount, destinationChainIds);
+    if (tokenRoutes.length === 0) {
+      console.log(`No active pool rebalance routes found for ${symbol}; skipping.`);
+      continue;
+    }
+
+    const { token } = tokenRoutes[0];
+    if (!(await tokenConfigUpdated(configStore, token.address))) {
+      console.log(
+        `WARNING: ${symbol} ConfigStore config still has a non-zero rate model and/or spokeTargetBalances.` +
+          " Has the updateTokenConfig() transaction been executed?"
+      );
+      if (execute && !(await utils.askYesNoQuestion(`Proceed with ${symbol} anyway?`))) {
+        continue;
+      }
+    }
+    routes.push(...tokenRoutes);
+  }
+
+  if (routes.length === 0) {
+    console.log("Nothing to do.");
+    return false;
+  }
+
+  console.log(`\nPlanned deposits + slow fill requests (signer ${signerAddr}):`);
+  routes.forEach((route) => printRoute(route, hubChainId));
+
+  // Report signer balances: per-token requirements on the hub chain, and native gas on each destination.
+  const symbolTotals: Record<string, { token: utils.ERC20; total: BigNumber }> = {};
+  routes.forEach(({ token, inputAmount }) => {
+    symbolTotals[token.symbol] ??= { token, total: bnZero };
+    symbolTotals[token.symbol].total = symbolTotals[token.symbol].total.add(inputAmount);
+  });
+
+  let fundingOk = true;
+  console.log(`\n${getNetworkName(hubChainId)} balances required:`);
+  for (const { token, total } of Object.values(symbolTotals)) {
+    const balance = await new Contract(token.address, ERC20.abi, provider).balanceOf(signerAddr);
+    const sufficient = balance.gte(total);
+    fundingOk &&= sufficient;
+    console.log(
+      `\t${token.symbol.padEnd(6)} ${formatUnits(total, token.decimals)}` +
+        ` (balance ${formatUnits(balance, token.decimals)})${sufficient ? "" : " ***INSUFFICIENT***"}`
+    );
+  }
+
+  console.log("\nDestination gas balances:");
+  for (const chainId of [...new Set(routes.map(({ destinationChainId }) => destinationChainId))]) {
+    const balance = await (await getProvider(chainId)).getBalance(signerAddr);
+    if (balance.eq(bnZero)) {
+      fundingOk = false;
+    }
+    console.log(
+      `\t${getNetworkName(chainId).padEnd(10)} ${formatUnits(balance, 18)}${balance.eq(bnZero) ? " ***EMPTY***" : ""}`
+    );
+  }
+
+  if (!execute) {
+    console.log("\nDry run complete. Re-run with --execute to submit transactions.");
+    return true;
+  }
+  if (!fundingOk && !(await utils.askYesNoQuestion("\nSigner appears underfunded. Proceed anyway?"))) {
+    return false;
+  }
+
+  // Approve the hub chain SpokePool once per token for the aggregate deposit amount.
+  const spokePool = await utils.getSpokePoolContract(hubChainId);
+  const originSigner = signer.connect(provider);
+  for (const { token, total } of Object.values(symbolTotals)) {
+    const erc20 = new Contract(token.address, ERC20.abi, originSigner);
+    const allowance = await erc20.allowance(signerAddr, spokePool.address);
+    if (allowance.lt(total)) {
+      console.log(`Approving SpokePool for ${formatUnits(total, token.decimals)} ${token.symbol}...`);
+      const approval = await erc20.approve(spokePool.address, total);
+      await approval.wait();
+      console.log(`Approval complete: ${blockExplorerLink(approval.hash, hubChainId)}.`);
+    }
+  }
+
+  const results: { route: SlowFillRoute; success: boolean }[] = [];
+  for (const route of routes) {
+    const { token, destinationChainId } = route;
+    const proceed = await utils.askYesNoQuestion(
+      `\nDeposit ${formatUnits(route.inputAmount, token.decimals)} ${token.symbol}` +
+        ` ${getNetworkName(hubChainId)} -> ${getNetworkName(destinationChainId)} and request slow fill?`
+    );
+    if (!proceed) {
+      continue;
+    }
+
+    let success = false;
+    try {
+      success = await depositAndRequestSlowFill(route, hubChainId, signer, recipient);
+    } catch (error) {
+      console.log(`Error on ${token.symbol} -> ${getNetworkName(destinationChainId)}: ${error}`);
+    }
+    results.push({ route, success });
+  }
+
+  console.log("\nSummary:");
+  results.forEach(({ route, success }) =>
+    console.log(
+      `\t${route.token.symbol.padEnd(6)} -> ${getNetworkName(route.destinationChainId).padEnd(10)}:` +
+        ` ${success ? "OK" : "FAILED"}`
+    )
+  );
+
+  return results.every(({ success }) => success);
+}
+
+function usage(badInput?: string): boolean {
+  const usageStr =
+    (badInput ? `\nUnrecognized input: "${badInput}".\n\n` : "") +
+    `
+    For each requested token, deposit on the HubPool chain to every chain with an active pool rebalance route, then
+    submit a corresponding slow fill request on the destination chain. Used to force pool rebalance leaves for every
+    (chain, token) pair when winding down LP support for a token. Run after the token's ConfigStore config has been
+    zeroed out, and before its pool rebalance routes are removed.
+
+    Usage:
+    \tyarn tsx ./scripts/depositAndRequestSlowFill --wallet <mnemonic|privateKey|gckms>
+    \t\t[--tokens ACX,WGHO,UMA]  Comma-separated token symbols (default: ACX,WGHO,UMA).
+    \t\t[--amount 1]             Deposit amount per route, in whole tokens (default: 1).
+    \t\t[--chainIds 10,137]      Restrict to these destination chains (default: all active routes).
+    \t\t[--recipient <address>]  Slow fill recipient (default: depositor).
+    \t\t[--execute]              Submit transactions (default: dry run).
+  `.slice(1);
+  console.log(usageStr);
+
+  return !isDefined(badInput);
+}
+
+async function main(argv: string[]): Promise<number> {
+  const opts = {
+    string: ["tokens", "amount", "chainIds", "recipient", "wallet"],
+    boolean: ["execute"],
+    default: {
+      tokens: "ACX,WGHO,UMA",
+      amount: "1",
+      execute: false,
+      wallet: "secret",
+    },
+    unknown: usage,
+  };
+  const args = minimist(argv, opts);
+
+  config();
+  let signer: Signer;
+  try {
+    signer = await getSigner({ keyType: args.wallet, cleanEnv: true });
+  } catch {
+    return usage(args.wallet) ? NODE_SUCCESS : NODE_INPUT_ERR;
+  }
+
+  const result = await run(args, signer);
+  return result ? NODE_SUCCESS : NODE_APP_ERR;
+}
+
+if (require.main === module) {
+  main(process.argv.slice(2))
+    .then(async (result) => {
+      process.exitCode = result;
+    })
+    .catch(async (error) => {
+      console.error("Process exited with", error);
+      process.exitCode = NODE_APP_ERR;
+    })
+    .finally(async () => {
+      await disconnectRedisClients();
+      exit(Number(process.exitCode));
+    });
+}

--- a/scripts/depositAndRequestSlowFill.ts
+++ b/scripts/depositAndRequestSlowFill.ts
@@ -26,6 +26,7 @@ import {
 import * as utils from "./utils";
 
 const { NODE_SUCCESS, NODE_INPUT_ERR, NODE_APP_ERR } = utils;
+const { PROTOCOL_DEFAULT_CHAIN_ID_INDICES } = sdkConsts;
 const { AddressZero } = ethers.constants;
 const { formatBytes32String } = ethers.utils;
 
@@ -86,11 +87,14 @@ async function getActiveRouteChainIds(
   hubChainId: number,
   l1Token: string
 ): Promise<{ chainId: number; destinationToken: string }[]> {
-  const [chainIds, disabledChainIds, liteChainIds] = await Promise.all(
+  const [_chainIds, disabledChainIds, liteChainIds] = await Promise.all(
     ["CHAIN_ID_INDICES", "DISABLED_CHAINS", "LITE_CHAIN_ID_INDICES"].map((key) =>
       getGlobalConfigArray(configStore, key)
     )
   );
+
+  // If CHAIN_ID_INDICES has never been set in the ConfigStore, the implicit initial protocol value applies.
+  const chainIds = _chainIds.length > 0 ? _chainIds : [...PROTOCOL_DEFAULT_CHAIN_ID_INDICES];
 
   const candidates = chainIds.filter(
     (chainId) => chainId !== hubChainId && !disabledChainIds.includes(chainId) && !liteChainIds.includes(chainId)
@@ -348,7 +352,8 @@ async function run(args: Record<string, string | boolean>, signer: Signer): Prom
   console.log(`\nPlanned deposits + slow fill requests (signer ${signerAddr}):`);
   routes.forEach((route) => printRoute(route, hubChainId));
 
-  // Report signer balances: per-token requirements on the hub chain, and native gas on each destination.
+  // Report signer balances: per-token requirements on the hub chain, and native gas on the hub chain (approvals
+  // and deposits) as well as each destination chain (slow fill requests).
   const symbolTotals: Record<string, { token: utils.ERC20; total: BigNumber }> = {};
   routes.forEach(({ token, inputAmount }) => {
     symbolTotals[token.symbol] ??= { token, total: bnZero };
@@ -367,8 +372,8 @@ async function run(args: Record<string, string | boolean>, signer: Signer): Prom
     );
   }
 
-  console.log("\nDestination gas balances:");
-  for (const chainId of [...new Set(routes.map(({ destinationChainId }) => destinationChainId))]) {
+  console.log("\nGas balances:");
+  for (const chainId of [...new Set([hubChainId, ...routes.map(({ destinationChainId }) => destinationChainId)])]) {
     const balance = await (await getProvider(chainId)).getBalance(signerAddr);
     if (balance.eq(bnZero)) {
       fundingOk = false;


### PR DESCRIPTION
## Motivation

Part of winding down LP support for ACX, WGHO (LGHO) & UMA ([Slack thread](https://risklabs.slack.com/archives/C09DHTZ47MZ/p1783114541418339)). After the ConfigStore `updateTokenConfig()` update zeroing the rate models & `spokeTargetBalances` executes, deposits + slow fill requests are needed for every affected (chain, token) pair so the next root bundle emits pool rebalance leaves that pull all SpokePool balances back to the hub — before the `setPoolRebalanceRoute()` removal executes.

## What

Adds `scripts/depositAndRequestSlowFill.ts` (patterned on `scripts/spokepool.ts`). For each requested token it:

1. Discovers every chain with an active HubPool pool rebalance route, excluding disabled and lite chains per the ConfigStore `CHAIN_ID_INDICES` / `DISABLED_CHAINS` / `LITE_CHAIN_ID_INDICES` global configs (so e.g. the stale Boba routes are naturally skipped).
2. Deposits on the hub chain SpokePool to each destination with `outputAmount == inputAmount` (0 relayer fee → fast fill is unprofitable, deposit stays unfilled), no exclusivity, empty message, max `fillDeadline`.
3. Reconstructs the relay data from the emitted `FundsDeposited` event (guaranteeing the hash matches the on-chain deposit), pre-checks `fillStatuses()`, and submits `requestSlowFill()` on the destination SpokePool.

Safety/UX:
- Dry run by default: prints discovered routes, per-token hub-chain balance requirements and destination gas balances. `--execute` submits with a per-route y/n confirmation.
- Warns (and prompts) if the token's ConfigStore config has not been zeroed yet, i.e. the prerequisite multisig txn hasn't executed.
- Treats an already-existing slow fill request as success; reports an outright fast fill as a failure to investigate.

Also adds `scripts/README_depositAndRequestSlowFill.md` (incl. the wind-down sequencing) and an AGENTS.md operator-scripts entry.

## Testing

- `yarn typecheck`, `eslint`, `prettier` clean.
- Dry run against production RPCs: discovers exactly the expected routes (ACX/UMA → Optimism, Polygon, Arbitrum; WGHO → Lens; Boba excluded) and correctly warns that the token configs are not yet zeroed.
- Full `--execute` run against anvil forks of Mainnet + Optimism: approval and deposit mined on the mainnet fork (`FundsDeposited` parsed, depositId extracted), `requestSlowFill()` mined on the Optimism fork, `RequestedSlowFill` emitted and `fillStatuses(relayDataHash) == 1` verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)