### PR TITLE
feat(deposit-address): skip deposit_executed publish when erc20Transfer metadata is on

### DIFF
--- a/docs/deposit-address-withdraw-pubsub.md
+++ b/docs/deposit-address-withdraw-pubsub.md
@@ -88,6 +88,7 @@ The publisher serializes the envelope as a UTF-8 JSON string and sends it as the
 
 `DepositAddressHandler._publishDepositExecuted` (called from `initiateDepositV3` only — v1 and the failure paths are out of scope) mirrors the above:
 
+0. Returns early (no publish) when `ENABLE_EXECUTE_ERC20_TRANSFER_METADATA=true`. In metadata mode the API emits the sweep ↔ funding-transfer link on-chain (a version-2 provenance blob via `AcrossEventEmitter`), so the indexer ingests the execution from chain events and the `deposit_executed` Pub/Sub event would be a redundant second signal. This override takes precedence over `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER`; the `withdraw_executed` path is unaffected.
 1. Runs only after a v3 deposit execute has confirmed on-chain **and** the refTxHash has been persisted to Redis.
 2. Filters `receipt.logs` for the input-token (`erc20Transfer.contractAddress`) ERC-20 `Transfer` whose `from` topic matches the deposit address. Unlike the withdraw path there is **no `to` filter** — the input token leaves the deposit address into the SpokePool / CCTP, with no fixed recipient — so any outgoing transfer of the input token qualifies. Picks the **last** match. Zero matches → warn + skip the publish.
 3. Builds the `deposit_executed` payload and publishes to the **same topic** as `withdraw_executed`.

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -741,11 +741,25 @@ export class DepositAddressHandler {
    * rolls back state and never throws to the caller — a dropped publish leaves the indexer row
    * pending until ops reconciles. Shares the topic with `withdraw_executed`; gated independently by
    * config.enableDepositAddressDepositPublisher.
+   *
+   * Skipped entirely when `enableExecuteErc20Transfer` is on: that mode has the API emit a
+   * version-2 provenance blob on-chain (via `AcrossEventEmitter`) linking the execute to the
+   * funding transfer, so the indexer already learns of the execution from chain events and the
+   * Pub/Sub event would be a redundant second signal for the same transition.
    */
   private async _publishDepositExecuted(
     receipt: TransactionReceipt,
     depositMessage: DepositAddressMessageV3
   ): Promise<void> {
+    if (this.config.enableExecuteErc20Transfer) {
+      this.logger.debug({
+        at: "DepositAddressHandler#_publishDepositExecuted",
+        message: "Skipping deposit_executed publish: on-chain erc20Transfer provenance metadata is enabled",
+        depositAddress: depositMessage.depositAddress,
+        txHash: receipt.transactionHash,
+      });
+      return;
+    }
     if (!this.config.enableDepositAddressDepositPublisher || !isDefined(this.executionPublisher)) {
       return;
     }

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -181,6 +181,13 @@ The bot publishes two lifecycle events to one shared GCP Pub/Sub topic so the co
 - `withdraw_executed` — when `ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER=true`, every confirmed refund withdraw (v1 + v3).
 - `deposit_executed` — when `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER=true`, every successful **v3** correct-transfer execution (`initiateDepositV3`). v1 deposits and failure events are out of scope.
 
+**`ENABLE_EXECUTE_ERC20_TRANSFER_METADATA` overrides the `deposit_executed` publish.** When metadata
+mode is on, the API emits the sweep ↔ funding-transfer link on-chain (a version-2 provenance blob via
+`AcrossEventEmitter`), so the indexer learns of the execution from chain events and the bot **skips**
+the `deposit_executed` Pub/Sub publish entirely — regardless of `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER`.
+The `withdraw_executed` publish is unaffected. Operators enabling metadata mode should therefore expect
+row transitions for v3 executes to come from the indexer's on-chain ingestion, not Pub/Sub.
+
 The consumer lives at `indexer/packages/indexer/src/pubsub/DepositAddressWithdrawConsumer.ts` (sibling repo). A single Pub/Sub client serves both events (same project + topic); it is constructed when **either** gate is on, and each publish path checks its own flag so the two events toggle independently.
 
 ### Env
@@ -188,7 +195,7 @@ The consumer lives at `indexer/packages/indexer/src/pubsub/DepositAddressWithdra
 | Name | Required | Description |
 | --- | --- | --- |
 | `ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER` | No (default `false`) | Gate for `withdraw_executed`. |
-| `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER` | No (default `false`) | Gate for `deposit_executed` (v3 executions). Independent of the withdraw gate. |
+| `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER` | No (default `false`) | Gate for `deposit_executed` (v3 executions). Independent of the withdraw gate. Ignored when `ENABLE_EXECUTE_ERC20_TRANSFER_METADATA=true` (the publish is skipped in favor of on-chain provenance). |
 | `PUBSUB_GCP_PROJECT_ID` | When either gate is on | GCP project that **hosts the topic** (may differ from the bot's runtime project — cross-project publish is supported when the runtime SA holds `roles/pubsub.publisher` on the topic in the host project). |
 | `PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC` | When either gate is on | Short topic name (e.g. `topic-deposit-address-execution` in prod, `…-sandbox` in non-prod). Shared by both events. |
 

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -1,10 +1,11 @@
 import sinon from "sinon";
 import { expect } from "chai";
-import { EvmAddress, getCurrentTime, HttpError, Signer, winston } from "../src/utils";
+import { EvmAddress, getCurrentTime, HttpError, Signer, TransactionReceipt, utils, winston } from "../src/utils";
 import { DepositAddressMessage, DepositAddressMessageV3 } from "../src/interfaces/DepositAddress";
 import { DepositAddressExecuteResponse, DepositAddressSignWithdrawResponse } from "../src/clients";
 import { DepositAddressHandler } from "../src/deposit-address/DepositAddressHandler";
 import { DepositAddressHandlerConfig } from "../src/deposit-address/DepositAddressHandlerConfig";
+import { ERC20_TRANSFER_TOPIC } from "../src/deposit-address/withdrawPayload";
 
 const SIGNER = "0x000000000000000000000000000000000000BEEF";
 const DEPOSIT_ADDRESS = "0x000000000000000000000000000000000000C0DE";
@@ -667,5 +668,64 @@ describe("DepositAddressHandler.initiateWithdrawV3 guards", function () {
     );
     expect(signWithdrawStub.notCalled).to.equal(true);
     expect(warnStub.calledOnce).to.equal(true);
+  });
+});
+
+describe("DepositAddressHandler._publishDepositExecuted", function () {
+  let handler: DepositAddressHandler;
+  let publishStub: sinon.SinonStub;
+
+  type Internals = {
+    _publishDepositExecuted: (r: TransactionReceipt, m: DepositAddressMessageV3) => Promise<void>;
+  };
+
+  // Receipt carrying an input-token Transfer out of the deposit address — what the payload builder
+  // matches on (address = input token, from = deposit address; no `to` filter on the deposit path).
+  const receipt = {
+    blockNumber: 123,
+    transactionHash: "0x" + "a".repeat(64),
+    logs: [
+      {
+        address: TOKEN,
+        topics: [
+          ERC20_TRANSFER_TOPIC,
+          utils.hexZeroPad(DEPOSIT_ADDRESS.toLowerCase(), 32),
+          utils.hexZeroPad(RECIPIENT.toLowerCase(), 32),
+        ],
+        logIndex: 7,
+      },
+    ],
+  } as unknown as TransactionReceipt;
+
+  beforeEach(function () {
+    publishStub = sinon.stub().resolves("msg-id");
+    const config = {
+      enableDepositAddressDepositPublisher: true,
+      enableExecuteErc20Transfer: false,
+    } as unknown as DepositAddressHandlerConfig;
+    handler = new DepositAddressHandler(
+      { debug: sinon.stub(), warn: sinon.stub() } as unknown as winston.Logger,
+      config,
+      {} as unknown as Signer,
+      []
+    );
+    (handler as unknown as { executionPublisher: { publishJson: sinon.SinonStub } }).executionPublisher = {
+      publishJson: publishStub,
+    };
+  });
+
+  afterEach(() => sinon.restore());
+
+  it("publishes deposit_executed when erc20Transfer metadata is off", async function () {
+    await (handler as unknown as Internals)._publishDepositExecuted(receipt, depositMessageV3());
+    expect(publishStub.calledOnce).to.equal(true);
+  });
+
+  it("skips deposit_executed publish when erc20Transfer metadata is on", async function () {
+    // With on-chain provenance metadata enabled, the Pub/Sub event is redundant.
+    (handler as unknown as { config: { enableExecuteErc20Transfer: boolean } }).config.enableExecuteErc20Transfer =
+      true;
+    await (handler as unknown as Internals)._publishDepositExecuted(receipt, depositMessageV3());
+    expect(publishStub.called).to.equal(false);
   });
 });


### PR DESCRIPTION
When `ENABLE_EXECUTE_ERC20_TRANSFER_METADATA` is enabled, `_publishDepositExecuted` now returns early — no `deposit_executed` Pub/Sub event is sent.

## Why

In that mode the API wraps the execute in a Multicall3 bundle that emits a version-2 provenance blob on-chain (via `AcrossEventEmitter`), linking the execute to its funding transfer. The indexer therefore learns of the execution from chain events, making the `deposit_executed` Pub/Sub event a redundant second signal for the same row transition.

## Behavior

- `ENABLE_EXECUTE_ERC20_TRANSFER_METADATA` off (default): unchanged — `deposit_executed` publishes per `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER`.
- On: `deposit_executed` publish is skipped (debug-logged). The withdraw path (`withdraw_executed`) is unaffected.

## Changes

- `DepositAddressHandler.ts` — early return in `_publishDepositExecuted` when the metadata flag is on.
- tests — new `_publishDepositExecuted` cases: publishes when the flag is off, skips when on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)