### PR TITLE
fix(rebalancer): only update order statuses for routes the adapter supports

### DIFF
--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -249,6 +249,8 @@ High-level flow:
 
 The runtime entrypoint is `runSameAssetRebalancer`, exposed as the `sameAssetRebalancer` bot. It is independent of cumulative mode: operators enable destination token/chain pairs under `sameAssetBalances`, while the support catalog controls which of those pairs can become routes.
 
+Cross-mode pending orders: the `swapRebalancer` and `sameAssetRebalancer` bots typically share a base signer and the Redis order store, so each bot's `updateRebalanceStatuses()` pass can encounter pending orders created by the other mode. Adapters only progress orders whose routes are in their own configured `availableRoutes` (`BaseAdapter._canProgressOrder`); unsupported orders are skipped with a debug log and left pending for the properly-configured bot to progress. If no configured instance supports an order's route (e.g. after config drift), the order is eventually TTL-pruned with a warning by `_redisCleanupPendingOrders`.
+
 ### Read-only mode: `ReadOnlyRebalancerClient`
 
 `ReadOnlyRebalancerClient` is used by consumers that only need pending-state visibility (for example, inventory

--- a/src/rebalancer/adapters/baseAdapter.ts
+++ b/src/rebalancer/adapters/baseAdapter.ts
@@ -130,7 +130,9 @@ export abstract class BaseAdapter implements RebalancerAdapter {
     return;
   }
 
-  supportsRoute(rebalanceRoute: RebalanceRoute): boolean {
+  // The adapter name is irrelevant to (and omitted from) the comparison, so callers can pass either a full
+  // RebalanceRoute or a pending order's route details.
+  supportsRoute(rebalanceRoute: Omit<RebalanceRoute, "adapter"> & { adapter?: string }): boolean {
     return this.availableRoutes.some(
       (route) =>
         route.sourceChain === rebalanceRoute.sourceChain &&
@@ -355,6 +357,23 @@ export abstract class BaseAdapter implements RebalancerAdapter {
       this.supportsRoute(rebalanceRoute),
       `Route is not supported: ${rebalanceRoute.sourceToken} ${rebalanceRoute.sourceChain} -> ${rebalanceRoute.destinationToken} ${rebalanceRoute.destinationChain}`
     );
+  }
+
+  // The Redis order store can be shared by multiple rebalancer bots running with the same signer (e.g. the
+  // swapRebalancer and sameAssetRebalancer), so updateRebalanceStatuses() can encounter pending orders created by a
+  // bot configured with a different route catalog. Each adapter should only progress orders whose routes it supports:
+  // skipped orders are left pending for a properly-configured instance to progress, and if no such instance exists
+  // (e.g. after config drift) the order is eventually TTL-pruned with a warning by _redisCleanupPendingOrders.
+  protected _canProgressOrder(at: string, cloid: string, orderDetails: OrderDetails): boolean {
+    if (this.supportsRoute(orderDetails)) {
+      return true;
+    }
+    const { sourceToken, sourceChain, destinationToken, destinationChain } = orderDetails;
+    this.logger.debug({
+      at,
+      message: `Skipping order ${cloid} with unsupported route ${sourceToken} ${sourceChain} -> ${destinationToken} ${destinationChain}; leaving it pending for a rebalancer instance configured with this route`,
+    });
+    return false;
   }
 
   protected async _wait(seconds: number): Promise<void> {

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -253,6 +253,9 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     }
     for (const cloid of pendingBridgeToBinanceDepositNetwork) {
       const orderDetails = await this._redisGetOrderDetailsRequired(cloid, this.baseSignerAddress);
+      if (!this._canProgressOrder("BinanceStablecoinSwapAdapter.updateRebalanceStatuses", cloid, orderDetails)) {
+        continue;
+      }
       const { sourceToken, amountToTransfer, sourceChain } = orderDetails;
       const binanceDepositNetwork = await this._getEntrypointNetwork(sourceChain, sourceToken);
       // Check if we have enough balance on HyperEVM to progress the order status:
@@ -302,6 +305,9 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     }
     for (const cloid of pendingDeposits) {
       const orderDetails = await this._redisGetOrderDetailsRequired(cloid, this.baseSignerAddress);
+      if (!this._canProgressOrder("BinanceStablecoinSwapAdapter.updateRebalanceStatuses", cloid, orderDetails)) {
+        continue;
+      }
       const { sourceToken, sourceChain, destinationToken, destinationChain, amountToTransfer } = orderDetails;
 
       const binanceBalance = await this._getBinanceBalance(sourceToken);
@@ -356,10 +362,11 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       });
     }
     for (const cloid of pendingSwaps) {
-      const { destinationToken, destinationChain } = await this._redisGetOrderDetailsRequired(
-        cloid,
-        this.baseSignerAddress
-      );
+      const orderDetails = await this._redisGetOrderDetailsRequired(cloid, this.baseSignerAddress);
+      if (!this._canProgressOrder("BinanceStablecoinSwapAdapter.updateRebalanceStatuses", cloid, orderDetails)) {
+        continue;
+      }
+      const { destinationToken, destinationChain } = orderDetails;
       const matchingFill = await this._getMatchingFillForCloid(cloid, this.baseSignerAddress);
       if (matchingFill) {
         const balance = await this._getBinanceBalance(destinationToken);
@@ -411,6 +418,9 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       // a bridge to the final non-Binance network destination chain if necessary.
 
       const orderDetails = await this._redisGetOrderDetailsRequired(cloid, this.baseSignerAddress);
+      if (!this._canProgressOrder("BinanceStablecoinSwapAdapter.updateRebalanceStatuses", cloid, orderDetails)) {
+        continue;
+      }
       const { sourceToken, destinationToken, destinationChain } = orderDetails;
       const matchingFill = this._routeRequiresSwap(sourceToken, destinationToken)
         ? (await this._getMatchingFillForCloid(cloid, this.baseSignerAddress))?.matchingFill

--- a/src/rebalancer/adapters/cctpAdapter.ts
+++ b/src/rebalancer/adapters/cctpAdapter.ts
@@ -110,6 +110,10 @@ export class CctpAdapter extends BaseAdapter {
       });
     }
     for (const cloid of pendingBridges) {
+      const orderDetails = await this._redisGetOrderDetailsRequired(cloid, this.baseSignerAddress);
+      if (!this._canProgressOrder("CctpAdapter.updateRebalanceStatuses", cloid, orderDetails)) {
+        continue;
+      }
       const [sourceChainId, txnHash] = cloid.split("-");
       const attestation = await this._getCctpAttestation(txnHash, Number(sourceChainId));
       if (!isDefined(attestation) || utils.getPendingAttestationStatus(attestation) === "pending") {

--- a/src/rebalancer/adapters/hyperliquid.ts
+++ b/src/rebalancer/adapters/hyperliquid.ts
@@ -295,6 +295,9 @@ export class HyperliquidStablecoinSwapAdapter extends BaseAdapter {
     }
     for (const cloid of pendingBridgeToHyperevm) {
       const orderDetails = await this._redisGetOrderDetailsRequired(cloid, this.baseSignerAddress);
+      if (!this._canProgressOrder("HyperliquidStablecoinSwapAdapter.updateRebalanceStatuses", cloid, orderDetails)) {
+        continue;
+      }
       const { sourceToken, amountToTransfer, sourceChain } = orderDetails;
       // Check if we have enough balance on HyperEVM to progress the order status:
       const hyperevmBalance = await this._getERC20Balance(
@@ -343,6 +346,9 @@ export class HyperliquidStablecoinSwapAdapter extends BaseAdapter {
     }
     for (const cloid of pendingDeposits) {
       const orderDetails = await this._redisGetOrderDetailsRequired(cloid, this.baseSignerAddress);
+      if (!this._canProgressOrder("HyperliquidStablecoinSwapAdapter.updateRebalanceStatuses", cloid, orderDetails)) {
+        continue;
+      }
       const orderResult = await this._createHlOrder(orderDetails, cloid);
       if (orderResult) {
         await this._redisUpdateOrderStatus(
@@ -378,6 +384,10 @@ export class HyperliquidStablecoinSwapAdapter extends BaseAdapter {
       }
     }
     for (const cloid of pendingSwaps) {
+      const existingOrder = await this._redisGetOrderDetailsRequired(cloid, this.baseSignerAddress);
+      if (!this._canProgressOrder("HyperliquidStablecoinSwapAdapter.updateRebalanceStatuses", cloid, existingOrder)) {
+        continue;
+      }
       const matchingFill = await this._getMatchingFillForCloid(this.baseSignerAddress, cloid);
       const matchingOpenOrder = openOrders.find((order) => order.cloid === cloid);
       if (matchingFill) {
@@ -387,7 +397,6 @@ export class HyperliquidStablecoinSwapAdapter extends BaseAdapter {
         });
 
         // Issue a withdrawal from HL now:
-        const existingOrder = await this._redisGetOrderDetailsRequired(cloid, this.baseSignerAddress);
         this.logger.debug({
           at: "HyperliquidStablecoinSwapAdapter.updateRebalanceStatuses",
           message: `Withdrawing ${matchingFill.amountToWithdraw.toString()} ${
@@ -408,7 +417,6 @@ export class HyperliquidStablecoinSwapAdapter extends BaseAdapter {
           at: "HyperliquidStablecoinSwapAdapter.updateRebalanceStatuses",
           message: `Order ${cloid} was never filled and no longer exists, creating new order`,
         });
-        const existingOrder = await this._redisGetOrderDetailsRequired(cloid, this.baseSignerAddress);
         await this._createHlOrder(existingOrder, cloid);
       } else {
         this.logger.debug({
@@ -432,6 +440,9 @@ export class HyperliquidStablecoinSwapAdapter extends BaseAdapter {
       // For each finalized withdrawal from Hypercore, delete its status from Redis and optionally initiate
       // a bridge to the final destination chain if necessary.
       const orderDetails = await this._redisGetOrderDetailsRequired(cloid, this.baseSignerAddress);
+      if (!this._canProgressOrder("HyperliquidStablecoinSwapAdapter.updateRebalanceStatuses", cloid, orderDetails)) {
+        continue;
+      }
       const { destinationToken, destinationChain } = orderDetails;
       const matchingFill = await this._getMatchingFillForCloid(this.baseSignerAddress, cloid);
       if (!matchingFill) {

--- a/src/rebalancer/adapters/oftAdapter.ts
+++ b/src/rebalancer/adapters/oftAdapter.ts
@@ -136,6 +136,10 @@ export class OftAdapter extends BaseAdapter {
       });
     }
     for (const txnHash of pendingBridges) {
+      const orderDetails = await this._redisGetOrderDetailsRequired(txnHash, this.baseSignerAddress);
+      if (!this._canProgressOrder("OftAdapter.updateRebalanceStatuses", txnHash, orderDetails)) {
+        continue;
+      }
       const status = await this._getOftStatus(txnHash);
       if (status === "SUCCEEDED") {
         // Order is no longer pending, so we can delete it.

--- a/test/RebalancerAdapter.routeSupport.ts
+++ b/test/RebalancerAdapter.routeSupport.ts
@@ -1,0 +1,128 @@
+import { expect, ethers, sinon } from "./utils";
+import winston from "winston";
+import { HyperliquidStablecoinSwapAdapter } from "../src/rebalancer/adapters/hyperliquid";
+import { CctpAdapter } from "../src/rebalancer/adapters/cctpAdapter";
+import { OftAdapter } from "../src/rebalancer/adapters/oftAdapter";
+import { RebalancerConfig } from "../src/rebalancer/RebalancerConfig";
+import { RebalanceRoute, OrderDetails } from "../src/rebalancer/utils/interfaces";
+import { BigNumber, bnZero, CHAIN_IDs, EvmAddress, toBNWei } from "../src/utils";
+
+const TEST_LOGGER = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+} as unknown as winston.Logger;
+
+// A pending order created by the swap rebalancer: swap USDT on Arbitrum into USDC on Mainnet via Hyperliquid.
+// Progressing its final leg requires a CCTP bridge from HyperEVM to Mainnet.
+const SWAP_ORDER_DETAILS: OrderDetails = {
+  sourceToken: "USDT",
+  sourceChain: CHAIN_IDs.ARBITRUM,
+  destinationToken: "USDC",
+  destinationChain: CHAIN_IDs.MAINNET,
+  amountToTransfer: toBNWei("100", 6),
+};
+
+const SWAP_ORDER_ROUTE: RebalanceRoute = {
+  sourceChain: SWAP_ORDER_DETAILS.sourceChain,
+  sourceToken: SWAP_ORDER_DETAILS.sourceToken,
+  destinationChain: SWAP_ORDER_DETAILS.destinationChain,
+  destinationToken: SWAP_ORDER_DETAILS.destinationToken,
+  adapter: "hyperliquid",
+};
+
+type AdapterInternals = {
+  initialized: boolean;
+  availableRoutes: RebalanceRoute[];
+  _redisGetPendingBridgesPreDeposit(account: EvmAddress): Promise<string[]>;
+  _redisGetPendingDeposits(account: EvmAddress): Promise<string[]>;
+  _redisGetPendingSwaps(account: EvmAddress): Promise<string[]>;
+  _redisGetPendingWithdrawals(account: EvmAddress): Promise<string[]>;
+  _redisGetOrderDetails(cloid: string, account: EvmAddress): Promise<OrderDetails | undefined>;
+  _getERC20Balance(chainId: number, tokenAddress: string, account: EvmAddress): Promise<BigNumber>;
+  _depositToHypercore(sourceToken: string, amount: BigNumber): Promise<void>;
+  _createHlOrder(orderDetails: OrderDetails, cloid: string): Promise<unknown>;
+  _getMatchingFillForCloid(account: EvmAddress, cloid: string): Promise<unknown>;
+  _bridgeToChain(token: string, originChain: number, destinationChain: number, amount: BigNumber): Promise<BigNumber>;
+};
+
+async function makeHyperliquidAdapter(): Promise<{
+  adapter: HyperliquidStablecoinSwapAdapter;
+  internals: AdapterInternals;
+}> {
+  const wallet = ethers.Wallet.createRandom();
+  const adapter = new HyperliquidStablecoinSwapAdapter(
+    TEST_LOGGER,
+    {} as RebalancerConfig,
+    wallet,
+    {} as CctpAdapter,
+    {} as OftAdapter
+  );
+  const internals = adapter as unknown as AdapterInternals;
+  internals.initialized = true;
+  adapter.baseSignerAddress = EvmAddress.from(await wallet.getAddress());
+  return { adapter, internals };
+}
+
+describe("Rebalancer adapters only progress orders for supported routes", function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  // Multiple rebalancer bots (e.g. swapRebalancer and sameAssetRebalancer) share a signer and Redis order store, so
+  // an adapter can encounter pending orders created by a bot with a different route catalog. Regression test for the
+  // sameAssetRebalancer crashing with "Route is not supported: USDC 999 -> USDC 1" while progressing a swap-created
+  // Hyperliquid order through its final CCTP bridge leg.
+  it("skips pending orders whose routes are not in availableRoutes without throwing", async function () {
+    const { adapter, internals } = await makeHyperliquidAdapter();
+    expect(internals.availableRoutes).to.deep.equal([]);
+
+    sinon.stub(internals, "_redisGetPendingBridgesPreDeposit").resolves(["cloid-bridge"]);
+    sinon.stub(internals, "_redisGetPendingDeposits").resolves(["cloid-deposit"]);
+    // Keep pending swaps empty so the pre-loop open-orders API lookup is not triggered.
+    sinon.stub(internals, "_redisGetPendingSwaps").resolves([]);
+    sinon.stub(internals, "_redisGetPendingWithdrawals").resolves(["cloid-withdrawal"]);
+    sinon.stub(internals, "_redisGetOrderDetails").resolves(SWAP_ORDER_DETAILS);
+
+    const depositToHypercore = sinon.stub(internals, "_depositToHypercore").resolves();
+    const createHlOrder = sinon.stub(internals, "_createHlOrder").resolves(undefined);
+    const getMatchingFill = sinon.stub(internals, "_getMatchingFillForCloid").resolves(undefined);
+    const bridgeToChain = sinon.stub(internals, "_bridgeToChain").resolves(bnZero);
+    const getBalance = sinon.stub(internals, "_getERC20Balance").resolves(bnZero);
+
+    await adapter.updateRebalanceStatuses();
+
+    expect(getBalance.called).to.equal(false);
+    expect(depositToHypercore.called).to.equal(false);
+    expect(createHlOrder.called).to.equal(false);
+    expect(getMatchingFill.called).to.equal(false);
+    expect(bridgeToChain.called).to.equal(false);
+  });
+
+  it("progresses pending orders whose routes are in availableRoutes", async function () {
+    const { adapter, internals } = await makeHyperliquidAdapter();
+    internals.availableRoutes = [SWAP_ORDER_ROUTE];
+
+    sinon.stub(internals, "_redisGetPendingBridgesPreDeposit").resolves(["cloid-bridge"]);
+    sinon.stub(internals, "_redisGetPendingDeposits").resolves([]);
+    sinon.stub(internals, "_redisGetPendingSwaps").resolves([]);
+    sinon.stub(internals, "_redisGetPendingWithdrawals").resolves([]);
+    sinon.stub(internals, "_redisGetOrderDetails").resolves(SWAP_ORDER_DETAILS);
+    // Report insufficient HyperEVM balance so the order is left pending after the route-support gate.
+    const getBalance = sinon.stub(internals, "_getERC20Balance").resolves(bnZero);
+    const depositToHypercore = sinon.stub(internals, "_depositToHypercore").resolves();
+
+    await adapter.updateRebalanceStatuses();
+
+    expect(getBalance.called).to.equal(true);
+    expect(depositToHypercore.called).to.equal(false);
+  });
+
+  it("supportsRoute accepts pending order details without an adapter name", async function () {
+    const { adapter, internals } = await makeHyperliquidAdapter();
+    expect(adapter.supportsRoute(SWAP_ORDER_DETAILS)).to.equal(false);
+    internals.availableRoutes = [SWAP_ORDER_ROUTE];
+    expect(adapter.supportsRoute(SWAP_ORDER_DETAILS)).to.equal(true);
+  });
+});


### PR DESCRIPTION
Replaces #3588 per review feedback there: instead of widening the CCTP/OFT adapters' route catalogs, each adapter now only updates statuses of orders for routes it supports.

## Problem

`zion-across-same-asset-rebalancer` crashes every run with:

```
AssertionError [ERR_ASSERTION]: Route is not supported: USDC 999 -> USDC 1
    at CctpAdapter._assertRouteIsSupported (baseAdapter.js:243)
    at CctpAdapter.initializeRebalance (cctpAdapter.js:56)
    at HyperliquidStablecoinSwapAdapter._bridgeToChain (hyperliquid.js:1011)
    at HyperliquidStablecoinSwapAdapter.updateRebalanceStatuses (hyperliquid.js:376)
```

The `swapRebalancer` and `sameAssetRebalancer` bots share a base signer (`bot4`) and the Redis order store, so each bot's `updateRebalanceStatuses()` pass encounters pending orders created by the other bot. Adapters progressed every pending order regardless of their own configured route catalog, so the sameAssetRebalancer (whose catalog contains no cctp/oft/hyperliquid routes) picked up a swap-created Hyperliquid order whose Hypercore withdrawal had finalized and crashed on the final CCTP bridge leg out of HyperEVM — killing the whole run before any same-asset work.

## Fix

Gate every pending-order loop in the Hyperliquid, Binance, CCTP, and OFT adapters' `updateRebalanceStatuses()` on the order's route being present in the adapter's own `availableRoutes` (new `BaseAdapter._canProgressOrder`, built on `supportsRoute` which now also accepts an order's route details without an adapter name).

- Unsupported orders are skipped with a debug log and left pending for the properly-configured bot to progress.
- If no configured instance supports an order's route (e.g. after config drift), the order is eventually TTL-pruned with the existing warning in `_redisCleanupPendingOrders`.
- As a side benefit, the two bots no longer progress each other's in-flight orders, which removes the concurrent double-execution window on shared orders (e.g. both bots observing the same finalized withdrawal and both firing the bridge leg).
- The skip is logged at `debug` since skipping the other bot's orders is expected on every run; happy to bump to `warn` if you'd rather have the visibility.

No changes to `getPendingRebalances()` — virtual-balance accounting still reflects all pending orders regardless of which bot progresses them.

## Testing

- New `test/RebalancerAdapter.routeSupport.ts`: a Hyperliquid adapter with an empty route catalog skips pending orders at every status without throwing (regression for the crash above); with the route configured, the same order is progressed; `supportsRoute` accepts order details.
- `yarn hardhat test` on the rebalancer/Binance suites — 74 passing.
- `tsc --noEmit` and `yarn lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)