### PR TITLE
feat(deposit-address): relay erc20Transfer provenance on v3 execute (env-gated)

### DIFF
--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -116,6 +116,20 @@ export interface DepositAddressExecuteRequest {
    * integrators); drives the CREATE2 salt + on-chain integrator tag. Required by the endpoint.
    */
   integratorId: string;
+  /**
+   * Optional reference to the inbound ERC-20 transfer that funded the sweep. When present, the API
+   * wraps `executeTx` in a Multicall3 bundle that also emits a version-2 provenance blob via
+   * `AcrossEventEmitter`, so the indexer can link the deposit-executed event to this transfer in the
+   * same receipt. `transactionHash` is a 32-byte hex hash (`^(0x)?[0-9a-fA-F]{64}$`); the numeric
+   * fields must be non-negative integers. Only sent when the bot is configured against an API that
+   * accepts the field (see `enableExecuteErc20Transfer`) — older APIs reject it as an unknown param.
+   */
+  erc20Transfer?: {
+    chainId: number;
+    blockNumber: number;
+    transactionHash: string;
+    logIndex: number;
+  };
 }
 
 export interface DepositAddressExecuteResponse {

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -1189,6 +1189,21 @@ export class DepositAddressHandler {
       amount: erc20Transfer.amount,
       executionFeeRecipient: this.signerAddress.toNative(),
       integratorId,
+      // Provenance reference to the inbound funding transfer. When accepted, the API folds this into a
+      // Multicall3 bundle that emits a version-2 provenance blob, giving the indexer an on-chain
+      // sweep ↔ funding-transfer link in the execute receipt. Gated because an API without the schema
+      // change rejects the field (400 INVALID_PARAM, `Expected type 'never'`). Number() is a no-op on
+      // an already-numeric chainId, so this keeps working if the indexer later types it as a number.
+      ...(this.config.enableExecuteErc20Transfer
+        ? {
+            erc20Transfer: {
+              chainId: Number(erc20Transfer.chainId),
+              blockNumber: erc20Transfer.blockNumber,
+              transactionHash: erc20Transfer.transactionHash,
+              logIndex: erc20Transfer.logIndex,
+            },
+          }
+        : {}),
     };
     // `_post` swallows errors and returns undefined, so retry on both throw and falsy return.
     try {

--- a/src/deposit-address/DepositAddressHandlerConfig.ts
+++ b/src/deposit-address/DepositAddressHandlerConfig.ts
@@ -48,7 +48,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
       WITHDRAW_ENABLED,
       ENABLE_V3_WITHDRAWALS,
       ENABLE_EXECUTE_INPUT_TOKEN,
-      ENABLE_EXECUTE_ERC20_TRANSFER,
+      ENABLE_EXECUTE_ERC20_TRANSFER_METADATA,
       ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER,
       ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER,
       PUBSUB_GCP_PROJECT_ID,
@@ -73,7 +73,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
     this.withdrawEnabled = WITHDRAW_ENABLED === "true";
     this.enableV3Withdrawals = ENABLE_V3_WITHDRAWALS === "true";
     this.enableExecuteInputToken = ENABLE_EXECUTE_INPUT_TOKEN === "true";
-    this.enableExecuteErc20Transfer = ENABLE_EXECUTE_ERC20_TRANSFER === "true";
+    this.enableExecuteErc20Transfer = ENABLE_EXECUTE_ERC20_TRANSFER_METADATA === "true";
 
     this.enableDepositAddressWithdrawPublisher = ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER === "true";
     this.enableDepositAddressDepositPublisher = ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER === "true";

--- a/src/deposit-address/DepositAddressHandlerConfig.ts
+++ b/src/deposit-address/DepositAddressHandlerConfig.ts
@@ -20,6 +20,8 @@ export class DepositAddressHandlerConfig extends CommonConfig {
   enableV3Withdrawals: boolean;
   /** Gate for relaying the funding token as `inputToken` on v3 executes. Requires an API that accepts the field. */
   enableExecuteInputToken: boolean;
+  /** Gate for relaying the `erc20Transfer` provenance object on v3 executes. Requires an API that accepts the field. */
+  enableExecuteErc20Transfer: boolean;
 
   /** Gate for publishing `withdraw_executed` events to GCP Pub/Sub. */
   enableDepositAddressWithdrawPublisher: boolean;
@@ -46,6 +48,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
       WITHDRAW_ENABLED,
       ENABLE_V3_WITHDRAWALS,
       ENABLE_EXECUTE_INPUT_TOKEN,
+      ENABLE_EXECUTE_ERC20_TRANSFER,
       ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER,
       ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER,
       PUBSUB_GCP_PROJECT_ID,
@@ -70,6 +73,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
     this.withdrawEnabled = WITHDRAW_ENABLED === "true";
     this.enableV3Withdrawals = ENABLE_V3_WITHDRAWALS === "true";
     this.enableExecuteInputToken = ENABLE_EXECUTE_INPUT_TOKEN === "true";
+    this.enableExecuteErc20Transfer = ENABLE_EXECUTE_ERC20_TRANSFER === "true";
 
     this.enableDepositAddressWithdrawPublisher = ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER === "true";
     this.enableDepositAddressDepositPublisher = ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER === "true";

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -58,6 +58,20 @@ property of the deposit address, not the bot's auth key) and is **required** by 
 endpoint — it folds into the CREATE2 salt + on-chain integrator tag, so the address is derived
 per-integrator. The bot relays it verbatim.
 
+Two optional execute fields are gated behind env flags because an API that predates their schema
+changes rejects an unknown param with `400 INVALID_PARAM`:
+
+- `ENABLE_EXECUTE_INPUT_TOKEN=true` → relays the funding token as `inputToken`.
+- `ENABLE_EXECUTE_ERC20_TRANSFER=true` → relays an `erc20Transfer` provenance reference
+  (`{ chainId, blockNumber, transactionHash, logIndex }` of the inbound funding transfer, taken
+  verbatim from the indexer message; `chainId` coerced to an integer). When accepted, the API wraps
+  `executeTx` in a Multicall3 bundle that additionally emits a version-2 provenance blob via
+  `AcrossEventEmitter`, giving the indexer an on-chain sweep ↔ funding-transfer link in the execute
+  receipt.
+
+Both default off; enable them only against an API that accepts the field (e.g. the test bot ahead of
+the production rollout).
+
 The flow (`initiateDepositV3`):
 
 1. Filter on `relayerOriginChains` and dedup against the same Redis/in-memory sets as v1 (the dedup

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -62,7 +62,7 @@ Two optional execute fields are gated behind env flags because an API that preda
 changes rejects an unknown param with `400 INVALID_PARAM`:
 
 - `ENABLE_EXECUTE_INPUT_TOKEN=true` → relays the funding token as `inputToken`.
-- `ENABLE_EXECUTE_ERC20_TRANSFER=true` → relays an `erc20Transfer` provenance reference
+- `ENABLE_EXECUTE_ERC20_TRANSFER_METADATA=true` → relays an `erc20Transfer` provenance reference
   (`{ chainId, blockNumber, transactionHash, logIndex }` of the inbound funding transfer, taken
   verbatim from the indexer message; `chainId` coerced to an integer). When accepted, the API wraps
   `executeTx` in a Multicall3 bundle that additionally emits a version-2 provenance blob via

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -364,8 +364,9 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
   it("relays funding context and integratorId, with executionFee omitted", async function () {
     await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());
     expect(executeStub.calledOnce).to.equal(true);
-    // Exact request body: the execute endpoint re-derives the address/materials from this
-    // identity, and its superstruct schema rejects unknown or missing keys.
+    // Exact request body with all execute feature flags off (the default / production shape): the
+    // execute endpoint re-derives the address/materials from this identity, and its superstruct
+    // schema rejects unknown or missing keys. Neither `inputToken` nor `erc20Transfer` is sent.
     expect(executeStub.firstCall.args[0]).to.deep.equal({
       destination: {
         token: { chainId: 1337, address: OUTPUT_TOKEN },
@@ -376,6 +377,31 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
       amount: "5000",
       executionFeeRecipient: SIGNER,
       integratorId: "0xdead",
+    });
+  });
+
+  it("relays erc20Transfer provenance when ENABLE_EXECUTE_ERC20_TRANSFER is on", async function () {
+    (handler as unknown as { config: { enableExecuteErc20Transfer: boolean } }).config.enableExecuteErc20Transfer =
+      true;
+    await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());
+    expect(executeStub.calledOnce).to.equal(true);
+    expect(executeStub.firstCall.args[0]).to.deep.equal({
+      destination: {
+        token: { chainId: 1337, address: OUTPUT_TOKEN },
+        recipient: RECIPIENT,
+      },
+      originChainId: 42161,
+      userAddress: REFUND_ADDRESS,
+      amount: "5000",
+      executionFeeRecipient: SIGNER,
+      integratorId: "0xdead",
+      // chainId coerced from the fixture's "42161" string; Number() is a no-op on a numeric value.
+      erc20Transfer: {
+        chainId: 42161,
+        blockNumber: 1_000_000,
+        transactionHash: "0x" + "3".repeat(64),
+        logIndex: 4,
+      },
     });
   });
 

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -380,7 +380,7 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
     });
   });
 
