### PR TITLE
fix(deposit-address): log rejected poll ticks instead of swallowing them

### DIFF
--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -319,7 +319,15 @@ export class DepositAddressHandler {
     scheduleTask(
       () => this.evaluateDepositAddresses(),
       this.config.indexerPollingInterval,
-      this.abortController.signal
+      this.abortController.signal,
+      // A rejected poll skips the whole batch for that tick; without this log the failure is
+      // invisible (scheduleTask otherwise swallows rejections) while fills silently stall.
+      (err) =>
+        this.logger.error({
+          at: "DepositAddressHandler#pollAndExecute",
+          message: "evaluateDepositAddresses failed; batch skipped this tick",
+          error: err instanceof Error ? err.message : String(err),
+        })
     );
     scheduleTask(() => this.kickWatchdog(), this.config.watchdogInterval, this.abortController.signal);
   }

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -20,6 +20,10 @@ The deposit-address handler polls the across-indexer for ERC-20 transfers that h
    rest of the handler.
 5. Handover via Redis (`InstanceCoordinator`) — exits cleanly when another instance takes over.
 
+Poll-loop failures are never silent: `pollAndExecute` passes an error handler to `scheduleTask`, so
+a rejected `evaluateDepositAddresses` tick (which skips that whole batch) is logged at error level
+instead of being swallowed by the scheduler.
+
 Cleanup in the `finally` block closes the Pub/Sub publisher and Redis clients.
 
 ## Indexer message classification

--- a/src/utils/Tasks.ts
+++ b/src/utils/Tasks.ts
@@ -1,10 +1,20 @@
 /**
  * Wrap an async task as a fire-and-forget callback for `setTimeout`/`setInterval` slots
- * that expect `() => void`. Rejections are swallowed so a failed task can't crash the process
- * via an unhandled rejection.
+ * that expect `() => void`. Rejections can't crash the process via an unhandled rejection:
+ * they are passed to `onError` when provided, otherwise swallowed. Prefer passing `onError` —
+ * a recurring task that fails silently on every tick is invisible until its downstream effects
+ * are (2026-07-15 deposit-address incident).
+ * @param onError Optional rejection handler. Must not throw; if it does, the error is swallowed.
  */
-export function fireAndForget(task: () => Promise<unknown>): () => void {
-  return () => void task().catch(() => undefined);
+export function fireAndForget(task: () => Promise<unknown>, onError?: (err: unknown) => void): () => void {
+  return () =>
+    void task().catch((err) => {
+      try {
+        onError?.(err);
+      } catch {
+        // A throwing error handler must not crash the process either.
+      }
+    });
 }
 
 /**
@@ -34,9 +44,15 @@ export function abortableDelay(seconds: number, signal: AbortSignal): Promise<vo
  * Schedule a recurring task, to be executed `interval` seconds after each successive call.
  * @param task Function that returns a Promise to be awaited.
  * @param interval Task interval.
+ * @param onError Optional per-tick rejection handler (see fireAndForget). Failures never stop the schedule.
  */
-export function scheduleTask(task: () => Promise<unknown>, interval: number, signal: AbortSignal): void {
-  const timer = setInterval(fireAndForget(task), interval * 1000);
+export function scheduleTask(
+  task: () => Promise<unknown>,
+  interval: number,
+  signal: AbortSignal,
+  onError?: (err: unknown) => void
+): void {
+  const timer = setInterval(fireAndForget(task, onError), interval * 1000);
   signal.addEventListener("abort", () => clearInterval(timer));
 }
 

--- a/test/Tasks.ts
+++ b/test/Tasks.ts
@@ -1,8 +1,50 @@
 import { expect } from "./utils";
 
-import { abortableDelay } from "../src/utils";
+import { abortableDelay, fireAndForget } from "../src/utils";
 
 describe("Tasks", function () {
+  describe("fireAndForget", function () {
+    // fireAndForget returns synchronously; rejections settle on a later microtask.
+    const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+
+    it("passes rejections to onError", async function () {
+      const seen: unknown[] = [];
+      const boom = new Error("boom");
+      fireAndForget(
+        () => Promise.reject(boom),
+        (err) => seen.push(err)
+      )();
+      await flushMicrotasks();
+      expect(seen).to.deep.equal([boom]);
+    });
+
+    it("swallows rejections when no onError is provided", async function () {
+      // Must not surface as an unhandled rejection (which would crash the process).
+      fireAndForget(() => Promise.reject(new Error("boom")))();
+      await flushMicrotasks();
+    });
+
+    it("swallows a throwing onError handler", async function () {
+      fireAndForget(
+        () => Promise.reject(new Error("boom")),
+        () => {
+          throw new Error("handler boom");
+        }
+      )();
+      await flushMicrotasks();
+    });
+
+    it("does not invoke onError when the task resolves", async function () {
+      const seen: unknown[] = [];
+      fireAndForget(
+        () => Promise.resolve("ok"),
+        (err) => seen.push(err)
+      )();
+      await flushMicrotasks();
+      expect(seen).to.deep.equal([]);
+    });
+  });
+
   describe("abortableDelay", function () {
     it("resolves after roughly the requested delay when not aborted", async function () {
       const controller = new AbortController();


### PR DESCRIPTION
## Context

Split out of #3578 (separation of concerns — this is the observability half of the 2026-07-15 PDA fill-latency incident fix).

During the incident, a rejected `evaluateDepositAddresses` tick skipped the whole poll batch and `fireAndForget` swallowed the rejection — every deposit-address execution silently stalled for the poison message's full 15-minute redelivery window with **zero error logs produced**. The message-level fix (not sinking the batch on one malformed message) lives in #3578; this PR makes any future poll-tick failure visible.

## Changes

- `fireAndForget`/`scheduleTask` accept an optional `onError` rejection handler. Default unchanged: swallow, so a failed task can't crash the process via an unhandled rejection. A throwing handler is itself swallowed.
- `pollAndExecute` passes a handler that logs a rejected `evaluateDepositAddresses` tick at error level ("batch skipped this tick").
- `src/deposit-address/README.md` documents the poll-loop error logging in the runtime-entrypoint section.

## Testing

- `yarn build` clean.
- `RELAYER_TEST=true hardhat test test/Tasks.ts` — 8 passing, including 4 new `fireAndForget` tests: rejection passed to `onError`, swallow-by-default, throwing-handler swallow, no invocation on success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)