### PR TITLE
feat(cctp-finalizer): support Avalanche as mint destination

### DIFF
--- a/src/cctp-finalizer/README.md
+++ b/src/cctp-finalizer/README.md
@@ -89,7 +89,7 @@ Typed errors in `errors.ts` drive retry decisions:
 
 `getRpcUrlForChain` enforces explicit RPC URLs. Set only the ones you need, but missing values for active destinations throw `RpcUrlNotConfiguredError`.
 
-- Mainnets: `ETHEREUM_RPC_URL`, `OPTIMISM_RPC_URL`, `POLYGON_RPC_URL`, `ARBITRUM_RPC_URL`, `BASE_RPC_URL`, `UNICHAIN_RPC_URL`, `LINEA_RPC_URL`, `WORLD_CHAIN_RPC_URL`, `HYPEREVM_RPC_URL`, `BSC_RPC_URL`, `MONAD_RPC_URL`, `SOLANA_RPC_URL`.
+- Mainnets: `ETHEREUM_RPC_URL`, `OPTIMISM_RPC_URL`, `POLYGON_RPC_URL`, `ARBITRUM_RPC_URL`, `BASE_RPC_URL`, `UNICHAIN_RPC_URL`, `LINEA_RPC_URL`, `WORLD_CHAIN_RPC_URL`, `HYPEREVM_RPC_URL`, `BSC_RPC_URL`, `MONAD_RPC_URL`, `INK_RPC_URL`, `AVALANCHE_RPC_URL`, `SOLANA_RPC_URL`.
 - Testnets: `SEPOLIA_RPC_URL`, `OPTIMISM_SEPOLIA_RPC_URL`, `ARBITRUM_SEPOLIA_RPC_URL`, `BASE_SEPOLIA_RPC_URL`, `POLYGON_AMOY_RPC_URL`, `ARBITRUM_NOVA_SEPOLIA_RPC_URL`, `HYPEREVM_TESTNET_RPC_URL`, `SOLANA_DEVNET_RPC_URL`.
 
 All RPC URLs should include authentication if the upstream provider requires it.

--- a/src/cctp-finalizer/services/cctpService.ts
+++ b/src/cctp-finalizer/services/cctpService.ts
@@ -338,6 +338,7 @@ export class CCTPService {
       56: process.env.BSC_RPC_URL,
       143: process.env.MONAD_RPC_URL,
       57073: process.env.INK_RPC_URL,
+      43114: process.env.AVALANCHE_RPC_URL,
       34268394551451: process.env.SOLANA_RPC_URL,
       // Test networks
       11155111: process.env.SEPOLIA_RPC_URL,


### PR DESCRIPTION
## Motivation

The cctp-finalizer service cannot currently submit mint (`receiveMessage`) transactions on Avalanche: `getRpcUrlForChain` in `src/cctp-finalizer/services/cctpService.ts` has no entry for chain 43114, so any Pub/Sub message with an Avalanche destination throws `RpcUrlNotConfiguredError` (non-retryable → the message is ACKed and dropped).

Requested by Alex M in Slack.

## Changes

- Add `43114: process.env.AVALANCHE_RPC_URL` to the production networks section of `getRpcUrlForChain`.
- Update the cctp-finalizer README's mainnet RPC list to include `AVALANCHE_RPC_URL` (and `INK_RPC_URL`, which was already in the code but missing from the doc).

## Notes

- Everything else needed for Avalanche is already in place: `ContractAddresses.ts` has the Avalanche CCTP V2 MessageTransmitter/TokenMessenger entries, the SDK/constants map `cctpDomain: 1` → 43114, and the GCKMS EVM signing key is chain-agnostic.
- The companion deployment change (adding `AVALANCHE_RPC_URL` to the `across-cctp-finalizer` Cloud Run service) is in UMAprotocol/zion — link to follow in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)