-  it("relays erc20Transfer provenance when ENABLE_EXECUTE_ERC20_TRANSFER is on", async function () {
+  it("relays erc20Transfer provenance when ENABLE_EXECUTE_ERC20_TRANSFER_METADATA is on", async function () {
     (handler as unknown as { config: { enableExecuteErc20Transfer: boolean } }).config.enableExecuteErc20Transfer =
       true;
     await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());


### PR DESCRIPTION
Relays an optional `erc20Transfer` provenance object on `POST /deposit-addresses/execute` (v3 execute path), gated behind a new env flag. Consumes quote-api [#2886](https://github.com/across-protocol/quote-api/pull/2886).

## Env

- `ENABLE_EXECUTE_ERC20_TRANSFER_METADATA` (default `false`) — when `true`, appends `erc20Transfer` to the execute request.

## Behavior

- **Off (default):** request body is unchanged — ends at `integratorId`, no `erc20Transfer`.
- **On:** appends `erc20Transfer: { chainId, blockNumber, transactionHash, logIndex }`, taken verbatim from the indexer message (`chainId` coerced via `Number()`, a no-op if already numeric). The API then wraps `executeTx` in a Multicall3 bundle emitting a version-2 provenance blob, giving the indexer an on-chain sweep ↔ funding-transfer link.

Mirrors the existing `ENABLE_EXECUTE_INPUT_TOKEN` flag.

## Changes

- `DepositAddressHandlerConfig.ts` — add `enableExecuteErc20Transfer` from `ENABLE_EXECUTE_ERC20_TRANSFER_METADATA`.
- `DepositAddressHandler.ts` — conditionally append `erc20Transfer` in `_getExecuteTx`.
- `AcrossSwapApiClient.ts` — add optional `erc20Transfer` on `DepositAddressExecuteRequest`.
- `README.md` — document the gated execute flags.
- tests — flag-off default asserts the field is absent; new case asserts it is sent when the flag is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)