### PR TITLE
feat(rebalancer): prioritize destination chains for cumulative rebalances

### DIFF
--- a/docs/rebalancer-config-from-deposit-flow.md
+++ b/docs/rebalancer-config-from-deposit-flow.md
@@ -15,12 +15,13 @@ The cumulative rebalancer works from aggregate token balances:
 5. The chosen transfer is capped by the remaining deficit, remaining excess, source-chain balance, and
    `maxAmountsToTransfer`.
 
-`cumulativeTargetBalances[token].chains` is both an allowlist and a source-priority map:
+`cumulativeTargetBalances[token].chains` is both an allowlist and a chain-priority map:
 
 - A chain must be present for that token to be eligible as a source or destination.
 - Lower numeric priority tiers are preferred when the token is being used as the source of excess inventory.
-- Destination priority is not used to force where replenishment lands. The client evaluates all configured destination
-  chains with valid routes and picks the cheapest estimated route.
+- Higher numeric priority tiers are preferred when the token is the destination deficit inventory. The client evaluates
+  all configured destination chains with valid routes, picks the highest-priority route under `maxFeePct`, and uses the
+  cheapest route among ties.
 
 Config can only select from routes generated in `src/rebalancer/buildRebalanceRoutes.ts`. If historical flow lands on a
 chain that is absent from `REBALANCE_CHAINS_BY_SYMBOL` for the relevant token, adding that chain to JSON config alone is
@@ -68,12 +69,15 @@ For example, if most `USDT -> USDC` fills consume USDC on Base and a smaller amo
 are natural USDC destinations. Mainnet can also be a deliberate USDC destination even when it is not the dominant final
 consumption chain, because Mainnet USDC is highly portable and can be rebalanced onward through many routes.
 
-Avoid broad destination allowlists unless that is intentional. Since destination selection is cost-based, an extra cheap
-route can attract replenishment to a chain that has little expected deposit demand.
+Avoid broad destination allowlists unless that is intentional. A high destination priority can attract replenishment to a
+chain even when a lower-priority route is cheaper.
 
 Choose source chains from where the input token historically accumulates and is supported by route construction. Put the
 highest-volume supported repayment chains in lower numeric priority tiers. Low-volume chains can either be omitted or
 left in a lower-priority tier if the operator intentionally wants to drain incidental inventory from them.
+
+Rank destination chains with higher numeric priority tiers when the operator wants replenishment to land there before
+cheaper lower-priority routes.
 
 ## Sizing Thresholds and Targets
 

--- a/docs/rebalancer-config-from-deposit-flow.md
+++ b/docs/rebalancer-config-from-deposit-flow.md
@@ -76,9 +76,6 @@ Choose source chains from where the input token historically accumulates and is 
 highest-volume supported repayment chains in lower numeric priority tiers. Low-volume chains can either be omitted or
 left in a lower-priority tier if the operator intentionally wants to drain incidental inventory from them.
 
-Rank destination chains with higher numeric priority tiers when the operator wants replenishment to land there before
-cheaper lower-priority routes.
-
 ## Sizing Thresholds and Targets
 
 `thresholdBalance` controls how often a token starts a refill; `targetBalance` controls how much inventory the bot tries

--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -191,7 +191,7 @@ Notes:
 
 - `targetBalance` and `thresholdBalance` values are human-readable and converted to token-native decimals.
 - `cumulativeTargetBalances` define per-token aggregate objectives plus allowed source/destination chain sets for `CumulativeBalanceRebalancerClient.rebalanceInventory()`.
-- `cumulativeTargetBalances[token].chains[chainId]` is a chain priority tier used when selecting where to source excess inventory from (lower tier is preferred for sourcing).
+- `cumulativeTargetBalances[token].chains[chainId]` is a chain priority tier used when selecting where to source excess inventory from and where to land deficit inventory. Lower tiers are preferred for sourcing; higher tiers are preferred for destinations.
 - `chainIds` are derived from the union of chains found in `cumulativeTargetBalances`.
 
 For an operator playbook on sizing these values from expected deposit fills, see
@@ -217,13 +217,13 @@ High-level flow:
 4. For each excess token used to fill a deficit token, sort source chains from `cumulativeTargetBalances[excessToken].chains` by:
    - chain `priorityTier` ascending,
    - then current chain balance descending.
-5. For each candidate source chain, evaluate all destination chains configured for the deficit token that have valid routes, then choose the route with the lowest `getEstimatedCost`.
+5. For each candidate source chain, evaluate all destination chains configured for the deficit token that have valid routes, then choose the highest destination priority tier with an estimated cost within `maxFeePct`. Routes in the same destination priority tier use the lowest `getEstimatedCost`.
 6. Cap transfer amount by remaining deficit, remaining excess, chain balance, and configured `maxAmountsToTransfer`. For mixed-asset routes such as `WETH <-> stablecoin`, the client converts between source and destination token amounts through hub-chain USD prices before capping and decrementing the remaining deficit.
 7. Enforce max fee pct and adapter pending-order caps before calling `initializeRebalance`.
 
 Design tradeoff:
 
-- Destination-chain selection evaluates all eligible routes to minimize expected cost. This improves route quality at the expense of additional runtime cost when many routes are configured.
+- Destination-chain selection evaluates all eligible routes and favors configured destination priority before expected cost. This sends replenishment to preferred inventory locations while still falling back to lower-priority routes when higher-priority routes exceed `maxFeePct`.
 
 ### Read-only mode: `ReadOnlyRebalancerClient`
 

