### PR TITLE
feat(DepositAddressHandler): relay funding token as inputToken on v3 execute (env-gated)

### DIFF
--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -98,6 +98,11 @@ export interface DepositAddressExecuteRequest {
     recipient: string;
   };
   originChainId: number;
+  // The origin token that funded the deposit address.
+  inputToken?: {
+    chainId: number;
+    address: string;
+  };
   /** The withdraw "user" identity committed at deposit-address creation (the refund address). */
   userAddress: string;
   /** Input amount as a decimal (or 0x-hex) bigint string. */

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -1177,6 +1177,14 @@ export class DepositAddressHandler {
         recipient: routeParams.recipient.address,
       },
       originChainId: Number(erc20Transfer.chainId),
+      ...(this.config.enableExecuteInputToken
+        ? {
+            inputToken: {
+              chainId: Number(erc20Transfer.chainId),
+              address: erc20Transfer.contractAddress,
+            },
+          }
+        : {}),
       userAddress: refundAddress.address,
       amount: erc20Transfer.amount,
       executionFeeRecipient: this.signerAddress.toNative(),

--- a/src/deposit-address/DepositAddressHandlerConfig.ts
+++ b/src/deposit-address/DepositAddressHandlerConfig.ts
@@ -18,6 +18,8 @@ export class DepositAddressHandlerConfig extends CommonConfig {
   withdrawEnabled: boolean;
   /** Gate for the v3 (upgradeable-counterfactual) refund-withdraw path. Independent of withdrawEnabled. */
   enableV3Withdrawals: boolean;
+  /** Gate for relaying the funding token as `inputToken` on v3 executes. Requires an API that accepts the field. */
+  enableExecuteInputToken: boolean;
 
   /** Gate for publishing `withdraw_executed` events to GCP Pub/Sub. */
   enableDepositAddressWithdrawPublisher: boolean;
@@ -43,6 +45,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
       INITIALIZATION_RETRY_ATTEMPTS,
       WITHDRAW_ENABLED,
       ENABLE_V3_WITHDRAWALS,
+      ENABLE_EXECUTE_INPUT_TOKEN,
       ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER,
       ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER,
       PUBSUB_GCP_PROJECT_ID,
@@ -66,6 +69,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
     this.initializationRetryAttempts = Number(INITIALIZATION_RETRY_ATTEMPTS ?? 3);
     this.withdrawEnabled = WITHDRAW_ENABLED === "true";
     this.enableV3Withdrawals = ENABLE_V3_WITHDRAWALS === "true";
+    this.enableExecuteInputToken = ENABLE_EXECUTE_INPUT_TOKEN === "true";
 
     this.enableDepositAddressWithdrawPublisher = ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER === "true";
     this.enableDepositAddressDepositPublisher = ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER === "true";

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -379,6 +379,24 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
     });
   });
 
+  it("relays the funding token as inputToken when ENABLE_EXECUTE_INPUT_TOKEN is on", async function () {
+    (handler as unknown as { config: { enableExecuteInputToken: boolean } }).config.enableExecuteInputToken = true;
+    await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());
+    expect(executeStub.calledOnce).to.equal(true);
+    expect(executeStub.firstCall.args[0]).to.deep.equal({
+      destination: {
+        token: { chainId: 1337, address: OUTPUT_TOKEN },
+        recipient: RECIPIENT,
+      },
+      originChainId: 42161,
+      inputToken: { chainId: 42161, address: TOKEN },
+      userAddress: REFUND_ADDRESS,
+      amount: "5000",
+      executionFeeRecipient: SIGNER,
+      integratorId: "0xdead",
+    });
+  });
+
   it("retries on undefined responses and gives up after exhausting retries", async function () {
     executeStub.resolves(undefined);
     const result = await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());


### PR DESCRIPTION
## What

Relays the funding token as `inputToken` on the v3 `/deposit-addresses/execute` request, gated behind a new `ENABLE_EXECUTE_INPUT_TOKEN` env flag (same pattern as `ENABLE_V3_WITHDRAWALS`). Off by default — a fleet deploy changes nothing until a bot's config opts in.

## Why

Without the field the quote API assumes origin-native USDC, mis-routing (or rejecting) deposits funded with any other token: a USDT-funded PDA gets priced as a USDC→USDT cross-asset intent and 400s ("Intent lane USDC -> USDT is not priceable"), surfacing bot-side as `Failed to fetch execute tx from swap API`. Live repro: depositKey `0xAC438eE7510B2dE292022331c73CE98924fC631A:0x0d31dd0e…6207` (Arbitrum USDT → HyperEVM USDT, OFT lane).

The handler already has the token — `erc20Transfer.contractAddress`, used for the on-chain balance check — it just wasn't relayed.

## Rollout

1. Merge + deploy fleet-wide (no behavior change; flag off everywhere).
2. bot-configs: set `ENABLE_EXECUTE_INPUT_TOKEN: true` on `zion-across-persistent-address-handler-test` (its API host, epic/pda, already accepts the field).
3. Prod flips the flag once the prod quote API accepts the optional field; the flag can then be defaulted on and retired.

## Notes

- The broadcast path already forwards `executeTx.value`, so OFT lanes (non-zero LayerZero fee) work with the flag on — the origin signer just needs dust native balance.
- Tests: flag-off case asserts the request stays byte-identical to today; flag-on case asserts the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)