### PR TITLE
improve(monitor): align balance report values on the decimal point

### DIFF
--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -15,7 +15,9 @@ import {
   bnUint32Max,
   Contract,
   convertFromWei,
+  createDecimalAligner,
   createFormatFunction,
+  formatFixedDecimals,
   ERC20,
   blockExplorerLink,
   blockExplorerLinks,
@@ -474,10 +476,19 @@ export class Monitor {
 
       for (const l1Token of allL1Tokens) {
         const l1TokenDecimals = l1Token.decimals;
-        const formatWei = createFormatFunction(2, 4, false, l1TokenDecimals);
+        // Fixed 4 decimals for every token so all values share the same precision;
+        // createFormatFunction renders sub-1 values with variable precision.
+        const formatWei = (amount: string) => formatFixedDecimals(amount, l1TokenDecimals, 4);
 
         // Collect all rows first so we can compute column widths for alignment.
-        type Row = { chain: string; token: string; current: string; pending: string; total: string };
+        type Row = {
+          chain: string;
+          token: string;
+          current: string;
+          inTransit: string;
+          pendingRepayment: string;
+          total: string;
+        };
         const rows: Row[] = [];
         let tokenTotal = bnZero;
 
@@ -491,6 +502,8 @@ export class Monitor {
             continue;
           }
 
+          const canonicalL2Token = getRemoteTokenForL1Token(l1Token.address, chainId, hubChainId);
+
           for (const l2Token of l2Tokens) {
             const { symbol: l2Symbol, decimals: l2Decimals } = this.getTokenInfo(l2Token, chainId);
             const toL1Decimals = ConvertDecimals(l2Decimals, l1TokenDecimals);
@@ -499,8 +512,8 @@ export class Monitor {
             const rawBalance = balanceIndex[chainId]?.[l2Token.toNative()] ?? bnZero;
             const currentBalance = toL1Decimals(rawBalance);
 
-            // Pending: cross-chain transfers + pending L2 withdrawals (hub chain only) + pending swap rebalances.
-            let pending = this.clients.crossChainTransferClient.getOutstandingCrossChainTransferAmount(
+            // In-transit: cross-chain transfers + pending L2 withdrawals (hub chain only) + pending swap rebalances.
+            let inTransit = this.clients.crossChainTransferClient.getOutstandingCrossChainTransferAmount(
               relayer,
               chainId,
               l1Token.address,
@@ -513,35 +526,44 @@ export class Monitor {
               assert(l2Tokens.length === 1, "Hub chain should only have one l2 token");
               const withdrawals = pendingL2Withdrawals[l1Token.address.toNative()] ?? {};
               const totalWithdrawals = Object.values(withdrawals).reduce((acc, amt) => acc.add(amt), bnZero);
-              pending = pending.add(totalWithdrawals);
+              inTransit = inTransit.add(totalWithdrawals);
             }
 
             // Only add pending rebalance amount for the canonical L2 token to avoid double-counting
             // when multiple contributor tokens exist on the same chain.
-            const canonicalL2Token = getRemoteTokenForL1Token(l1Token.address, chainId, hubChainId);
             if (isDefined(canonicalL2Token) && l2Token.eq(canonicalL2Token)) {
               const pendingRebalanceAmount = pendingRebalances[chainId]?.[l1Token.symbol];
               if (isDefined(pendingRebalanceAmount) && !pendingRebalanceAmount.isZero()) {
-                pending = pending.add(toL1Decimals(pendingRebalanceAmount));
+                inTransit = inTransit.add(toL1Decimals(pendingRebalanceAmount));
               }
             }
 
-            const totalBalance = currentBalance.add(pending);
-            tokenTotal = tokenTotal.add(totalBalance);
+            // Upcoming refunds are tracked by the exact L2 token the refund leaf pays out in.
+            const pendingRepayment = this.bundleDataApproxClient.getUpcomingRefunds(
+              chainId,
+              l1Token.address,
+              relayer,
+              l2Token
+            );
+            const balance = currentBalance.add(inTransit);
+            const rowTotal = balance.add(pendingRepayment);
+            tokenTotal = tokenTotal.add(rowTotal);
 
             // Skip rows where all value columns are zero.
-            if (!currentBalance.isZero() || !pending.isZero()) {
+            if (!currentBalance.isZero() || !inTransit.isZero() || !pendingRepayment.isZero()) {
               rows.push({
                 chain: getNetworkName(chainId),
                 token: l2Symbol,
                 current: formatWei(currentBalance.toString()),
-                pending: formatWei(pending.toString()),
-                total: formatWei(totalBalance.toString()),
+                inTransit: formatWei(inTransit.toString()),
+                pendingRepayment: formatWei(pendingRepayment.toString()),
+                total: formatWei(rowTotal.toString()),
               });
             }
 
-            // Machine-readable debug log — skip zero-balance entries.
-            if (!totalBalance.isZero()) {
+            // Machine-readable debug log — skip zero-balance entries. Excludes upcoming refunds
+            // so the exported balance metric keeps its historical meaning.
+            if (!balance.isZero()) {
               this.logger.debug({
                 at: "Monitor#reportRelayerBalances",
                 message: "Machine-readable single balance report",
@@ -550,24 +572,11 @@ export class Monitor {
                 l2TokenSymbol: l2Symbol,
                 chainName: getNetworkName(chainId),
                 decimals: l1TokenDecimals,
-                balanceInWei: totalBalance.toString(),
-                balance: Number(formatUnits(totalBalance, l1TokenDecimals)),
+                balanceInWei: balance.toString(),
+                balance: Number(formatUnits(balance, l1TokenDecimals)),
                 datadog: true,
               });
             }
-          }
-
-          // Upcoming refund row per chain (one per chain, not per L2 token).
-          const upcomingRefunds = this.bundleDataApproxClient.getUpcomingRefunds(chainId, l1Token.address, relayer);
-          if (upcomingRefunds.gt(0)) {
-            tokenTotal = tokenTotal.add(upcomingRefunds);
-            rows.push({
-              chain: getNetworkName(chainId),
-              token: "refunds",
-              current: "-",
-              pending: "-",
-              total: formatWei(upcomingRefunds.toString()),
-            });
           }
         }
 
@@ -576,22 +585,24 @@ export class Monitor {
           continue;
         }
 
-        // Build stacked key-value format for mobile readability.
+        // Ledger-style stacked layout: the detail lines share a left value column; Totals sit in an
+        // offset right column that the bottom TOTAL sums down. Both columns align on the decimal point.
         const totalFormatted = formatWei(tokenTotal.toString());
-        const valueWidth = Math.max(
-          ...rows.flatMap((r) => [r.current, r.pending, r.total].map((v) => v.length)),
-          totalFormatted.length
-        );
+        const alignDetail = createDecimalAligner(rows.flatMap((r) => [r.current, r.inTransit, r.pendingRepayment]));
+        const alignTotal = createDecimalAligner([...rows.map((r) => r.total), totalFormatted]);
+        const totalIndent = " ".repeat(alignDetail(rows[0].current).length + 2);
+        // Fixed-width label field; literal tabs render inconsistently in Slack.
+        const label = (name: string) => `  ${name}`.padEnd(22);
         let tokenMrkdwn = "```\n";
         for (const row of rows) {
           tokenMrkdwn += `${row.chain} — ${row.token}\n`;
-          if (row.current !== "-") {
-            tokenMrkdwn += `  Current: ${row.current.padStart(valueWidth)}\n`;
-            tokenMrkdwn += `  Pending: ${row.pending.padStart(valueWidth)}\n`;
-          }
-          tokenMrkdwn += `  Total:   ${row.total.padStart(valueWidth)}\n\n`;
+          tokenMrkdwn += `${label("Current:")}${alignDetail(row.current)}`.trimEnd() + "\n";
+          tokenMrkdwn += `${label("In-Transit:")}${alignDetail(row.inTransit)}`.trimEnd() + "\n";
+          tokenMrkdwn += `${label("Pending Repayment:")}${alignDetail(row.pendingRepayment)}`.trimEnd() + "\n";
+          tokenMrkdwn += `${label("Total:")}${totalIndent}${alignTotal(row.total)}`.trimEnd() + "\n\n";
         }
-        tokenMrkdwn += `  TOTAL:   ${totalFormatted.padStart(valueWidth)}\n`;
+        tokenMrkdwn += `${label("")}${totalIndent}${"-".repeat(alignTotal(totalFormatted).length)}\n`;
+        tokenMrkdwn += `${label("TOTAL:")}${totalIndent}${alignTotal(totalFormatted)}`.trimEnd() + "\n";
         tokenMrkdwn += "```";
 
         this.logger.info({

--- a/src/utils/NumberUtils.ts
+++ b/src/utils/NumberUtils.ts
@@ -1,3 +1,6 @@
+import { BigNumberish } from "./BNUtils";
+import { formatUnits } from "./SDKUtils";
+
 /**
  * @notice Should be used as a replacement for Number.toFixed() where the result is not rounded to the set
  * number of decimals. toFixed() automatically rounds the last digit.
@@ -13,4 +16,38 @@ export function truncate(number: number, decimals: number): number {
     .toLocaleString("en-US", { useGrouping: false, maximumSignificantDigits: 21 })
     .split(".");
   return Number(`${integer}.${fractional.slice(0, Math.max(0, Math.trunc(decimals)))}`) || 0;
+}
+
+/**
+ * @notice Formats a raw token amount to a fixed number of decimal places (truncated, comma-grouped).
+ * Unlike createFormatFunction, every value gets the same precision, so columns of values line up.
+ * @param amount The raw amount in the token's smallest unit (e.g. wei).
+ * @param decimals The token's decimals, used to scale the raw amount.
+ * @param displayDecimals The exact number of decimal places to render.
+ * @returns The formatted amount (e.g. "69,539.59").
+ */
+export function formatFixedDecimals(amount: BigNumberish, decimals: number, displayDecimals: number): string {
+  const [integer, fraction = ""] = formatUnits(amount, decimals).split(".");
+  const grouped = integer.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return displayDecimals > 0
+    ? `${grouped}.${fraction.padEnd(displayDecimals, "0").slice(0, displayDecimals)}`
+    : grouped;
+}
+
+/**
+ * @notice Builds a padding function that aligns pre-formatted numeric strings on the decimal point.
+ * Values without a decimal point (e.g. integer-only or placeholder values) are right-aligned to the integer column.
+ * @param values Every value that will share the column, used to compute the fixed widths.
+ * @returns A function padding any of those values to the common width (all outputs are equal length).
+ */
+export function createDecimalAligner(values: string[]): (value: string) => string {
+  const integerWidth = Math.max(0, ...values.map((value) => value.split(".")[0].length));
+  const fractionWidth = Math.max(0, ...values.map((value) => value.split(".")[1]?.length ?? 0));
+  return (value: string): string => {
+    const [integer, fraction = ""] = value.split(".");
+    const alignedFraction = (fraction.length > 0 ? `.${fraction}` : "").padEnd(
+      fractionWidth > 0 ? fractionWidth + 1 : 0
+    );
+    return `${integer.padStart(integerWidth)}${alignedFraction}`;
+  };
 }

--- a/test/NumberUtils.ts
+++ b/test/NumberUtils.ts
@@ -1,4 +1,4 @@
-import { truncate } from "../src/utils/NumberUtils";
+import { createDecimalAligner, formatFixedDecimals, truncate } from "../src/utils/NumberUtils";
 import { expect } from "./utils";
 
 describe("truncate", function () {
@@ -24,5 +24,54 @@ describe("truncate", function () {
 
   it("handles large numbers rendered in scientific notation", function () {
     expect(truncate(1.234e21, 2)).to.equal(1.234e21);
+  });
+});
+
+describe("formatFixedDecimals", function () {
+  it("renders every value with the same number of decimals", function () {
+    expect(formatFixedDecimals("69539593700000000000000", 18, 2)).to.equal("69,539.59");
+    expect(formatFixedDecimals("0", 18, 2)).to.equal("0.00");
+    expect(formatFixedDecimals("5000000000000000", 18, 2)).to.equal("0.00"); // 0.005 truncates.
+  });
+
+  it("truncates rather than rounds", function () {
+    expect(formatFixedDecimals("999999999999999999", 18, 2)).to.equal("0.99");
+  });
+
+  it("groups the integer part with commas", function () {
+    expect(formatFixedDecimals("218878730000", 6, 2)).to.equal("218,878.73");
+    expect(formatFixedDecimals("1234567890000000", 6, 2)).to.equal("1,234,567,890.00");
+  });
+
+  it("supports zero display decimals", function () {
+    expect(formatFixedDecimals("69539593700000000000000", 18, 0)).to.equal("69,539");
+  });
+});
+
+describe("createDecimalAligner", function () {
+  it("aligns values of mixed precision on the decimal point", function () {
+    const align = createDecimalAligner(["69,539.59", "0.000", "218,878.73"]);
+    expect(align("69,539.59")).to.equal(" 69,539.59 ");
+    expect(align("0.000")).to.equal("      0.000");
+    expect(align("218,878.73")).to.equal("218,878.73 ");
+  });
+
+  it("pads all values to the same total width", function () {
+    const values = ["1.2", "34.5678", "9", "1,000.00"];
+    const align = createDecimalAligner(values);
+    const widths = new Set(values.map((v) => align(v).length));
+    expect(widths.size).to.equal(1);
+  });
+
+  it("right-aligns values without a decimal point to the integer column", function () {
+    const align = createDecimalAligner(["123.45", "-"]);
+    expect(align("-")).to.equal("  -   ");
+    expect(align("123.45")).to.equal("123.45");
+  });
+
+  it("handles integer-only value sets", function () {
+    const align = createDecimalAligner(["7", "1,000"]);
+    expect(align("7")).to.equal("    7");
+    expect(align("1,000")).to.equal("1,000");
   });
 });


### PR DESCRIPTION
> **Stacked on #3598** — merge that first. This PR's base is #3598's branch; once #3598 lands, this retargets to master with only the formatting diff.

## Motivation

Requested by Paul in Slack: the relayer balance report padded values by raw string length and mixed precisions, so decimal points drifted between lines and the report was hard to sum by eye. Follow-up requests renamed the categories and folded the separate refunds rows into the per-token rows.

## Changes

- Add `createDecimalAligner` to `src/utils/NumberUtils.ts`: given every value that shares a column, returns a padder that left-pads integer parts and right-pads fractional parts to fixed widths, so all values align on the decimal point.
- Add `formatFixedDecimals`: `createFormatFunction(2, 4, ...)` renders values ≥ 1 with exactly 2 decimals (`toFixed(2)`) but values < 1 with 4 *significant digits* (`toPrecision(4)`), so a zero pending printed as `0.000` next to `69,539.59`. The new helper truncates every value to an exact decimal count (comma-grouped), giving uniform precision.
- Anchor the report on 4 decimal places for every token: uniform within a table, resolves ~cents on stables and ~$10 on BTC. Totals are still summed from full-precision BigNumbers.
- Rework `Monitor#reportRelayerBalances` into a ledger layout: detail lines share a left value column, each chain's `Total` sits in a second column offset to the right, and the bottom `TOTAL` (chain-cumulative) aligns under that column so it sums straight down. Labels occupy a fixed 22-column field (spaces rather than literal tabs, which render inconsistently in Slack).
- Rename `Pending` → `In-Transit`, and replace the separate per-chain `refunds` rows with a `Pending Repayment` line on each row, attributed to the exact L2 token the refund leaf pays out in via the `repaymentToken` filter from #3598. Every row now renders the same four lines (`Current` / `In-Transit` / `Pending Repayment` / `Total`), which also removes the `-` placeholder special case.
- The machine-readable Datadog debug log still reports current + in-transit only (upcoming refunds were never part of that metric).
- Unit tests for both formatting helpers in `test/NumberUtils.ts`.

## Before / after

Before:

```
Mainnet — DAI
  Current:  69,539.59
  Pending:      0.000
  Total:    69,539.59

Mainnet — refunds
  Total:     1,111.00

Blast — USDB
  Current:     329.16
  Pending:      0.000
  Total:       329.16

  TOTAL:   219,989.73
```

After:

```
Mainnet — DAI
  Current:            69,539.5937
  In-Transit:              0.0000
  Pending Repayment:   1,111.0000
  Total:                            70,650.5937

Blast — USDB
  Current:               329.1600
  In-Transit:              0.0000
  Pending Repayment:       0.0000
  Total:                               329.1600

                                   ------------
  TOTAL:                           219,989.7337
```

`Monitor#reportSpokePoolRunningBalances` has a similar misalignment; left untouched to keep this scoped, but it can adopt the same helpers in a follow-up if wanted.

No README/AGENTS updates needed: no behavior, config, or interface changes beyond the mrkdwn layout of one log message.

## Testing

- `yarn hardhat test test/BundleDataApproxClient.ts test/NumberUtils.ts test/Monitor.ts test/InventoryClient.InventoryRebalance.ts test/InventoryClient.RefundChain.ts` — 87 passing
- `yarn build`, eslint + prettier clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
