### PR TITLE
Revert "feat(deposit-address): relay erc20Transfer provenance on v3 execute (#3569)"

### DIFF
--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -116,19 +116,6 @@ export interface DepositAddressExecuteRequest {
    * integrators); drives the CREATE2 salt + on-chain integrator tag. Required by the endpoint.
    */
   integratorId: string;
-  /**
-   * Optional reference to the inbound ERC-20 transfer that funded the sweep. When present, the API
-   * wraps `executeTx` in a Multicall3 bundle that also emits a version-2 provenance blob via
-   * `AcrossEventEmitter`, so the indexer can link the deposit-executed event to this transfer in the
-   * same receipt. `transactionHash` is a 32-byte hex hash (`^(0x)?[0-9a-fA-F]{64}$`); the numeric
-   * fields must be non-negative integers.
-   */
-  erc20Transfer?: {
-    chainId: number;
-    blockNumber: number;
-    transactionHash: string;
-    logIndex: number;
-  };
 }
 
 export interface DepositAddressExecuteResponse {

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -1189,17 +1189,6 @@ export class DepositAddressHandler {
       amount: erc20Transfer.amount,
       executionFeeRecipient: this.signerAddress.toNative(),
       integratorId,
-      // Provenance reference to the inbound funding transfer. The API folds this into a Multicall3
-      // bundle that emits a version-2 provenance blob, giving the indexer an on-chain sweep ↔
-      // funding-transfer link in the execute receipt. The endpoint requires chainId as a
-      // non-negative integer; Number() is a no-op on an already-numeric value, so this keeps working
-      // if the indexer later types chainId as a number.
-      erc20Transfer: {
-        chainId: Number(erc20Transfer.chainId),
-        blockNumber: erc20Transfer.blockNumber,
-        transactionHash: erc20Transfer.transactionHash,
-        logIndex: erc20Transfer.logIndex,
-      },
     };
     // `_post` swallows errors and returns undefined, so retry on both throw and falsy return.
     try {

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -53,13 +53,6 @@ context only — origin chain, amount, destination route, refund identity — pl
 `executionFeeRecipient` and the `integratorId` the address was derived with. `executionFee` is
 currently omitted (the API defaults it to 0); bot-side fee pricing is a follow-up task.
 
-The bot also relays an `erc20Transfer` provenance reference — `{ chainId, blockNumber,
-transactionHash, logIndex }` of the inbound funding transfer, taken verbatim from the indexer
-message (`chainId` coerced to an integer). When present, the API wraps `executeTx` in a Multicall3
-bundle that additionally emits a version-2 provenance blob via `AcrossEventEmitter`, so the indexer
-gets an explicit sweep ↔ funding-transfer link in the same execute receipt. It is optional on the
-endpoint; the bot always has these fields, so it always sends them.
-
 The `integratorId` (2-byte hex) is sourced from the indexer message's `integrator` projection (a
 property of the deposit address, not the bot's auth key) and is **required** by the execute
 endpoint — it folds into the CREATE2 salt + on-chain integrator tag, so the address is derived

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -376,22 +376,7 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
       amount: "5000",
       executionFeeRecipient: SIGNER,
       integratorId: "0xdead",
-      // Provenance reference to the inbound funding transfer; chainId coerced to a number.
-      erc20Transfer: {
-        chainId: 42161,
-        blockNumber: 1_000_000,
-        transactionHash: "0x" + "3".repeat(64),
-        logIndex: 4,
-      },
     });
-  });
-
-  it("handles a numeric erc20Transfer.chainId (Number() is a no-op)", async function () {
-    const message = depositMessageV3();
-    // Simulate a future indexer response that types chainId as a number.
-    (message.erc20Transfer as unknown as { chainId: number }).chainId = 42161;
-    await (handler as unknown as Internals)._getExecuteTx(message);
-    expect(executeStub.firstCall.args[0].erc20Transfer.chainId).to.equal(42161);
   });
 
   it("relays the funding token as inputToken when ENABLE_EXECUTE_INPUT_TOKEN is on", async function () {
@@ -409,13 +394,6 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
       amount: "5000",
       executionFeeRecipient: SIGNER,
       integratorId: "0xdead",
-      // erc20Transfer provenance is always relayed, independent of the inputToken flag.
-      erc20Transfer: {
-        chainId: 42161,
-        blockNumber: 1_000_000,
-        transactionHash: "0x" + "3".repeat(64),
-        logIndex: 4,
-      },
     });
   });
 


### PR DESCRIPTION
Reverts #3569 (squash-merge commit `a3b67ca`).

Removes the `erc20Transfer` provenance object from the v3 deposit-address execute request (`initiateDepositV3` → `_getExecuteTx`) and the corresponding field on `DepositAddressExecuteRequest`, tests, and README docs.

## Scope

- Only the additions from #3569 are reverted. The `inputToken` v3-execute feature (#3570) is untouched — it landed in master independently and predates the squash, so it is not part of this revert.
- `yarn tsc --noEmit` clean; deposit-address suite green (31 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)