### PR TITLE
fix(deposit-address): handle native-token (sentinel) transfers

### DIFF
--- a/docs/deposit-address-withdraw-pubsub.md
+++ b/docs/deposit-address-withdraw-pubsub.md
@@ -36,7 +36,7 @@ type WithdrawExecutedPayload = {
     chainId: number;       // withdraw tx chain
     blockNumber: number;   // withdraw tx block
     txHash: string;        // withdraw tx hash, lowercase hex
-    logIndex: number;      // logIndex of the ERC20 Transfer leaving the deposit address
+    logIndex: number;      // logIndex of the ERC20 Transfer leaving the deposit address (native refunds: the Withdraw event)
     erc20Transfer: {
       chainId: number;
       blockNumber: number;
@@ -82,7 +82,7 @@ The publisher serializes the envelope as a UTF-8 JSON string and sends it as the
 `DepositAddressHandler._publishWithdrawExecuted` in `src/deposit-address/DepositAddressHandler.ts` (shared by the v1 `initiateWithdraw` and v3 `initiateWithdrawV3` paths — the payload is version-agnostic, only the refund-address field location differs):
 
 1. Runs only after a refund withdraw has been confirmed on-chain **and** the depositKey has been persisted to Redis. Ordering matters: we never publish without first committing to "this depositKey is done", which prevents handover from racing the publish into a duplicate withdraw.
-2. Filters `receipt.logs` for ERC-20 `Transfer(address,address,uint256)` events whose `address` matches the token contract, whose `from` topic matches the deposit address, AND whose `to` topic matches the refund address (`routeParams.refundAddress` for v1, `refundAddress.address` for v3). The `to` match disambiguates fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address in one tx. Picks the **last** match as a final tiebreaker (handles Multicall3-bundled withdraws where intermediate transfers to the same refund address may also appear). Zero matches → warn + skip the publish (do not raise).
+2. Filters `receipt.logs` for ERC-20 `Transfer(address,address,uint256)` events whose `address` matches the token contract, whose `from` topic matches the deposit address, AND whose `to` topic matches the refund address (`routeParams.refundAddress` for v1, `refundAddress.address` for v3). The `to` match disambiguates fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address in one tx. Picks the **last** match as a final tiebreaker (handles Multicall3-bundled withdraws where intermediate transfers to the same refund address may also appear). Zero matches → warn + skip the publish (do not raise). **Native-token refunds** (`erc20Transfer.contractAddress` is the native sentinel `0xEeee…EEeE`; v3 scheme only — the v1 path skips native up front) emit no `Transfer` log; the builder instead filters for the `Withdraw(address indexed token, address indexed to, uint256 amount)` event emitted **by the deposit address** (the `WithdrawImplementation` runs via delegatecall) with `token = sentinel` and `to = refundAddress`, same last-match rule.
 3. Builds the payload above and calls `GcpPubSubPublisher.publishJson`.
 4. Wraps the call in try/catch; on failure, logs at `error` level with `notificationPath: "across-bot-error"` and continues. The withdraw is on-chain and Redis-persisted — there is no rollback and no in-process retry.
 
@@ -112,7 +112,7 @@ A single `GcpPubSubPublisher` client serves both event types (same project + top
 | --- | --- | --- |
 | GCP publish raises after internal retries | Log + continue. | Indexer row stays `auto_pending`. Ops reconciles manually. |
 | Bot crashes between Redis persist and publish | No replay on next start. | Same as above; one dropped event per crash. |
-| Receipt missing any Transfer log out of the deposit address | Warn + skip publish. | Indexer row stays `auto_pending`. Withdraw is still on-chain and reflected via the bot's existing log. |
+| Receipt missing any Transfer log out of the deposit address (or, for native refunds, any `Withdraw` event from it) | Warn + skip publish. | Indexer row stays `auto_pending`. Withdraw is still on-chain and reflected via the bot's existing log. |
 | Indexer message missing `blockNumber` / `logIndex` | Type-system / runtime error. | We treat the fields as required; the indexer API always populates them. A drift would fail loudly rather than silently skip. |
 
 ## Contributor recommendations

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -723,7 +723,8 @@ export class DepositAddressHandler {
         : depositMessage.routeParams.refundAddress;
       this.logger.warn({
         at: "DepositAddressHandler#_publishWithdrawExecuted",
-        message: "Skipping publish: no ERC20 Transfer (deposit address → refund address) found in receipt",
+        message:
+          "Skipping publish: no settlement log (ERC20 Transfer / native Withdraw, deposit address → refund address) found in receipt",
         depositAddress: depositMessage.depositAddress,
         refundAddress,
         token: depositMessage.erc20Transfer.contractAddress,

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -21,6 +21,7 @@ import {
   blockExplorerLink,
   BigNumber,
   normalizeDepositAddressMessage,
+  isNativeTokenSentinel,
   toAddressType,
   TransactionReceipt,
   getCurrentTime,
@@ -490,6 +491,21 @@ export class DepositAddressHandler {
       return;
     }
 
+    // Native-token (sentinel) withdraws are only supported on the v3 scheme — the v1 withdraw
+    // contract path cannot move native funds, so calling the sign-withdraw API would only fail.
+    if (isNativeTokenSentinel(token)) {
+      this.logger.debug({
+        at: "DepositAddressHandler#initiateWithdraw",
+        message: "Skipping withdraw: native-token withdraws are not supported on v1 deposit addresses",
+        depositAddress,
+        token,
+        depositKey,
+        refTxHash,
+        chainId,
+      });
+      return;
+    }
+
     // Skip if a previous instance (or this one) already executed this withdraw (persisted in Redis).
     if (this.executedWithdrawKeys.has(depositKey)) {
       this.logger.debug({
@@ -512,12 +528,9 @@ export class DepositAddressHandler {
     try {
       // Defensive on-chain balance check — guards against reorged indexer messages and against
       // acting on a deposit-address that has already been withdrawn through another path.
-      const provider = this.providersByChain[chainId];
-      const tokenContract = new Contract(token, ERC20_ABI, provider);
-
       let onchainBalance: BigNumber;
       try {
-        onchainBalance = await tokenContract.balanceOf(depositAddress);
+        onchainBalance = await this.getDepositAddressBalance(chainId, token, depositAddress);
       } catch (err) {
         this.logger.warn({
           at: "DepositAddressHandler#initiateWithdraw",
@@ -879,8 +892,11 @@ export class DepositAddressHandler {
     // input token on the origin chain. If it has not, then we either (1) have already processed this
     // deposit, or (2) received a transaction from the indexer which has been reorged and will be processed
     // once the funds arrive to the deposit address.
-    const inputTokenContract = new Contract(inputToken, ERC20_ABI, factoryContract.provider);
-    const balanceOfContract = await inputTokenContract.balanceOf(depositMessage.depositAddress);
+    const balanceOfContract = await this.getDepositAddressBalance(
+      originChainId,
+      inputToken,
+      depositMessage.depositAddress
+    );
     if (balanceOfContract.lt(inputAmount)) {
       this.logger.debug({
         at: "DepositAddressHandler#initiateDeposit",
@@ -1048,8 +1064,7 @@ export class DepositAddressHandler {
 
       // Defensive on-chain balance check — guards against reorged indexer messages and against
       // acting on a deposit-address that has already been executed through another path.
-      const inputTokenContract = new Contract(inputToken, ERC20_ABI, this.providersByChain[originChainId]);
-      const onchainBalance: BigNumber = await inputTokenContract.balanceOf(depositAddress);
+      const onchainBalance: BigNumber = await this.getDepositAddressBalance(originChainId, inputToken, depositAddress);
       if (onchainBalance.lt(toBN(amount))) {
         this.logger.debug({
           at: "DepositAddressHandler#initiateDepositV3",
@@ -1333,10 +1348,9 @@ export class DepositAddressHandler {
 
       // Defensive on-chain balance check — guards against reorged indexer messages and against
       // acting on a deposit-address already withdrawn through another path.
-      const tokenContract = new Contract(token, ERC20_ABI, this.providersByChain[chainId]);
       let onchainBalance: BigNumber;
       try {
-        onchainBalance = await tokenContract.balanceOf(depositAddress);
+        onchainBalance = await this.getDepositAddressBalance(chainId, token, depositAddress);
       } catch (err) {
         this.logger.warn({
           at: "DepositAddressHandler#initiateWithdrawV3",
@@ -1508,6 +1522,20 @@ export class DepositAddressHandler {
     assert(isDefined(provider), `Provider not found for chain ${chainId}`);
     const code = await provider.getCode(address, blockTag ?? "latest");
     return (code?.length ?? 0) > 2; // "0x".length = 2;
+  }
+
+  /**
+   * @notice Returns the deposit address's balance of `token` on `chainId`. Native transfers are
+   * indexed with the sentinel token address, which has no contract — read those via
+   * `provider.getBalance` instead of `balanceOf` (which reverts on the sentinel).
+   */
+  private async getDepositAddressBalance(chainId: number, token: string, depositAddress: string): Promise<BigNumber> {
+    const provider = this.providersByChain[chainId];
+    assert(isDefined(provider), `Provider not found for chain ${chainId}`);
+    if (isNativeTokenSentinel(token)) {
+      return provider.getBalance(depositAddress);
+    }
+    return new Contract(token, ERC20_ABI, provider).balanceOf(depositAddress);
   }
 
   /*

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -47,6 +47,20 @@ Each message also carries a top-level `version` that selects the execution schem
 | `3` | Upgradeable-counterfactual scheme — `correct_transfer` goes to the v3 execute path (below); `mis_route` goes to the v3 refund-withdraw path (below) when `ENABLE_V3_WITHDRAWALS=true`; `intent_refund` and other classifications are dropped (not yet supported on v3). |
 | anything else (e.g. `2`) | Dropped (debug-logged) before normalization, since unsupported payloads may not carry a shape the normalizer can dereference. |
 
+**Native-token transfers.** The indexer detects native transfers to deposit addresses via traces
+and synthesizes them into the same message shape: `erc20Transfer.contractAddress` carries the
+native sentinel `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` (`NATIVE_ASSET` in the counterfactual
+contracts) and `logIndex` is synthetic. Native never matches a route's input token, so these
+messages always classify `mis_route` / `intent_refund` and enter the refund-withdraw paths, never
+the deposit-execute paths. Native withdraws are supported **only on the v3 scheme**: v3's
+`WithdrawImplementation` sends native via `call` when `token == NATIVE_ASSET`, so the v3 withdraw
+path relays the sentinel verbatim to the sign-withdraw endpoint. The v1 withdraw contract path
+cannot move native funds, so the v1 path skips sentinel messages up front (debug log, no API call).
+The bot handles the sentinel in two further places: on-chain balance checks go through
+`getDepositAddressBalance`, which reads `provider.getBalance(depositAddress)` for the sentinel
+(there is no contract at that address — `balanceOf` reverts) and ERC-20 `balanceOf` otherwise; and
+the Pub/Sub payload builder matches a different settlement log (see below).
+
 Normalization itself is guarded per message: a supported-version payload that still fails
 `normalizeDepositAddressMessage` (malformed shape) is dropped with a warn — never allowed to sink
 the rest of the batch. `counterfactualMaterials` may legitimately be absent on v1 messages (deposit
@@ -233,7 +247,7 @@ Every Pub/Sub message uses an envelope: `{ "type": "<message_type>", "data": <ty
 }
 ```
 
-All integer fields are `number`; tx hashes are lowercase hex strings. The `erc20Transfer` block identifies the original user transfer (the indexer keys rows on it); the sibling fields identify the execution transaction the bot just sent. The `logIndex` is the index of the ERC-20 `Transfer(address,address,uint256)` event whose `address` matches `erc20Transfer.contractAddress` and whose `from` is the deposit address; the **last** such log is used.
+All integer fields are `number`; tx hashes are lowercase hex strings. The `erc20Transfer` block identifies the original user transfer (the indexer keys rows on it); the sibling fields identify the execution transaction the bot just sent. The `logIndex` is the index of the ERC-20 `Transfer(address,address,uint256)` event whose `address` matches `erc20Transfer.contractAddress` and whose `from` is the deposit address; the **last** such log is used. For native-token withdraws (`contractAddress` = the native sentinel, v3 only) there is no ERC-20 Transfer — the `logIndex` is instead that of the `Withdraw(address,address,uint256)` event emitted by the deposit address itself (delegatecalled `WithdrawImplementation`), with the sentinel in the `token` topic; the same `to`-filter and last-match rules apply.
 
 - **`withdraw_executed`** additionally requires `to` to equal the user's `routeParams.refundAddress`. Matching on `to` disambiguates fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address in one tx (one to the user, one to a fee recipient), and the last match handles Multicall3-bundled withdraws with intermediate hops to the same refund address.
 - **`deposit_executed`** omits the `to` filter — the input token leaves the deposit address into the SpokePool / CCTP with no fixed recipient — so any outgoing transfer of the input token qualifies.

--- a/src/deposit-address/withdrawPayload.ts
+++ b/src/deposit-address/withdrawPayload.ts
@@ -1,7 +1,14 @@
 import { AnyDepositAddressMessage, DepositAddressMessageV3, isDepositAddressMessageV3 } from "../interfaces";
-import { isDefined, TransactionReceipt, utils } from "../utils";
+import { isDefined, isNativeTokenSentinel, TransactionReceipt, utils } from "../utils";
 
 export const ERC20_TRANSFER_TOPIC = utils.id("Transfer(address,address,uint256)");
+
+/**
+ * `Withdraw(address indexed token, address indexed to, uint256 amount)` emitted by
+ * `WithdrawImplementation` (via delegatecall, so `log.address` is the deposit address). Native
+ * withdraws emit no ERC20 `Transfer`, so this event is the only on-chain trace of the settlement.
+ */
+export const WITHDRAW_TOPIC = utils.id("Withdraw(address,address,uint256)");
 
 /**
  * Body of a deposit-address execution lifecycle event (`withdraw_executed` / `deposit_executed`).
@@ -36,14 +43,18 @@ export type DepositExecutedPayload = {
 };
 
 /**
- * Returns the last ERC20 `Transfer(address,address,uint256)` log in `receipt` whose `address`
- * matches `token` and whose `from` topic matches `depositAddress`. When `to` is provided, the
- * `to` topic must match as well — used by the withdraw path to disambiguate fee-on-transfer /
- * tax / burn tokens that emit several Transfer events from the deposit address in one tx. The
- * deposit-execute path omits `to`: funds leave the deposit address to the SpokePool / CCTP
- * (no fixed recipient), so any outgoing transfer of the input token qualifies. The **last** match
- * is returned in both cases — the final settlement out of the deposit address (handles
- * Multicall3-bundled txs with intermediate hops). Returns `undefined` when no log matches.
+ * Returns the last log in `receipt` recording `token` leaving `depositAddress`. When `to` is
+ * provided, the recipient topic must match as well — used by the withdraw path to disambiguate
+ * fee-on-transfer / tax / burn tokens that emit several Transfer events from the deposit address
+ * in one tx. The deposit-execute path omits `to`: funds leave the deposit address to the
+ * SpokePool / CCTP (no fixed recipient), so any outgoing transfer of the input token qualifies.
+ * The **last** match is returned in both cases — the final settlement out of the deposit address
+ * (handles Multicall3-bundled txs with intermediate hops). Returns `undefined` when no log matches.
+ *
+ * For ERC-20 tokens the log is the `Transfer(address,address,uint256)` emitted by the token
+ * contract (`from` topic = deposit address). For the native-token sentinel there is no Transfer
+ * event; the log is the `Withdraw(address,address,uint256)` emitted by the deposit address itself
+ * (delegatecalled `WithdrawImplementation`), with the sentinel in the `token` topic.
  */
 function findLastTransferFromDepositAddress(
   receipt: TransactionReceipt,
@@ -51,16 +62,23 @@ function findLastTransferFromDepositAddress(
   depositAddress: string,
   to?: string
 ): TransactionReceipt["logs"][number] | undefined {
-  const paddedFrom = utils.hexZeroPad(depositAddress.toLowerCase(), 32);
   const paddedTo = isDefined(to) ? utils.hexZeroPad(to.toLowerCase(), 32) : undefined;
-  const transferLogs = receipt.logs.filter(
-    (log) =>
-      log.address.toLowerCase() === token.toLowerCase() &&
-      log.topics[0] === ERC20_TRANSFER_TOPIC &&
-      log.topics[1]?.toLowerCase() === paddedFrom &&
-      (!isDefined(paddedTo) || log.topics[2]?.toLowerCase() === paddedTo)
-  );
-  return transferLogs.length === 0 ? undefined : transferLogs[transferLogs.length - 1];
+  const matchingLogs = isNativeTokenSentinel(token)
+    ? receipt.logs.filter(
+        (log) =>
+          log.address.toLowerCase() === depositAddress.toLowerCase() &&
+          log.topics[0] === WITHDRAW_TOPIC &&
+          log.topics[1]?.toLowerCase() === utils.hexZeroPad(token.toLowerCase(), 32) &&
+          (!isDefined(paddedTo) || log.topics[2]?.toLowerCase() === paddedTo)
+      )
+    : receipt.logs.filter(
+        (log) =>
+          log.address.toLowerCase() === token.toLowerCase() &&
+          log.topics[0] === ERC20_TRANSFER_TOPIC &&
+          log.topics[1]?.toLowerCase() === utils.hexZeroPad(depositAddress.toLowerCase(), 32) &&
+          (!isDefined(paddedTo) || log.topics[2]?.toLowerCase() === paddedTo)
+      );
+  return matchingLogs.length === 0 ? undefined : matchingLogs[matchingLogs.length - 1];
 }
 
 /**

--- a/src/utils/DepositAddressUtils.ts
+++ b/src/utils/DepositAddressUtils.ts
@@ -84,15 +84,16 @@ export function normalizeDepositAddressMessage(message: DepositAddressMessage): 
 /**
  * Sentinel address representing the chain's native token. The counterfactual contracts
  * (`NATIVE_ASSET` in CounterfactualConstants.sol) and the indexer's trace-based native-transfer
- * detection both use it: native transfers arrive with `erc20Transfer.contractAddress` set to this
- * value and a synthetic `logIndex`. Native balances must be read via `provider.getBalance` —
- * there is no contract at this address, so `balanceOf` reverts.
+ * detection (its `NATIVE_TOKEN_SENTINEL_ADDRESS`, which this constant mirrors by name) both use
+ * it: native transfers arrive with `erc20Transfer.contractAddress` set to this value and a
+ * synthetic `logIndex`. Native balances must be read via `provider.getBalance` — there is no
+ * contract at this address, so `balanceOf` reverts.
  */
-export const NATIVE_TOKEN_SENTINEL = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+export const NATIVE_TOKEN_SENTINEL_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 
 /** Returns true when `token` is the native-token sentinel address (case-insensitive). */
 export function isNativeTokenSentinel(token: string): boolean {
-  return token.toLowerCase() === NATIVE_TOKEN_SENTINEL.toLowerCase();
+  return token.toLowerCase() === NATIVE_TOKEN_SENTINEL_ADDRESS.toLowerCase();
 }
 
 /**

--- a/src/utils/DepositAddressUtils.ts
+++ b/src/utils/DepositAddressUtils.ts
@@ -82,6 +82,20 @@ export function normalizeDepositAddressMessage(message: DepositAddressMessage): 
 }
 
 /**
+ * Sentinel address representing the chain's native token. The counterfactual contracts
+ * (`NATIVE_ASSET` in CounterfactualConstants.sol) and the indexer's trace-based native-transfer
+ * detection both use it: native transfers arrive with `erc20Transfer.contractAddress` set to this
+ * value and a synthetic `logIndex`. Native balances must be read via `provider.getBalance` —
+ * there is no contract at this address, so `balanceOf` reverts.
+ */
+export const NATIVE_TOKEN_SENTINEL = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+
+/** Returns true when `token` is the native-token sentinel address (case-insensitive). */
+export function isNativeTokenSentinel(token: string): boolean {
+  return token.toLowerCase() === NATIVE_TOKEN_SENTINEL.toLowerCase();
+}
+
+/**
  * Returns a unique key for a deposit so we can track if it was already executed (e.g. in observedExecutedDeposits).
  * Accepts any message version — the key only depends on the shared deposit-address/transfer envelope.
  */

--- a/test/DepositAddressHandler.publish.ts
+++ b/test/DepositAddressHandler.publish.ts
@@ -7,7 +7,7 @@ import {
   ERC20_TRANSFER_TOPIC,
   WITHDRAW_TOPIC,
 } from "../src/deposit-address/withdrawPayload";
-import { NATIVE_TOKEN_SENTINEL } from "../src/utils/DepositAddressUtils";
+import { NATIVE_TOKEN_SENTINEL_ADDRESS } from "../src/utils/DepositAddressUtils";
 import { getGcpPubSubPublisher } from "../src/messaging/gcp";
 
 const DEPOSIT_ADDRESS = "0x000000000000000000000000000000000000C0DE";
@@ -209,7 +209,7 @@ describe("buildWithdrawExecutedPayload", function () {
 
   it("matches the Withdraw event emitted by the deposit address for native-token (sentinel) withdraws", function () {
     const message = depositMessage();
-    message.erc20Transfer.contractAddress = NATIVE_TOKEN_SENTINEL;
+    message.erc20Transfer.contractAddress = NATIVE_TOKEN_SENTINEL_ADDRESS;
     const receipt = fakeReceipt([
       // ERC20 Transfer of some token from the deposit address — wrong topic[0] for native.
       {
@@ -219,17 +219,17 @@ describe("buildWithdrawExecutedPayload", function () {
       // Withdraw emitted by another contract — wrong log.address.
       {
         address: OTHER_TOKEN,
-        topics: [WITHDRAW_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL), topicAddress(REFUND_ADDRESS)],
+        topics: [WITHDRAW_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL_ADDRESS), topicAddress(REFUND_ADDRESS)],
       },
       // Gas-fee leg (deductGasFromRefund) — Withdraw to the fee recipient, wrong topic[2].
       {
         address: DEPOSIT_ADDRESS,
-        topics: [WITHDRAW_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL), topicAddress(FEE_RECIPIENT)],
+        topics: [WITHDRAW_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL_ADDRESS), topicAddress(FEE_RECIPIENT)],
       },
       // The match: Withdraw(sentinel, refundAddress) emitted by the deposit address itself.
       {
         address: DEPOSIT_ADDRESS,
-        topics: [WITHDRAW_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL), topicAddress(REFUND_ADDRESS)],
+        topics: [WITHDRAW_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL_ADDRESS), topicAddress(REFUND_ADDRESS)],
       },
     ]);
     const payload = buildWithdrawExecutedPayload(receipt, message);
@@ -238,11 +238,11 @@ describe("buildWithdrawExecutedPayload", function () {
 
   it("matches native withdraws case-insensitively on the sentinel address", function () {
     const message = depositMessage();
-    message.erc20Transfer.contractAddress = NATIVE_TOKEN_SENTINEL.toLowerCase();
+    message.erc20Transfer.contractAddress = NATIVE_TOKEN_SENTINEL_ADDRESS.toLowerCase();
     const receipt = fakeReceipt([
       {
         address: DEPOSIT_ADDRESS,
-        topics: [WITHDRAW_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL), topicAddress(REFUND_ADDRESS)],
+        topics: [WITHDRAW_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL_ADDRESS), topicAddress(REFUND_ADDRESS)],
       },
     ]);
     const payload = buildWithdrawExecutedPayload(receipt, message);
@@ -251,12 +251,12 @@ describe("buildWithdrawExecutedPayload", function () {
 
   it("returns undefined for a native withdraw when no Withdraw (depositAddress -> refundAddress) exists", function () {
     const message = depositMessage();
-    message.erc20Transfer.contractAddress = NATIVE_TOKEN_SENTINEL;
+    message.erc20Transfer.contractAddress = NATIVE_TOKEN_SENTINEL_ADDRESS;
     const receipt = fakeReceipt([
       // Only the fee leg is present — no settlement to the refund address.
       {
         address: DEPOSIT_ADDRESS,
-        topics: [WITHDRAW_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL), topicAddress(FEE_RECIPIENT)],
+        topics: [WITHDRAW_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL_ADDRESS), topicAddress(FEE_RECIPIENT)],
       },
     ]);
     expect(buildWithdrawExecutedPayload(receipt, message)).to.be.undefined;

--- a/test/DepositAddressHandler.publish.ts
+++ b/test/DepositAddressHandler.publish.ts
@@ -5,7 +5,9 @@ import {
   buildDepositExecutedPayload,
   buildWithdrawExecutedPayload,
   ERC20_TRANSFER_TOPIC,
+  WITHDRAW_TOPIC,
 } from "../src/deposit-address/withdrawPayload";
+import { NATIVE_TOKEN_SENTINEL } from "../src/utils/DepositAddressUtils";
 import { getGcpPubSubPublisher } from "../src/messaging/gcp";
 
 const DEPOSIT_ADDRESS = "0x000000000000000000000000000000000000C0DE";
@@ -203,6 +205,61 @@ describe("buildWithdrawExecutedPayload", function () {
     ]);
     const payload = buildWithdrawExecutedPayload(receipt, depositMessage());
     expect(payload?.data.logIndex).to.equal(2);
+  });
+
+  it("matches the Withdraw event emitted by the deposit address for native-token (sentinel) withdraws", function () {
+    const message = depositMessage();
+    message.erc20Transfer.contractAddress = NATIVE_TOKEN_SENTINEL;
+    const receipt = fakeReceipt([
+      // ERC20 Transfer of some token from the deposit address — wrong topic[0] for native.
+      {
+        address: OTHER_TOKEN,
+        topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS), topicAddress(REFUND_ADDRESS)],
+      },
+      // Withdraw emitted by another contract — wrong log.address.
+      {
+        address: OTHER_TOKEN,
+        topics: [WITHDRAW_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL), topicAddress(REFUND_ADDRESS)],
+      },
+      // Gas-fee leg (deductGasFromRefund) — Withdraw to the fee recipient, wrong topic[2].
+      {
+        address: DEPOSIT_ADDRESS,
+        topics: [WITHDRAW_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL), topicAddress(FEE_RECIPIENT)],
+      },
+      // The match: Withdraw(sentinel, refundAddress) emitted by the deposit address itself.
+      {
+        address: DEPOSIT_ADDRESS,
+        topics: [WITHDRAW_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL), topicAddress(REFUND_ADDRESS)],
+      },
+    ]);
+    const payload = buildWithdrawExecutedPayload(receipt, message);
+    expect(payload?.data.logIndex).to.equal(3);
+  });
+
+  it("matches native withdraws case-insensitively on the sentinel address", function () {
+    const message = depositMessage();
+    message.erc20Transfer.contractAddress = NATIVE_TOKEN_SENTINEL.toLowerCase();
+    const receipt = fakeReceipt([
+      {
+        address: DEPOSIT_ADDRESS,
+        topics: [WITHDRAW_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL), topicAddress(REFUND_ADDRESS)],
+      },
+    ]);
+    const payload = buildWithdrawExecutedPayload(receipt, message);
+    expect(payload?.data.logIndex).to.equal(0);
+  });
+
+  it("returns undefined for a native withdraw when no Withdraw (depositAddress -> refundAddress) exists", function () {
+    const message = depositMessage();
+    message.erc20Transfer.contractAddress = NATIVE_TOKEN_SENTINEL;
+    const receipt = fakeReceipt([
+      // Only the fee leg is present — no settlement to the refund address.
+      {
+        address: DEPOSIT_ADDRESS,
+        topics: [WITHDRAW_TOPIC, topicAddress(NATIVE_TOKEN_SENTINEL), topicAddress(FEE_RECIPIENT)],
+      },
+    ]);
+    expect(buildWithdrawExecutedPayload(receipt, message)).to.be.undefined;
   });
 });
 

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -6,6 +6,7 @@ import { DepositAddressExecuteResponse, DepositAddressSignWithdrawResponse } fro
 import { DepositAddressHandler } from "../src/deposit-address/DepositAddressHandler";
 import { DepositAddressHandlerConfig } from "../src/deposit-address/DepositAddressHandlerConfig";
 import { ERC20_TRANSFER_TOPIC } from "../src/deposit-address/withdrawPayload";
+import { NATIVE_TOKEN_SENTINEL } from "../src/utils/DepositAddressUtils";
 
 const SIGNER = "0x000000000000000000000000000000000000BEEF";
 const DEPOSIT_ADDRESS = "0x000000000000000000000000000000000000C0DE";
@@ -698,6 +699,33 @@ describe("DepositAddressHandler.initiateWithdrawV3 guards", function () {
     );
     expect(signWithdrawStub.notCalled).to.equal(true);
     expect(warnStub.calledOnce).to.equal(true);
+  });
+});
+
+describe("DepositAddressHandler.initiateWithdraw (v1) native-token guard", function () {
+  afterEach(() => sinon.restore());
+
+  it("skips native-sentinel withdraws without calling the sign-withdraw API", async function () {
+    const chainId = 1; // depositMessage()'s erc20Transfer.chainId
+    const config = { withdrawEnabled: true, relayerOriginChains: [chainId] } as unknown as DepositAddressHandlerConfig;
+    const debugStub = sinon.stub();
+    const logger = { warn: sinon.stub(), debug: debugStub } as unknown as winston.Logger;
+    const handler = new DepositAddressHandler(logger, config, {} as unknown as Signer, []);
+    const signedWithdrawStub = sinon.stub().resolves({ signedWithdrawTx: { chainId } });
+    (handler as unknown as { api: { signedWithdraw: sinon.SinonStub } }).api = {
+      signedWithdraw: signedWithdrawStub,
+    };
+
+    const message = depositMessage({ withdrawLeaf });
+    message.erc20Transfer.transferClassification = "mis_route";
+    message.erc20Transfer.contractAddress = NATIVE_TOKEN_SENTINEL;
+
+    await (handler as unknown as { initiateWithdraw: (m: DepositAddressMessage) => Promise<void> }).initiateWithdraw(
+      message
+    );
+    expect(signedWithdrawStub.notCalled).to.equal(true);
+    expect(debugStub.calledOnce).to.equal(true);
+    expect(debugStub.firstCall.firstArg.message).to.contain("not supported on v1");
   });
 });
 

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -1,12 +1,12 @@
 import sinon from "sinon";
 import { expect } from "chai";
-import { EvmAddress, getCurrentTime, HttpError, Signer, TransactionReceipt, utils, winston } from "../src/utils";
+import { EvmAddress, getCurrentTime, HttpError, Signer, toBN, TransactionReceipt, utils, winston } from "../src/utils";
 import { DepositAddressMessage, DepositAddressMessageV3 } from "../src/interfaces/DepositAddress";
 import { DepositAddressExecuteResponse, DepositAddressSignWithdrawResponse } from "../src/clients";
 import { DepositAddressHandler } from "../src/deposit-address/DepositAddressHandler";
 import { DepositAddressHandlerConfig } from "../src/deposit-address/DepositAddressHandlerConfig";
 import { ERC20_TRANSFER_TOPIC } from "../src/deposit-address/withdrawPayload";
-import { NATIVE_TOKEN_SENTINEL } from "../src/utils/DepositAddressUtils";
+import { NATIVE_TOKEN_SENTINEL_ADDRESS } from "../src/utils/DepositAddressUtils";
 
 const SIGNER = "0x000000000000000000000000000000000000BEEF";
 const DEPOSIT_ADDRESS = "0x000000000000000000000000000000000000C0DE";
@@ -718,7 +718,7 @@ describe("DepositAddressHandler.initiateWithdraw (v1) native-token guard", funct
 
     const message = depositMessage({ withdrawLeaf });
     message.erc20Transfer.transferClassification = "mis_route";
-    message.erc20Transfer.contractAddress = NATIVE_TOKEN_SENTINEL;
+    message.erc20Transfer.contractAddress = NATIVE_TOKEN_SENTINEL_ADDRESS;
 
     await (handler as unknown as { initiateWithdraw: (m: DepositAddressMessage) => Promise<void> }).initiateWithdraw(
       message
@@ -726,6 +726,73 @@ describe("DepositAddressHandler.initiateWithdraw (v1) native-token guard", funct
     expect(signedWithdrawStub.notCalled).to.equal(true);
     expect(debugStub.calledOnce).to.equal(true);
     expect(debugStub.firstCall.firstArg.message).to.contain("not supported on v1");
+  });
+});
+
+describe("DepositAddressHandler.initiateWithdrawV3 balance check", function () {
+  let handler: DepositAddressHandler;
+  let signWithdrawStub: sinon.SinonStub;
+  let getBalanceStub: sinon.SinonStub;
+  let warnStub: sinon.SinonStub;
+  let debugStub: sinon.SinonStub;
+  const chainId = 42161;
+
+  type Internals = { initiateWithdrawV3: (m: DepositAddressMessageV3) => Promise<void> };
+
+  /** Native-token mis_route message — `contractAddress` carries the indexer's native sentinel. */
+  function nativeWithdrawMessageV3(): DepositAddressMessageV3 {
+    const message = withdrawMessageV3();
+    message.erc20Transfer.contractAddress = NATIVE_TOKEN_SENTINEL_ADDRESS;
+    return message;
+  }
+
+  beforeEach(function () {
+    const config = {
+      enableV3Withdrawals: true,
+      relayerOriginChains: [chainId],
+    } as unknown as DepositAddressHandlerConfig;
+    warnStub = sinon.stub();
+    debugStub = sinon.stub();
+    const logger = { warn: warnStub, debug: debugStub } as unknown as winston.Logger;
+    handler = new DepositAddressHandler(logger, config, {} as unknown as Signer, []);
+    // The sign-withdraw stub returns a mismatched chainId so the flow stops right after the API
+    // call — these tests only exercise the balance check in front of it.
+    signWithdrawStub = sinon.stub().resolves({ signedWithdrawTx: { chainId: chainId + 1 } });
+    (handler as unknown as { api: { signWithdrawDepositAddressV3: sinon.SinonStub } }).api = {
+      signWithdrawDepositAddressV3: signWithdrawStub,
+    };
+    (handler as unknown as { observedExecutedWithdraws: Record<number, Set<string>> }).observedExecutedWithdraws = {
+      [chainId]: new Set<string>(),
+    };
+    // Bare stub, deliberately NOT an ethers Provider: `getBalance` serves the native path, and any
+    // ERC-20 read attempt fails loudly (`new Contract(...)` rejects a non-Provider).
+    getBalanceStub = sinon.stub().resolves(toBN("5000"));
+    (handler as unknown as { providersByChain: Record<number, unknown> }).providersByChain = {
+      [chainId]: { getBalance: getBalanceStub },
+    };
+  });
+
+  afterEach(() => sinon.restore());
+
+  it("reads the native balance via provider.getBalance for sentinel withdraws and proceeds", async function () {
+    await (handler as unknown as Internals).initiateWithdrawV3(nativeWithdrawMessageV3());
+    expect(getBalanceStub.calledOnceWith(DEPOSIT_ADDRESS)).to.equal(true);
+    expect(signWithdrawStub.calledOnce).to.equal(true);
+  });
+
+  it("skips a native withdraw when the native balance is below the transfer amount", async function () {
+    getBalanceStub.resolves(toBN("4999"));
+    await (handler as unknown as Internals).initiateWithdrawV3(nativeWithdrawMessageV3());
+    expect(signWithdrawStub.notCalled).to.equal(true);
+    expect(debugStub.calledOnce).to.equal(true);
+  });
+
+  it("still reads ERC-20 balances via the token contract, warning and skipping when the read fails", async function () {
+    await (handler as unknown as Internals).initiateWithdrawV3(withdrawMessageV3());
+    expect(getBalanceStub.notCalled).to.equal(true);
+    expect(signWithdrawStub.notCalled).to.equal(true);
+    expect(warnStub.calledOnce).to.equal(true);
+    expect(warnStub.firstCall.firstArg.message).to.contain("failed to fetch deposit address balance");
   });
 });
 

--- a/test/DepositAddressUtils.ts
+++ b/test/DepositAddressUtils.ts
@@ -1,6 +1,11 @@
 import { expect } from "chai";
 import { CHAIN_IDs, getEthersCompatibleAddress, toAddressType } from "../src/utils";
-import { getDepositKey, normalizeDepositAddressMessage } from "../src/utils/DepositAddressUtils";
+import {
+  getDepositKey,
+  isNativeTokenSentinel,
+  NATIVE_TOKEN_SENTINEL_ADDRESS,
+  normalizeDepositAddressMessage,
+} from "../src/utils/DepositAddressUtils";
 import { DepositAddressMessage } from "../src/interfaces/DepositAddress";
 
 /** Indexer API sample: Tron origin, Base destination, USDT correct_transfer. */
@@ -158,5 +163,19 @@ describe("DepositAddressUtils", function () {
 
     expect(getDepositKey(normalized)).to.equal(`${normalized.depositAddress}:${raw.erc20Transfer.transactionHash}`);
     expect(getDepositKey(normalized)).to.not.equal(getDepositKey(raw));
+  });
+});
+
+describe("isNativeTokenSentinel", function () {
+  it("matches the sentinel in any casing", function () {
+    expect(isNativeTokenSentinel(NATIVE_TOKEN_SENTINEL_ADDRESS)).to.equal(true);
+    expect(isNativeTokenSentinel(NATIVE_TOKEN_SENTINEL_ADDRESS.toLowerCase())).to.equal(true);
+    expect(isNativeTokenSentinel(NATIVE_TOKEN_SENTINEL_ADDRESS.toUpperCase().replace("0X", "0x"))).to.equal(true);
+  });
+
+  it("rejects other addresses", function () {
+    expect(isNativeTokenSentinel("0x0000000000000000000000000000000000000000")).to.equal(false);
+    expect(isNativeTokenSentinel("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")).to.equal(false);
+    expect(isNativeTokenSentinel("")).to.equal(false);
   });
 });


### PR DESCRIPTION
## Problem

The indexer now detects native transfers to deposit addresses via traces (across-protocol/indexer#1140) and delivers them with `erc20Transfer.contractAddress` set to the native sentinel `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`. The bot's defensive balance check called `balanceOf` on that address — there is no contract there, so the call reverts and every native withdraw was skipped:

```
Skipping withdraw: failed to fetch deposit address balance
token: 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE
err: call revert exception (method="balanceOf(address)", ...)
```

## Changes

- **`src/utils/DepositAddressUtils.ts`** — `NATIVE_TOKEN_SENTINEL` + `isNativeTokenSentinel()` (mirrors `NATIVE_ASSET` in the counterfactual contracts, across-protocol/contracts#1469).
- **`DepositAddressHandler.ts`** — new `getDepositAddressBalance()` helper: `provider.getBalance()` for the sentinel, ERC-20 `balanceOf` otherwise. Applied to all four balance-check sites (both withdraw paths; deposit paths defensively — native always classifies `mis_route`/`intent_refund`, never `correct_transfer`).
- **v1 vs v3** — native withdraws are supported **only on the v3 scheme** (`WithdrawImplementation` sends native via `call` when `token == NATIVE_ASSET`). `initiateWithdraw` (v1) now skips sentinel messages up front with a debug log and no API call; `initiateWithdrawV3` relays the sentinel verbatim to the sign-withdraw endpoint.
- **`withdrawPayload.ts`** — native withdraws emit no ERC-20 `Transfer`, so the `withdraw_executed` Pub/Sub payload would have been silently skipped (row stuck in `auto_pending`). The builder now matches the `Withdraw(address indexed token, address indexed to, uint256 amount)` event emitted by the deposit address itself (delegatecalled `WithdrawImplementation`) when the token is the sentinel. The existing `to = refundAddress` filter and last-match rules apply, which also skips the `deductGasFromRefund` fee leg.
- **Tests** — payload matching for native (fee-leg disambiguation, case-insensitivity, no-match → skip) and the v1 skip guard.
- **Docs** — `src/deposit-address/README.md`: native-transfer classification, balance helper, v3-only withdraw support, payload fallback.

## Notes

- Native funds landing on a **v1** deposit address are deliberately left in place — recovery would go through another path (e.g. the admin withdraw manager).
- Verified: typecheck, eslint, prettier, and all deposit-address suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)