### PR TITLE
feat: Create SameAssetRebalancer

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,10 @@ import { runFinalizer } from "./src/finalizer";
 import { version } from "./package.json";
 import { runRefiller } from "./src/refiller";
 import { runHyperliquidExecutor, runHyperliquidFinalizer } from "./src/hyperliquid";
-import { runCumulativeBalanceRebalancer as swapRebalancer } from "./src/rebalancer";
+import {
+  runCumulativeBalanceRebalancer as swapRebalancer,
+  runSameAssetRebalancer as sameAssetRebalancer,
+} from "./src/rebalancer";
 import { runGaslessRelayer } from "./src/gasless";
 import { runDepositAddressHandler } from "./src/deposit-address";
 
@@ -38,6 +41,7 @@ const CMDS = {
   hlFinalizer: runHyperliquidFinalizer,
   inventoryManager: runInventoryManager,
   swapRebalancer: swapRebalancer,
+  sameAssetRebalancer: sameAssetRebalancer,
   gaslessRelayer: runGaslessRelayer,
   depositAddressHandler: runDepositAddressHandler,
 };

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "run-hlFinalizer": "node ./dist/index.js --hlFinalizer",
     "run-inventoryManager": "node ./dist/index.js --inventoryManager",
     "run-inventoryManager-swapper": "node ./dist/index.js --swapRebalancer",
