### PR TITLE
fix(InventoryClient): Make blocked-rebalance log figures self-consistent

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -998,8 +998,10 @@ export class InventoryClient {
           this.trackCrossChainTransfer(l1Token, l2Token, amount, chainId);
         }
       } else {
-        // Extract unexecutable rebalances for logging.
-        unexecutedRebalances.push(rebalance);
+        // Extract unexecutable rebalances for logging. Overwrite the planning-time L1 balance with the unallocated
+        // balance remaining at decision time, since rebalances approved earlier in this loop may have earmarked
+        // part of it and are the actual reason this transfer was blocked.
+        unexecutedRebalances.push({ ...rebalance, balance: unallocatedBalance });
       }
     }
 
@@ -1101,14 +1103,19 @@ export class InventoryClient {
 
         const { symbol, decimals } = tokenInfo;
         const l2TokenFormatter = createFormatFunction(2, 4, false, decimals);
-        const distributionPct = tokenDistributionPerL1Token[l1Token.toNative()][chainId][l2Token.toNative()].mul(100);
+        // Compute the allocation from the same live balances printed alongside it, rather than from the distribution
+        // snapshot taken before this run's approved rebalances were tracked, so all figures are self-consistent.
+        const currentBalance = this.getBalanceOnChain(chainId, l1Token, l2Token);
         const cumulativeBalance = this.getCumulativeBalance(l1Token);
+        const distributionPct = cumulativeBalance.gt(bnZero)
+          ? currentBalance.mul(this.scalar).div(cumulativeBalance).mul(100)
+          : bnZero;
         mrkdwn +=
           `- ${symbol} transfer blocked. Required to send ` +
-          `${l1Formatter(amount)} but relayer has ` +
-          `${l1Formatter(balance)} on L1. There is currently ` +
-          `${l1Formatter(this.getBalanceOnChain(chainId, l1Token, l2Token))} ${symbol} on ` +
-          `${getNetworkName(chainId)} which is ` +
+          `${l1Formatter(amount)} but relayer had only ` +
+          `${l1Formatter(balance)} unallocated on L1 when the transfer was evaluated. There is currently ` +
+          `${l1Formatter(currentBalance)} ${symbol} on ` +
+          `${getNetworkName(chainId)} (including pending inbound transfers) which is ` +
           `${this.formatWei(distributionPct)}% of the total ` +
           `${l1Formatter(cumulativeBalance)} ${symbol}.` +
           " This chain's pending L1->L2 transfer amount is " +


### PR DESCRIPTION
## Motivation

The `transfer blocked` lines in the "Executed Inventory rebalances" log mix two points in time, producing self-contradictory output. Example from production (Slack, 2026-07-08):

> WETH transfer blocked. Required to send 102.57 but relayer has 908.16 on L1. There is currently 909.73 WETH on Robinhood which is 0.07501% of the total 2,082.72 WETH.

909.73 / 2,082.72 is 43.68%, not 0.07501%, and a 102.57 send being blocked while "relayer has 908.16 on L1" looks nonsensical.

Two causes, both in `rebalanceInventoryIfNeeded`:

1. `distributionPct` came from `tokenDistributionPerL1Token`, snapshotted **at the top of the function**, while the chain balance, cumulative total, and pending-transfer figures on the same line are recomputed **after** approved rebalances have been tracked via `trackCrossChainTransfer` (which moves L1 balance into the destination chain's pending L1→L2 amount). In the example, ~908 WETH was earmarked to Robinhood earlier in the same run: the live balance read 909.73 while the percentage still reflected the pre-run ~1.56 WETH.
2. The `balance` printed was the planning-time L1 balance captured in the rebalance object, not the unallocated balance remaining at decision time (the value the `amount.lte(unallocatedBalance)` gate actually uses), hiding the real reason for the block.

## Changes

- Compute `distributionPct` from the same live `getBalanceOnChain` / `getCumulativeBalance` reads that are printed alongside it, so the figures on one line are always self-consistent.
- Record the decision-time unallocated L1 balance on unexecuted rebalances and reword the message accordingly ("relayer had only X unallocated on L1 when the transfer was evaluated").
- Clarify that the chain balance includes pending inbound transfers.

Same scenario after this change:

> WETH transfer blocked. Required to send 102.57 but relayer had only 0.00 unallocated on L1 when the transfer was evaluated. There is currently 909.73 WETH on Robinhood (including pending inbound transfers) which is 43.68% of the total 2,082.72 WETH.

Logging-only change; no behavior change to rebalance planning or execution. No README/AGENTS updates needed since no documented behavior, config, or interface changes.

## Verification

- `tsc --noEmit`: clean
- `eslint src/clients/InventoryClient.ts`: clean
- `npx hardhat test test/InventoryClient.InventoryRebalance.ts`: 15 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)