### PR TITLE
feat(deposit-address): relay erc20Transfer provenance on v3 execute

### DIFF
--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -111,6 +111,19 @@ export interface DepositAddressExecuteRequest {
    * integrators); drives the CREATE2 salt + on-chain integrator tag. Required by the endpoint.
    */
   integratorId: string;
+  /**
+   * Optional reference to the inbound ERC-20 transfer that funded the sweep. When present, the API
+   * wraps `executeTx` in a Multicall3 bundle that also emits a version-2 provenance blob via
+   * `AcrossEventEmitter`, so the indexer can link the deposit-executed event to this transfer in the
+   * same receipt. `transactionHash` is a 32-byte hex hash (`^(0x)?[0-9a-fA-F]{64}$`); the numeric
+   * fields must be non-negative integers.
+   */
+  erc20Transfer?: {
+    chainId: number;
+    blockNumber: number;
+    transactionHash: string;
+    logIndex: number;
+  };
 }
 
 export interface DepositAddressExecuteResponse {

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -1192,10 +1192,10 @@ export class DepositAddressHandler {
       // Provenance reference to the inbound funding transfer. The API folds this into a Multicall3
       // bundle that emits a version-2 provenance blob, giving the indexer an on-chain sweep ↔
       // funding-transfer link in the execute receipt. The endpoint requires chainId as a
-      // non-negative integer; coerce only when the indexer message hands it to us as a string, so a
-      // future switch to a numeric chainId in the polled response keeps working unchanged.
+      // non-negative integer; Number() is a no-op on an already-numeric value, so this keeps working
+      // if the indexer later types chainId as a number.
       erc20Transfer: {
-        chainId: typeof erc20Transfer.chainId === "number" ? erc20Transfer.chainId : Number(erc20Transfer.chainId),
+        chainId: Number(erc20Transfer.chainId),
         blockNumber: erc20Transfer.blockNumber,
         transactionHash: erc20Transfer.transactionHash,
         logIndex: erc20Transfer.logIndex,

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -1181,6 +1181,16 @@ export class DepositAddressHandler {
       amount: erc20Transfer.amount,
       executionFeeRecipient: this.signerAddress.toNative(),
       integratorId,
+      // Provenance reference to the inbound funding transfer. The API folds this into a Multicall3
+      // bundle that emits a version-2 provenance blob, giving the indexer an on-chain sweep ↔
+      // funding-transfer link in the execute receipt. chainId is stringly-typed on the indexer
+      // message; the endpoint requires a non-negative integer.
+      erc20Transfer: {
+        chainId: Number(erc20Transfer.chainId),
+        blockNumber: erc20Transfer.blockNumber,
+        transactionHash: erc20Transfer.transactionHash,
+        logIndex: erc20Transfer.logIndex,
+      },
     };
     // `_post` swallows errors and returns undefined, so retry on both throw and falsy return.
     try {

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -1187,8 +1187,7 @@ export class DepositAddressHandler {
       // non-negative integer; coerce only when the indexer message hands it to us as a string, so a
       // future switch to a numeric chainId in the polled response keeps working unchanged.
       erc20Transfer: {
-        chainId:
-          typeof erc20Transfer.chainId === "number" ? erc20Transfer.chainId : Number(erc20Transfer.chainId),
+        chainId: typeof erc20Transfer.chainId === "number" ? erc20Transfer.chainId : Number(erc20Transfer.chainId),
         blockNumber: erc20Transfer.blockNumber,
         transactionHash: erc20Transfer.transactionHash,
         logIndex: erc20Transfer.logIndex,

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -1183,10 +1183,12 @@ export class DepositAddressHandler {
       integratorId,
       // Provenance reference to the inbound funding transfer. The API folds this into a Multicall3
       // bundle that emits a version-2 provenance blob, giving the indexer an on-chain sweep ↔
-      // funding-transfer link in the execute receipt. chainId is stringly-typed on the indexer
-      // message; the endpoint requires a non-negative integer.
+      // funding-transfer link in the execute receipt. The endpoint requires chainId as a
+      // non-negative integer; coerce only when the indexer message hands it to us as a string, so a
+      // future switch to a numeric chainId in the polled response keeps working unchanged.
       erc20Transfer: {
-        chainId: Number(erc20Transfer.chainId),
+        chainId:
+          typeof erc20Transfer.chainId === "number" ? erc20Transfer.chainId : Number(erc20Transfer.chainId),
         blockNumber: erc20Transfer.blockNumber,
         transactionHash: erc20Transfer.transactionHash,
         logIndex: erc20Transfer.logIndex,

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -53,6 +53,13 @@ context only — origin chain, amount, destination route, refund identity — pl
 `executionFeeRecipient` and the `integratorId` the address was derived with. `executionFee` is
 currently omitted (the API defaults it to 0); bot-side fee pricing is a follow-up task.
 
+The bot also relays an `erc20Transfer` provenance reference — `{ chainId, blockNumber,
+transactionHash, logIndex }` of the inbound funding transfer, taken verbatim from the indexer
+message (`chainId` coerced to an integer). When present, the API wraps `executeTx` in a Multicall3
+bundle that additionally emits a version-2 provenance blob via `AcrossEventEmitter`, so the indexer
+gets an explicit sweep ↔ funding-transfer link in the same execute receipt. It is optional on the
+endpoint; the bot always has these fields, so it always sends them.
+
 The `integratorId` (2-byte hex) is sourced from the indexer message's `integrator` projection (a
 property of the deposit address, not the bot's auth key) and is **required** by the execute
 endpoint — it folds into the CREATE2 salt + on-chain integrator tag, so the address is derived

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -386,7 +386,7 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
     });
   });
 
-  it("passes a numeric erc20Transfer.chainId through without re-coercion", async function () {
+  it("handles a numeric erc20Transfer.chainId (Number() is a no-op)", async function () {
     const message = depositMessageV3();
     // Simulate a future indexer response that types chainId as a number.
     (message.erc20Transfer as unknown as { chainId: number }).chainId = 42161;

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -376,7 +376,22 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
       amount: "5000",
       executionFeeRecipient: SIGNER,
       integratorId: "0xdead",
+      // Provenance reference to the inbound funding transfer; chainId coerced to a number.
+      erc20Transfer: {
+        chainId: 42161,
+        blockNumber: 1_000_000,
+        transactionHash: "0x" + "3".repeat(64),
+        logIndex: 4,
+      },
     });
+  });
+
+  it("passes a numeric erc20Transfer.chainId through without re-coercion", async function () {
+    const message = depositMessageV3();
+    // Simulate a future indexer response that types chainId as a number.
+    (message.erc20Transfer as unknown as { chainId: number }).chainId = 42161;
+    await (handler as unknown as Internals)._getExecuteTx(message);
+    expect(executeStub.firstCall.args[0].erc20Transfer.chainId).to.equal(42161);
   });
 
   it("retries on undefined responses and gives up after exhausting retries", async function () {


### PR DESCRIPTION
Attach the new optional erc20Transfer object ({ chainId, blockNumber, transactionHash, logIndex }) to POST /deposit-addresses/execute requests. When present, the quote-api wraps executeTx in a Multicall3 bundle that also emits a version-2 provenance blob via AcrossEventEmitter, giving the indexer an on-chain sweep <-> funding-transfer link in the execute receipt.

The bot always has these fields on the indexer message, so it always sends them (chainId is coerced to an integer as the endpoint requires).