### PR TITLE
chore(InventoryClient): Comment out shortfall rebalance logic

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -853,8 +853,10 @@ export class InventoryClient {
         const l2Tokens = this.getRemoteTokensForL1Token(l1Token, chainId);
         l2Tokens.forEach((l2Token) => {
           // Make sure to prioritize shortfall rebalances over ordinary rebalances by pushing them into the array first
-          const shortfallRebalances = this._getPossibleShortfallRebalances(l1Token, chainId, l2Token);
-          rebalancesRequired.push(...shortfallRebalances);
+          // Temporarily disabled: shortfall rebalances emit one tiny per-deposit transfer each, which the mainnet
+          // balance-changed check in rebalanceInventoryIfNeeded perpetually skips. Rely on target-allocation rebalances.
+          // const shortfallRebalances = this._getPossibleShortfallRebalances(l1Token, chainId, l2Token);
+          // rebalancesRequired.push(...shortfallRebalances);
           const inventoryRebalance = this._getPossibleInventoryRebalances(cumulativeBalance, l1Token, chainId, l2Token);
           if (inventoryRebalance) {
             rebalancesRequired.push(inventoryRebalance);

--- a/test/InventoryClient.InventoryRebalance.ts
+++ b/test/InventoryClient.InventoryRebalance.ts
@@ -262,7 +262,9 @@ describe("InventoryClient: Rebalancing inventory", function () {
     expect(spyLogIncludes(spy, -2, '"proRataShare":"7.00%"')).to.be.true;
   });
 
-  it("Correctly decides when to execute rebalances: token shortfall", async function () {
+  // Skipped: shortfall rebalances are temporarily disabled in InventoryClient.getPossibleRebalances(). Re-enable
+  // alongside that logic.
+  it.skip("Correctly decides when to execute rebalances: token shortfall", async function () {
     // Test the case where the funds on a particular chain are too low to meet a relay (shortfall) and the bot rebalances.
     await inventoryClient.update();
     await inventoryClient.rebalanceInventoryIfNeeded();


### PR DESCRIPTION
Shortfall rebalances emit one tiny per-deposit transfer each, which the mainnet balance-changed guard perpetually skips (0/24 USDC→USDG rebalances on Robinhood over 12h). This comments out that path (2 lines) so we rely on target-allocation rebalances only.