--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -219,7 +219,7 @@ High-level flow:
    - then current chain balance descending.
 5. For each candidate source chain, evaluate all destination chains configured for the deficit token that have valid routes, then choose the highest destination priority tier with an estimated cost within `maxFeePct`. Routes in the same destination priority tier use the lowest `getEstimatedCost`.
 6. Cap transfer amount by remaining deficit, remaining excess, chain balance, and configured `maxAmountsToTransfer`. For mixed-asset routes such as `WETH <-> stablecoin`, the client converts between source and destination token amounts through hub-chain USD prices before capping and decrementing the remaining deficit.
-7. Enforce max fee pct and adapter pending-order caps before calling `initializeRebalance`.
+7. Enforce max fee pct and adapter pending-order caps before calling `initializeRebalance`. If an affordable ranked route declines during initialization, try the next affordable route.
 
 Design tradeoff:
 

--- a/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
+++ b/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
@@ -272,16 +272,17 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
             }
             return a.cost.lt(b.cost) ? -1 : 1;
           });
-          // Select highest ranked route under the max fee guard:
+          // Select ranked routes under the max fee guard:
           const maxFee = amountToTransferCapped.mul(maxFeePct).div(toBNWei(100));
-          const chosenRoute = rebalanceRoutesWithCosts.find(({ cost }) => cost.lte(maxFee));
-          if (!isDefined(chosenRoute)) {
+          const candidateRoutes = rebalanceRoutesWithCosts.filter(({ cost }) => cost.lte(maxFee));
+          if (candidateRoutes.length === 0) {
             this.logger.debug({
               at: "CumulativeBalanceRebalancerClient.rebalanceInventory",
               message: `No route found under max fee of ${maxFee.toString()}`,
             });
             continue;
           }
+          const highestRankedRoute = candidateRoutes[0];
           this.logger.debug({
             at: "RebalanceClient.rebalanceCumulativeInventory",
             message: `Evaluating sending of ${amountToTransferCapped.toString()} of ${excessToken} from ${getNetworkName(
@@ -293,12 +294,12 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
             excessRemaining: excessRemaining.toString(),
             deficitRemainingConvertedToExcessToken: deficitRemainingConverted.toString(),
             maxAmountToTransfer: maxAmountToTransfer?.toString(),
-            routePriorityTier: chosenRoute.priorityTier,
-            routeCost: `[${chosenRoute.route.adapter}] ${getNetworkName(
-              chosenRoute.route.sourceChain
-            )} ${chosenRoute.route.sourceToken} -> ${getNetworkName(chosenRoute.route.destinationChain)} ${
-              chosenRoute.route.destinationToken
-            }: ${chosenRoute.cost.toString()}`,
+            routePriorityTier: highestRankedRoute.priorityTier,
+            routeCost: `[${highestRankedRoute.route.adapter}] ${getNetworkName(
+              highestRankedRoute.route.sourceChain
+            )} ${highestRankedRoute.route.sourceToken} -> ${getNetworkName(
+              highestRankedRoute.route.destinationChain
+            )} ${highestRankedRoute.route.destinationToken}: ${highestRankedRoute.cost.toString()}`,
             rebalanceRouteCosts: rebalanceRoutesWithCosts.map(({ route, cost, priorityTier }) => {
               return {
                 [route.adapter]: `[P${priorityTier}] ${route.sourceToken} on ${getNetworkName(route.sourceChain)} -> ${
@@ -320,34 +321,37 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
             : deficitRemaining.sub(deficitReduction);
           const nextExcessRemaining = excessRemaining.sub(amountTransferredL1);
           const nextSourceBalance = currentBalance.sub(amountToTransferCapped);
-          this.logger.debug({
-            at: "RebalanceClient.rebalanceCumulativeInventory",
-            message: `Initializing new ${chosenRoute.route.adapter} ${fromWei(amountToTransferCapped, chainDecimals)} ${excessToken} rebalance from ${getNetworkName(chosenRoute.route.sourceChain)} to ${getNetworkName(chosenRoute.route.destinationChain)} ${deficitToken}`,
-            adapter: chosenRoute.route.adapter,
-            expectedFees: fromWei(chosenRoute.cost, chainDecimals),
-          });
+          for (const chosenRoute of candidateRoutes) {
+            this.logger.debug({
+              at: "RebalanceClient.rebalanceCumulativeInventory",
+              message: `Initializing new ${chosenRoute.route.adapter} ${fromWei(amountToTransferCapped, chainDecimals)} ${excessToken} rebalance from ${getNetworkName(chosenRoute.route.sourceChain)} to ${getNetworkName(chosenRoute.route.destinationChain)} ${deficitToken}`,
+              adapter: chosenRoute.route.adapter,
+              expectedFees: fromWei(chosenRoute.cost, chainDecimals),
+            });
 
-          if (this.config.sendingTransactionsEnabled) {
-            const initializedAmount = await this.adapters[chosenRoute.route.adapter].initializeRebalance(
-              chosenRoute.route,
-              amountToTransferCapped
-            );
-            if (initializedAmount.eq(bnZero)) {
-              this.logger.debug({
-                at: "CumulativeBalanceRebalancerClient.rebalanceInventory",
-                message: `Adapter ${chosenRoute.route.adapter} declined to initialize rebalance; preserving remaining excess for later routes`,
-                route: chosenRoute.route,
-                requestedAmountToTransfer: amountToTransferCapped.toString(),
-              });
-              continue;
+            if (this.config.sendingTransactionsEnabled) {
+              const initializedAmount = await this.adapters[chosenRoute.route.adapter].initializeRebalance(
+                chosenRoute.route,
+                amountToTransferCapped
+              );
+              if (initializedAmount.eq(bnZero)) {
+                this.logger.debug({
+                  at: "CumulativeBalanceRebalancerClient.rebalanceInventory",
+                  message: `Adapter ${chosenRoute.route.adapter} declined to initialize rebalance; trying next route`,
+                  route: chosenRoute.route,
+                  requestedAmountToTransfer: amountToTransferCapped.toString(),
+                });
+                continue;
+              }
             }
-          }
 
-          // Decrement the deficit remaining, the excess remaining for this token, and the current balance for this
-          // token only after the adapter successfully initializes the rebalance.
-          deficitRemaining = nextDeficitRemaining;
-          excessRemaining = nextExcessRemaining;
-          currentBalancesOnChain[chosenRoute.route.sourceChain][excessToken] = nextSourceBalance;
+            // Decrement the deficit remaining, the excess remaining for this token, and the current balance for this
+            // token only after the adapter successfully initializes the rebalance.
+            deficitRemaining = nextDeficitRemaining;
+            excessRemaining = nextExcessRemaining;
+            currentBalancesOnChain[chosenRoute.route.sourceChain][excessToken] = nextSourceBalance;
+            break;
+          }
         }
 
         // Overwrite the excess remaining for the token to decrement the excess for the next deficit to evaluate.

--- a/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
+++ b/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
@@ -15,7 +15,7 @@ import {
   toBNWei,
 } from "../../utils";
 import { ExcessOrDeficit, RebalanceRoute } from "../utils/interfaces";
-import { sortDeficitFunction, sortExcessFunction, sortHigherPriorityTier } from "../utils/utils";
+import { sortDeficitFunction, sortExcessFunction } from "../utils/utils";
 import { BaseRebalancerClient } from "./BaseRebalancerClient";
 import { getAcrossHost } from "../../clients/AcrossAPIClient";
 
@@ -230,21 +230,14 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
           // for all possible destination chains and then select the highest priority chain with the lowest
           // estimated cost.
           const allDestinationChains = cumulativeTargetBalances[deficitToken].chains;
-          const destinationChainIds = Object.entries(allDestinationChains).map(([chainId]) => Number(chainId));
-          const rebalanceRoutesToEvaluate: RebalanceRoute[] = [];
-          for (const route of availableRebalanceRoutes) {
-            destinationChainIds.forEach((destinationChain) => {
-              if (
-                availableAdapters.includes(route.adapter) &&
-                route.sourceChain === Number(chainId) &&
-                route.sourceToken === excessToken &&
-                route.destinationChain === destinationChain &&
-                route.destinationToken === deficitToken
-              ) {
-                rebalanceRoutesToEvaluate.push(route);
-              }
-            });
-          }
+          const rebalanceRoutesToEvaluate = availableRebalanceRoutes.filter(
+            (route) =>
+              availableAdapters.includes(route.adapter) &&
+              route.sourceChain === Number(chainId) &&
+              route.sourceToken === excessToken &&
+              route.destinationToken === deficitToken &&
+              isDefined(allDestinationChains[route.destinationChain])
+          );
 
           if (rebalanceRoutesToEvaluate.length === 0) {
             this.logger.debug({
@@ -270,9 +263,7 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
             };
           });
           rebalanceRoutesWithCosts.sort((a, b) => {
-            const aPriorityTier = a.priorityTier;
-            const bPriorityTier = b.priorityTier;
-            const sortedPriorityTier = sortHigherPriorityTier(aPriorityTier, bPriorityTier);
+            const sortedPriorityTier = b.priorityTier - a.priorityTier;
             if (sortedPriorityTier !== 0) {
               return sortedPriorityTier;
             }

--- a/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
+++ b/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
@@ -15,7 +15,7 @@ import {
   toBNWei,
 } from "../../utils";
 import { ExcessOrDeficit, RebalanceRoute } from "../utils/interfaces";
-import { sortDeficitFunction, sortExcessFunction } from "../utils/utils";
+import { sortDeficitFunction, sortExcessFunction, sortHigherPriorityTier } from "../utils/utils";
 import { BaseRebalancerClient } from "./BaseRebalancerClient";
 import { getAcrossHost } from "../../clients/AcrossAPIClient";
 
@@ -227,13 +227,13 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
           }
 
           // To determine which destination chain to receive the deficit token on, we check the estimated cost
-          // for all possible destination chains and then select the chain with the lowest estimated cost.
-          const allDestinationChains = Object.entries(cumulativeTargetBalances[deficitToken].chains).map(([chainId]) =>
-            Number(chainId)
-          );
+          // for all possible destination chains and then select the highest priority chain with the lowest
+          // estimated cost.
+          const allDestinationChains = cumulativeTargetBalances[deficitToken].chains;
+          const destinationChainIds = Object.entries(allDestinationChains).map(([chainId]) => Number(chainId));
           const rebalanceRoutesToEvaluate: RebalanceRoute[] = [];
           for (const route of availableRebalanceRoutes) {
-            allDestinationChains.forEach((destinationChain) => {
+            destinationChainIds.forEach((destinationChain) => {
               if (
                 availableAdapters.includes(route.adapter) &&
                 route.sourceChain === Number(chainId) &&
@@ -258,9 +258,10 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
             });
             continue;
           }
-          const rebalanceRouteCosts = await mapAsync(rebalanceRoutesToEvaluate, async (route) => {
+          const rebalanceRoutesWithCosts = await mapAsync(rebalanceRoutesToEvaluate, async (route) => {
             return {
               route,
+              priorityTier: allDestinationChains[route.destinationChain],
               cost: await this.adapters[route.adapter].getEstimatedCost(
                 route,
                 amountToTransferCapped,
@@ -268,13 +269,28 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
               ),
             };
           });
-          rebalanceRouteCosts.sort((a, b) => {
+          rebalanceRoutesWithCosts.sort((a, b) => {
+            const aPriorityTier = a.priorityTier;
+            const bPriorityTier = b.priorityTier;
+            const sortedPriorityTier = sortHigherPriorityTier(aPriorityTier, bPriorityTier);
+            if (sortedPriorityTier !== 0) {
+              return sortedPriorityTier;
+            }
             if (a.cost.eq(b.cost)) {
               return 0;
             }
             return a.cost.lt(b.cost) ? -1 : 1;
           });
-          const cheapestCostRoute = rebalanceRouteCosts[0];
+          // Select highest ranked route under the max fee guard:
+          const maxFee = amountToTransferCapped.mul(maxFeePct).div(toBNWei(100));
+          const chosenRoute = rebalanceRoutesWithCosts.find(({ cost }) => cost.lte(maxFee));
+          if (!isDefined(chosenRoute)) {
+            this.logger.debug({
+              at: "CumulativeBalanceRebalancerClient.rebalanceInventory",
+              message: `No route found under max fee of ${maxFee.toString()}`,
+            });
+            continue;
+          }
           this.logger.debug({
             at: "RebalanceClient.rebalanceCumulativeInventory",
             message: `Evaluating sending of ${amountToTransferCapped.toString()} of ${excessToken} from ${getNetworkName(
@@ -286,28 +302,20 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
             excessRemaining: excessRemaining.toString(),
             deficitRemainingConvertedToExcessToken: deficitRemainingConverted.toString(),
             maxAmountToTransfer: maxAmountToTransfer?.toString(),
-            cheapestCostRoute: `[${cheapestCostRoute.route.adapter}] ${getNetworkName(
-              cheapestCostRoute.route.sourceChain
-            )} ${cheapestCostRoute.route.sourceToken} -> ${getNetworkName(cheapestCostRoute.route.destinationChain)} ${
-              cheapestCostRoute.route.destinationToken
-            }: ${cheapestCostRoute.cost.toString()}`,
-            rebalanceRouteCosts: rebalanceRouteCosts.map(({ route, cost }) => {
+            routePriorityTier: chosenRoute.priorityTier,
+            routeCost: `[${chosenRoute.route.adapter}] ${getNetworkName(
+              chosenRoute.route.sourceChain
+            )} ${chosenRoute.route.sourceToken} -> ${getNetworkName(chosenRoute.route.destinationChain)} ${
+              chosenRoute.route.destinationToken
+            }: ${chosenRoute.cost.toString()}`,
+            rebalanceRouteCosts: rebalanceRoutesWithCosts.map(({ route, cost, priorityTier }) => {
               return {
-                [route.adapter]: `${route.sourceToken} on ${getNetworkName(route.sourceChain)} -> ${
+                [route.adapter]: `[P${priorityTier}] ${route.sourceToken} on ${getNetworkName(route.sourceChain)} -> ${
                   route.destinationToken
                 } on ${getNetworkName(route.destinationChain)}: ${cost.toString()}`,
               };
             }),
           });
-
-          const maxFee = amountToTransferCapped.mul(maxFeePct).div(toBNWei(100));
-          if (cheapestCostRoute.cost.gt(maxFee)) {
-            this.logger.debug({
-              at: "CumulativeBalanceRebalancerClient.rebalanceInventory",
-              message: `Cheapest expected cost ${cheapestCostRoute.cost.toString()} is greater than max fee ${maxFee.toString()}, exiting`,
-            });
-            continue;
-          }
 
           const chainToL1Converter = ConvertDecimals(chainDecimals, l1TokenDecimals);
           const amountTransferredL1 = chainToL1Converter(amountToTransferCapped);
@@ -323,21 +331,21 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
           const nextSourceBalance = currentBalance.sub(amountToTransferCapped);
           this.logger.debug({
             at: "RebalanceClient.rebalanceCumulativeInventory",
-            message: `Initializing new ${cheapestCostRoute.route.adapter} ${fromWei(amountToTransferCapped, chainDecimals)} ${excessToken} rebalance from ${getNetworkName(cheapestCostRoute.route.sourceChain)} to ${getNetworkName(cheapestCostRoute.route.destinationChain)} ${deficitToken}`,
-            adapter: cheapestCostRoute.route.adapter,
-            expectedFees: fromWei(cheapestCostRoute.cost, chainDecimals),
+            message: `Initializing new ${chosenRoute.route.adapter} ${fromWei(amountToTransferCapped, chainDecimals)} ${excessToken} rebalance from ${getNetworkName(chosenRoute.route.sourceChain)} to ${getNetworkName(chosenRoute.route.destinationChain)} ${deficitToken}`,
+            adapter: chosenRoute.route.adapter,
+            expectedFees: fromWei(chosenRoute.cost, chainDecimals),
           });
 
           if (this.config.sendingTransactionsEnabled) {
-            const initializedAmount = await this.adapters[cheapestCostRoute.route.adapter].initializeRebalance(
-              cheapestCostRoute.route,
+            const initializedAmount = await this.adapters[chosenRoute.route.adapter].initializeRebalance(
+              chosenRoute.route,
               amountToTransferCapped
             );
             if (initializedAmount.eq(bnZero)) {
               this.logger.debug({
                 at: "CumulativeBalanceRebalancerClient.rebalanceInventory",
-                message: `Adapter ${cheapestCostRoute.route.adapter} declined to initialize rebalance; preserving remaining excess for later routes`,
-                route: cheapestCostRoute.route,
+                message: `Adapter ${chosenRoute.route.adapter} declined to initialize rebalance; preserving remaining excess for later routes`,
+                route: chosenRoute.route,
                 requestedAmountToTransfer: amountToTransferCapped.toString(),
               });
               continue;
@@ -348,7 +356,7 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
           // token only after the adapter successfully initializes the rebalance.
           deficitRemaining = nextDeficitRemaining;
           excessRemaining = nextExcessRemaining;
-          currentBalancesOnChain[cheapestCostRoute.route.sourceChain][excessToken] = nextSourceBalance;
+          currentBalancesOnChain[chosenRoute.route.sourceChain][excessToken] = nextSourceBalance;
         }
 
         // Overwrite the excess remaining for the token to decrement the excess for the next deficit to evaluate.

--- a/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
+++ b/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
@@ -14,7 +14,7 @@ import {
   PriceClient,
   toBNWei,
 } from "../../utils";
-import { ExcessOrDeficit, RebalanceRoute } from "../utils/interfaces";
+import { ExcessOrDeficit } from "../utils/interfaces";
 import { sortDeficitFunction, sortExcessFunction } from "../utils/utils";
 import { BaseRebalancerClient } from "./BaseRebalancerClient";
 import { getAcrossHost } from "../../clients/AcrossAPIClient";

--- a/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
+++ b/src/rebalancer/clients/CumulativeBalanceRebalancerClient.ts
@@ -282,7 +282,6 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
             });
             continue;
           }
-          const highestRankedRoute = candidateRoutes[0];
           this.logger.debug({
             at: "RebalanceClient.rebalanceCumulativeInventory",
             message: `Evaluating sending of ${amountToTransferCapped.toString()} of ${excessToken} from ${getNetworkName(
@@ -294,12 +293,6 @@ export class CumulativeBalanceRebalancerClient extends BaseRebalancerClient {
             excessRemaining: excessRemaining.toString(),
             deficitRemainingConvertedToExcessToken: deficitRemainingConverted.toString(),
             maxAmountToTransfer: maxAmountToTransfer?.toString(),
-            routePriorityTier: highestRankedRoute.priorityTier,
-            routeCost: `[${highestRankedRoute.route.adapter}] ${getNetworkName(
-              highestRankedRoute.route.sourceChain
-            )} ${highestRankedRoute.route.sourceToken} -> ${getNetworkName(
-              highestRankedRoute.route.destinationChain
-            )} ${highestRankedRoute.route.destinationToken}: ${highestRankedRoute.cost.toString()}`,
             rebalanceRouteCosts: rebalanceRoutesWithCosts.map(({ route, cost, priorityTier }) => {
               return {
                 [route.adapter]: `[P${priorityTier}] ${route.sourceToken} on ${getNetworkName(route.sourceChain)} -> ${

--- a/src/rebalancer/utils/utils.ts
+++ b/src/rebalancer/utils/utils.ts
@@ -43,12 +43,6 @@ function compareNormalizedAmounts(
   }
   return converter(normalizedAmountA).gt(normalizedAmountB) ? -1 : 1;
 }
-export function sortHigherPriorityTier(priorityTierA: number, priorityTierB: number): number {
-  return priorityTierB - priorityTierA;
-}
-function sortLowerPriorityTier(priorityTierA: number, priorityTierB: number): number {
-  return priorityTierA - priorityTierB;
-}
 // Excesses are always sorted in priority from lowest to highest and then by amount from largest to smallest.
 export function sortExcessFunction(
   excessA: ExcessOrDeficit,
@@ -57,7 +51,7 @@ export function sortExcessFunction(
 ): number {
   const { priorityTier: priorityTierA } = excessA;
   const { priorityTier: priorityTierB } = excessB;
-  const sortedPriorityTier = sortLowerPriorityTier(priorityTierA, priorityTierB);
+  const sortedPriorityTier = priorityTierA - priorityTierB;
   if (sortedPriorityTier !== 0) {
     return sortedPriorityTier;
   }
@@ -71,7 +65,7 @@ export function sortDeficitFunction(
 ): number {
   const { priorityTier: priorityTierA } = deficitA;
   const { priorityTier: priorityTierB } = deficitB;
-  const sortedPriorityTier = sortHigherPriorityTier(priorityTierA, priorityTierB);
+  const sortedPriorityTier = priorityTierB - priorityTierA;
   if (sortedPriorityTier !== 0) {
     return sortedPriorityTier;
   }

--- a/src/rebalancer/utils/utils.ts
+++ b/src/rebalancer/utils/utils.ts
@@ -43,6 +43,12 @@ function compareNormalizedAmounts(
   }
   return converter(normalizedAmountA).gt(normalizedAmountB) ? -1 : 1;
 }
+export function sortHigherPriorityTier(priorityTierA: number, priorityTierB: number): number {
+  return priorityTierB - priorityTierA;
+}
+function sortLowerPriorityTier(priorityTierA: number, priorityTierB: number): number {
+  return priorityTierA - priorityTierB;
+}
 // Excesses are always sorted in priority from lowest to highest and then by amount from largest to smallest.
 export function sortExcessFunction(
   excessA: ExcessOrDeficit,
@@ -51,8 +57,9 @@ export function sortExcessFunction(
 ): number {
   const { priorityTier: priorityTierA } = excessA;
   const { priorityTier: priorityTierB } = excessB;
-  if (priorityTierA !== priorityTierB) {
-    return priorityTierA - priorityTierB;
+  const sortedPriorityTier = sortLowerPriorityTier(priorityTierA, priorityTierB);
+  if (sortedPriorityTier !== 0) {
+    return sortedPriorityTier;
   }
   return compareNormalizedAmounts(excessA, excessB, tokenPricesUsd);
 }
@@ -64,8 +71,9 @@ export function sortDeficitFunction(
 ): number {
   const { priorityTier: priorityTierA } = deficitA;
   const { priorityTier: priorityTierB } = deficitB;
-  if (priorityTierA !== priorityTierB) {
-    return priorityTierB - priorityTierA;
+  const sortedPriorityTier = sortHigherPriorityTier(priorityTierA, priorityTierB);
+  if (sortedPriorityTier !== 0) {
+    return sortedPriorityTier;
   }
   return compareNormalizedAmounts(deficitA, deficitB, tokenPricesUsd);
 }

--- a/src/rebalancer/utils/utils.ts
+++ b/src/rebalancer/utils/utils.ts
@@ -51,9 +51,8 @@ export function sortExcessFunction(
 ): number {
   const { priorityTier: priorityTierA } = excessA;
   const { priorityTier: priorityTierB } = excessB;
-  const sortedPriorityTier = priorityTierA - priorityTierB;
-  if (sortedPriorityTier !== 0) {
-    return sortedPriorityTier;
+  if (priorityTierA !== priorityTierB) {
+    return priorityTierA - priorityTierB;
   }
   return compareNormalizedAmounts(excessA, excessB, tokenPricesUsd);
 }
@@ -65,9 +64,8 @@ export function sortDeficitFunction(
 ): number {
   const { priorityTier: priorityTierA } = deficitA;
   const { priorityTier: priorityTierB } = deficitB;
-  const sortedPriorityTier = priorityTierB - priorityTierA;
-  if (sortedPriorityTier !== 0) {
-    return sortedPriorityTier;
+  if (priorityTierA !== priorityTierB) {
+    return priorityTierB - priorityTierA;
   }
   return compareNormalizedAmounts(deficitA, deficitB, tokenPricesUsd);
 }

--- a/test/RebalancerClient.cumulativeRebalancing.ts
+++ b/test/RebalancerClient.cumulativeRebalancing.ts
@@ -539,7 +539,7 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     expect(adapter1.rebalances[1].route.sourceChain).to.equal(CHAIN_C);
   });
 
-  it("For a given excess token and source chain, rebalance route is chosen using cheapest expected cost", async function () {
+  it("For a given excess token and source chain, same-priority routes choose cheapest expected cost", async function () {
     const cumulativeBalances = {
       [USDC]: bnZero,
       [USDT]: amount(USDT, "100"),
@@ -573,6 +573,78 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     expect(adapter1.rebalances.length).to.equal(0);
     expect(adapter2.rebalances.length).to.equal(1);
     expect(adapter2.rebalances[0].route.destinationChain).to.equal(CHAIN_A);
+  });
+
+  it("For a given excess token and source chain, destination priority wins before expected cost", async function () {
+    const cumulativeBalances = {
+      [USDC]: bnZero,
+      [USDT]: amount(USDT, "100"),
+    };
+    const currentBalances = {
+      [CHAIN_A]: { [USDC]: bnZero, [USDT]: amount(USDT, "100") },
+      [CHAIN_B]: { [USDC]: bnZero },
+    };
+    const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
+      [USDC]: buildTarget(USDC, "50", "40", 0, { [CHAIN_A]: 0, [CHAIN_B]: 1 }),
+      [USDT]: buildTarget(USDT, "0", "0", 0, { [CHAIN_A]: 0 }),
+    };
+    const baseSigner = ethers.Wallet.createRandom();
+    const cheapLowPriorityAdapter = new MockRebalancerAdapter(baseSigner);
+    const expensiveHighPriorityAdapter = new MockRebalancerAdapter(baseSigner);
+    const cheapLowPriorityRoute = makeRoute(CHAIN_A, CHAIN_A, USDT, USDC, "cheapLowPriorityAdapter");
+    const expensiveHighPriorityRoute = makeRoute(CHAIN_A, CHAIN_B, USDT, USDC, "expensiveHighPriorityAdapter");
+    cheapLowPriorityAdapter.setEstimatedCost(cheapLowPriorityRoute, amount(USDT, "1"));
+    expensiveHighPriorityAdapter.setEstimatedCost(expensiveHighPriorityRoute, amount(USDT, "5"));
+    const rebalancerClient = await createClient(
+      cumulativeTargetBalances,
+      { cheapLowPriorityAdapter, expensiveHighPriorityAdapter },
+      [cheapLowPriorityRoute, expensiveHighPriorityRoute],
+      {},
+      { cheapLowPriorityAdapter: 10, expensiveHighPriorityAdapter: 10 },
+      baseSigner
+    );
+
+    await rebalancerClient.rebalanceInventory(cumulativeBalances, currentBalances, MAX_FEE_PCT);
+
+    expect(cheapLowPriorityAdapter.rebalances.length).to.equal(0);
+    expect(expensiveHighPriorityAdapter.rebalances.length).to.equal(1);
+    expect(expensiveHighPriorityAdapter.rebalances[0].route.destinationChain).to.equal(CHAIN_B);
+  });
+
+  it("For a given excess token and source chain, destination priority falls back when max fee is exceeded", async function () {
+    const cumulativeBalances = {
+      [USDC]: bnZero,
+      [USDT]: amount(USDT, "100"),
+    };
+    const currentBalances = {
+      [CHAIN_A]: { [USDC]: bnZero, [USDT]: amount(USDT, "100") },
+      [CHAIN_B]: { [USDC]: bnZero },
+    };
+    const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
+      [USDC]: buildTarget(USDC, "50", "40", 0, { [CHAIN_A]: 0, [CHAIN_B]: 1 }),
+      [USDT]: buildTarget(USDT, "0", "0", 0, { [CHAIN_A]: 0 }),
+    };
+    const baseSigner = ethers.Wallet.createRandom();
+    const cheapLowPriorityAdapter = new MockRebalancerAdapter(baseSigner);
+    const expensiveHighPriorityAdapter = new MockRebalancerAdapter(baseSigner);
+    const cheapLowPriorityRoute = makeRoute(CHAIN_A, CHAIN_A, USDT, USDC, "cheapLowPriorityAdapter");
+    const expensiveHighPriorityRoute = makeRoute(CHAIN_A, CHAIN_B, USDT, USDC, "expensiveHighPriorityAdapter");
+    cheapLowPriorityAdapter.setEstimatedCost(cheapLowPriorityRoute, amount(USDT, "1"));
+    expensiveHighPriorityAdapter.setEstimatedCost(expensiveHighPriorityRoute, amount(USDT, "6"));
+    const rebalancerClient = await createClient(
+      cumulativeTargetBalances,
+      { cheapLowPriorityAdapter, expensiveHighPriorityAdapter },
+      [cheapLowPriorityRoute, expensiveHighPriorityRoute],
+      {},
+      { cheapLowPriorityAdapter: 10, expensiveHighPriorityAdapter: 10 },
+      baseSigner
+    );
+
+    await rebalancerClient.rebalanceInventory(cumulativeBalances, currentBalances, toBNWei("10"));
+
+    expect(cheapLowPriorityAdapter.rebalances.length).to.equal(1);
+    expect(cheapLowPriorityAdapter.rebalances[0].route.destinationChain).to.equal(CHAIN_A);
+    expect(expensiveHighPriorityAdapter.rebalances.length).to.equal(0);
   });
 
   it("Sizes WETH deficits using excess-token USD value instead of raw decimals", async function () {

--- a/test/RebalancerClient.cumulativeRebalancing.ts
+++ b/test/RebalancerClient.cumulativeRebalancing.ts
@@ -575,77 +575,54 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     expect(adapter2.rebalances[0].route.destinationChain).to.equal(CHAIN_A);
   });
 
-  it("For a given excess token and source chain, destination priority wins before expected cost", async function () {
-    const cumulativeBalances = {
-      [USDC]: bnZero,
-      [USDT]: amount(USDT, "100"),
-    };
-    const currentBalances = {
-      [CHAIN_A]: { [USDC]: bnZero, [USDT]: amount(USDT, "100") },
-      [CHAIN_B]: { [USDC]: bnZero },
-    };
-    const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
-      [USDC]: buildTarget(USDC, "50", "40", 0, { [CHAIN_A]: 0, [CHAIN_B]: 1 }),
-      [USDT]: buildTarget(USDT, "0", "0", 0, { [CHAIN_A]: 0 }),
-    };
-    const baseSigner = ethers.Wallet.createRandom();
-    const cheapLowPriorityAdapter = new MockRebalancerAdapter(baseSigner);
-    const expensiveHighPriorityAdapter = new MockRebalancerAdapter(baseSigner);
-    const cheapLowPriorityRoute = makeRoute(CHAIN_A, CHAIN_A, USDT, USDC, "cheapLowPriorityAdapter");
-    const expensiveHighPriorityRoute = makeRoute(CHAIN_A, CHAIN_B, USDT, USDC, "expensiveHighPriorityAdapter");
-    cheapLowPriorityAdapter.setEstimatedCost(cheapLowPriorityRoute, amount(USDT, "1"));
-    expensiveHighPriorityAdapter.setEstimatedCost(expensiveHighPriorityRoute, amount(USDT, "5"));
-    const rebalancerClient = await createClient(
-      cumulativeTargetBalances,
-      { cheapLowPriorityAdapter, expensiveHighPriorityAdapter },
-      [cheapLowPriorityRoute, expensiveHighPriorityRoute],
-      {},
-      { cheapLowPriorityAdapter: 10, expensiveHighPriorityAdapter: 10 },
-      baseSigner
-    );
+  for (const { title, highPriorityCost, maxFeePct, expectedDestinationChain } of [
+    {
+      title: "destination priority wins before expected cost",
+      highPriorityCost: "5",
+      maxFeePct: MAX_FEE_PCT,
+      expectedDestinationChain: CHAIN_B,
+    },
+    {
+      title: "destination priority falls back when max fee is exceeded",
+      highPriorityCost: "6",
+      maxFeePct: toBNWei("10"),
+      expectedDestinationChain: CHAIN_A,
+    },
+  ]) {
+    it(`For a given excess token and source chain, ${title}`, async function () {
+      const cumulativeBalances = {
+        [USDC]: bnZero,
+        [USDT]: amount(USDT, "100"),
+      };
+      const currentBalances = {
+        [CHAIN_A]: { [USDC]: bnZero, [USDT]: amount(USDT, "100") },
+        [CHAIN_B]: { [USDC]: bnZero },
+      };
+      const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
+        [USDC]: buildTarget(USDC, "50", "40", 0, { [CHAIN_A]: 0, [CHAIN_B]: 1 }),
+        [USDT]: buildTarget(USDT, "0", "0", 0, { [CHAIN_A]: 0 }),
+      };
+      const baseSigner = ethers.Wallet.createRandom();
+      const adapter1 = new MockRebalancerAdapter(baseSigner);
+      const lowPriorityRoute = makeRoute(CHAIN_A, CHAIN_A, USDT, USDC, "adapter1");
+      const highPriorityRoute = makeRoute(CHAIN_A, CHAIN_B, USDT, USDC, "adapter1");
+      adapter1.setEstimatedCost(lowPriorityRoute, amount(USDT, "1"));
+      adapter1.setEstimatedCost(highPriorityRoute, amount(USDT, highPriorityCost));
+      const rebalancerClient = await createClient(
+        cumulativeTargetBalances,
+        { adapter1 },
+        [lowPriorityRoute, highPriorityRoute],
+        {},
+        { adapter1: 10 },
+        baseSigner
+      );
 
-    await rebalancerClient.rebalanceInventory(cumulativeBalances, currentBalances, MAX_FEE_PCT);
+      await rebalancerClient.rebalanceInventory(cumulativeBalances, currentBalances, maxFeePct);
 
-    expect(cheapLowPriorityAdapter.rebalances.length).to.equal(0);
-    expect(expensiveHighPriorityAdapter.rebalances.length).to.equal(1);
-    expect(expensiveHighPriorityAdapter.rebalances[0].route.destinationChain).to.equal(CHAIN_B);
-  });
-
-  it("For a given excess token and source chain, destination priority falls back when max fee is exceeded", async function () {
-    const cumulativeBalances = {
-      [USDC]: bnZero,
-      [USDT]: amount(USDT, "100"),
-    };
-    const currentBalances = {
-      [CHAIN_A]: { [USDC]: bnZero, [USDT]: amount(USDT, "100") },
-      [CHAIN_B]: { [USDC]: bnZero },
-    };
-    const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
-      [USDC]: buildTarget(USDC, "50", "40", 0, { [CHAIN_A]: 0, [CHAIN_B]: 1 }),
-      [USDT]: buildTarget(USDT, "0", "0", 0, { [CHAIN_A]: 0 }),
-    };
-    const baseSigner = ethers.Wallet.createRandom();
-    const cheapLowPriorityAdapter = new MockRebalancerAdapter(baseSigner);
-    const expensiveHighPriorityAdapter = new MockRebalancerAdapter(baseSigner);
-    const cheapLowPriorityRoute = makeRoute(CHAIN_A, CHAIN_A, USDT, USDC, "cheapLowPriorityAdapter");
-    const expensiveHighPriorityRoute = makeRoute(CHAIN_A, CHAIN_B, USDT, USDC, "expensiveHighPriorityAdapter");
-    cheapLowPriorityAdapter.setEstimatedCost(cheapLowPriorityRoute, amount(USDT, "1"));
-    expensiveHighPriorityAdapter.setEstimatedCost(expensiveHighPriorityRoute, amount(USDT, "6"));
-    const rebalancerClient = await createClient(
-      cumulativeTargetBalances,
-      { cheapLowPriorityAdapter, expensiveHighPriorityAdapter },
-      [cheapLowPriorityRoute, expensiveHighPriorityRoute],
-      {},
-      { cheapLowPriorityAdapter: 10, expensiveHighPriorityAdapter: 10 },
-      baseSigner
-    );
-
-    await rebalancerClient.rebalanceInventory(cumulativeBalances, currentBalances, toBNWei("10"));
-
-    expect(cheapLowPriorityAdapter.rebalances.length).to.equal(1);
-    expect(cheapLowPriorityAdapter.rebalances[0].route.destinationChain).to.equal(CHAIN_A);
-    expect(expensiveHighPriorityAdapter.rebalances.length).to.equal(0);
-  });
+      expect(adapter1.rebalances.length).to.equal(1);
+      expect(adapter1.rebalances[0].route.destinationChain).to.equal(expectedDestinationChain);
+    });
+  }
 
   it("Sizes WETH deficits using excess-token USD value instead of raw decimals", async function () {
     const restorePrices = withFixedTokenPrices({

--- a/test/RebalancerClient.cumulativeRebalancing.ts
+++ b/test/RebalancerClient.cumulativeRebalancing.ts
@@ -575,7 +575,7 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     expect(adapter2.rebalances[0].route.destinationChain).to.equal(CHAIN_A);
   });
 
-  for (const { title, highPriorityCost, maxFeePct, expectedDestinationChain } of [
+  for (const { title, highPriorityCost, maxFeePct, expectedDestinationChain, declineHighPriorityRoute } of [
     {
       title: "destination priority wins before expected cost",
       highPriorityCost: "5",
@@ -587,6 +587,13 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
       highPriorityCost: "6",
       maxFeePct: toBNWei("10"),
       expectedDestinationChain: CHAIN_A,
+    },
+    {
+      title: "destination priority falls back when the preferred route declines",
+      highPriorityCost: "5",
+      maxFeePct: MAX_FEE_PCT,
+      expectedDestinationChain: CHAIN_A,
+      declineHighPriorityRoute: true,
     },
   ]) {
     it(`For a given excess token and source chain, ${title}`, async function () {
@@ -608,6 +615,9 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
       const highPriorityRoute = makeRoute(CHAIN_A, CHAIN_B, USDT, USDC, "adapter1");
       adapter1.setEstimatedCost(lowPriorityRoute, amount(USDT, "1"));
       adapter1.setEstimatedCost(highPriorityRoute, amount(USDT, highPriorityCost));
+      if (declineHighPriorityRoute) {
+        adapter1.setInitializeRebalanceResult(highPriorityRoute, bnZero);
+      }
       const rebalancerClient = await createClient(
         cumulativeTargetBalances,
         { adapter1 },


### PR DESCRIPTION
## Summary
- prefer higher-priority destination chains when selecting cumulative rebalance routes
- fall back to lower-priority routes when preferred routes exceed max fee
- update rebalancer docs and route-selection tests

## Validation
- yarn test test/RebalancerClient.cumulativeRebalancing.ts test/RebalancerClient.utils.ts
- git diff --check