### PR TITLE
feat(Relayer): Prioritize deposits by earliest fill deadline

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -488,13 +488,16 @@ export class Relayer {
         .map((spokePoolClient) => [spokePoolClient.chainId, spokePoolClient])
     );
 
-    // Filter the resulting deposits according to relayer configuration.
+    // Filter the resulting deposits according to relayer configuration, then order them oldest-first. This ensures
+    // the oldest deposits are evaluated - and, when the per-loop rate limit truncates the list, retained - ahead of
+    // newer ones. getUnfilledDeposits otherwise returns deposits grouped by origin chain; quoteTimestamp approximates
+    // a deposit's creation time and is comparable across origin chains, unlike per-chain block numbers.
     return Object.fromEntries(
       Object.values(destinationSpokePoolClients).map((destinationSpokePoolClient) => [
         destinationSpokePoolClient.chainId,
-        getUnfilledDeposits(destinationSpokePoolClient, originSpokePoolClients, hubPoolClient, this.fillStatus).filter(
-          (deposit) => this.filterDeposit(deposit)
-        ),
+        getUnfilledDeposits(destinationSpokePoolClient, originSpokePoolClients, hubPoolClient, this.fillStatus)
+          .filter((deposit) => this.filterDeposit(deposit))
+          .sort((a, b) => a.deposit.quoteTimestamp - b.deposit.quoteTimestamp),
       ])
     );
   }

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -488,16 +488,17 @@ export class Relayer {
         .map((spokePoolClient) => [spokePoolClient.chainId, spokePoolClient])
     );
 
-    // Filter the resulting deposits according to relayer configuration, then order them oldest-first. This ensures
-    // the oldest deposits are evaluated - and, when the per-loop rate limit truncates the list, retained - ahead of
-    // newer ones. getUnfilledDeposits otherwise returns deposits grouped by origin chain; quoteTimestamp approximates
-    // a deposit's creation time and is comparable across origin chains, unlike per-chain block numbers.
+    // Filter the resulting deposits according to relayer configuration, then order them by fill deadline, earliest
+    // first. This ensures the most urgent deposits (closest to their fill deadline) are evaluated - and, when the
+    // per-loop rate limit truncates the list, retained - ahead of others. getUnfilledDeposits otherwise returns
+    // deposits grouped by origin chain; fillDeadline is a timestamp comparable across origin chains, unlike the
+    // per-chain block numbers the deposits would otherwise be ordered by.
     return Object.fromEntries(
       Object.values(destinationSpokePoolClients).map((destinationSpokePoolClient) => [
         destinationSpokePoolClient.chainId,
         getUnfilledDeposits(destinationSpokePoolClient, originSpokePoolClients, hubPoolClient, this.fillStatus)
           .filter((deposit) => this.filterDeposit(deposit))
-          .sort((a, b) => a.deposit.quoteTimestamp - b.deposit.quoteTimestamp),
+          .sort((a, b) => a.deposit.fillDeadline - b.deposit.fillDeadline),
       ])
     );
   }


### PR DESCRIPTION
The relayer evaluated unfilled deposits grouped by origin chain (and truncated that order under the per-loop rate limit), not by urgency. This sorts each destination's unfilled deposits by `fillDeadline` ascending so the deposits closest to expiry are evaluated and retained first.
