### PR TITLE
fix(InventoryClient): Loosen pre-rebalance mainnet balance check

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -970,27 +970,33 @@ export class InventoryClient {
       // the rebalance to this particular chain. Note that if the sum of all rebalances required exceeds the l1
       // balance then this logic ensures that we only fill the first n number of chains where we can.
       if (toBN(amount).lte(unallocatedBalance)) {
-        // As a precautionary step before proceeding, check that the token balance for the token we're about to send
-        // hasn't changed on L1. It's possible its changed since we updated the inventory due to one or more of the
-        // RPC's returning slowly, leading to concurrent/overlapping instances of the bot running.
+        // As a precautionary step before proceeding, re-read the on-chain L1 balance and confirm we still hold enough
+        // to actually fund this transfer. The inventory snapshot may be stale (slow RPCs, or concurrent/overlapping
+        // bot instances that already moved funds), but a benign change - e.g. an incoming repayment that increased the
+        // balance - should not block the rebalance. Only skip if the current balance can no longer cover `amount`.
+        // TODO: This is a temporary loosening of the previous exact balance-equality guard, which was perpetually
+        // skipping rebalances whenever the mainnet balance drifted at all (e.g. from repayment inflows). It weakens
+        // the protection against concurrent/overlapping bot instances double-spending, so we must revisit this and
+        // decide on the right long-term safeguard.
         const tokenContract = new Contract(l1Token.toNative(), ERC20.abi, this.hubPoolClient.hubPool.signer);
         const currentBalance = await tokenContract.balanceOf(this.relayer.toNative());
 
-        const balanceChanged = !balance.eq(currentBalance);
-        const [message, log] = balanceChanged
-          ? ["🚧 Token balance on mainnet changed, skipping rebalance", this.logger.warn]
-          : ["Token balance in relayer on mainnet is as expected, sending cross chain transfer", this.logger.debug];
+        const insufficientBalance = currentBalance.lt(toBN(amount));
+        const [message, log] = insufficientBalance
+          ? ["🚧 Insufficient mainnet balance to fund rebalance, skipping", this.logger.warn]
+          : ["Sufficient mainnet balance to fund rebalance, sending cross chain transfer", this.logger.debug];
         log({
           at: "InventoryClient",
           message,
           l1Token,
           l2Token,
           l2ChainId: chainId,
+          amount,
           balance,
           currentBalance,
         });
 
-        if (!balanceChanged) {
+        if (!insufficientBalance) {
           possibleRebalances.push(rebalance);
           // Decrement token balance in client for this chain and increment cross chain counter.
           this.trackCrossChainTransfer(l1Token, l2Token, amount, chainId);

--- a/test/InventoryClient.InventoryRebalance.ts
+++ b/test/InventoryClient.InventoryRebalance.ts
@@ -395,7 +395,7 @@ describe("InventoryClient: Rebalancing inventory", function () {
       .to.be.true;
   });
 
-  it("Refuses to send rebalance when ERC20 balance changes", async function () {
+  it("Only refuses to send rebalance when on-chain balance cannot fund the transfer", async function () {
     await inventoryClient.update();
     await inventoryClient.rebalanceInventoryIfNeeded();
 
@@ -422,15 +422,17 @@ describe("InventoryClient: Rebalancing inventory", function () {
       )
     ).to.equal(expectedAlloc);
 
-    // Set USDC balance to be lower than expected.
+    // Set the on-chain USDC balance below the rebalance amount so we can no longer fund the transfer. The rebalance
+    // should be skipped even though inventory accounting still thinks the funds are available.
+    mainnetUsdcContract.balanceOf.whenCalledWith(owner.address).returns(toMegaWei(1));
+    await inventoryClient.rebalanceInventoryIfNeeded();
+    expect(spyLogIncludes(spy, -2, "Insufficient mainnet balance to fund rebalance")).to.be.true;
+
+    // A balance that merely changed but still covers the transfer must NOT block the rebalance (the point of the
+    // loosened check). Set the balance slightly below the snapshot but far above the rebalance amount.
     mainnetUsdcContract.balanceOf
       .whenCalledWith(owner.address)
       .returns(initialAllocation[MAINNET][mainnetUsdc].sub(toMegaWei(1)));
-    await inventoryClient.rebalanceInventoryIfNeeded();
-    expect(spyLogIncludes(spy, -2, "Token balance on mainnet changed")).to.be.true;
-
-    // Reset and check again.
-    mainnetUsdcContract.balanceOf.whenCalledWith(owner.address).returns(initialAllocation[MAINNET][mainnetUsdc]);
     await inventoryClient.rebalanceInventoryIfNeeded();
     expect(lastSpyLogIncludes(spy, "Executed Inventory rebalances")).to.be.true;
   });


### PR DESCRIPTION
Loosens the pre-rebalance mainnet balance guard from exact-equality to a sufficiency check (`currentBalance >= amount`), so benign balance drift (e.g. incoming repayments) no longer perpetually skips rebalances. Marked temporary with a TODO to revisit the double-spend safeguard.