### PR TITLE
fix(deposit-address): handle native-token (sentinel) refund withdraws

### DIFF
--- a/docs/deposit-address-withdraw-pubsub.md
+++ b/docs/deposit-address-withdraw-pubsub.md
@@ -36,7 +36,7 @@ type WithdrawExecutedPayload = {
     chainId: number;       // withdraw tx chain
     blockNumber: number;   // withdraw tx block
     txHash: string;        // withdraw tx hash, lowercase hex
-    logIndex: number;      // logIndex of the ERC20 Transfer leaving the deposit address
+    logIndex: number;      // logIndex of the ERC20 Transfer leaving the deposit address (native refunds: the Withdraw event)
     erc20Transfer: {
       chainId: number;
       blockNumber: number;
@@ -82,7 +82,7 @@ The publisher serializes the envelope as a UTF-8 JSON string and sends it as the
 `DepositAddressHandler._publishWithdrawExecuted` in `src/deposit-address/DepositAddressHandler.ts` (shared by the v1 `initiateWithdraw` and v3 `initiateWithdrawV3` paths — the payload is version-agnostic, only the refund-address field location differs):
 
 1. Runs only after a refund withdraw has been confirmed on-chain **and** the depositKey has been persisted to Redis. Ordering matters: we never publish without first committing to "this depositKey is done", which prevents handover from racing the publish into a duplicate withdraw.
-2. Filters `receipt.logs` for ERC-20 `Transfer(address,address,uint256)` events whose `address` matches the token contract, whose `from` topic matches the deposit address, AND whose `to` topic matches the refund address (`routeParams.refundAddress` for v1, `refundAddress.address` for v3). The `to` match disambiguates fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address in one tx. Picks the **last** match as a final tiebreaker (handles Multicall3-bundled withdraws where intermediate transfers to the same refund address may also appear). Zero matches → warn + skip the publish (do not raise).
+2. Filters `receipt.logs` for ERC-20 `Transfer(address,address,uint256)` events whose `address` matches the token contract, whose `from` topic matches the deposit address, AND whose `to` topic matches the refund address (`routeParams.refundAddress` for v1, `refundAddress.address` for v3). The `to` match disambiguates fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address in one tx. Picks the **last** match as a final tiebreaker (handles Multicall3-bundled withdraws where intermediate transfers to the same refund address may also appear). Zero matches → warn + skip the publish (do not raise). **Native-token refunds** (`erc20Transfer.contractAddress` is the native sentinel `0xEeee…EEeE`) emit no `Transfer` log; the builder instead filters for the `Withdraw(address indexed token, address indexed to, uint256 amount)` event emitted **by the deposit address** (the `WithdrawImplementation` runs via delegatecall) with `token = sentinel` and `to = refundAddress`, same last-match rule.
 3. Builds the payload above and calls `GcpPubSubPublisher.publishJson`.
 4. Wraps the call in try/catch; on failure, logs at `error` level with `notificationPath: "across-bot-error"` and continues. The withdraw is on-chain and Redis-persisted — there is no rollback and no in-process retry.
 
@@ -112,7 +112,7 @@ A single `GcpPubSubPublisher` client serves both event types (same project + top
 | --- | --- | --- |
 | GCP publish raises after internal retries | Log + continue. | Indexer row stays `auto_pending`. Ops reconciles manually. |
 | Bot crashes between Redis persist and publish | No replay on next start. | Same as above; one dropped event per crash. |
-| Receipt missing any Transfer log out of the deposit address | Warn + skip publish. | Indexer row stays `auto_pending`. Withdraw is still on-chain and reflected via the bot's existing log. |
+| Receipt missing any Transfer log out of the deposit address (or, for native refunds, any `Withdraw` event from it) | Warn + skip publish. | Indexer row stays `auto_pending`. Withdraw is still on-chain and reflected via the bot's existing log. |
 | Indexer message missing `blockNumber` / `logIndex` | Type-system / runtime error. | We treat the fields as required; the indexer API always populates them. A drift would fail loudly rather than silently skip. |
 
 ## Contributor recommendations

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -25,6 +25,7 @@ import {
   TransactionReceipt,
   getCurrentTime,
   isHttpError,
+  isNativeTokenSentinel,
 } from "../utils";
 import { getRedisCache, RedisCacheInterface } from "../cache/Redis";
 import {
@@ -512,12 +513,9 @@ export class DepositAddressHandler {
     try {
       // Defensive on-chain balance check — guards against reorged indexer messages and against
       // acting on a deposit-address that has already been withdrawn through another path.
-      const provider = this.providersByChain[chainId];
-      const tokenContract = new Contract(token, ERC20_ABI, provider);
-
       let onchainBalance: BigNumber;
       try {
-        onchainBalance = await tokenContract.balanceOf(depositAddress);
+        onchainBalance = await this._getDepositAddressBalance(chainId, token, depositAddress);
       } catch (err) {
         this.logger.warn({
           at: "DepositAddressHandler#initiateWithdraw",
@@ -710,7 +708,8 @@ export class DepositAddressHandler {
         : depositMessage.routeParams.refundAddress;
       this.logger.warn({
         at: "DepositAddressHandler#_publishWithdrawExecuted",
-        message: "Skipping publish: no ERC20 Transfer (deposit address → refund address) found in receipt",
+        message:
+          "Skipping publish: no settlement log (ERC20 Transfer / native Withdraw, deposit address → refund address) found in receipt",
         depositAddress: depositMessage.depositAddress,
         refundAddress,
         token: depositMessage.erc20Transfer.contractAddress,
@@ -1333,10 +1332,9 @@ export class DepositAddressHandler {
 
       // Defensive on-chain balance check — guards against reorged indexer messages and against
       // acting on a deposit-address already withdrawn through another path.
-      const tokenContract = new Contract(token, ERC20_ABI, this.providersByChain[chainId]);
       let onchainBalance: BigNumber;
       try {
-        onchainBalance = await tokenContract.balanceOf(depositAddress);
+        onchainBalance = await this._getDepositAddressBalance(chainId, token, depositAddress);
       } catch (err) {
         this.logger.warn({
           at: "DepositAddressHandler#initiateWithdrawV3",
@@ -1493,6 +1491,19 @@ export class DepositAddressHandler {
         ? this._getSignedWithdrawV3(depositMessage, withdrawLeaf, --retriesRemaining)
         : undefined;
     }
+  }
+
+  /**
+   * Fetches the deposit address's balance of `token` on `chainId`. Native-token transfers are
+   * indexed with `NATIVE_TOKEN_SENTINEL_ADDRESS` as their `contractAddress` — there is no ERC-20
+   * contract to `balanceOf`, so read the account's native balance instead.
+   */
+  private async _getDepositAddressBalance(chainId: number, token: string, depositAddress: string): Promise<BigNumber> {
+    const provider = this.providersByChain[chainId];
+    if (isNativeTokenSentinel(token)) {
+      return provider.getBalance(depositAddress);
+    }
+    return new Contract(token, ERC20_ABI, provider).balanceOf(depositAddress);
   }
 
   private getExecuteContract(address: string, originChainId: number, useDispatcher: boolean): Contract {

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -2,6 +2,26 @@
 
 The deposit-address handler polls the across-indexer for ERC-20 transfers that have landed on counterfactual deposit addresses and either executes them as deposits or refunds them back to the user.
 
+## Native token transfers
+
+Native-token (ETH) transfers to deposit addresses are indexed via traces (indexer PR #1140) and
+arrive on the same message shape with the sentinel `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`
+as `erc20Transfer.contractAddress` (`NATIVE_TOKEN_SENTINEL_ADDRESS` in `src/utils/DepositAddressUtils.ts`,
+mirroring `NATIVE_ASSET` in the contracts repo). Native transfers never classify `correct_transfer`
+(native is never a route's input token), so they only reach the refund-withdraw paths. Two spots
+special-case the sentinel:
+
+- **Balance check** — `_getDepositAddressBalance` reads `provider.getBalance(depositAddress)`
+  instead of `balanceOf` (there is no ERC-20 contract at the sentinel; a `balanceOf` call reverts
+  with `CALL_EXCEPTION` / empty data).
+- **`withdraw_executed` publish** — a native refund emits no ERC-20 `Transfer` log; the payload
+  builder instead matches the `Withdraw(token, to, amount)` event the on-chain
+  `WithdrawImplementation` emits via delegatecall from the deposit address (see
+  [`withdrawPayload.ts`](./withdrawPayload.ts)).
+
+The sentinel is otherwise forwarded verbatim (e.g. as `token` on the sign-withdraw request); the
+quote-api and the on-chain `WithdrawImplementation` branch on it server-/chain-side.
+
 ## Runtime entrypoint
 
 `runDepositAddressHandler` in [`index.ts`](./index.ts) wires up:
@@ -178,7 +198,7 @@ On each poll, entries whose source messages are no longer returned by the indexe
 
 1. Filter on `relayerOriginChains`; skip if the refund chain is not configured.
 2. Skip if the depositKey is already in the executed-withdraws set (Redis or in-memory in-flight).
-3. Read on-chain balance of `depositAddress`; skip if below the transfer amount (defends against reorged indexer messages and concurrent withdraws via other paths).
+3. Read on-chain balance of `depositAddress`; skip if below the transfer amount (defends against reorged indexer messages and concurrent withdraws via other paths). Native-sentinel transfers read the account's native balance instead of `balanceOf` (see "Native token transfers").
 4. Fetch a signed-withdraw quote from the swap API. The response bundles deploy + signed-withdraw into a single Multicall3 call when the deposit clone is not yet on-chain.
 5. Submit the tx via `TransactionClient`; wait for confirmation.
 6. Persist the depositKey to Redis.
@@ -235,7 +255,7 @@ Every Pub/Sub message uses an envelope: `{ "type": "<message_type>", "data": <ty
 
 All integer fields are `number`; tx hashes are lowercase hex strings. The `erc20Transfer` block identifies the original user transfer (the indexer keys rows on it); the sibling fields identify the execution transaction the bot just sent. The `logIndex` is the index of the ERC-20 `Transfer(address,address,uint256)` event whose `address` matches `erc20Transfer.contractAddress` and whose `from` is the deposit address; the **last** such log is used.
 
-- **`withdraw_executed`** additionally requires `to` to equal the user's `routeParams.refundAddress`. Matching on `to` disambiguates fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address in one tx (one to the user, one to a fee recipient), and the last match handles Multicall3-bundled withdraws with intermediate hops to the same refund address.
+- **`withdraw_executed`** additionally requires `to` to equal the user's `routeParams.refundAddress`. Matching on `to` disambiguates fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address in one tx (one to the user, one to a fee recipient), and the last match handles Multicall3-bundled withdraws with intermediate hops to the same refund address. For native-sentinel refunds the matched log is instead the deposit address's `Withdraw(address,address,uint256)` event with `token = sentinel` and `to = refundAddress` (raw ETH moves emit no `Transfer`); its `logIndex` populates `data.logIndex`.
 - **`deposit_executed`** omits the `to` filter — the input token leaves the deposit address into the SpokePool / CCTP with no fixed recipient — so any outgoing transfer of the input token qualifies.
 
 Zero matches → warn + skip the publish.

--- a/src/deposit-address/withdrawPayload.ts
+++ b/src/deposit-address/withdrawPayload.ts
@@ -1,7 +1,10 @@
 import { AnyDepositAddressMessage, DepositAddressMessageV3, isDepositAddressMessageV3 } from "../interfaces";
-import { isDefined, TransactionReceipt, utils } from "../utils";
+import { isDefined, isNativeTokenSentinel, TransactionReceipt, utils } from "../utils";
 
 export const ERC20_TRANSFER_TOPIC = utils.id("Transfer(address,address,uint256)");
+
+/** `Withdraw(address indexed token, address indexed to, uint256 amount)` emitted by the counterfactual WithdrawImplementation. */
+export const WITHDRAW_EVENT_TOPIC = utils.id("Withdraw(address,address,uint256)");
 
 /**
  * Body of a deposit-address execution lifecycle event (`withdraw_executed` / `deposit_executed`).
@@ -64,9 +67,37 @@ function findLastTransferFromDepositAddress(
 }
 
 /**
+ * Returns the last `Withdraw(address,address,uint256)` log emitted **by the deposit address**
+ * whose `token` topic matches `token` and whose `to` topic matches `to`. Native withdrawals move
+ * raw ETH, so the receipt carries no ERC-20 `Transfer` log; instead the WithdrawImplementation
+ * (delegatecalled by the deposit-address proxy, so `log.address` is the deposit address) emits
+ * `Withdraw(token, to, amount)` with the native sentinel as `token`. The **last** match is
+ * returned, mirroring `findLastTransferFromDepositAddress`. Returns `undefined` when no log matches.
+ */
+function findLastNativeWithdrawFromDepositAddress(
+  receipt: TransactionReceipt,
+  token: string,
+  depositAddress: string,
+  to: string
+): TransactionReceipt["logs"][number] | undefined {
+  const paddedToken = utils.hexZeroPad(token.toLowerCase(), 32);
+  const paddedTo = utils.hexZeroPad(to.toLowerCase(), 32);
+  const withdrawLogs = receipt.logs.filter(
+    (log) =>
+      log.address.toLowerCase() === depositAddress.toLowerCase() &&
+      log.topics[0] === WITHDRAW_EVENT_TOPIC &&
+      log.topics[1]?.toLowerCase() === paddedToken &&
+      log.topics[2]?.toLowerCase() === paddedTo
+  );
+  return withdrawLogs.length === 0 ? undefined : withdrawLogs[withdrawLogs.length - 1];
+}
+
+/**
  * Builds the `withdraw_executed` payload published to GCP Pub/Sub. Returns `undefined` when
  * the receipt contains no ERC20 `Transfer` event matching the expected
  * `(address=token, from=depositAddress, to=refundAddress)` — caller should warn and skip.
+ * For native-token refunds (`token` is the native sentinel) the marker is the deposit address's
+ * `Withdraw(token, to, amount)` event instead — raw ETH moves emit no `Transfer` log.
  *
  * The `to=refundAddress` constraint disambiguates fee-on-transfer / tax / burn tokens that
  * emit several `Transfer` events from the deposit address in one tx (one to the user, one
@@ -90,7 +121,9 @@ export function buildWithdrawExecutedPayload(
     ? depositMessage.refundAddress.address
     : depositMessage.routeParams.refundAddress;
 
-  const transferLog = findLastTransferFromDepositAddress(receipt, token, depositAddress, refundAddress);
+  const transferLog = isNativeTokenSentinel(token)
+    ? findLastNativeWithdrawFromDepositAddress(receipt, token, depositAddress, refundAddress)
+    : findLastTransferFromDepositAddress(receipt, token, depositAddress, refundAddress);
   if (!isDefined(transferLog)) {
     return undefined;
   }

--- a/src/utils/DepositAddressUtils.ts
+++ b/src/utils/DepositAddressUtils.ts
@@ -90,6 +90,19 @@ export function getDepositKey(depositMessage: AnyDepositAddressMessage): string 
 }
 
 /**
+ * Sentinel address the deposit-address stack uses for the chain's native token. Native transfers
+ * to deposit addresses have no ERC-20 contract, so the indexer stamps this sentinel on
+ * `erc20Transfer.contractAddress` (mirrors `NATIVE_ASSET` in across-protocol/contracts
+ * `CounterfactualConstants.sol` and `NATIVE_TOKEN_SENTINEL_ADDRESS` in the indexer).
+ */
+export const NATIVE_TOKEN_SENTINEL_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+
+/** Returns whether `token` is the native-token sentinel (case-insensitive). */
+export function isNativeTokenSentinel(token: string): boolean {
+  return token.toLowerCase() === NATIVE_TOKEN_SENTINEL_ADDRESS.toLowerCase();
+}
+
+/**
  * Builds an AugmentedTransaction that calls CounterfactualDepositFactory.deploy.
  * Deploys the counterfactual deposit contract at a deterministic address.
  * paramsHash is computed inside as keccak256(abi.encode(routeParams)).

--- a/test/DepositAddressHandler.publish.ts
+++ b/test/DepositAddressHandler.publish.ts
@@ -1,10 +1,11 @@
 import { expect } from "chai";
-import { utils, TransactionReceipt } from "../src/utils";
+import { utils, TransactionReceipt, NATIVE_TOKEN_SENTINEL_ADDRESS } from "../src/utils";
 import { DepositAddressMessage, DepositAddressMessageV3 } from "../src/interfaces/DepositAddress";
 import {
   buildDepositExecutedPayload,
   buildWithdrawExecutedPayload,
   ERC20_TRANSFER_TOPIC,
+  WITHDRAW_EVENT_TOPIC,
 } from "../src/deposit-address/withdrawPayload";
 import { getGcpPubSubPublisher } from "../src/messaging/gcp";
 
@@ -203,6 +204,79 @@ describe("buildWithdrawExecutedPayload", function () {
     ]);
     const payload = buildWithdrawExecutedPayload(receipt, depositMessage());
     expect(payload?.data.logIndex).to.equal(2);
+  });
+});
+
+describe("buildWithdrawExecutedPayload (native token)", function () {
+  // Native refunds move raw ETH — no ERC-20 Transfer log — so the marker is the deposit
+  // address's `Withdraw(token, to, amount)` event (emitted via delegatecall, hence
+  // `log.address` is the deposit address, not the WithdrawImplementation).
+  function nativeWithdrawMessage(): DepositAddressMessage {
+    const message = depositMessage();
+    message.erc20Transfer.contractAddress = NATIVE_TOKEN_SENTINEL_ADDRESS;
+    message.erc20Transfer.transferClassification = "mis_route";
+    return message;
+  }
+
+  it("picks the Withdraw event emitted by the deposit address matching (token=sentinel, to=refundAddress)", function () {
+    const receipt = fakeReceipt([
+      // ERC-20 Transfer of some other token — must not match a native withdraw.
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(REFUND_ADDRESS)] },
+      // Withdraw event emitted by a different contract — wrong log.address.
+      {
+        address: TOKEN,
+        topics: [WITHDRAW_EVENT_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL_ADDRESS), topicAddress(REFUND_ADDRESS)],
+      },
+      // Withdraw of an ERC-20 token from the deposit address — wrong token topic.
+      { address: DEPOSIT_ADDRESS, topics: [WITHDRAW_EVENT_TOPIC, topicAddress(TOKEN), topicAddress(REFUND_ADDRESS)] },
+      // Withdraw to another recipient — wrong `to` topic.
+      {
+        address: DEPOSIT_ADDRESS,
+        topics: [WITHDRAW_EVENT_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL_ADDRESS), topicAddress(FEE_RECIPIENT)],
+      },
+      // The match.
+      {
+        address: DEPOSIT_ADDRESS,
+        topics: [WITHDRAW_EVENT_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL_ADDRESS), topicAddress(REFUND_ADDRESS)],
+      },
+    ]);
+
+    const payload = buildWithdrawExecutedPayload(receipt, nativeWithdrawMessage());
+    expect(payload).to.not.be.undefined;
+    expect(payload?.data.logIndex).to.equal(4);
+    expect(payload?.data.txHash).to.equal(REFUND_TX.toLowerCase());
+  });
+
+  it("picks the LAST matching Withdraw event when multiple exist (e.g. Multicall3-bundled withdraw)", function () {
+    const nativeWithdrawLog = {
+      address: DEPOSIT_ADDRESS,
+      topics: [WITHDRAW_EVENT_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL_ADDRESS), topicAddress(REFUND_ADDRESS)],
+    };
+    const receipt = fakeReceipt([nativeWithdrawLog, nativeWithdrawLog]);
+    const payload = buildWithdrawExecutedPayload(receipt, nativeWithdrawMessage());
+    expect(payload?.data.logIndex).to.equal(1);
+  });
+
+  it("matches case-insensitively on the sentinel and refund address", function () {
+    const message = nativeWithdrawMessage();
+    message.erc20Transfer.contractAddress = NATIVE_TOKEN_SENTINEL_ADDRESS.toLowerCase();
+    message.routeParams.refundAddress = REFUND_ADDRESS.toUpperCase().replace("0X", "0x");
+    const receipt = fakeReceipt([
+      {
+        address: DEPOSIT_ADDRESS.toLowerCase(),
+        topics: [WITHDRAW_EVENT_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL_ADDRESS), topicAddress(REFUND_ADDRESS)],
+      },
+    ]);
+    const payload = buildWithdrawExecutedPayload(receipt, message);
+    expect(payload?.data.logIndex).to.equal(0);
+  });
+
+  it("returns undefined when the receipt carries no matching Withdraw event", function () {
+    const receipt = fakeReceipt([
+      // An ERC-20 Transfer out of the deposit address is not a native settlement marker.
+      { address: TOKEN, topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(REFUND_ADDRESS)] },
+    ]);
+    expect(buildWithdrawExecutedPayload(receipt, nativeWithdrawMessage())).to.be.undefined;
   });
 });
 

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -1,6 +1,16 @@
 import sinon from "sinon";
 import { expect } from "chai";
-import { EvmAddress, getCurrentTime, HttpError, Signer, TransactionReceipt, utils, winston } from "../src/utils";
+import {
+  EvmAddress,
+  getCurrentTime,
+  HttpError,
+  NATIVE_TOKEN_SENTINEL_ADDRESS,
+  Signer,
+  toBN,
+  TransactionReceipt,
+  utils,
+  winston,
+} from "../src/utils";
 import { DepositAddressMessage, DepositAddressMessageV3 } from "../src/interfaces/DepositAddress";
 import { DepositAddressExecuteResponse, DepositAddressSignWithdrawResponse } from "../src/clients";
 import { DepositAddressHandler } from "../src/deposit-address/DepositAddressHandler";
@@ -698,6 +708,80 @@ describe("DepositAddressHandler.initiateWithdrawV3 guards", function () {
     );
     expect(signWithdrawStub.notCalled).to.equal(true);
     expect(warnStub.calledOnce).to.equal(true);
+  });
+});
+
+describe("DepositAddressHandler.initiateWithdrawV3 balance check", function () {
+  let handler: DepositAddressHandler;
+  let signWithdrawStub: sinon.SinonStub;
+  let getBalanceStub: sinon.SinonStub;
+  let warnStub: sinon.SinonStub;
+  let debugStub: sinon.SinonStub;
+  const chainId = 42161;
+
+  type Internals = { initiateWithdrawV3: (m: DepositAddressMessageV3) => Promise<void> };
+
+  /** Native-token mis_route message — `contractAddress` carries the indexer's native sentinel. */
+  function nativeWithdrawMessageV3(): DepositAddressMessageV3 {
+    const message = withdrawMessageV3();
+    message.erc20Transfer.contractAddress = NATIVE_TOKEN_SENTINEL_ADDRESS;
+    return message;
+  }
+
+  beforeEach(function () {
+    const config = {
+      enableV3Withdrawals: true,
+      relayerOriginChains: [chainId],
+    } as unknown as DepositAddressHandlerConfig;
+    warnStub = sinon.stub();
+    debugStub = sinon.stub();
+    const logger = { warn: warnStub, debug: debugStub } as unknown as winston.Logger;
+    handler = new DepositAddressHandler(logger, config, {} as unknown as Signer, []);
+    // The sign-withdraw stub returns a mismatched chainId so the flow stops right after the API
+    // call — these tests only exercise the balance check in front of it.
+    signWithdrawStub = sinon.stub().resolves({ signedWithdrawTx: { chainId: chainId + 1 } });
+    (handler as unknown as { api: { signWithdrawDepositAddressV3: sinon.SinonStub } }).api = {
+      signWithdrawDepositAddressV3: signWithdrawStub,
+    };
+    (handler as unknown as { observedExecutedWithdraws: Record<number, Set<string>> }).observedExecutedWithdraws = {
+      [chainId]: new Set<string>(),
+    };
+    // Bare stub, deliberately NOT an ethers Provider: `getBalance` serves the native path, and any
+    // ERC-20 read attempt (`new Contract(...)` rejects a non-Provider) fails loudly.
+    getBalanceStub = sinon.stub().resolves(toBN("5000"));
+    (handler as unknown as { providersByChain: Record<number, unknown> }).providersByChain = {
+      [chainId]: { getBalance: getBalanceStub },
+    };
+  });
+
+  afterEach(() => sinon.restore());
+
+  it("fetches the native balance via provider.getBalance for the native sentinel and proceeds", async function () {
+    await (handler as unknown as Internals).initiateWithdrawV3(nativeWithdrawMessageV3());
+    expect(getBalanceStub.calledOnceWithExactly(DEPOSIT_ADDRESS)).to.equal(true);
+    expect(signWithdrawStub.calledOnce).to.equal(true);
+    // The sentinel is forwarded verbatim to the sign-withdraw endpoint.
+    expect(signWithdrawStub.firstCall.args[0].token).to.equal(NATIVE_TOKEN_SENTINEL_ADDRESS);
+  });
+
+  it("skips a native withdraw when the native balance is below the transfer amount", async function () {
+    getBalanceStub.resolves(toBN("4999"));
+    await (handler as unknown as Internals).initiateWithdrawV3(nativeWithdrawMessageV3());
+    expect(signWithdrawStub.notCalled).to.equal(true);
+    expect(debugStub.calledOnce).to.equal(true);
+    expect(debugStub.firstCall.args[0].message).to.equal(
+      "Skipping withdraw: deposit address balance below transfer amount"
+    );
+  });
+
+  it("still reads ERC-20 tokens via balanceOf: a failed contract read warns and skips", async function () {
+    // Non-sentinel token + non-Provider stub → the ERC-20 read rejects; the withdraw must be
+    // skipped with the balance-fetch warn, never routed to provider.getBalance.
+    await (handler as unknown as Internals).initiateWithdrawV3(withdrawMessageV3());
+    expect(getBalanceStub.notCalled).to.equal(true);
+    expect(signWithdrawStub.notCalled).to.equal(true);
+    expect(warnStub.calledOnce).to.equal(true);
+    expect(warnStub.firstCall.args[0].message).to.equal("Skipping withdraw: failed to fetch deposit address balance");
   });
 });
 

--- a/test/DepositAddressUtils.ts
+++ b/test/DepositAddressUtils.ts
@@ -1,6 +1,11 @@
 import { expect } from "chai";
 import { CHAIN_IDs, getEthersCompatibleAddress, toAddressType } from "../src/utils";
-import { getDepositKey, normalizeDepositAddressMessage } from "../src/utils/DepositAddressUtils";
+import {
+  getDepositKey,
+  isNativeTokenSentinel,
+  NATIVE_TOKEN_SENTINEL_ADDRESS,
+  normalizeDepositAddressMessage,
+} from "../src/utils/DepositAddressUtils";
 import { DepositAddressMessage } from "../src/interfaces/DepositAddress";
 
 /** Indexer API sample: Tron origin, Base destination, USDT correct_transfer. */
@@ -158,5 +163,11 @@ describe("DepositAddressUtils", function () {
 
     expect(getDepositKey(normalized)).to.equal(`${normalized.depositAddress}:${raw.erc20Transfer.transactionHash}`);
     expect(getDepositKey(normalized)).to.not.equal(getDepositKey(raw));
+  });
+
+  it("isNativeTokenSentinel matches the sentinel case-insensitively and rejects other addresses", function () {
+    expect(isNativeTokenSentinel(NATIVE_TOKEN_SENTINEL_ADDRESS)).to.equal(true);
+    expect(isNativeTokenSentinel(NATIVE_TOKEN_SENTINEL_ADDRESS.toLowerCase())).to.equal(true);
+    expect(isNativeTokenSentinel("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")).to.equal(false);
   });
 });


### PR DESCRIPTION
## Summary

The deposit-address handler skipped every native-token refund withdraw: native transfers to deposit addresses are indexed via traces ([indexer#1140](https://github.com/across-protocol/indexer/pull/1140)) and arrive with the sentinel `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` as `erc20Transfer.contractAddress`, and the defensive balance check called `balanceOf(depositAddress)` on the sentinel — which reverts (`CALL_EXCEPTION`, `data: 0x`), e.g.:

```
[warn] DepositAddressHandler#initiateWithdrawV3 ⭢ Skipping withdraw: failed to fetch deposit address balance
  token: 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE  chainId: 42161
```

## Changes

- **`src/utils/DepositAddressUtils.ts`** — `NATIVE_TOKEN_SENTINEL_ADDRESS` + `isNativeTokenSentinel()` (mirrors `NATIVE_ASSET` in the contracts repo and the indexer's sentinel constant).
- **`DepositAddressHandler`** — new `_getDepositAddressBalance(chainId, token, depositAddress)`: `provider.getBalance` for the sentinel, ERC-20 `balanceOf` otherwise. Used by both refund-withdraw paths (`initiateWithdraw` v1 and `initiateWithdrawV3`). The deposit-execute paths are untouched — native never classifies `correct_transfer` (it never matches a route's input token), so it only reaches the withdraw paths as `mis_route`.
- **`withdrawPayload.ts`** — native refunds move raw ETH and emit no ERC-20 `Transfer` log, so `buildWithdrawExecutedPayload` would have returned `undefined` and the `withdraw_executed` publish would have been skipped (indexer row stuck in `auto_pending`). For the sentinel it now matches the `Withdraw(address indexed token, address indexed to, uint256 amount)` event that `WithdrawImplementation` emits via delegatecall from the deposit address (`token = sentinel`, `to = refundAddress`, last-match rule as before). Consumer-side, the outer `logIndex` just populates the withdraw-tx columns, so referencing the `Withdraw` event is compatible.
- The sentinel is forwarded **verbatim** as `token` on the sign-withdraw request — the quote-api builds `submitterData` with it and the on-chain `WithdrawImplementation` branches on `NATIVE_ASSET` to send raw ETH (contracts `periphery/counterfactual/WithdrawImplementation.sol`).
- Docs: `src/deposit-address/README.md` (new "Native token transfers" section) and `docs/deposit-address-withdraw-pubsub.md`.

## Tests

- `initiateWithdrawV3` balance check: sentinel → `provider.getBalance` (proceeds / skips below amount); ERC-20 token still goes through the contract read and a failed read warns + skips.
- `buildWithdrawExecutedPayload` native: matches the deposit address's `Withdraw` event (rejects wrong emitter / token / recipient), last-match, case-insensitive, `undefined` when absent.
- `isNativeTokenSentinel` unit tests.

`yarn hardhat test test/DepositAddressHandler.ts test/DepositAddressHandler.publish.ts test/DepositAddressUtils.ts` → 60 passing. `yarn build`, eslint + prettier clean.

## Note for reviewers

The quote-api's `sign-withdraw` gas-fee deduction prices the refund token via `getTokenByAddress(token, chainId)`. If the sentinel is not in that registry for the PDA chains, native withdraws will 422 (`UNPRICEABLE_REFUND_TOKEN`) and be terminally skipped by the bot — worth verifying server-side support before enabling in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)