### PR TITLE
chore(deps): bump @across-protocol/sdk to 4.4.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.123",
     "@across-protocol/contracts": "5.0.24",
-    "@across-protocol/sdk": "4.4.11",
+    "@across-protocol/sdk": "4.4.12",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,10 +34,10 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.4.11":
-  version "4.4.11"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.4.11.tgz#fcad736ae2a627df6c7d070d85fc567bc048ef4e"
-  integrity sha512-JzCVrxI4KmZ2oKotsh2THFlT7BfmOpDBesyMPsHCgcqFtz6oNQHUlxhwxY7x0PWPj5d/4Rg6CMClDmQp6RC8Iw==
+"@across-protocol/sdk@4.4.12":
+  version "4.4.12"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.4.12.tgz#4a4dbcf8f03ef3dd61e1ebab2925d8e3193a23cf"
+  integrity sha512-P9bsJRjesT3u6lvSOMm1JtLGNHNsZERC/Z7N1nHR6QteztW6DCwOMHQUl/K06iO95JyTb+BJkn+y32y8JQAxlg==
   dependencies:
     "@across-protocol/constants" "^3.1.123"
     "@across-protocol/contracts" "5.0.24"


### PR DESCRIPTION
## What

- `@across-protocol/sdk` 4.4.11 → **4.4.12**

(`@across-protocol/contracts` stays at 5.0.24 — already in lockstep with the SDK's pin.)

## Why

Picks up two RetryProvider fixes shipping together in 4.4.12:

- across-protocol/sdk#1483 — quorum failures with no fallback providers left now throw the intended "Not enough providers agreed to meet quorum" error instead of crashing with `ReferenceError: Cannot access 'quorumResult' before initialization`. This is the error that has been killing `zion-across-proposer` runs (5 consecutive runs on 2026-07-15, previously 2026-06-22) and other dataworker/monitor bots since April.
- across-protocol/sdk#1441 — per-provider failures are summarized into single-line, log-safe messages instead of `err.stack`, keeping RPC URLs (and embedded API keys) out of aggregate error messages and logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
