### PR TITLE
feat(dataworker): skip relayer refund leaves refunding blocked addresses

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2502,16 +2502,40 @@ export class Dataworker {
     const submitExecution = this.config.sendingTransactionsEnabled;
     assert(isDefined(spokePoolAddress), "_executeRelayerRefundLeaves: SpokePoolClient missing spokePoolAddress");
 
+    // Skip leaves that would refund a blocked address. Leaf execution is atomic, so a leaf refunding a
+    // blocked address must be skipped in its entirety, including any other relayers' refunds bundled into
+    // the same leaf.
+    const blockedRefundAddresses = this.config.blockedRefundAddresses ?? [];
+    const executableLeaves = leaves.filter((leaf) => {
+      const blockedRefunds = leaf.refundAddresses.filter((refundAddress) =>
+        blockedRefundAddresses.some((blockedAddress) => blockedAddress.eq(refundAddress))
+      );
+      if (blockedRefunds.length === 0) {
+        return true;
+      }
+      this.logger.warn({
+        at: "Dataworker#_executeRelayerRefundLeaves",
+        message: `Skipping relayer refund leaf #${leaf.leafId} on chain ${leaf.chainId} refunding blocked address(es)`,
+        root: relayerRefundTree.getHexRoot(),
+        bundle: rootBundleId,
+        blockedRefundAddresses: blockedRefunds.map((address) => address.toNative()),
+      });
+      return false;
+    });
+    if (executableLeaves.length === 0) {
+      return;
+    }
+
     // Pre-compute msg.value per leaf id to use consistently in allocation and execution
     const msgValuesByLeafId: Map<number, BigNumber | undefined> = new Map();
-    await forEachAsync(leaves, async (leaf) => {
+    await forEachAsync(executableLeaves, async (leaf) => {
       msgValuesByLeafId.set(leaf.leafId, await this._getMsgValueForRelayerRefundLeaf(client, leaf));
     });
 
     // Filter for leaves where the contract has the funding to send the required tokens.
     const fundedLeaves = (
       await Promise.all(
-        leaves.map(async (leaf) => {
+        executableLeaves.map(async (leaf) => {
           if (leaf.chainId !== chainId) {
             throw new Error("Leaf chainId does not match input chainId");
           }

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -1,5 +1,12 @@
 import { CommonConfig, ProcessEnv } from "../common";
-import { assert, getArweaveJWKSigner, parseJson, isDefined } from "../utils";
+import { assert, EvmAddress, getArweaveJWKSigner, parseJson, isDefined } from "../utils";
+
+// Refund addresses that the executor should never send relayer refunds to. Used as the default for
+// blockedRefundAddresses when EXECUTOR_BLOCKED_REFUND_ADDRESSES is unset.
+const DEFAULT_BLOCKED_REFUND_ADDRESSES = JSON.stringify([
+  "0xA6fb971F3B7a9b9F76EdA76bc89268fe26560189",
+  "0xa0c0e9f307b5a26ca3fb5891c19154fc7a02bef7",
+]);
 
 export class DataworkerConfig extends CommonConfig {
   readonly minChallengeLeadTime: number;
@@ -38,6 +45,11 @@ export class DataworkerConfig extends CommonConfig {
   // A list of chains to ignore slow fill/relayer refund execution. Primarily used for debugging purposes.
   readonly executorIgnoreChains: number[];
 
+  // Relayer refund leaves refunding any of these addresses are not executed. Note that leaf execution is
+  // atomic, so any other refunds sharing a leaf with a blocked address are withheld as well. Setting
+  // EXECUTOR_BLOCKED_REFUND_ADDRESSES replaces the default list entirely.
+  readonly blockedRefundAddresses: EvmAddress[];
+
   // Used to instruct the dataworker to load data from arweave in times when doing so is optional (i.e. execution).
   readonly loadArweaveData: boolean | undefined;
 
@@ -57,6 +69,7 @@ export class DataworkerConfig extends CommonConfig {
       FORCE_PROPOSAL_BUNDLE_RANGE,
       PERSIST_BUNDLES_TO_ARWEAVE,
       EXECUTOR_IGNORE_CHAINS,
+      EXECUTOR_BLOCKED_REFUND_ADDRESSES = DEFAULT_BLOCKED_REFUND_ADDRESSES,
       MIN_CHALLENGE_LEAD_TIME = "600",
       AWAIT_CHALLENGE_PERIOD = "false",
       DISPUTE_COOLDOWN,
@@ -89,6 +102,9 @@ export class DataworkerConfig extends CommonConfig {
     this.l2ExecutorEnabled = L2_EXECUTOR_ENABLED === "true";
     this.l1ExecutorEnabled = L1_EXECUTOR_ENABLED === "true";
     this.executorIgnoreChains = parseJson.numberArray(EXECUTOR_IGNORE_CHAINS);
+    this.blockedRefundAddresses = parseJson
+      .stringArray(EXECUTOR_BLOCKED_REFUND_ADDRESSES)
+      .map((address) => EvmAddress.from(address));
     if (this.l2ExecutorEnabled) {
       assert(
         isDefined(this.spokeRootsLookbackCount) && this.spokeRootsLookbackCount > 0,

--- a/src/dataworker/README.md
+++ b/src/dataworker/README.md
@@ -23,3 +23,7 @@ The dataworker runtime file is index.ts. This file contains a `runDataworker()` 
 1. Checks if there is an existing pending root bundle. If there is one, validate it. If invalid, submit a dispute, otherwise proceed.
 2. If no existing pending root bundle, construct and propose a new one.
 3. If existing pending root bundle has passed its optimistic challenge liveness window, then execute it by calling functions on the `HubPool` and functions on each spoke network's `SpokePool`. Recall that each root bundle refers to a Merkle root describing the list of relayer and depositor refunds. Therefore, executing these refunds amounts to submitting Merkle leaves from this Merkle root to the HubPool/SpokePool and letting those contracts send out payments based on those Merkle leaf contents.
+
+## Executor refund blocklist
+
+The executor refuses to execute any relayer refund leaf that would refund a blocked address. Because leaf execution is atomic, all other refunds sharing a leaf with a blocked address are withheld as well; each skipped leaf is logged at `warn`. The default blocklist is hardcoded in `DataworkerConfig` and can be replaced entirely by setting `EXECUTOR_BLOCKED_REFUND_ADDRESSES` to a JSON array of addresses.

--- a/test/Dataworker.executeRelayerRefunds.ts
+++ b/test/Dataworker.executeRelayerRefunds.ts
@@ -1,5 +1,5 @@
 import { HubPoolClient, MultiCallerClient, SpokePoolClient } from "../src/clients";
-import { EvmAddress, buildRelayerRefundTree, MAX_UINT_VAL, RelayerRefundLeaf, toBNWei } from "../src/utils";
+import { EvmAddress, bnZero, buildRelayerRefundTree, MAX_UINT_VAL, RelayerRefundLeaf, toBNWei } from "../src/utils";
 import {
   MAX_L1_TOKENS_PER_POOL_REBALANCE_LEAF,
   MAX_REFUNDS_PER_RELAYER_REFUND_LEAF,
@@ -7,7 +7,7 @@ import {
   destinationChainId,
 } from "./constants";
 import { setupDataworker } from "./fixtures/Dataworker.Fixture";
-import { Contract, SignerWithAddress, depositV3, ethers, expect, fillV3Relay } from "./utils";
+import { Contract, SignerWithAddress, depositV3, ethers, expect, fillV3Relay, randomAddress } from "./utils";
 
 // Tested
 import { BalanceAllocator } from "../src/clients/BalanceAllocator";
@@ -102,6 +102,47 @@ describe("Dataworker: Execute relayer refunds", function () {
     expect(multiCallerClient.transactionCount()).to.equal(1);
 
     await multiCallerClient.executeTxnQueues();
+  });
+  it("Ignores leaves refunding blocked refund addresses", async function () {
+    const blockedRelayer = randomAddress();
+    dataworkerInstance.config.blockedRefundAddresses.push(EvmAddress.from(blockedRelayer));
+    const refundLeaves: RelayerRefundLeaf[] = [
+      {
+        amountToReturn: bnZero,
+        chainId: hubPoolClient.chainId,
+        refundAmounts: [toBNWei("1")],
+        leafId: 0,
+        l2TokenAddress: EvmAddress.from(l1Token_1.address),
+        refundAddresses: [EvmAddress.from(blockedRelayer)],
+      },
+      {
+        amountToReturn: bnZero,
+        chainId: hubPoolClient.chainId,
+        refundAmounts: [toBNWei("1")],
+        leafId: 1,
+        l2TokenAddress: EvmAddress.from(l1Token_1.address),
+        refundAddresses: [EvmAddress.from(randomAddress())],
+      },
+    ];
+    const relayerRefundTree = buildRelayerRefundTree(refundLeaves);
+    await spokePool_4.relayRootBundle(
+      relayerRefundTree.getHexRoot(),
+      "0x0000000000000000000000000000000000000000000000000000000000000000"
+    );
+    await l1Token_1.mint(spokePool_4.address, amountToDeposit);
+    await updateAllClients();
+    await dataworkerInstance._executeRelayerRefundLeaves(
+      refundLeaves,
+      await getNewBalanceAllocator(),
+      spokePoolClients[hubPoolClient.chainId],
+      relayerRefundTree,
+      0
+    );
+
+    // Only the leaf without a blocked refund address should be enqueued for execution.
+    expect(multiCallerClient.transactionCount()).to.equal(1);
+    const [queuedTxn] = multiCallerClient.getQueuedTransactions(hubPoolClient.chainId);
+    expect(queuedTxn.args[1].leafId).to.equal(1);
   });
   it("Modifies BalanceAllocator when executing hub chain leaf", async function () {
     const refundLeaves: RelayerRefundLeaf[] = [

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -225,6 +225,7 @@ export async function setupDataworker(
     {
       awaitChallengePeriod: awaitChallengePeriod ?? false,
       executorIgnoreChains: [],
+      blockedRefundAddresses: [],
       sendingTransactionsEnabled: true,
     } as unknown as DataworkerConfig,
     dataworkerClients,


### PR DESCRIPTION
## Motivation

We want the dataworker executor to withhold relayer refunds destined for specific addresses:

- `0xA6fb971F3B7a9b9F76EdA76bc89268fe26560189`
- `0xa0c0e9f307b5a26ca3fb5891c19154fc7a02bef7`

The dataworker cannot alter leaf contents (the reconstructed root must match the proposed root), so this is implemented as an execution-time skip.

## Changes

- **`DataworkerConfig`**: new `blockedRefundAddresses` config, defaulting to the two addresses above. Setting `EXECUTOR_BLOCKED_REFUND_ADDRESSES` (JSON string array) **replaces** the default list entirely, so it can also be used to unblock or extend without a code change. Addresses are validated at startup via `EvmAddress.from`, and comparisons are on raw bytes so casing doesn't matter.
- **`Dataworker#_executeRelayerRefundLeaves`**: filters out any leaf whose `refundAddresses` contain a blocked address before msg.value computation and balance allocation. Placing the filter here covers both execution paths: the mainnet fast-path (refund leaves executed atomically alongside the mainnet pool rebalance leaf) and the regular L2 executor path. Each skipped leaf is logged at `warn` with the offending addresses, root, and bundle id.
- **`src/dataworker/README.md`**: documents the blocklist behavior and env var.

## Caveat

Leaf execution is atomic on-chain, so a leaf containing a blocked refund address is skipped in its entirety — any other relayers' refunds bundled into the same leaf are withheld with it (and will remain unexecuted until the leaf is executed by some other actor or the blocklist changes). The `warn` log makes this visible on every executor run while the bundle remains within the lookback window.

## Testing

- New test in `test/Dataworker.executeRelayerRefunds.ts`: builds two refund leaves (one refunding a blocked address, one clean) and asserts only the clean leaf is enqueued for execution.
- `yarn build` and lint pass; all tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AwNYDz6oYJB4n41QNw3kT