### PR TITLE
chore(deps): bump @across-protocol/sdk to 4.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@across-protocol/constants": "^3.1.119",
-    "@across-protocol/contracts": "5.0.21",
-    "@across-protocol/sdk": "4.4.6",
+    "@across-protocol/contracts": "5.0.22",
+    "@across-protocol/sdk": "4.4.8",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.119.tgz#95baca79e9fe1cef7fa3936803c8ff05d31a1827"
   integrity sha512-WaYqz7WAuE49kuDekkZoisBKMfmCWw6Rt8+MC44nyS4CO5CwiFZmYAn+dsqy5YgpdQElimxpdTG4m5PAr/cxNw==
 
-"@across-protocol/contracts@5.0.21":
-  version "5.0.21"
-  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-5.0.21.tgz#491a45d6fe1666690ece38e71adea7a22fb12e6b"
-  integrity sha512-4AJCfCAEWWO/eGD+gGyRV7rDvSvfJl/2uBJQroyZ3+Bs0IDgtBLmW7yxrXE9vb51/IX5YCTQf21UMYPG9eEZfg==
+"@across-protocol/contracts@5.0.22":
+  version "5.0.22"
+  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-5.0.22.tgz#ed7775b3f5b86d3c52603907be2874025b2c7d08"
+  integrity sha512-78TJgVE/XWvPz/7Ofxp2IiI4Dfi3lXId1bBcCLbp98C7IHsOmXea7xv+vBn+YI6J2lCN9QUNOHO8ZFqbQUz4Xw==
   dependencies:
     "@across-protocol/constants" "^3.1.118"
     "@coral-xyz/anchor" "^0.31.1"
@@ -34,13 +34,13 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.4.6":
-  version "4.4.6"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.4.6.tgz#a191bde8dc2cc9ca61bffb6fe747cb5acac3ca8d"
-  integrity sha512-hFCha8NMqGHXYGGYXS0/DAtEPi6TIWXOHp9RGzAcnFLqA42WOXwNDRTpS3x/X0DfXJnQSqhqsCw9c2+cFZwD3g==
+"@across-protocol/sdk@4.4.8":
+  version "4.4.8"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.4.8.tgz#e6c0e65050705852fc5d1dec1f6dcc759623e59d"
+  integrity sha512-FQXyTUO6jKfShQqUJ55oPzEbnV+90tf2mkMpYC6LiBZMAdt6GcgXwwYg49xPnoMPJMoaNPEYJe95/Jb1jVSt6w==
   dependencies:
     "@across-protocol/constants" "^3.1.119"
-    "@across-protocol/contracts" "5.0.21"
+    "@across-protocol/contracts" "5.0.22"
     "@coral-xyz/anchor" "^0.30.1"
     "@eth-optimism/sdk" "^3.3.1"
     "@ethersproject/bignumber" "^5.7.0"


### PR DESCRIPTION
## What

- `@across-protocol/sdk` 4.4.6 → **4.4.8**
- `@across-protocol/contracts` 5.0.21 → **5.0.22** (lockstep with the SDK's pin — without it yarn nests a second contracts copy under the SDK and `tsc` fails on nominally-incompatible `MerkleTree` types)

## Why

Picks up across-protocol/sdk#1479 (v4.4.8): `HubPoolClient` now retains pre-lookback `RootBundleExecuted` events, so validating a bundle with slow relay leaves on idle (chain, token) pairs no longer re-scans ~10.5M blocks of HubPool history once per pair. That scan inflated dataworker/disputer root-builds from ~20s to 17–23 min and pushed validator attestations past the disputer watchdog's deadline — two valid proposals were auto-disputed on 2026-07-06 ([Slack](https://risklabs.slack.com/archives/C03GKNS03C7/p1783365026960569)).

Deploying this image is gate #1 for re-enabling the proposer (UMAprotocol/bot-configs#4152).

## Testing

`yarn tsc --noEmit` clean locally against the bumped deps; relying on CI for the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)