+    "run-inventoryManager-sameAsset": "node ./dist/index.js --sameAssetRebalancer",
     "run-gaslessRelayer": "node ./dist/index.js --gaslessRelayer",
     "run-depositAddressHandler": "node ./dist/index.js --depositAddressHandler",
     "relay": "node ./dist/index.js --relayer",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "node": ">=22.18.0"
   },
   "dependencies": {
-    "@across-protocol/constants": "^3.1.119",
+    "@across-protocol/constants": "^3.1.122",
     "@across-protocol/contracts": "5.0.22",
-    "@across-protocol/sdk": "4.4.8",
+    "@across-protocol/sdk": "4.4.9",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -1330,7 +1330,7 @@ export class InventoryClient {
             this.hubPoolClient.chainId
           );
           if (!adapter.isSupportedL2Bridge(l2BridgeLookupToken)) {
-            this.logger.warn({
+            this.logger.debug({
               at: "InventoryClient#withdrawExcessBalances",
               message: `No L2 bridge configured for ${getNetworkName(chainId)} for token ${l2BridgeLookupToken}`,
             });

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -55,6 +55,7 @@ import { RebalancerClient } from "../rebalancer/utils/interfaces";
 
 type TokenDistribution = { [l2Token: string]: BigNumber };
 type TokenDistributionPerL1Token = { [l1Token: string]: { [chainId: number]: TokenDistribution } };
+type L2Withdrawal = { l2Token: Address; amountToWithdraw: BigNumber };
 
 export type Rebalance = {
   chainId: number;
@@ -940,12 +941,12 @@ export class InventoryClient {
 
   // Trigger a rebalance if the current balance on any L2 chain, including shortfalls, is less than the threshold
   // allocation.
-  async rebalanceInventoryIfNeeded(): Promise<void> {
+  async rebalanceInventoryIfNeeded(returnRebalancesOnly = false): Promise<Rebalance[]> {
     // Note: these types are just used inside this method, so they are declared in-line.
     type ExecutedRebalance = Rebalance & { hash: string };
 
     if (!this.isInventoryManagementEnabled()) {
-      return;
+      return [];
     }
 
     const tokenDistributionPerL1Token = this.getTokenDistributionPerL1Token();
@@ -954,7 +955,7 @@ export class InventoryClient {
     const rebalancesRequired = this.getPossibleRebalances();
     if (rebalancesRequired.length === 0) {
       this.log("No rebalances required");
-      return;
+      return [];
     }
 
     const possibleRebalances: Rebalance[] = [];
@@ -1014,6 +1015,10 @@ export class InventoryClient {
       rebalancesRequired,
       possibleRebalances,
     });
+
+    if (returnRebalancesOnly) {
+      return possibleRebalances;
+    }
 
     // Finally, execute the rebalances.
     // TODO: The logic below is slow as it waits for each transaction to be included before sending the next one. This
@@ -1135,6 +1140,7 @@ export class InventoryClient {
     if (mrkdwn) {
       this.log("Executed Inventory rebalances 📒", { mrkdwn }, "info");
     }
+    return executedTransactions;
   }
 
   async unwrapWeth(): Promise<void> {
@@ -1271,13 +1277,14 @@ export class InventoryClient {
     }
   }
 
-  async withdrawExcessBalances(): Promise<void> {
+  async withdrawExcessBalances(returnWithdrawasOnly = false): Promise<{
+    [chainId: number]: L2Withdrawal[];
+  }> {
     if (!this.isInventoryManagementEnabled()) {
-      return;
+      return {};
     }
 
     const chainIds = this.getEnabledL2Chains();
-    type L2Withdrawal = { l2Token: Address; amountToWithdraw: BigNumber };
     const withdrawalsRequired: { [chainId: number]: L2Withdrawal[] } = {};
     const chainMrkdwns: { [chainId: number]: string } = {};
 
@@ -1439,11 +1446,15 @@ export class InventoryClient {
 
     if (Object.keys(withdrawalsRequired).length === 0) {
       this.log("No excess balances to withdraw");
-      return;
+      return {};
     } else {
       this.log("Excess balances to withdraw", {
         withdrawalsRequired,
       });
+    }
+
+    if (returnWithdrawasOnly) {
+      return withdrawalsRequired;
     }
 
     // Now, go through each chain and submit transactions. We cannot batch them unfortunately since the bridges
@@ -1482,6 +1493,7 @@ export class InventoryClient {
       });
       this.log("Executed excess L2 inventory withdrawal 📒", { mrkdwn: chainMrkdwns[Number(chainId)] }, "info");
     });
+    return withdrawalsRequired;
   }
 
   constructConsideringRebalanceDebugLog(distribution: TokenDistributionPerL1Token): void {

--- a/src/rebalancer/RebalancerClientHelper.ts
+++ b/src/rebalancer/RebalancerClientHelper.ts
@@ -9,17 +9,17 @@ import { ReadOnlyRebalancerClient } from "./clients/ReadOnlyRebalancerClient";
 import { RebalancerConfig } from "./RebalancerConfig";
 import { buildRebalanceRoutes } from "./buildRebalanceRoutes";
 import { RebalancerAdapter, RebalanceRoute } from "./utils/interfaces";
+import { SameAssetRebalancerClient } from "./clients/SameAssetRebalancerClient";
+import { buildSameAssetRebalanceRoutes } from "./buildSameAssetRebalanceRoutes";
 
 export type AdapterName = "cctp" | "oft" | "hyperliquid" | "binance";
 
 function constructRebalancerDependencies(
   logger: winston.Logger,
-  baseSigner: Signer,
-  rebalanceRoutesOverride?: RebalanceRoute[]
+  baseSigner: Signer
 ): {
   rebalancerConfig: RebalancerConfig;
   adapters: Partial<{ [name in AdapterName]: RebalancerAdapter }>;
-  rebalanceRoutes: RebalanceRoute[];
 } {
   const rebalancerConfig = new RebalancerConfig(process.env);
 
@@ -41,14 +41,13 @@ function constructRebalancerDependencies(
     oftAdapter
   );
   const adapterMap = { hyperliquid: hyperliquidAdapter, binance: binanceAdapter, cctp: cctpAdapter, oft: oftAdapter };
-  const rebalanceRoutes = rebalanceRoutesOverride ?? buildRebalanceRoutes(rebalancerConfig);
 
   // @todo: Add test-net support for this client. For now, we only support production and we do not construct
   // any adapters or routes when running on test net.
   const adaptersToUpdate: Partial<{ [name in AdapterName]: RebalancerAdapter }> =
     rebalancerConfig.hubPoolChainId === CHAIN_IDs.MAINNET ? adapterMap : {};
 
-  return { rebalancerConfig, adapters: adaptersToUpdate, rebalanceRoutes };
+  return { rebalancerConfig, adapters: adaptersToUpdate };
 }
 
 export async function constructCumulativeBalanceRebalancerClient(
@@ -56,11 +55,8 @@ export async function constructCumulativeBalanceRebalancerClient(
   baseSigner: Signer,
   rebalanceRoutesOverride?: RebalanceRoute[]
 ): Promise<CumulativeBalanceRebalancerClient> {
-  const { rebalancerConfig, adapters, rebalanceRoutes } = constructRebalancerDependencies(
-    logger,
-    baseSigner,
-    rebalanceRoutesOverride
-  );
+  const { rebalancerConfig, adapters } = constructRebalancerDependencies(logger, baseSigner);
+  const rebalanceRoutes = rebalanceRoutesOverride ?? buildRebalanceRoutes(rebalancerConfig);
   const isReadonly = false;
   const rebalancerClient = new CumulativeBalanceRebalancerClient(
     logger,
@@ -83,6 +79,35 @@ export async function constructCumulativeBalanceRebalancerClient(
   logger.debug({
     at: "RebalancerClientHelper.constructCumulativeBalanceRebalancerClient",
     message: "CumulativeBalanceRebalancerClient initialized",
+    rebalancerConfig,
+    adapterNames: Object.keys(adapters),
+  });
+  return rebalancerClient;
+}
+
+export async function constructSameAssetRebalancerClient(
+  logger: winston.Logger,
+  baseSigner: Signer,
+  rebalanceRoutesOverride?: RebalanceRoute[]
+): Promise<SameAssetRebalancerClient> {
+  const { rebalancerConfig, adapters } = constructRebalancerDependencies(logger, baseSigner);
+  const rebalanceRoutes = rebalanceRoutesOverride ?? buildSameAssetRebalanceRoutes(rebalancerConfig);
+  const isReadonly = false;
+  const rebalancerClient = new SameAssetRebalancerClient(logger, rebalancerConfig, adapters, baseSigner, isReadonly);
+  // Initialize the CCTP and OFT Adapters first before initializing the Binance and HL adapters which use the former
+  // adapters. Only initialize them if they are present in the adapters map.
+  const adapterInitPromises: Promise<void>[] = [];
+  if (adapters["cctp"]) {
+    adapterInitPromises.push(adapters["cctp"].initialize(rebalanceRoutes));
+  }
+  if (adapters["oft"]) {
+    adapterInitPromises.push(adapters["oft"].initialize(rebalanceRoutes));
+  }
+  await Promise.all(adapterInitPromises);
+  await rebalancerClient.initialize(rebalanceRoutes);
+  logger.debug({
+    at: "RebalancerClientHelper.constructSameAssetRebalancerClient",
+    message: "SameAssetRebalancerClient initialized",
     rebalancerConfig,
     adapterNames: Object.keys(adapters),
   });

--- a/src/rebalancer/RebalancerClientHelper.ts
+++ b/src/rebalancer/RebalancerClientHelper.ts
@@ -3,6 +3,7 @@ import { BinanceStablecoinSwapAdapter } from "./adapters/binance";
 import { CctpAdapter } from "./adapters/cctpAdapter";
 import { HyperliquidStablecoinSwapAdapter } from "./adapters/hyperliquid";
 import { OftAdapter } from "./adapters/oftAdapter";
+import { BaseRebalancerClient } from "./clients/BaseRebalancerClient";
 import { CumulativeBalanceRebalancerClient } from "./clients/CumulativeBalanceRebalancerClient";
 import { ReadOnlyRebalancerClient } from "./clients/ReadOnlyRebalancerClient";
 
@@ -13,13 +14,21 @@ import { SameAssetRebalancerClient } from "./clients/SameAssetRebalancerClient";
 import { buildSameAssetRebalanceRoutes } from "./buildSameAssetRebalanceRoutes";
 
 export type AdapterName = "cctp" | "oft" | "hyperliquid" | "binance";
+type AdapterMap = { [name: string]: RebalancerAdapter };
+type RebalancerClientConstructor<T extends BaseRebalancerClient> = new (
+  logger: winston.Logger,
+  rebalancerConfig: RebalancerConfig,
+  adapters: AdapterMap,
+  baseSigner: Signer,
+  isReadonly: boolean
+) => T;
 
 function constructRebalancerDependencies(
   logger: winston.Logger,
   baseSigner: Signer
 ): {
   rebalancerConfig: RebalancerConfig;
-  adapters: Partial<{ [name in AdapterName]: RebalancerAdapter }>;
+  adapters: AdapterMap;
 } {
   const rebalancerConfig = new RebalancerConfig(process.env);
 
@@ -44,10 +53,37 @@ function constructRebalancerDependencies(
 
   // @todo: Add test-net support for this client. For now, we only support production and we do not construct
   // any adapters or routes when running on test net.
-  const adaptersToUpdate: Partial<{ [name in AdapterName]: RebalancerAdapter }> =
-    rebalancerConfig.hubPoolChainId === CHAIN_IDs.MAINNET ? adapterMap : {};
+  const adaptersToUpdate: AdapterMap = rebalancerConfig.hubPoolChainId === CHAIN_IDs.MAINNET ? adapterMap : {};
 
   return { rebalancerConfig, adapters: adaptersToUpdate };
+}
+
+async function constructInitializedRebalancerClient<T extends BaseRebalancerClient>(
+  logger: winston.Logger,
+  baseSigner: Signer,
+  Client: RebalancerClientConstructor<T>,
+  getRebalanceRoutes: (rebalancerConfig: RebalancerConfig) => RebalanceRoute[],
+  isReadonly: boolean,
+  logLabel: string,
+  message: string
+): Promise<T> {
+  const { rebalancerConfig, adapters } = constructRebalancerDependencies(logger, baseSigner);
+  const rebalanceRoutes = getRebalanceRoutes(rebalancerConfig);
+  const rebalancerClient = new Client(logger, rebalancerConfig, adapters, baseSigner, isReadonly);
+
+  await Promise.all(
+    ["cctp", "oft"].flatMap((adapterName) =>
+      adapters[adapterName] ? [adapters[adapterName].initialize(rebalanceRoutes)] : []
+    )
+  );
+  await rebalancerClient.initialize(rebalanceRoutes);
+  logger.debug({
+    at: `RebalancerClientHelper.${logLabel}`,
+    message,
+    rebalancerConfig,
+    adapterNames: Object.keys(adapters),
+  });
+  return rebalancerClient;
 }
 
 export async function constructCumulativeBalanceRebalancerClient(
@@ -55,34 +91,15 @@ export async function constructCumulativeBalanceRebalancerClient(
   baseSigner: Signer,
   rebalanceRoutesOverride?: RebalanceRoute[]
 ): Promise<CumulativeBalanceRebalancerClient> {
-  const { rebalancerConfig, adapters } = constructRebalancerDependencies(logger, baseSigner);
-  const rebalanceRoutes = rebalanceRoutesOverride ?? buildRebalanceRoutes(rebalancerConfig);
-  const isReadonly = false;
-  const rebalancerClient = new CumulativeBalanceRebalancerClient(
+  return constructInitializedRebalancerClient(
     logger,
-    rebalancerConfig,
-    adapters,
     baseSigner,
-    isReadonly
+    CumulativeBalanceRebalancerClient,
+    (rebalancerConfig) => rebalanceRoutesOverride ?? buildRebalanceRoutes(rebalancerConfig),
+    false,
+    "constructCumulativeBalanceRebalancerClient",
+    "CumulativeBalanceRebalancerClient initialized"
   );
-  // Initialize the CCTP and OFT Adapters first before initializing the Binance and HL adapters which use the former
-  // adapters. Only initialize them if they are present in the adapters map.
-  const adapterInitPromises: Promise<void>[] = [];
-  if (adapters["cctp"]) {
-    adapterInitPromises.push(adapters["cctp"].initialize(rebalanceRoutes));
-  }
-  if (adapters["oft"]) {
-    adapterInitPromises.push(adapters["oft"].initialize(rebalanceRoutes));
-  }
-  await Promise.all(adapterInitPromises);
-  await rebalancerClient.initialize(rebalanceRoutes);
-  logger.debug({
-    at: "RebalancerClientHelper.constructCumulativeBalanceRebalancerClient",
-    message: "CumulativeBalanceRebalancerClient initialized",
-    rebalancerConfig,
-    adapterNames: Object.keys(adapters),
-  });
-  return rebalancerClient;
 }
 
 export async function constructSameAssetRebalancerClient(
@@ -90,55 +107,30 @@ export async function constructSameAssetRebalancerClient(
   baseSigner: Signer,
   rebalanceRoutesOverride?: RebalanceRoute[]
 ): Promise<SameAssetRebalancerClient> {
-  const { rebalancerConfig, adapters } = constructRebalancerDependencies(logger, baseSigner);
-  const rebalanceRoutes = rebalanceRoutesOverride ?? buildSameAssetRebalanceRoutes(rebalancerConfig);
-  const isReadonly = false;
-  const rebalancerClient = new SameAssetRebalancerClient(logger, rebalancerConfig, adapters, baseSigner, isReadonly);
-  // Initialize the CCTP and OFT Adapters first before initializing the Binance and HL adapters which use the former
-  // adapters. Only initialize them if they are present in the adapters map.
-  const adapterInitPromises: Promise<void>[] = [];
-  if (adapters["cctp"]) {
-    adapterInitPromises.push(adapters["cctp"].initialize(rebalanceRoutes));
-  }
-  if (adapters["oft"]) {
-    adapterInitPromises.push(adapters["oft"].initialize(rebalanceRoutes));
-  }
-  await Promise.all(adapterInitPromises);
-  await rebalancerClient.initialize(rebalanceRoutes);
-  logger.debug({
-    at: "RebalancerClientHelper.constructSameAssetRebalancerClient",
-    message: "SameAssetRebalancerClient initialized",
-    rebalancerConfig,
-    adapterNames: Object.keys(adapters),
-  });
-  return rebalancerClient;
+  return constructInitializedRebalancerClient(
+    logger,
+    baseSigner,
+    SameAssetRebalancerClient,
+    (rebalancerConfig) => rebalanceRoutesOverride ?? buildSameAssetRebalanceRoutes(rebalancerConfig),
+    false,
+    "constructSameAssetRebalancerClient",
+    "SameAssetRebalancerClient initialized"
+  );
 }
 
 export async function constructReadOnlyRebalancerClient(
   logger: winston.Logger,
   baseSigner: Signer
 ): Promise<ReadOnlyRebalancerClient> {
-  const { rebalancerConfig, adapters } = constructRebalancerDependencies(logger, baseSigner);
-  const isReadonly = true;
-  const rebalancerClient = new ReadOnlyRebalancerClient(logger, rebalancerConfig, adapters, baseSigner, isReadonly);
-  // Initialize the CCTP and OFT Adapters first before initializing the Binance and HL adapters which use the former
-  // adapters. Only initialize them if they are present in the adapters map.
-  const adapterInitPromises: Promise<void>[] = [];
-  if (adapters["cctp"]) {
-    adapterInitPromises.push(adapters["cctp"].initialize([]));
-  }
-  if (adapters["oft"]) {
-    adapterInitPromises.push(adapters["oft"].initialize([]));
-  }
-  await Promise.all(adapterInitPromises);
-  await rebalancerClient.initialize([]);
-  logger.debug({
-    at: "RebalancerClientHelper.constructReadOnlyRebalancerClient",
-    message: "ReadOnlyRebalancerClient initialized",
-    rebalancerConfig,
-    adapterNames: Object.keys(adapters),
-  });
-  return rebalancerClient;
+  return constructInitializedRebalancerClient(
+    logger,
+    baseSigner,
+    ReadOnlyRebalancerClient,
+    () => [],
+    true,
+    "constructReadOnlyRebalancerClient",
+    "ReadOnlyRebalancerClient initialized"
+  );
 }
 
 export async function constructAdapter(

--- a/src/rebalancer/RebalancerConfig.ts
+++ b/src/rebalancer/RebalancerConfig.ts
@@ -10,7 +10,7 @@ import { assert, BigNumber, isDefined, readFileSync, toBNWei, getTokenInfoFromSy
  *     "USDC": { "threshold": "3000000", "target": "3500000", "priorityTier": 0, "chains": { "1": 0 } }
  *   },
  *   "sameAssetBalances": {
- *     "USDT": { "chains": { "1": 0, "43114": 1 } },
+ *     "USDT": { "chains": { "43114": 1 } },
  *   },
  *   "maxAmountsToTransfer": {
  *     "USDT": "1000",
@@ -25,7 +25,8 @@ import { assert, BigNumber, isDefined, readFileSync, toBNWei, getTokenInfoFromSy
  * - cumulativeTargetBalance values are human-readable amounts (e.g. "100" for 100 USDT) and will be
  *   converted to the token's native decimals on the respective chain.
  * - sameAssetBalances chains enable each chain + token combination we want to support in the same asset rebalancer.
- *   Target and threshold amounts are implied by the inventory config used by the InventoryClient.
+ *   Target and threshold amounts are implied by the inventory config used by the InventoryClient. Chains listed
+ *   should only be L2 chains that we want to rebalance from L1 to. L2->L1 is delegated to the InventoryClient.
  * - priorityTiers are essentially numbers that you assign to a chain based on how important it is to hold
  *   liquidity or meet the target balance on that chain. The higher priority deficits are filled first and the lowest
  *   priority excesses are used first.
@@ -143,6 +144,7 @@ export class RebalancerConfig extends CommonConfig {
 
     this.sameAssetBalances = {};
     if (isDefined(rebalancerConfig.sameAssetBalances)) {
+      chainIdSet.add(this.hubPoolChainId);
       for (const [token, chainConfig] of Object.entries(
         rebalancerConfig.sameAssetBalances as Record<string, { chains: { [chainId: number]: number } }>
       )) {

--- a/src/rebalancer/RebalancerConfig.ts
+++ b/src/rebalancer/RebalancerConfig.ts
@@ -147,7 +147,10 @@ export class RebalancerConfig extends CommonConfig {
         rebalancerConfig.sameAssetBalances as Record<string, { chains: { [chainId: number]: number } }>
       )) {
         this.sameAssetBalances[token] = Object.fromEntries(
-          Object.entries(chainConfig.chains).map(([chainId, priorityTier]) => [Number(chainId), priorityTier])
+          Object.entries(chainConfig.chains).map(([chainId, priorityTier]) => {
+            chainIdSet.add(Number(chainId));
+            return [Number(chainId), priorityTier];
+          })
         );
       }
     }

--- a/src/rebalancer/RebalancerConfig.ts
+++ b/src/rebalancer/RebalancerConfig.ts
@@ -24,8 +24,8 @@ import { assert, BigNumber, isDefined, readFileSync, toBNWei, getTokenInfoFromSy
  *
  * - cumulativeTargetBalance values are human-readable amounts (e.g. "100" for 100 USDT) and will be
  *   converted to the token's native decimals on the respective chain.
- * - sameAssetBalances values are priority tiers for each chain + token combination we want to support in the
- *   same asset rebalancer. Target and threshold amounts are implied by the inventory config used by the InventoryClient.
+ * - sameAssetBalances chains enable each chain + token combination we want to support in the same asset rebalancer.
+ *   Target and threshold amounts are implied by the inventory config used by the InventoryClient.
  * - priorityTiers are essentially numbers that you assign to a chain based on how important it is to hold
  *   liquidity or meet the target balance on that chain. The higher priority deficits are filled first and the lowest
  *   priority excesses are used first.
@@ -53,7 +53,7 @@ export interface CumulativeTargetBalanceConfig {
 }
 
 export interface SameAssetConfig {
-  [token: string]: { [chainId: number]: number };
+  [token: string]: { [chainId: number]: true };
 }
 
 export interface MaxAmountToTransferChainConfig {
@@ -147,9 +147,9 @@ export class RebalancerConfig extends CommonConfig {
         rebalancerConfig.sameAssetBalances as Record<string, { chains: { [chainId: number]: number } }>
       )) {
         this.sameAssetBalances[token] = Object.fromEntries(
-          Object.entries(chainConfig.chains).map(([chainId, priorityTier]) => {
+          Object.keys(chainConfig.chains).map((chainId) => {
             chainIdSet.add(Number(chainId));
-            return [Number(chainId), priorityTier];
+            return [Number(chainId), true];
           })
         );
       }

--- a/src/rebalancer/RebalancerConfig.ts
+++ b/src/rebalancer/RebalancerConfig.ts
@@ -9,6 +9,9 @@ import { assert, BigNumber, isDefined, readFileSync, toBNWei, getTokenInfoFromSy
  *     "USDT": { "threshold": "1000000", "target": "1500000", "priorityTier": 0, "chains": { "1": 0 } },
  *     "USDC": { "threshold": "3000000", "target": "3500000", "priorityTier": 0, "chains": { "1": 0 } }
  *   },
+ *   "sameAssetBalances": {
+ *     "USDT": { "chains": { "1": 0, "43114": 1 } },
+ *   },
  *   "maxAmountsToTransfer": {
  *     "USDT": "1000",
  *     "USDC": "1000"
@@ -21,6 +24,8 @@ import { assert, BigNumber, isDefined, readFileSync, toBNWei, getTokenInfoFromSy
  *
  * - cumulativeTargetBalance values are human-readable amounts (e.g. "100" for 100 USDT) and will be
  *   converted to the token's native decimals on the respective chain.
+ * - sameAssetBalances values are priority tiers for each chain + token combination we want to support in the
+ *   same asset rebalancer. Target and threshold amounts are implied by the inventory config used by the InventoryClient.
  * - priorityTiers are essentially numbers that you assign to a chain based on how important it is to hold
  *   liquidity or meet the target balance on that chain. The higher priority deficits are filled first and the lowest
  *   priority excesses are used first.
@@ -47,6 +52,10 @@ export interface CumulativeTargetBalanceConfig {
   [token: string]: ChainConfig;
 }
 
+export interface SameAssetConfig {
+  [token: string]: { [chainId: number]: number };
+}
+
 export interface MaxAmountToTransferChainConfig {
   [chainId: number]: BigNumber;
 }
@@ -61,6 +70,7 @@ export interface MaxPendingOrdersConfig {
 
 export class RebalancerConfig extends CommonConfig {
   public cumulativeTargetBalances: CumulativeTargetBalanceConfig;
+  public sameAssetBalances: SameAssetConfig;
   public maxAmountsToTransfer: MaxAmountToTransferConfig;
   public maxPendingOrders: MaxPendingOrdersConfig;
 
@@ -128,6 +138,17 @@ export class RebalancerConfig extends CommonConfig {
             Object.entries(chainConfig.chains).map(([chainId, priorityTier]) => [Number(chainId), priorityTier])
           ),
         };
+      }
+    }
+
+    this.sameAssetBalances = {};
+    if (isDefined(rebalancerConfig.sameAssetBalances)) {
+      for (const [token, chainConfig] of Object.entries(
+        rebalancerConfig.sameAssetBalances as Record<string, { chains: { [chainId: number]: number } }>
+      )) {
+        this.sameAssetBalances[token] = Object.fromEntries(
+          Object.entries(chainConfig.chains).map(([chainId, priorityTier]) => [Number(chainId), priorityTier])
+        );
       }
     }
 

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -316,7 +316,7 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       }
       this.logger.debug({
         at: "BinanceStablecoinSwapAdapter.updateRebalanceStatuses",
-        message: `Sufficient balance to place market order for cloid ${cloid}`,
+        message: `Sufficient balance to place market order or withdraw for cloid ${cloid}`,
         availableBalance: binanceBalanceWei.toString(),
         requiredBalance: amountToTransfer.toString(),
       });

--- a/src/rebalancer/buildSameAssetRebalanceRoutes.ts
+++ b/src/rebalancer/buildSameAssetRebalanceRoutes.ts
@@ -1,0 +1,37 @@
+import { RebalancerConfig } from "./RebalancerConfig";
+import { RebalanceRoute } from "./utils/interfaces";
+
+type AdapterName = "binance" | "hyperliquid" | "cctp" | "oft";
+
+const SAME_ASSET_ROUTES_SUPPORTED: Record<string, Record<number, AdapterName>> = {
+  USDT: {
+    "43114": "binance",
+    "1": "binance",
+  },
+};
+export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): RebalanceRoute[] {
+  const routes = new Set<RebalanceRoute>();
+
+  // If a supported route exists in the rebalancer config, return it.
+  for (const [token, chainConfig] of Object.entries(SAME_ASSET_ROUTES_SUPPORTED)) {
+    for (const [chainId, adapter] of Object.entries(chainConfig)) {
+      for (const [otherChainId, otherAdapter] of Object.entries(chainConfig)) {
+        if (
+          Number(chainId) !== Number(otherChainId) &&
+          adapter === otherAdapter &&
+          rebalancerConfig.sameAssetBalances[token][Number(chainId)] &&
+          rebalancerConfig.sameAssetBalances[token][Number(otherChainId)]
+        ) {
+          routes.add({
+            sourceChain: Number(chainId),
+            destinationChain: Number(otherChainId),
+            sourceToken: token,
+            destinationToken: token,
+            adapter: adapter,
+          });
+        }
+      }
+    }
+  }
+  return Array.from(routes);
+}

--- a/src/rebalancer/buildSameAssetRebalanceRoutes.ts
+++ b/src/rebalancer/buildSameAssetRebalanceRoutes.ts
@@ -1,3 +1,4 @@
+import { isDefined } from "../utils";
 import { RebalancerConfig } from "./RebalancerConfig";
 import { RebalanceRoute } from "./utils/interfaces";
 
@@ -9,7 +10,7 @@ const SAME_ASSET_ROUTES_SUPPORTED: Record<string, Record<number, AdapterName>> =
     "1": "binance",
   },
 };
-export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): RebalanceRoute[] {
+export function buildSameAssetRebalanceRoutes(rebalancerConfig: RebalancerConfig): RebalanceRoute[] {
   const routes = new Set<RebalanceRoute>();
 
   // If a supported route exists in the rebalancer config, return it.
@@ -19,8 +20,8 @@ export function buildRebalanceRoutes(rebalancerConfig: RebalancerConfig): Rebala
         if (
           Number(chainId) !== Number(otherChainId) &&
           adapter === otherAdapter &&
-          rebalancerConfig.sameAssetBalances[token][Number(chainId)] &&
-          rebalancerConfig.sameAssetBalances[token][Number(otherChainId)]
+          isDefined(rebalancerConfig.sameAssetBalances?.[token]?.[Number(chainId)]) &&
+          isDefined(rebalancerConfig.sameAssetBalances?.[token]?.[Number(otherChainId)])
         ) {
           routes.add({
             sourceChain: Number(chainId),

--- a/src/rebalancer/buildSameAssetRebalanceRoutes.ts
+++ b/src/rebalancer/buildSameAssetRebalanceRoutes.ts
@@ -1,4 +1,4 @@
-import { isDefined } from "../utils";
+import { CHAIN_IDs, isDefined } from "../utils";
 import { RebalancerConfig } from "./RebalancerConfig";
 import { RebalanceRoute } from "./utils/interfaces";
 
@@ -7,30 +7,28 @@ type AdapterName = "binance" | "hyperliquid" | "cctp" | "oft";
 const SAME_ASSET_ROUTES_SUPPORTED: Record<string, Record<number, AdapterName>> = {
   USDT: {
     "43114": "binance",
-    "1": "binance",
   },
 };
+
+// @dev For now, the SameAssetRebalancerClient only supports rebalancing between L1 and the listed L2 chains in
+// the mapping above.
 export function buildSameAssetRebalanceRoutes(rebalancerConfig: RebalancerConfig): RebalanceRoute[] {
   const routes = new Set<RebalanceRoute>();
 
   // If a supported route exists in the rebalancer config, return it.
   for (const [token, chainConfig] of Object.entries(SAME_ASSET_ROUTES_SUPPORTED)) {
     for (const [chainId, adapter] of Object.entries(chainConfig)) {
-      for (const [otherChainId, otherAdapter] of Object.entries(chainConfig)) {
-        if (
-          Number(chainId) !== Number(otherChainId) &&
-          adapter === otherAdapter &&
-          isDefined(rebalancerConfig.sameAssetBalances?.[token]?.[Number(chainId)]) &&
-          isDefined(rebalancerConfig.sameAssetBalances?.[token]?.[Number(otherChainId)])
-        ) {
-          routes.add({
-            sourceChain: Number(chainId),
-            destinationChain: Number(otherChainId),
-            sourceToken: token,
-            destinationToken: token,
-            adapter: adapter,
-          });
-        }
+      if (
+        isDefined(rebalancerConfig.sameAssetBalances?.[token]?.[Number(chainId)]) &&
+        Number(chainId) !== CHAIN_IDs.MAINNET
+      ) {
+        routes.add({
+          sourceChain: CHAIN_IDs.MAINNET,
+          destinationChain: Number(chainId),
+          sourceToken: token,
+          destinationToken: token,
+          adapter: adapter,
+        });
       }
     }
   }

--- a/src/rebalancer/clients/SameAssetRebalancerClient.ts
+++ b/src/rebalancer/clients/SameAssetRebalancerClient.ts
@@ -32,8 +32,10 @@ export class SameAssetRebalancerClient extends BaseRebalancerClient {
     // Every rebalance route we have is between L1 and some L2 chain and is set in the RebalancerConfig
     for (const route of this.rebalanceRoutes) {
       if (
-        (route.sourceChain === this.config.hubPoolChainId && route.destinationChain !== this.config.hubPoolChainId) ||
-        (route.sourceChain !== this.config.hubPoolChainId && route.destinationChain === this.config.hubPoolChainId)
+        !(
+          (route.sourceChain === this.config.hubPoolChainId && route.destinationChain !== this.config.hubPoolChainId) ||
+          (route.sourceChain !== this.config.hubPoolChainId && route.destinationChain === this.config.hubPoolChainId)
+        )
       ) {
         throw new Error(
           `Rebalance route ${route.sourceChain} to ${route.destinationChain} is not between L1 and some L2 chain`
@@ -88,7 +90,7 @@ export class SameAssetRebalancerClient extends BaseRebalancerClient {
       .map(([chainId, withdrawals]) => {
         return withdrawals.map((withdrawal) => {
           const matchingRebalanceRoute = this.rebalanceRoutes.find((route) => {
-            const l2Token = getTokenInfoFromSymbol(route.destinationToken, route.destinationChain);
+            const l2Token = getTokenInfoFromSymbol(route.sourceToken, route.sourceChain);
             return (
               route.sourceChain === Number(chainId) &&
               route.destinationChain === this.config.hubPoolChainId &&
@@ -108,6 +110,16 @@ export class SameAssetRebalancerClient extends BaseRebalancerClient {
       .filter(isDefined);
 
     for (const rebalance of l1ToL2Rebalances.concat(l2ToL1Withdrawals)) {
+      const availableAdapters = await this.getAvailableAdapters();
+      if (!availableAdapters.includes(rebalance.adapter)) {
+        this.logger.debug({
+          at: "SameAssetRebalancerClient.rebalanceInventory",
+          message: `Adapter ${rebalance.adapter} is not available; trying next route`,
+          route: rebalance,
+        });
+        continue;
+      }
+
       const { sourceToken, destinationToken, sourceChain, destinationChain, amount } = rebalance;
       const maxAmountToTransfer = this.config.maxAmountsToTransfer[sourceToken]?.[sourceChain];
       const amountToTransferCapped =

--- a/src/rebalancer/clients/SameAssetRebalancerClient.ts
+++ b/src/rebalancer/clients/SameAssetRebalancerClient.ts
@@ -1,0 +1,154 @@
+import {
+  BigNumber,
+  getTokenInfoFromSymbol,
+  EvmAddress,
+  isDefined,
+  toBNWei,
+  fromWei,
+  getNetworkName,
+  bnZero,
+  assert,
+} from "../../utils";
+import { BaseRebalancerClient } from "./BaseRebalancerClient";
+import { InventoryClient } from "../../clients";
+import { RebalanceRoute } from "../utils/interfaces";
+
+export class SameAssetRebalancerClient extends BaseRebalancerClient {
+  constructor(...args: ConstructorParameters<typeof BaseRebalancerClient>) {
+    super(...args);
+  }
+
+  /**
+   * @notice Rebalances cumulative balances of tokens across chains where cumulative token balances are above
+   * configured targets to tokens that have cumulative balances below configured thresholds. Tokens are sourced
+   * from chains sorted by configured priority tier and current balance level.
+   * @param cumulativeBalances Dictionary of token -> cumulative virtual balances.
+   * @param currentBalancesOnChain Dictionary of chainId -> token -> current on-chain balance.
+   * @param maxFeePct Maximum fee percentage to allow for rebalances.
+   */
+  override async rebalanceInventory(inventoryClient: InventoryClient, maxFeePct: BigNumber): Promise<void> {
+    // Assert invariants:
+
+    // Every rebalance route we have is between L1 and some L2 chain and is set in the RebalancerConfig
+    for (const route of this.rebalanceRoutes) {
+      if (
+        (route.sourceChain === this.config.hubPoolChainId && route.destinationChain !== this.config.hubPoolChainId) ||
+        (route.sourceChain !== this.config.hubPoolChainId && route.destinationChain === this.config.hubPoolChainId)
+      ) {
+        throw new Error(
+          `Rebalance route ${route.sourceChain} to ${route.destinationChain} is not between L1 and some L2 chain`
+        );
+      }
+      assert(
+        route.sourceToken === route.destinationToken,
+        `Rebalance route ${route.sourceChain} to ${route.destinationChain} has different source and destination tokens`
+      );
+      const chainsEnabledForToken = Object.keys(this.config.sameAssetBalances[route.sourceToken]).map(Number);
+      if (
+        !chainsEnabledForToken.includes(route.destinationChain) ||
+        !chainsEnabledForToken.includes(route.sourceChain)
+      ) {
+        throw new Error(
+          `Rebalance route ${route.sourceChain} to ${route.destinationChain} is not configured in RebalancerConfig for token ${route.sourceToken}`
+        );
+      }
+    }
+
+    // Get list of rebalances to execute from InventoryClient:
+    // - rebalanceInventoryIfNeeded()
+    // - withdrawExcessInventory()
+    const _l1ToL2Rebalances = await inventoryClient.rebalanceInventoryIfNeeded(true);
+    const _l2ToL1Withdrawals = await inventoryClient.withdrawExcessBalances(true);
+
+    // Filter out rebalances to only those we have rebalance routes for.
+    const l1ToL2Rebalances: (RebalanceRoute & { amount: BigNumber })[] = _l1ToL2Rebalances
+      .map((rebalance) => {
+        const matchingRebalanceRoute = this.rebalanceRoutes.find((route) => {
+          const l1Token = EvmAddress.from(
+            getTokenInfoFromSymbol(route.sourceToken, this.config.hubPoolChainId).address.toNative()
+          );
+          const l2Token = getTokenInfoFromSymbol(route.destinationToken, route.destinationChain);
+          return (
+            route.sourceChain === this.config.hubPoolChainId &&
+            route.destinationChain === rebalance.chainId &&
+            l1Token.eq(rebalance.l1Token) &&
+            l2Token.address.eq(rebalance.l2Token)
+          );
+        });
+        if (!matchingRebalanceRoute) {
+          return undefined;
+        }
+        return {
+          ...matchingRebalanceRoute,
+          amount: rebalance.amount,
+        };
+      })
+      .filter(isDefined);
+    const l2ToL1Withdrawals: (RebalanceRoute & { amount: BigNumber })[] = Object.entries(_l2ToL1Withdrawals)
+      .map(([chainId, withdrawals]) => {
+        return withdrawals.map((withdrawal) => {
+          const matchingRebalanceRoute = this.rebalanceRoutes.find((route) => {
+            const l2Token = getTokenInfoFromSymbol(route.destinationToken, route.destinationChain);
+            return (
+              route.sourceChain === Number(chainId) &&
+              route.destinationChain === this.config.hubPoolChainId &&
+              l2Token.address.eq(withdrawal.l2Token)
+            );
+          });
+          if (!matchingRebalanceRoute) {
+            return undefined;
+          }
+          return {
+            ...matchingRebalanceRoute,
+            amount: withdrawal.amountToWithdraw,
+          };
+        });
+      })
+      .flat()
+      .filter(isDefined);
+
+    for (const rebalance of l1ToL2Rebalances.concat(l2ToL1Withdrawals)) {
+      const { sourceToken, destinationToken, sourceChain, destinationChain, amount } = rebalance;
+      const maxAmountToTransfer = this.config.maxAmountsToTransfer[sourceToken]?.[sourceChain];
+      const amountToTransferCapped =
+        isDefined(maxAmountToTransfer) && amount.gt(maxAmountToTransfer) ? maxAmountToTransfer : amount;
+      const maxFee = amountToTransferCapped.mul(maxFeePct).div(toBNWei(100));
+      const estimatedCost = await this.adapters[rebalance.adapter].getEstimatedCost(
+        rebalance,
+        amountToTransferCapped,
+        false /* debugLog set to false because the logs would be really noisy, though detailed about how each estimated cost was computed */
+      );
+      if (estimatedCost.gt(maxFee)) {
+        this.logger.debug({
+          at: "SameAssetRebalancerClient.rebalanceInventory",
+          message: `Estimated cost of ${estimatedCost.toString()} is greater than max fee of ${maxFee.toString()}`,
+        });
+        continue;
+      }
+
+      const l1TokenInfo = getTokenInfoFromSymbol(sourceToken, sourceChain);
+      this.logger.debug({
+        at: "SameAssetRebalancerClient.rebalanceInventory",
+        message: `Initializing new ${rebalance.adapter} ${fromWei(amountToTransferCapped, l1TokenInfo.decimals)} ${sourceToken} rebalance from ${getNetworkName(sourceChain)} to ${getNetworkName(destinationChain)} ${destinationToken}`,
+        adapter: rebalance.adapter,
+        expectedFees: fromWei(estimatedCost, l1TokenInfo.decimals),
+      });
+
+      if (this.config.sendingTransactionsEnabled) {
+        const initializedAmount = await this.adapters[rebalance.adapter].initializeRebalance(
+          rebalance,
+          amountToTransferCapped
+        );
+        if (initializedAmount.eq(bnZero)) {
+          this.logger.debug({
+            at: "SameAssetRebalancerClient.rebalanceInventory",
+            message: `Adapter ${rebalance.adapter} declined to initialize rebalance; trying next route`,
+            route: rebalance,
+            requestedAmountToTransfer: amountToTransferCapped.toString(),
+          });
+          continue;
+        }
+      }
+    }
+  }
+}

--- a/src/rebalancer/clients/SameAssetRebalancerClient.ts
+++ b/src/rebalancer/clients/SameAssetRebalancerClient.ts
@@ -8,15 +8,19 @@ import {
   getNetworkName,
   bnZero,
   assert,
-  Address,
 } from "../../utils";
 import { BaseRebalancerClient } from "./BaseRebalancerClient";
 import { InventoryClient, Rebalance } from "../../clients";
 import { RebalanceRoute } from "../utils/interfaces";
 
 type RebalanceWithAmount = RebalanceRoute & { amount: BigNumber };
-type L2Withdrawal = { l2Token: Address; amountToWithdraw: BigNumber };
 
+/**
+ * @notice This client supports rebalancing between L1 and the listed L2 chains in the RebalancerConfig where the
+ * InventoryClient can't already support it. For example, from L1 to L2 via Binance for any other chains besides BSC
+ * is impossible in the InventoryClient because once a deposit lands in Binance we don't know where its final
+ * destination chain is unless we track it via Redis like we do with this client (and not in the InventoryClient).
+ */
 export class SameAssetRebalancerClient extends BaseRebalancerClient {
   override async rebalanceInventory(inventoryClient: InventoryClient, maxFeePct: BigNumber): Promise<void> {
     // Assert invariants:
@@ -24,10 +28,8 @@ export class SameAssetRebalancerClient extends BaseRebalancerClient {
     // Every rebalance route we have is between L1 and some L2 chain and is set in the RebalancerConfig
     for (const route of this.rebalanceRoutes) {
       if (
-        !(
-          (route.sourceChain === this.config.hubPoolChainId && route.destinationChain !== this.config.hubPoolChainId) ||
-          (route.sourceChain !== this.config.hubPoolChainId && route.destinationChain === this.config.hubPoolChainId)
-        )
+        (route.sourceChain === this.config.hubPoolChainId && route.destinationChain === this.config.hubPoolChainId) ||
+        (route.sourceChain !== this.config.hubPoolChainId && route.destinationChain !== this.config.hubPoolChainId)
       ) {
         throw new Error(
           `Rebalance route ${route.sourceChain} to ${route.destinationChain} is not between L1 and some L2 chain`
@@ -37,36 +39,23 @@ export class SameAssetRebalancerClient extends BaseRebalancerClient {
         route.sourceToken === route.destinationToken,
         `Rebalance route ${route.sourceChain} to ${route.destinationChain} has different source and destination tokens`
       );
-      if (
-        !this.config.sameAssetBalances[route.sourceToken]?.[route.destinationChain] ||
-        !this.config.sameAssetBalances[route.sourceToken]?.[route.sourceChain]
-      ) {
+      if (!this.config.sameAssetBalances[route.sourceToken]?.[route.destinationChain]) {
         throw new Error(
-          `Rebalance route ${route.sourceChain} to ${route.destinationChain} is not configured in RebalancerConfig for token ${route.sourceToken}`
+          `Rebalance route to ${route.destinationChain} is not configured in RebalancerConfig for token ${route.sourceToken}`
         );
       }
     }
 
     // Get list of rebalances to execute from InventoryClient:
-    // - rebalanceInventoryIfNeeded()
-    // - withdrawExcessInventory()
     const _l1ToL2Rebalances = await inventoryClient.rebalanceInventoryIfNeeded(true);
-    const _l2ToL1Withdrawals = await inventoryClient.withdrawExcessBalances(true);
 
     // Filter out rebalances to only those we have rebalance routes for.
     const l1ToL2Rebalances: RebalanceWithAmount[] = _l1ToL2Rebalances.flatMap((rebalance) => {
       const route = this.routeForL1ToL2Rebalance(rebalance);
       return route ? [{ ...route, amount: rebalance.amount }] : [];
     });
-    const l2ToL1Withdrawals: RebalanceWithAmount[] = Object.entries(_l2ToL1Withdrawals).flatMap(
-      ([chainId, withdrawals]) =>
-        withdrawals.flatMap((withdrawal) => {
-          const route = this.routeForL2ToL1Withdrawal(Number(chainId), withdrawal);
-          return route ? [{ ...route, amount: withdrawal.amountToWithdraw }] : [];
-        })
-    );
 
-    for (const rebalance of l1ToL2Rebalances.concat(l2ToL1Withdrawals)) {
+    for (const rebalance of l1ToL2Rebalances) {
       const availableAdapters = await this.getAvailableAdapters();
       if (!availableAdapters.includes(rebalance.adapter)) {
         this.logger.debug({
@@ -132,17 +121,6 @@ export class SameAssetRebalancerClient extends BaseRebalancerClient {
         route.destinationChain === rebalance.chainId &&
         l1Token.eq(rebalance.l1Token) &&
         l2Token.address.eq(rebalance.l2Token)
-      );
-    });
-  }
-
-  private routeForL2ToL1Withdrawal(chainId: number, withdrawal: L2Withdrawal): RebalanceRoute | undefined {
-    return this.rebalanceRoutes.find((route) => {
-      const l2Token = getTokenInfoFromSymbol(route.sourceToken, route.sourceChain);
-      return (
-        route.sourceChain === chainId &&
-        route.destinationChain === this.config.hubPoolChainId &&
-        l2Token.address.eq(withdrawal.l2Token)
       );
     });
   }

--- a/src/rebalancer/clients/SameAssetRebalancerClient.ts
+++ b/src/rebalancer/clients/SameAssetRebalancerClient.ts
@@ -80,16 +80,20 @@ export class SameAssetRebalancerClient extends BaseRebalancerClient {
         this.logger.debug({
           at: "SameAssetRebalancerClient.rebalanceInventory",
           message: `Estimated cost of ${estimatedCost.toString()} is greater than max fee of ${maxFee.toString()}`,
+          amountToTransferCapped: amountToTransferCapped.toString(),
         });
         continue;
       }
 
-      const l1TokenInfo = getTokenInfoFromSymbol(sourceToken, sourceChain);
+      const sourceTokenInfo = getTokenInfoFromSymbol(sourceToken, sourceChain);
       this.logger.debug({
         at: "SameAssetRebalancerClient.rebalanceInventory",
-        message: `Initializing new ${rebalance.adapter} ${fromWei(amountToTransferCapped, l1TokenInfo.decimals)} ${sourceToken} rebalance from ${getNetworkName(sourceChain)} to ${getNetworkName(destinationChain)} ${destinationToken}`,
+        message: `Initializing new ${rebalance.adapter} ${fromWei(amountToTransferCapped, sourceTokenInfo.decimals)} ${sourceToken} rebalance from ${getNetworkName(sourceChain)} to ${getNetworkName(destinationChain)} ${destinationToken}`,
         adapter: rebalance.adapter,
-        expectedFees: fromWei(estimatedCost, l1TokenInfo.decimals),
+        expectedFees: fromWei(estimatedCost, sourceTokenInfo.decimals),
+        desiredAmountToTransfer: fromWei(amount, sourceTokenInfo.decimals),
+        maxAmountToTransfer: fromWei(maxAmountToTransfer, sourceTokenInfo.decimals),
+        amountToTransferCapped: fromWei(amountToTransferCapped, sourceTokenInfo.decimals),
       });
 
       if (this.config.sendingTransactionsEnabled) {
@@ -102,7 +106,6 @@ export class SameAssetRebalancerClient extends BaseRebalancerClient {
             at: "SameAssetRebalancerClient.rebalanceInventory",
             message: `Adapter ${rebalance.adapter} declined to initialize rebalance; trying next route`,
             route: rebalance,
-            requestedAmountToTransfer: amountToTransferCapped.toString(),
           });
           continue;
         }

--- a/src/rebalancer/clients/SameAssetRebalancerClient.ts
+++ b/src/rebalancer/clients/SameAssetRebalancerClient.ts
@@ -8,24 +8,16 @@ import {
   getNetworkName,
   bnZero,
   assert,
+  Address,
 } from "../../utils";
 import { BaseRebalancerClient } from "./BaseRebalancerClient";
-import { InventoryClient } from "../../clients";
+import { InventoryClient, Rebalance } from "../../clients";
 import { RebalanceRoute } from "../utils/interfaces";
 
-export class SameAssetRebalancerClient extends BaseRebalancerClient {
-  constructor(...args: ConstructorParameters<typeof BaseRebalancerClient>) {
-    super(...args);
-  }
+type RebalanceWithAmount = RebalanceRoute & { amount: BigNumber };
+type L2Withdrawal = { l2Token: Address; amountToWithdraw: BigNumber };
 
-  /**
-   * @notice Rebalances cumulative balances of tokens across chains where cumulative token balances are above
-   * configured targets to tokens that have cumulative balances below configured thresholds. Tokens are sourced
-   * from chains sorted by configured priority tier and current balance level.
-   * @param cumulativeBalances Dictionary of token -> cumulative virtual balances.
-   * @param currentBalancesOnChain Dictionary of chainId -> token -> current on-chain balance.
-   * @param maxFeePct Maximum fee percentage to allow for rebalances.
-   */
+export class SameAssetRebalancerClient extends BaseRebalancerClient {
   override async rebalanceInventory(inventoryClient: InventoryClient, maxFeePct: BigNumber): Promise<void> {
     // Assert invariants:
 
@@ -45,10 +37,9 @@ export class SameAssetRebalancerClient extends BaseRebalancerClient {
         route.sourceToken === route.destinationToken,
         `Rebalance route ${route.sourceChain} to ${route.destinationChain} has different source and destination tokens`
       );
-      const chainsEnabledForToken = Object.keys(this.config.sameAssetBalances[route.sourceToken]).map(Number);
       if (
-        !chainsEnabledForToken.includes(route.destinationChain) ||
-        !chainsEnabledForToken.includes(route.sourceChain)
+        !this.config.sameAssetBalances[route.sourceToken]?.[route.destinationChain] ||
+        !this.config.sameAssetBalances[route.sourceToken]?.[route.sourceChain]
       ) {
         throw new Error(
           `Rebalance route ${route.sourceChain} to ${route.destinationChain} is not configured in RebalancerConfig for token ${route.sourceToken}`
@@ -63,51 +54,17 @@ export class SameAssetRebalancerClient extends BaseRebalancerClient {
     const _l2ToL1Withdrawals = await inventoryClient.withdrawExcessBalances(true);
 
     // Filter out rebalances to only those we have rebalance routes for.
-    const l1ToL2Rebalances: (RebalanceRoute & { amount: BigNumber })[] = _l1ToL2Rebalances
-      .map((rebalance) => {
-        const matchingRebalanceRoute = this.rebalanceRoutes.find((route) => {
-          const l1Token = EvmAddress.from(
-            getTokenInfoFromSymbol(route.sourceToken, this.config.hubPoolChainId).address.toNative()
-          );
-          const l2Token = getTokenInfoFromSymbol(route.destinationToken, route.destinationChain);
-          return (
-            route.sourceChain === this.config.hubPoolChainId &&
-            route.destinationChain === rebalance.chainId &&
-            l1Token.eq(rebalance.l1Token) &&
-            l2Token.address.eq(rebalance.l2Token)
-          );
-        });
-        if (!matchingRebalanceRoute) {
-          return undefined;
-        }
-        return {
-          ...matchingRebalanceRoute,
-          amount: rebalance.amount,
-        };
-      })
-      .filter(isDefined);
-    const l2ToL1Withdrawals: (RebalanceRoute & { amount: BigNumber })[] = Object.entries(_l2ToL1Withdrawals)
-      .map(([chainId, withdrawals]) => {
-        return withdrawals.map((withdrawal) => {
-          const matchingRebalanceRoute = this.rebalanceRoutes.find((route) => {
-            const l2Token = getTokenInfoFromSymbol(route.sourceToken, route.sourceChain);
-            return (
-              route.sourceChain === Number(chainId) &&
-              route.destinationChain === this.config.hubPoolChainId &&
-              l2Token.address.eq(withdrawal.l2Token)
-            );
-          });
-          if (!matchingRebalanceRoute) {
-            return undefined;
-          }
-          return {
-            ...matchingRebalanceRoute,
-            amount: withdrawal.amountToWithdraw,
-          };
-        });
-      })
-      .flat()
-      .filter(isDefined);
+    const l1ToL2Rebalances: RebalanceWithAmount[] = _l1ToL2Rebalances.flatMap((rebalance) => {
+      const route = this.routeForL1ToL2Rebalance(rebalance);
+      return route ? [{ ...route, amount: rebalance.amount }] : [];
+    });
+    const l2ToL1Withdrawals: RebalanceWithAmount[] = Object.entries(_l2ToL1Withdrawals).flatMap(
+      ([chainId, withdrawals]) =>
+        withdrawals.flatMap((withdrawal) => {
+          const route = this.routeForL2ToL1Withdrawal(Number(chainId), withdrawal);
+          return route ? [{ ...route, amount: withdrawal.amountToWithdraw }] : [];
+        })
+    );
 
     for (const rebalance of l1ToL2Rebalances.concat(l2ToL1Withdrawals)) {
       const availableAdapters = await this.getAvailableAdapters();
@@ -162,5 +119,31 @@ export class SameAssetRebalancerClient extends BaseRebalancerClient {
         }
       }
     }
+  }
+
+  private routeForL1ToL2Rebalance(rebalance: Rebalance): RebalanceRoute | undefined {
+    return this.rebalanceRoutes.find((route) => {
+      const l1Token = EvmAddress.from(
+        getTokenInfoFromSymbol(route.sourceToken, this.config.hubPoolChainId).address.toNative()
+      );
+      const l2Token = getTokenInfoFromSymbol(route.destinationToken, route.destinationChain);
+      return (
+        route.sourceChain === this.config.hubPoolChainId &&
+        route.destinationChain === rebalance.chainId &&
+        l1Token.eq(rebalance.l1Token) &&
+        l2Token.address.eq(rebalance.l2Token)
+      );
+    });
+  }
+
+  private routeForL2ToL1Withdrawal(chainId: number, withdrawal: L2Withdrawal): RebalanceRoute | undefined {
+    return this.rebalanceRoutes.find((route) => {
+      const l2Token = getTokenInfoFromSymbol(route.sourceToken, route.sourceChain);
+      return (
+        route.sourceChain === chainId &&
+        route.destinationChain === this.config.hubPoolChainId &&
+        l2Token.address.eq(withdrawal.l2Token)
+      );
+    });
   }
 }

--- a/src/rebalancer/index.ts
+++ b/src/rebalancer/index.ts
@@ -1,17 +1,13 @@
-import { InventoryClient } from "../clients";
+import { InventoryClient, TokenClient } from "../clients";
 import { updateSpokePoolClients } from "../common";
-import { constructRelayerClients } from "../relayer/RelayerClientHelper";
+import { constructRelayerClients, RelayerClients } from "../relayer/RelayerClientHelper";
 import { RelayerConfig } from "../relayer/RelayerConfig";
 import {
   assert,
   BigNumber,
-  bnZero,
   config,
-  ConvertDecimals,
   disconnectRedisClients,
-  EvmAddress,
   getTokenInfoFromSymbol,
-  isDefined,
   Signer,
   toBNWei,
   winston,
@@ -19,7 +15,10 @@ import {
 import { CumulativeBalanceRebalancerClient } from "./clients/CumulativeBalanceRebalancerClient";
 import { SameAssetRebalancerClient } from "./clients/SameAssetRebalancerClient";
 
-import { constructCumulativeBalanceRebalancerClient } from "./RebalancerClientHelper";
+import {
+  constructCumulativeBalanceRebalancerClient,
+  constructSameAssetRebalancerClient,
+} from "./RebalancerClientHelper";
 import { RebalancerConfig } from "./RebalancerConfig";
 import { RebalancerAdapter, RebalancerClient } from "./utils/interfaces";
 config();
@@ -27,16 +26,20 @@ let logger: winston.Logger;
 
 type RebalancerRunContext = {
   rebalancerConfig: RebalancerConfig;
-  adaptersToUpdate: Set<RebalancerAdapter>;
   inventoryClient: InventoryClient;
   rebalancerClient: RebalancerClient;
 };
 
 const sweepableAdapters: string[] = ["hyperliquid"];
 
-async function initializeRebalancerRun(_logger: winston.Logger, baseSigner: Signer): Promise<RebalancerRunContext> {
-  const logLabel = "runCumulativeBalanceRebalancer";
-  logger = _logger;
+async function setupClients(
+  _logger: winston.Logger,
+  baseSigner: Signer,
+  logLabel: string
+): Promise<{
+  relayerClients: RelayerClients;
+  rebalancerConfig: RebalancerConfig;
+}> {
   const rebalancerConfig = new RebalancerConfig(process.env);
   logger.debug({ at: `index.ts:${logLabel}`, message: "Rebalancer Config loaded", rebalancerConfig });
   const relayerConfig = new RelayerConfig(process.env);
@@ -61,8 +64,19 @@ async function initializeRebalancerRun(_logger: winston.Logger, baseSigner: Sign
     inventoryClient.setBundleData();
     await inventoryClient.update(rebalancerConfig.chainIds);
   }
-  const rebalancerClient = await constructCumulativeBalanceRebalancerClient(logger, baseSigner);
+  return {
+    relayerClients,
+    rebalancerConfig,
+  };
+}
 
+async function updateAdapters(
+  rebalancerClient: RebalancerClient,
+  rebalancerConfig: RebalancerConfig,
+  tokenClient: TokenClient,
+  inventoryClient: InventoryClient,
+  logLabel: string
+): Promise<Set<RebalancerAdapter>> {
   let timerStart = performance.now();
 
   // Make sure we update the upstream adapters first, so there is a small chance of progressing an intermediate
@@ -107,10 +121,43 @@ async function initializeRebalancerRun(_logger: winston.Logger, baseSigner: Sign
     message: "Refreshed TokenClient balances post-status-update",
     duration: performance.now() - timerStart,
   });
+  const inventoryManagement = inventoryClient.isInventoryManagementEnabled();
+  if (inventoryManagement) {
+    await inventoryClient.update(rebalancerConfig.chainIds);
+  }
+  return adaptersToUpdate;
+}
+
+async function initializeCumulativeRebalancerRun(
+  _logger: winston.Logger,
+  baseSigner: Signer
+): Promise<RebalancerRunContext> {
+  const logLabel = "runCumulativeBalanceRebalancer";
+  logger = _logger;
+  const { relayerClients, rebalancerConfig } = await setupClients(logger, baseSigner, logLabel);
+  const { inventoryClient, tokenClient } = relayerClients;
+  const rebalancerClient = await constructCumulativeBalanceRebalancerClient(logger, baseSigner);
+  await updateAdapters(rebalancerClient, rebalancerConfig, tokenClient, inventoryClient, logLabel);
 
   return {
     rebalancerConfig,
-    adaptersToUpdate,
+    inventoryClient,
+    rebalancerClient,
+  };
+}
+
+async function initializeSameAssetRebalancerRun(
+  _logger: winston.Logger,
+  baseSigner: Signer
+): Promise<RebalancerRunContext> {
+  const logLabel = "runSameAssetRebalancer";
+  logger = _logger;
+  const { relayerClients, rebalancerConfig } = await setupClients(logger, baseSigner, logLabel);
+  const { inventoryClient, tokenClient } = relayerClients;
+  const rebalancerClient = await constructSameAssetRebalancerClient(logger, baseSigner);
+  await updateAdapters(rebalancerClient, rebalancerConfig, tokenClient, inventoryClient, logLabel);
+  return {
+    rebalancerConfig,
     inventoryClient,
     rebalancerClient,
   };
@@ -145,73 +192,13 @@ export function loadCumulativeModeBalances(
   return { currentBalances, cumulativeBalances };
 }
 
-async function applyPendingCumulativeRebalanceAdjustments(
-  baseSigner: Signer,
-  rebalancerConfig: RebalancerConfig,
-  adaptersToUpdate: Set<RebalancerAdapter>,
-  logLabel: string,
-  cumulativeBalances?: { [token: string]: BigNumber }
-): Promise<void> {
-  let timerStart = performance.now();
-  for (const adapter of adaptersToUpdate) {
-    timerStart = performance.now();
-    const pendingRebalances = await adapter.getPendingRebalances(EvmAddress.from(await baseSigner.getAddress()));
-    logger.debug({
-      at: `index.ts:${logLabel}`,
-      message: `Completed getting pending rebalances for adapter ${adapter.constructor.name}`,
-      duration: performance.now() - timerStart,
-    });
-    if (Object.keys(pendingRebalances).length > 0) {
-      logger.debug({
-        at: `index.ts:${logLabel}`,
-        message: `Pending rebalances for adapter ${adapter.constructor.name}`,
-        pendingRebalances: Object.entries(pendingRebalances).map(([chainId, tokens]) => ({
-          [chainId]: Object.fromEntries(Object.entries(tokens).map(([token, amount]) => [token, amount.toString()])),
-        })),
-      });
-    }
-
-    for (const [chainId, tokens] of Object.entries(pendingRebalances)) {
-      for (const [token, amount] of Object.entries(tokens)) {
-        const pendingRebalanceAmount = amount ?? bnZero;
-        if (cumulativeBalances && isDefined(cumulativeBalances[token])) {
-          // Convert pending rebalance amount to L1 token decimals
-          const l1TokenInfo = getTokenInfoFromSymbol(token, rebalancerConfig.hubPoolChainId);
-          const chainDecimals = getTokenInfoFromSymbol(token, Number(chainId)).decimals;
-          const chainToL1Converter = ConvertDecimals(chainDecimals, l1TokenInfo.decimals);
-          const pendingRebalanceAmountConverted = chainToL1Converter(pendingRebalanceAmount);
-          cumulativeBalances[token] = cumulativeBalances[token].add(pendingRebalanceAmountConverted);
-        }
-
-        if (!pendingRebalanceAmount.eq(bnZero)) {
-          logger.debug({
-            at: `index.ts:${logLabel}`,
-            message: `${pendingRebalanceAmount.gt(bnZero) ? "Added" : "Subtracted"} pending rebalance amount from ${
-              adapter.constructor.name
-            } of ${pendingRebalanceAmount.toString()} to cumulative (virtual) balance for ${token} on ${chainId}`,
-            pendingRebalanceAmount: pendingRebalanceAmount.toString(),
-            newCumulativeBalance: cumulativeBalances?.[token]?.toString(),
-          });
-        }
-      }
-    }
-  }
-}
-
 export async function runCumulativeBalanceRebalancer(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
   const logLabel = "runCumulativeBalanceRebalancer";
-  const { rebalancerConfig, adaptersToUpdate, inventoryClient, rebalancerClient } = await initializeRebalancerRun(
+  const { rebalancerConfig, inventoryClient, rebalancerClient } = await initializeCumulativeRebalancerRun(
     _logger,
     baseSigner
   );
   const { currentBalances, cumulativeBalances } = loadCumulativeModeBalances(rebalancerConfig, inventoryClient);
-  await applyPendingCumulativeRebalanceAdjustments(
-    baseSigner,
-    rebalancerConfig,
-    adaptersToUpdate,
-    logLabel,
-    cumulativeBalances
-  );
 
   let timerStart = performance.now();
   // Finally, send out new rebalances:
@@ -245,7 +232,7 @@ export async function runCumulativeBalanceRebalancer(_logger: winston.Logger, ba
 
 export async function runSameAssetRebalancer(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
   const logLabel = "runSameAssetRebalancer";
-  const { rebalancerClient, inventoryClient } = await initializeRebalancerRun(_logger, baseSigner);
+  const { rebalancerClient, inventoryClient } = await initializeSameAssetRebalancerRun(_logger, baseSigner);
 
   let timerStart = performance.now();
   // Finally, send out new rebalances:

--- a/src/rebalancer/index.ts
+++ b/src/rebalancer/index.ts
@@ -20,7 +20,7 @@ import {
   constructSameAssetRebalancerClient,
 } from "./RebalancerClientHelper";
 import { RebalancerConfig } from "./RebalancerConfig";
-import { RebalancerAdapter, RebalancerClient } from "./utils/interfaces";
+import { RebalancerClient } from "./utils/interfaces";
 config();
 let logger: winston.Logger;
 
@@ -29,6 +29,7 @@ type RebalancerRunContext = {
   inventoryClient: InventoryClient;
   rebalancerClient: RebalancerClient;
 };
+type RebalancerClientConstructor = (_logger: winston.Logger, baseSigner: Signer) => Promise<RebalancerClient>;
 
 const sweepableAdapters: string[] = ["hyperliquid"];
 
@@ -76,7 +77,7 @@ async function updateAdapters(
   tokenClient: TokenClient,
   inventoryClient: InventoryClient,
   logLabel: string
-): Promise<Set<RebalancerAdapter>> {
+): Promise<void> {
   let timerStart = performance.now();
 
   // Make sure we update the upstream adapters first, so there is a small chance of progressing an intermediate
@@ -85,7 +86,6 @@ async function updateAdapters(
   const upstreamAdapterNames: string[] = allAdapters.filter((adapter) => adapter === "cctp" || adapter === "oft");
   const downstreamAdapterNames = allAdapters.filter((adapter) => !upstreamAdapterNames.includes(adapter));
   const adapterNamesToUpdate = [...upstreamAdapterNames, ...downstreamAdapterNames];
-  const adaptersToUpdate = new Set(adapterNamesToUpdate.map((adapterName) => rebalancerClient.adapters[adapterName]));
   for (const adapterName of adapterNamesToUpdate) {
     const adapter = rebalancerClient.adapters[adapterName];
     timerStart = performance.now();
@@ -125,37 +125,20 @@ async function updateAdapters(
   if (inventoryManagement) {
     await inventoryClient.update(rebalancerConfig.chainIds);
   }
-  return adaptersToUpdate;
 }
 
-async function initializeCumulativeRebalancerRun(
+async function initializeRebalancerRun(
   _logger: winston.Logger,
-  baseSigner: Signer
+  baseSigner: Signer,
+  logLabel: string,
+  constructRebalancerClient: RebalancerClientConstructor
 ): Promise<RebalancerRunContext> {
-  const logLabel = "runCumulativeBalanceRebalancer";
   logger = _logger;
   const { relayerClients, rebalancerConfig } = await setupClients(logger, baseSigner, logLabel);
   const { inventoryClient, tokenClient } = relayerClients;
-  const rebalancerClient = await constructCumulativeBalanceRebalancerClient(logger, baseSigner);
+  const rebalancerClient = await constructRebalancerClient(logger, baseSigner);
   await updateAdapters(rebalancerClient, rebalancerConfig, tokenClient, inventoryClient, logLabel);
 
-  return {
-    rebalancerConfig,
-    inventoryClient,
-    rebalancerClient,
-  };
-}
-
-async function initializeSameAssetRebalancerRun(
-  _logger: winston.Logger,
-  baseSigner: Signer
-): Promise<RebalancerRunContext> {
-  const logLabel = "runSameAssetRebalancer";
-  logger = _logger;
-  const { relayerClients, rebalancerConfig } = await setupClients(logger, baseSigner, logLabel);
-  const { inventoryClient, tokenClient } = relayerClients;
-  const rebalancerClient = await constructSameAssetRebalancerClient(logger, baseSigner);
-  await updateAdapters(rebalancerClient, rebalancerConfig, tokenClient, inventoryClient, logLabel);
   return {
     rebalancerConfig,
     inventoryClient,
@@ -194,9 +177,11 @@ export function loadCumulativeModeBalances(
 
 export async function runCumulativeBalanceRebalancer(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
   const logLabel = "runCumulativeBalanceRebalancer";
-  const { rebalancerConfig, inventoryClient, rebalancerClient } = await initializeCumulativeRebalancerRun(
+  const { rebalancerConfig, inventoryClient, rebalancerClient } = await initializeRebalancerRun(
     _logger,
-    baseSigner
+    baseSigner,
+    logLabel,
+    constructCumulativeBalanceRebalancerClient
   );
   const { currentBalances, cumulativeBalances } = loadCumulativeModeBalances(rebalancerConfig, inventoryClient);
 
@@ -232,10 +217,14 @@ export async function runCumulativeBalanceRebalancer(_logger: winston.Logger, ba
 
 export async function runSameAssetRebalancer(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
   const logLabel = "runSameAssetRebalancer";
-  const { rebalancerClient, inventoryClient } = await initializeSameAssetRebalancerRun(_logger, baseSigner);
+  const { rebalancerClient, inventoryClient } = await initializeRebalancerRun(
+    _logger,
+    baseSigner,
+    logLabel,
+    constructSameAssetRebalancerClient
+  );
 
   let timerStart = performance.now();
-  // Finally, send out new rebalances:
   try {
     if (process.env.SEND_REBALANCES === "true") {
       timerStart = performance.now();
@@ -246,11 +235,7 @@ export async function runSameAssetRebalancer(_logger: winston.Logger, baseSigner
         message: "Completed rebalancing inventory",
         duration: performance.now() - timerStart,
       });
-      timerStart = performance.now();
     }
-    // Maybe now enter a loop where we update rebalances continuously every X seconds until the next run where
-    // we call rebalance inventory? The thinking is we should rebalance inventory once per "run" and then continually
-    // update rebalance statuses/finalize pending rebalances.
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error("Error running rebalancer", error);

--- a/src/rebalancer/index.ts
+++ b/src/rebalancer/index.ts
@@ -17,6 +17,7 @@ import {
   winston,
 } from "../utils";
 import { CumulativeBalanceRebalancerClient } from "./clients/CumulativeBalanceRebalancerClient";
+import { SameAssetRebalancerClient } from "./clients/SameAssetRebalancerClient";
 
 import { constructCumulativeBalanceRebalancerClient } from "./RebalancerClientHelper";
 import { RebalancerConfig } from "./RebalancerConfig";
@@ -223,6 +224,36 @@ export async function runCumulativeBalanceRebalancer(_logger: winston.Logger, ba
         currentBalances,
         maxFeePct
       );
+      logger.debug({
+        at: `index.ts:${logLabel}`,
+        message: "Completed rebalancing inventory",
+        duration: performance.now() - timerStart,
+      });
+      timerStart = performance.now();
+    }
+    // Maybe now enter a loop where we update rebalances continuously every X seconds until the next run where
+    // we call rebalance inventory? The thinking is we should rebalance inventory once per "run" and then continually
+    // update rebalance statuses/finalize pending rebalances.
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error("Error running rebalancer", error);
+    throw error;
+  } finally {
+    await disconnectRedisClients(logger);
+  }
+}
+
+export async function runSameAssetRebalancer(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
+  const logLabel = "runSameAssetRebalancer";
+  const { rebalancerClient, inventoryClient } = await initializeRebalancerRun(_logger, baseSigner);
+
+  let timerStart = performance.now();
+  // Finally, send out new rebalances:
+  try {
+    if (process.env.SEND_REBALANCES === "true") {
+      timerStart = performance.now();
+      const maxFeePct = toBNWei(process.env.MAX_FEE_PCT ?? "2.5", 18);
+      await (rebalancerClient as SameAssetRebalancerClient).rebalanceInventory(inventoryClient, maxFeePct);
       logger.debug({
         at: `index.ts:${logLabel}`,
         message: "Completed rebalancing inventory",

--- a/src/rebalancer/utils/interfaces.ts
+++ b/src/rebalancer/utils/interfaces.ts
@@ -26,6 +26,7 @@ export interface RebalanceRoute {
 }
 
 export interface RebalancerClient {
+  adapters: Record<string, RebalancerAdapter>;
   getPendingRebalances(account: EvmAddress): Promise<{ [chainId: number]: { [token: string]: BigNumber } }>;
 }
 

--- a/src/utils/BinanceUtils.ts
+++ b/src/utils/BinanceUtils.ts
@@ -64,6 +64,7 @@ type BinanceApiWithRecvWindow = BinanceApi & {
 // Alias for Binance network symbols.
 export const BINANCE_NETWORKS: { [chainId: number]: string } = {
   [CHAIN_IDs.ARBITRUM]: "ARBITRUM",
+  [CHAIN_IDs.AVALANCHE]: "AVAXC",
   [CHAIN_IDs.BASE]: "BASE",
   [CHAIN_IDs.BSC]: "BSC",
   [CHAIN_IDs.MAINNET]: "ETH",

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -32,6 +32,10 @@ describe("Binance adapter helpers", function () {
     expect(resolveBinanceCoinSymbol("USDC")).to.equal("USDC");
   });
 
+  it("maps Avalanche to Binance AVAXC", async function () {
+    expect(BINANCE_NETWORKS[CHAIN_IDs.AVALANCHE]).to.equal("AVAXC");
+  });
+
   it("detects same-coin Binance routes that should skip the swap leg", async function () {
     expect(isSameBinanceCoin("WETH", "WETH")).to.equal(true);
     expect(isSameBinanceCoin("USDC", "USDC")).to.equal(true);

--- a/test/InventoryClient.InventoryRebalance.ts
+++ b/test/InventoryClient.InventoryRebalance.ts
@@ -262,6 +262,18 @@ describe("InventoryClient: Rebalancing inventory", function () {
     expect(spyLogIncludes(spy, -2, '"proRataShare":"7.00%"')).to.be.true;
   });
 
+  it("Returns possible rebalances without sending bridge transactions", async function () {
+    tokenClient.decrementLocalBalance(ARBITRUM, toAddressType(l2TokensForUsdc[ARBITRUM], ARBITRUM), toMegaWei(500));
+
+    await inventoryClient.update();
+    const rebalances = await inventoryClient.rebalanceInventoryIfNeeded(true);
+
+    expect(rebalances.length).to.equal(1);
+    expect(rebalances[0].chainId).to.equal(ARBITRUM);
+    expect(rebalances[0].amount.eq(toMegaWei(515))).to.be.true;
+    expect(adapterManager.tokensSentCrossChain[ARBITRUM]).to.be.undefined;
+  });
+
   // Skipped: shortfall rebalances are temporarily disabled in InventoryClient.getPossibleRebalances(). Re-enable
   // alongside that logic.
   it.skip("Correctly decides when to execute rebalances: token shortfall", async function () {
@@ -481,6 +493,27 @@ describe("InventoryClient: Rebalancing inventory", function () {
       expect(adapterManager.withdrawalsRequired[0].l2ChainId).eq(testChain);
       expect(adapterManager.withdrawalsRequired[0].l2Token.toNative()).eq(testL2Token.toNative());
       expect(adapterManager.withdrawalsRequired[0].address.toNative()).eq(owner.address);
+    });
+
+    it("Returns excess withdrawals without sending L2 withdrawals", async function () {
+      const currentCumulativeBalance = inventoryClient.getCumulativeBalance(EvmAddress.from(testL1Token));
+      tokenClient.setTokenData(testChain, testL2Token, currentCumulativeBalance);
+      const currentAllocationPct = inventoryClient
+        .getBalanceOnChain(testChain, EvmAddress.from(testL1Token))
+        .mul(toWei(1))
+        .div(inventoryClient.getCumulativeBalance(EvmAddress.from(testL1Token)));
+
+      const withdrawals = await inventoryClient.withdrawExcessBalances(true);
+      const expectedWithdrawalPct = currentAllocationPct.sub(
+        inventoryConfig.tokenConfig[testL1Token][testL2Token.toNative()][testChain].targetPct
+      );
+      const expectedWithdrawalAmount = expectedWithdrawalPct
+        .mul(inventoryClient.getCumulativeBalance(EvmAddress.from(testL1Token)))
+        .div(toWei(1));
+
+      expect(withdrawals[testChain][0].amountToWithdraw).eq(expectedWithdrawalAmount);
+      expect(withdrawals[testChain][0].l2Token.toNative()).eq(testL2Token.toNative());
+      expect(adapterManager.withdrawalsRequired.length).to.equal(0);
     });
 
     it("Withdrawal amount is in correct L2 token decimals", async function () {

--- a/test/RebalancerClient.buildRebalanceRoutes.ts
+++ b/test/RebalancerClient.buildRebalanceRoutes.ts
@@ -2,6 +2,7 @@ import { expect } from "./utils";
 import { CHAIN_IDs } from "../src/utils";
 import { RebalancerConfig } from "../src/rebalancer/RebalancerConfig";
 import { buildRebalanceRoutes } from "../src/rebalancer/buildRebalanceRoutes";
+import { buildSameAssetRebalanceRoutes } from "../src/rebalancer/buildSameAssetRebalanceRoutes";
 
 function buildSyntheticRebalancerConfig(): RebalancerConfig {
   return new RebalancerConfig({
@@ -127,6 +128,21 @@ function buildSyntheticRebalancerConfigWithTron(): RebalancerConfig {
       maxPendingOrders: {
         hyperliquid: 3,
         binance: 3,
+      },
+    }),
+  });
+}
+
+function buildSyntheticSameAssetRebalancerConfig(): RebalancerConfig {
+  return new RebalancerConfig({
+    HUB_CHAIN_ID: String(CHAIN_IDs.MAINNET),
+    REBALANCER_CONFIG: JSON.stringify({
+      sameAssetBalances: {
+        USDT: {
+          chains: {
+            [CHAIN_IDs.AVALANCHE]: 0,
+          },
+        },
       },
     }),
   });
@@ -286,5 +302,22 @@ describe("buildRebalanceRoutes", function () {
     expect(hasRoute(CHAIN_IDs.BASE, "USDC", CHAIN_IDs.TRON, "USDT", "hyperliquid")).to.equal(false);
     expect(hasRoute(CHAIN_IDs.TRON, "USDT", CHAIN_IDs.OPTIMISM, "USDT", "oft")).to.equal(false);
     expect(hasRoute(CHAIN_IDs.OPTIMISM, "USDT", CHAIN_IDs.TRON, "USDT", "oft")).to.equal(false);
+  });
+});
+
+describe("buildSameAssetRebalanceRoutes", function () {
+  it("builds configured L1-to-L2 same-asset routes only", function () {
+    const routes = buildSameAssetRebalanceRoutes(buildSyntheticSameAssetRebalancerConfig());
+
+    expect(routes).to.deep.equal([
+      {
+        sourceChain: CHAIN_IDs.MAINNET,
+        destinationChain: CHAIN_IDs.AVALANCHE,
+        sourceToken: "USDT",
+        destinationToken: "USDT",
+        adapter: "binance",
+      },
+    ]);
+    expect(routeExists(routes, CHAIN_IDs.AVALANCHE, "USDT", CHAIN_IDs.MAINNET, "USDT", "binance")).to.equal(false);
   });
 });

--- a/test/RebalancerClient.cumulativeRebalancing.ts
+++ b/test/RebalancerClient.cumulativeRebalancing.ts
@@ -1,12 +1,15 @@
 import { RebalancerAdapter, RebalanceRoute } from "../src/rebalancer/utils/interfaces";
 import { CumulativeBalanceRebalancerClient } from "../src/rebalancer/clients/CumulativeBalanceRebalancerClient";
+import { SameAssetRebalancerClient } from "../src/rebalancer/clients/SameAssetRebalancerClient";
 import {
   CumulativeTargetBalanceConfig,
   MaxAmountToTransferConfig,
   MaxPendingOrdersConfig,
   RebalancerConfig,
+  SameAssetConfig,
 } from "../src/rebalancer/RebalancerConfig";
-import { bnZero, EvmAddress, getTokenInfoFromSymbol, Signer, toBNWei } from "../src/utils";
+import { InventoryClient, Rebalance } from "../src/clients";
+import { bnZero, CHAIN_IDs, EvmAddress, getTokenInfoFromSymbol, Signer, toBNWei } from "../src/utils";
 import { BigNumber, createSpyLogger, ethers, expect } from "./utils";
 
 describe("RebalancerClient.cumulativeRebalancing", () => {
@@ -826,6 +829,82 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
   });
 });
 
+describe("RebalancerClient.sameAssetRebalancing", () => {
+  const HUB_POOL_CHAIN_ID = CHAIN_IDs.MAINNET;
+  const DESTINATION_CHAIN_ID = CHAIN_IDs.AVALANCHE;
+  const USDT = "USDT";
+  const amount = (humanAmount: string): BigNumber => toBNWei(humanAmount, 6);
+  const route: RebalanceRoute = {
+    sourceChain: HUB_POOL_CHAIN_ID,
+    destinationChain: DESTINATION_CHAIN_ID,
+    sourceToken: USDT,
+    destinationToken: USDT,
+    adapter: "binance",
+  };
+
+  async function createSameAssetClient(adapter: MockRebalancerAdapter): Promise<SameAssetRebalancerClient> {
+    const config = new MockRebalancerConfig(
+      {},
+      { [USDT]: { [HUB_POOL_CHAIN_ID]: amount("100") } },
+      { binance: 10 },
+      HUB_POOL_CHAIN_ID,
+      { [USDT]: { [DESTINATION_CHAIN_ID]: true } }
+    );
+    const { spyLogger } = createSpyLogger();
+    const client = new SameAssetRebalancerClient(spyLogger, config, { binance: adapter }, adapter.baseSigner, false);
+    await client.initialize([route]);
+    return client;
+  }
+
+  function makeInventoryClient(rebalances: Rebalance[]): InventoryClient {
+    return {
+      rebalanceInventoryIfNeeded: async (returnRebalancesOnly?: boolean) => {
+        expect(returnRebalancesOnly).to.equal(true);
+        return rebalances;
+      },
+    } as unknown as InventoryClient;
+  }
+
+  function makeRebalance(chainId: number, humanAmount: string): Rebalance {
+    return {
+      chainId,
+      l1Token: EvmAddress.from(getTokenInfoFromSymbol(USDT, HUB_POOL_CHAIN_ID).address.toNative()),
+      l2Token: getTokenInfoFromSymbol(USDT, chainId).address,
+      balance: amount("1000"),
+      amount: amount(humanAmount),
+      isShortfallRebalance: false,
+    };
+  }
+
+  it("filters inventory rebalances and caps by the L1 source-chain limit", async () => {
+    const adapter = new MockRebalancerAdapter(ethers.Wallet.createRandom());
+    const client = await createSameAssetClient(adapter);
+
+    await client.rebalanceInventory(
+      makeInventoryClient([makeRebalance(DESTINATION_CHAIN_ID, "250"), makeRebalance(CHAIN_IDs.OPTIMISM, "250")]),
+      toBNWei("100")
+    );
+
+    expect(adapter.rebalances.length).to.equal(1);
+    expect(adapter.rebalances[0].route.sourceChain).to.equal(HUB_POOL_CHAIN_ID);
+    expect(adapter.rebalances[0].route.destinationChain).to.equal(DESTINATION_CHAIN_ID);
+    expect(adapter.rebalances[0].route.sourceToken).to.equal(USDT);
+    expect(adapter.rebalances[0].route.destinationToken).to.equal(USDT);
+    expect(adapter.rebalances[0].route.adapter).to.equal("binance");
+    expect(adapter.rebalances[0].amount.eq(amount("100"))).to.equal(true);
+  });
+
+  it("skips same-asset rebalances over the max fee", async () => {
+    const adapter = new MockRebalancerAdapter(ethers.Wallet.createRandom());
+    adapter.setEstimatedCost(route, amount("6"));
+    const client = await createSameAssetClient(adapter);
+
+    await client.rebalanceInventory(makeInventoryClient([makeRebalance(DESTINATION_CHAIN_ID, "100")]), toBNWei("5"));
+
+    expect(adapter.rebalances.length).to.equal(0);
+  });
+});
+
 class MockRebalancerAdapter implements RebalancerAdapter {
   public baseSignerAddress!: EvmAddress;
   public rebalances: { route: RebalanceRoute; amount: BigNumber }[] = [];
@@ -833,7 +912,7 @@ class MockRebalancerAdapter implements RebalancerAdapter {
   public initializeRebalanceResultMapping: { [route: string]: BigNumber } = {};
   private pendingOrders: string[] | undefined;
   private pendingRebalances: { [chainId: number]: { [token: string]: BigNumber } } = {};
-  private readonly baseSigner: Signer;
+  readonly baseSigner: Signer;
 
   constructor(baseSigner: Signer) {
     this.baseSigner = baseSigner;
@@ -848,7 +927,7 @@ class MockRebalancerAdapter implements RebalancerAdapter {
   }
 
   initializeRebalance(rebalanceRoute: RebalanceRoute, amountToTransfer: BigNumber): Promise<BigNumber> {
-    const result = this.initializeRebalanceResultMapping[JSON.stringify(rebalanceRoute)] ?? amountToTransfer;
+    const result = this.initializeRebalanceResultMapping[this.routeKey(rebalanceRoute)] ?? amountToTransfer;
     if (result.gt(bnZero)) {
       this.rebalances.push({ route: rebalanceRoute, amount: amountToTransfer });
     }
@@ -880,22 +959,28 @@ class MockRebalancerAdapter implements RebalancerAdapter {
   }
 
   setEstimatedCost(route: RebalanceRoute, cost: BigNumber): void {
-    this.estimatedCostMapping[JSON.stringify(route)] = cost;
+    this.estimatedCostMapping[this.routeKey(route)] = cost;
   }
 
   setInitializeRebalanceResult(route: RebalanceRoute, amount: BigNumber): void {
-    this.initializeRebalanceResultMapping[JSON.stringify(route)] = amount;
+    this.initializeRebalanceResultMapping[this.routeKey(route)] = amount;
   }
 
   getEstimatedCost(rebalanceRoute: RebalanceRoute, amountToTransfer: BigNumber, debugLog: boolean): Promise<BigNumber> {
     void amountToTransfer;
     void debugLog;
-    return Promise.resolve(this.estimatedCostMapping[JSON.stringify(rebalanceRoute)] ?? bnZero);
+    return Promise.resolve(this.estimatedCostMapping[this.routeKey(rebalanceRoute)] ?? bnZero);
+  }
+
+  private routeKey(route: RebalanceRoute): string {
+    const { sourceChain, destinationChain, sourceToken, destinationToken, adapter } = route;
+    return JSON.stringify({ sourceChain, destinationChain, sourceToken, destinationToken, adapter });
   }
 }
 
 class MockRebalancerConfig extends RebalancerConfig {
   declare public cumulativeTargetBalances: CumulativeTargetBalanceConfig;
+  declare public sameAssetBalances: SameAssetConfig;
   declare public maxAmountsToTransfer: MaxAmountToTransferConfig;
   declare public maxPendingOrders: MaxPendingOrdersConfig;
   declare public hubPoolChainId: number;
@@ -905,10 +990,12 @@ class MockRebalancerConfig extends RebalancerConfig {
     cumulativeBalanceTargets: CumulativeTargetBalanceConfig,
     maxAmountsToTransfer: MaxAmountToTransferConfig = {},
     maxPendingOrders: MaxPendingOrdersConfig = {},
-    hubPoolChainId = 1
+    hubPoolChainId = 1,
+    sameAssetBalances: SameAssetConfig = {}
   ) {
     super({});
     this.cumulativeTargetBalances = cumulativeBalanceTargets;
+    this.sameAssetBalances = sameAssetBalances;
     this.maxAmountsToTransfer = maxAmountsToTransfer;
     this.maxPendingOrders = maxPendingOrders;
     this.hubPoolChainId = hubPoolChainId;

--- a/test/RebalancerConfig.ts
+++ b/test/RebalancerConfig.ts
@@ -1,6 +1,6 @@
 import { join } from "path";
 import { RebalancerConfig } from "../src/rebalancer/RebalancerConfig";
-import { toBNWei } from "../src/utils";
+import { CHAIN_IDs, toBNWei } from "../src/utils";
 import { expect } from "./utils";
 
 describe("RebalancerConfig", () => {
@@ -101,6 +101,28 @@ describe("RebalancerConfig", () => {
     expect(config.maxAmountsToTransfer.DAI[10]).to.equal(toBNWei("2", 18));
   });
 
+  it("sets same-asset source and destination chain transfer caps", () => {
+    const env = makeEnv({
+      REBALANCER_CONFIG: JSON.stringify({
+        sameAssetBalances: {
+          USDT: {
+            chains: { [CHAIN_IDs.AVALANCHE]: 1 },
+          },
+        },
+        maxAmountsToTransfer: {
+          USDT: "1000",
+        },
+      }),
+    });
+
+    const config = new RebalancerConfig(env);
+
+    expect(config.sameAssetBalances.USDT).to.deep.equal({ [CHAIN_IDs.AVALANCHE]: true });
+    expect(new Set(config.chainIds)).to.deep.equal(new Set([CHAIN_IDs.MAINNET, CHAIN_IDs.AVALANCHE]));
+    expect(config.maxAmountsToTransfer.USDT[CHAIN_IDs.MAINNET]).to.equal(toBNWei("1000", 6));
+    expect(config.maxAmountsToTransfer.USDT[CHAIN_IDs.AVALANCHE]).to.equal(toBNWei("1000", 6));
+  });
+
   it("sets maxPendingOrders from config", () => {
     const env = makeEnv({
       REBALANCER_CONFIG: JSON.stringify({
@@ -162,6 +184,7 @@ describe("RebalancerConfig", () => {
     const config = new RebalancerConfig(env);
 
     expect(config.cumulativeTargetBalances).to.deep.equal({});
+    expect(config.sameAssetBalances).to.deep.equal({});
     expect(config.maxAmountsToTransfer).to.deep.equal({});
     expect(config.maxPendingOrders).to.deep.equal({});
     expect(config.chainIds).to.deep.equal([]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.118.tgz#3d82d1e162dc1803d0ed6cb11f3865598f46cf70"
   integrity sha512-JIUzkl285Oyfs1nnqubUlb4p5gCPh6RcirPR6o2MWUShSwq99sh1z62wDfOBheiCDnYfqgMoC2iVjDbFJWISXA==
 
-"@across-protocol/constants@^3.1.119":
-  version "3.1.119"
-  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.119.tgz#95baca79e9fe1cef7fa3936803c8ff05d31a1827"
-  integrity sha512-WaYqz7WAuE49kuDekkZoisBKMfmCWw6Rt8+MC44nyS4CO5CwiFZmYAn+dsqy5YgpdQElimxpdTG4m5PAr/cxNw==
+"@across-protocol/constants@^3.1.122":
+  version "3.1.122"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.122.tgz#8b23afe8b57efe227f99d357ea0f094effa36ff8"
+  integrity sha512-uaPGyhnl3DV8fEKPRzlpo+rYFThTF24ef75e+QLm+8q31yeXPbAL6gNo11vNMC+MnNtuLk5eUHGwrtjdQUbxCA==
 
 "@across-protocol/contracts@5.0.22":
   version "5.0.22"
@@ -34,12 +34,12 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.4.8":
-  version "4.4.8"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.4.8.tgz#e6c0e65050705852fc5d1dec1f6dcc759623e59d"
-  integrity sha512-FQXyTUO6jKfShQqUJ55oPzEbnV+90tf2mkMpYC6LiBZMAdt6GcgXwwYg49xPnoMPJMoaNPEYJe95/Jb1jVSt6w==
+"@across-protocol/sdk@4.4.9":
+  version "4.4.9"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.4.9.tgz#c6c2153f8de57ac2a2d974cc517e789f8b31f7b2"
+  integrity sha512-yQu3+QY6c02QMShtHfSun8r2W+kVRSlD9kTkj/+khjlsoNFt4kb3J9JFAi5gxAG/sc3UllpJaPdTZQ9VVjN/zA==
   dependencies:
-    "@across-protocol/constants" "^3.1.119"
+    "@across-protocol/constants" "^3.1.122"
     "@across-protocol/contracts" "5.0.22"
     "@coral-xyz/anchor" "^0.30.1"
     "@eth-optimism/sdk" "^3.3.1"


### PR DESCRIPTION
- Extend InventoryClient withdrawExcessBalances() and rebalanceInventoryIfNeeded() to allow caller to retrieve the set of potential rebalances (based on the configured inventory config) without executing any rebalances through the InventoryClient
- Creates a SameAssetRebalancerClient that (1) asks the InventoryClient for the set of rebalances + withdrawals and (2) executes them using the `swap-rebalancer/`'s adapters
- Creates a setup script that hardcodes USDT rebalances through Binance  between Ethereum and Avalanche
- Adds a new bot parallel to the `swapRebalancer` that can be run independently from the swap rebalancer called the `sameAssetRebalancer`

