### PR TITLE
chore: remove Binance L2 bridge route for Arbitrum DAI

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -682,7 +682,6 @@ export const CUSTOM_L2_BRIDGE: Record<number, Record<string, L2BridgeConstructor
     [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: L2UsdcCCTPBridge,
     [TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.MAINNET]]: OFTL2Bridge,
     [TOKEN_SYMBOLS_MAP.WETH.addresses[CHAIN_IDs.MAINNET]]: L2BinanceCEXNativeBridge,
-    [TOKEN_SYMBOLS_MAP.DAI.addresses[CHAIN_IDs.MAINNET]]: L2BinanceCEXBridge,
   },
   [CHAIN_IDs.ARC]: {
     [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: L2UsdcCCTPBridge,


### PR DESCRIPTION
Removes the `CUSTOM_L2_BRIDGE` mapping of Arbitrum DAI → `BinanceCEXBridge`.

Binance does not accept DAI deposits on the Arbitrum network — `getDepositAddress` fails with error 031056 ("Deposit for this coin and network has been disabled"), and Binance's public capital config shows DAI deposits unsupported on Arbitrum/ETH/Polygon (BSC only) with DAI withdrawals disabled on **all** networks. The route has failed identically since it was first exercised on 2025-09-29, so it cannot be used for L2→L1 rebalancing in either direction.

With this entry removed:
- `AdapterManager` no longer claims an L2 withdrawal bridge for Arbitrum DAI (`isSupportedL2Bridge` returns false), so the rebalancer skips it at debug level instead of erroring.
- `hasBinanceRoute(42161, DAI)` correctly returns false for repayment-chain preferences.

The inventory config that triggered the failing withdrawals was reverted in UMAprotocol/configurama#126. Slack context: https://risklabs.slack.com/archives/C073ELHSDQ8/p1784308573016539

`tsc --noEmit` and `eslint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)