### PR TITLE
fix(finalizer): protect pending swap orders' source balance from Binance finalizer withdrawals

### DIFF
--- a/src/finalizer/utils/binance.ts
+++ b/src/finalizer/utils/binance.ts
@@ -306,9 +306,25 @@ async function getPendingBinanceRebalanceDeductions(
 ): Promise<Record<string, number>> {
   const binanceAdapter = await constructAdapter(logger, hubSigner, "binance");
   const lookupAccounts = getEvmBinanceRebalanceLookupAccounts(recipientAddresses, await hubSigner.getAddress());
-  const pendingRebalances = (
-    await Promise.all(lookupAccounts.map((account) => binanceAdapter.getPendingRebalances(account)))
-  ).reduce<{
+  const [pendingRebalances, pendingDepositSourceAmounts] = await Promise.all([
+    mapAsync(lookupAccounts, (account) => binanceAdapter.getPendingRebalances(account)),
+    mapAsync(lookupAccounts, (account) => binanceAdapter.getPendingDepositSourceAmounts(account)),
+  ]);
+  // Destination-side credits and source-side deposit amounts are netted separately before being summed:
+  // getPendingRebalances() carries negative on-chain adjustments (e.g. intermediate bridge legs) that must not
+  // cancel the exchange-balance protection for orders whose source-token deposit is credited but not yet consumed.
+  // Without the source-side deduction, the finalizer can withdraw a pending order's just-credited input funds to
+  // service unrelated finalization backlog, starving the order until its TTL prunes it.
+  return sumBinanceCoinAmounts(
+    getPositivePendingRebalanceAmountsByBinanceCoin(combineChainTokenAmounts(pendingRebalances)),
+    getPositivePendingRebalanceAmountsByBinanceCoin(combineChainTokenAmounts(pendingDepositSourceAmounts))
+  );
+}
+
+function combineChainTokenAmounts(amountsList: { [chainId: number]: { [token: string]: BigNumber } }[]): {
+  [chainId: number]: { [token: string]: BigNumber };
+} {
+  return amountsList.reduce<{
     [chainId: number]: { [token: string]: BigNumber };
   }>((acc, pending) => {
     for (const [_chainId, tokenBalances] of Object.entries(pending)) {
@@ -320,7 +336,16 @@ async function getPendingBinanceRebalanceDeductions(
     }
     return acc;
   }, {});
-  return getPositivePendingRebalanceAmountsByBinanceCoin(pendingRebalances);
+}
+
+export function sumBinanceCoinAmounts(...amountsByCoin: Record<string, number>[]): Record<string, number> {
+  const totals: Record<string, number> = {};
+  for (const amounts of amountsByCoin) {
+    for (const [coin, amount] of Object.entries(amounts)) {
+      totals[coin] = (totals[coin] ?? 0) + amount;
+    }
+  }
+  return totals;
 }
 
 export function getEvmBinanceRebalanceLookupAccounts(addresses: string[], signerAddress?: string): EvmAddress[] {

--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -279,8 +279,12 @@ Running the Rebalancer allows the relayer to support in-protocol swap flows whil
 
 The Binance finalizer sweeps exchange balances as a fallback path. Before withdrawing, it constructs a read-only Binance
 adapter, reads pending Binance rebalances with `getPendingRebalances(account)`, and subtracts positive destination-token
-amounts from the shared exchange-account withdrawal capacity. The Binance adapter marks expected swap lifecycle
-transfers, and stale balances are eventually swept if swaps do not complete.
+amounts from the shared exchange-account withdrawal capacity. It also reads `getPendingDepositSourceAmounts(account)`
+and subtracts the source-token amounts of orders still in `PENDING_DEPOSIT`, so a just-credited swap deposit cannot be
+withdrawn to service unrelated finalization backlog before the order places its spot order (which would starve the
+order until its TTL prunes it). The two deduction maps are netted to positive amounts independently before being
+summed, so negative destination-side adjustments never cancel source-side protection. The Binance adapter marks
+expected swap lifecycle transfers, and stale balances are eventually swept if swaps do not complete.
 
 When Binance reports `RW00441`, the account has recently credited deposit value that is not withdrawal-unlocked yet.
 The Binance adapter treats this as a retryable wait state and leaves the order pending. The Binance finalizer reads

--- a/src/rebalancer/adapters/baseAdapter.ts
+++ b/src/rebalancer/adapters/baseAdapter.ts
@@ -140,6 +140,34 @@ export abstract class BaseAdapter implements RebalancerAdapter {
     );
   }
 
+  /**
+   * @notice Source-token amounts for orders in PENDING_DEPOSIT status, keyed by source chain and token
+   * (`amountToTransfer` is denominated in source-chain token decimals). These funds have been sent to — and may
+   * already be credited on — the venue, but the order still needs them available to progress (e.g. to place its
+   * spot order). Balance-based sweepers such as the Binance finalizer must deduct these amounts from any
+   * withdrawable-balance calculation; otherwise they can drain a pending order's input funds and starve the order
+   * until its REBALANCER_PENDING_ORDER_TTL prunes it.
+   */
+  async getPendingDepositSourceAmounts(
+    account: EvmAddress
+  ): Promise<{ [chainId: number]: { [token: string]: BigNumber } }> {
+    const pendingSourceAmounts: { [chainId: number]: { [token: string]: BigNumber } } = {};
+    const pendingDeposits = await this._redisGetPendingDeposits(account);
+    for (const cloid of pendingDeposits) {
+      // Tolerate a details key that expired between the status-set listing and this lookup.
+      const orderDetails = await this._redisGetOrderDetails(cloid, account);
+      if (!isDefined(orderDetails)) {
+        continue;
+      }
+      const { sourceChain, sourceToken, amountToTransfer } = orderDetails;
+      pendingSourceAmounts[sourceChain] ??= {};
+      pendingSourceAmounts[sourceChain][sourceToken] = (pendingSourceAmounts[sourceChain][sourceToken] ?? bnZero).add(
+        amountToTransfer
+      );
+    }
+    return pendingSourceAmounts;
+  }
+
   // ////////////////////////////////////////////////////////////
   // ABSTRACT PUBLIC METHODS
   // ////////////////////////////////////////////////////////////

--- a/src/rebalancer/utils/interfaces.ts
+++ b/src/rebalancer/utils/interfaces.ts
@@ -13,6 +13,12 @@ export interface RebalancerAdapter {
   // Get all currently unfinalized rebalance amounts. Should be used to add a virtual balance credit for the chain
   // + token in question.
   getPendingRebalances(account: EvmAddress): Promise<{ [chainId: number]: { [token: string]: BigNumber } }>;
+
+  // Get the source-token amounts of orders in PENDING_DEPOSIT status, keyed by source chain and token
+  // (denominated in source-chain token decimals). These funds are in flight to — or already credited on — the
+  // venue and must remain available for the order to progress, so balance-based sweepers (e.g. the Binance
+  // finalizer) should deduct them from any withdrawable-balance calculation.
+  getPendingDepositSourceAmounts(account: EvmAddress): Promise<{ [chainId: number]: { [token: string]: BigNumber } }>;
   getPendingOrders(): Promise<string[]>;
   getEstimatedCost(rebalanceRoute: RebalanceRoute, amountToTransfer: BigNumber, debugLog: boolean): Promise<BigNumber>;
 }

--- a/test/BinanceFinalizer.ts
+++ b/test/BinanceFinalizer.ts
@@ -3,6 +3,7 @@ import {
   getEvmBinanceRebalanceLookupAccounts,
   getPositivePendingRebalanceAmountsByBinanceCoin,
   getSweepableOrphanBinanceBalance,
+  sumBinanceCoinAmounts,
 } from "../src/finalizer/utils/binance";
 import { bnZero, CHAIN_IDs, EvmAddress, toBNWei } from "../src/utils";
 
@@ -55,6 +56,30 @@ describe("Binance finalizer helpers", function () {
     });
 
     expect(deductions).to.deep.equal({ USDT: 75 });
+  });
+
+  it("sums destination-side and pending-deposit source-side deductions by Binance coin", function () {
+    const merged = sumBinanceCoinAmounts({ USDC: 100 }, { USDT: 75, USDC: 25 });
+
+    expect(merged).to.deep.equal({ USDC: 125, USDT: 75 });
+  });
+
+  it("keeps pending-deposit source deductions when destination-side adjustments net negative for the same coin", function () {
+    // A pending USDT -> USDC swap order in PENDING_DEPOSIT protects its USDT input via the source-side map. A
+    // negative destination-side adjustment for the same coin (e.g. an intermediate bridge leg of another order)
+    // must not cancel that protection, so each map is netted to positive amounts before the two are summed.
+    const destinationSide = getPositivePendingRebalanceAmountsByBinanceCoin({
+      [CHAIN_IDs.ARBITRUM]: {
+        USDT: bnZero.sub(toBNWei("50", 6)),
+      },
+    });
+    const sourceSide = getPositivePendingRebalanceAmountsByBinanceCoin({
+      [CHAIN_IDs.BSC]: {
+        USDT: toBNWei("75", 18),
+      },
+    });
+
+    expect(sumBinanceCoinAmounts(destinationSide, sourceSide)).to.deep.equal({ USDT: 75 });
   });
 
   it("subtracts credited, swap, and pending rebalance amounts from orphan sweep candidates", function () {

--- a/test/RebalancerClient.cumulativeRebalancing.ts
+++ b/test/RebalancerClient.cumulativeRebalancing.ts
@@ -867,6 +867,10 @@ class MockRebalancerAdapter implements RebalancerAdapter {
     return Promise.resolve(this.pendingRebalances);
   }
 
+  getPendingDepositSourceAmounts(): Promise<{ [chainId: number]: { [token: string]: BigNumber } }> {
+    return Promise.resolve({});
+  }
+
   getPendingOrders(): Promise<string[]> {
     return Promise.resolve(this.pendingOrders ?? this.rebalances.map((x, i) => i.toString()));
   }


### PR DESCRIPTION
## Problem

The Binance finalizer deducts pending rebalance orders' **destination-token** amounts (`getPendingRebalances`) from the shared exchange account's withdrawable balance, but nothing protects the **source-token** side of an order in `PENDING_DEPOSIT`. When a swap order's deposit is credited while the finalizer has withdrawal backlog in the same coin, the finalizer withdraws the just-credited funds to service that backlog. The order then fails its balance check every cycle ("Available balance for input token ... is less than amount to transfer"), never places its spot order, and starves until `REBALANCER_PENDING_ORDER_TTL` (default 1h) elapses and `BaseAdapter._redisCleanupPendingOrders` prunes it.

Observed 7 times over 2026-07-01 → 2026-07-08 on USDT→USDC (HyperEVM) swap-rebalancer orders. Fully traced example (2026-07-08, cloid `0xe42d273cb1ce29c53aad23e9241606cd`):

- 04:56:09 — 82,385.72 USDT-BNB transferred to the Binance deposit address ([tx](https://bscscan.com/tx/0x2a845bbb98e1347aa594e8fdde705d74d42d4ae22ed9884fdfe1d014603a60ff)), order created in `pending-deposit`
- ~04:58 — Binance credits the deposit
- 04:59:27 — finalizer withdraws exactly 82,385.724629 USDT back to BSC against a pre-existing 158k `amountToFinalize` backlog (`pendingRebalanceDeduction` was 0 for USDT — only the destination-side USDC was protected)
- 05:56:12 — order pruned without finalization

## Change

- Add `RebalancerAdapter.getPendingDepositSourceAmounts(account)` — source-token amounts of orders in `PENDING_DEPOSIT`, keyed by source chain/token — implemented generically in `BaseAdapter` from the existing Redis status set (all adapters extend `BaseAdapter`).
- `getPendingBinanceRebalanceDeductions` now also deducts these source-token amounts. The source- and destination-side maps are netted to positive per-coin amounts **independently** before being summed, so negative on-chain adjustments in `getPendingRebalances` (e.g. intermediate bridge legs) cannot cancel the source-side protection.
- Docs: updated the Binance Finalizer section of `src/rebalancer/README.md`.

The deduction is deliberately conservative: for same-coin (no-swap) routes the order is briefly protected on both source and destination sides while in `PENDING_DEPOSIT`; over-deduction only delays finalizer sweeps, which self-resolves when the order progresses or is pruned.

## Not in scope (follow-up)

The prune events also revealed a second issue: the 30-minute `SWAP` deposit tag expires while the finalizer's deposit-history lookback is much longer, so *every* swap deposit — including successfully swapped ones — is later re-counted into the finalizer's `amountToFinalize` ledger (this is where the 158k/248k backlog that consumed the traced order's deposit came from). That accounting fix is intentionally left to a separate PR.

## Testing

- `yarn tsc --noEmit` clean
- `hardhat test test/BinanceFinalizer.ts` — 9 passing (2 new)
- `hardhat test test/RebalancerClient.cumulativeRebalancing.ts` — 19 passing
- eslint + prettier clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)