### PR TITLE
fix(rebalancer): isolate per-adapter failures in getPendingRebalances

### DIFF
--- a/docs/rebalancer-mode-adapter-architecture.md
+++ b/docs/rebalancer-mode-adapter-architecture.md
@@ -44,6 +44,7 @@ The post-refactor lifecycle is explicitly two-stage:
 Key invariant:
 
 - read-only clients call `initialize([])` and still support pending-state reads (`getPendingRebalances`), because pending-state aggregation does not depend on active routes.
+- pending-state reads are failure-isolated per adapter: an adapter whose `getPendingRebalances` throws is logged with a warning and treated as contributing no pending rebalances for that pass, rather than failing the aggregate read.
 
 ## Data flow (current behavior)
 

--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -277,6 +277,10 @@ Lifecycle note:
   pending-state reads do not depend on route selection.
 - Consumers pass the relayer/account they want to inspect into `getPendingRebalances(account)`; the client aggregates
   only the pending state owned by that EVM address.
+- `getPendingRebalances(account)` isolates per-adapter failures: if one adapter's pending-state read throws (e.g. its
+  upstream exchange API is down), the client logs a warning and aggregates the remaining adapters instead of throwing.
+  Consumers such as the relayer's `InventoryClient` keep running with that adapter's in-flight rebalances temporarily
+  uncounted in virtual balances.
 
 Runtime entrypoints in `src/rebalancer/`:
 

--- a/src/rebalancer/clients/BaseRebalancerClient.ts
+++ b/src/rebalancer/clients/BaseRebalancerClient.ts
@@ -49,13 +49,27 @@ export abstract class BaseRebalancerClient implements RebalancerClient {
    * @notice Get all currently unfinalized rebalance amounts. Should be used to add virtual balance credits or
    * debits for the token and chain combinations. Will filter rebalances by the passed in account.
    * @dev Does not depend on this.rebalanceRoutes, only calls getPendingRebalances() for each configured adapter.
+   * @dev An adapter whose pending-state read throws is logged and treated as having no pending rebalances so that
+   * one adapter's upstream outage cannot fail the aggregate read for every consumer.
    * @return Dictionary of chainId -> token -> amount where positive amounts present pending rebalance credits to that
    * chain while negative amounts represent debits that should be subtracted from that chain's current balance.
    */
   async getPendingRebalances(account: EvmAddress): Promise<{ [chainId: number]: { [token: string]: BigNumber } }> {
     const pendingRebalances: { [chainId: number]: { [token: string]: BigNumber } } = {};
-    await forEachAsync(Object.values(this.adapters), async (adapter) => {
-      const pending = await adapter.getPendingRebalances(account);
+    await forEachAsync(Object.entries(this.adapters), async ([adapterName, adapter]) => {
+      let pending: { [chainId: number]: { [token: string]: BigNumber } };
+      try {
+        pending = await adapter.getPendingRebalances(account);
+      } catch (err) {
+        // The failed adapter's in-flight rebalances stay invisible to virtual balances until its
+        // dependency recovers; that undercount is preferable to aborting the caller's whole run.
+        this.logger.warn({
+          at: "BaseRebalancerClient.getPendingRebalances",
+          message: `Failed to get pending rebalances from ${adapterName} adapter; treating them as empty`,
+          err: String(err),
+        });
+        return;
+      }
       Object.entries(pending).forEach(([_chainId, tokenBalance]) => {
         const chainId = Number(_chainId);
         Object.entries(tokenBalance).forEach(([token, amount]) => {

--- a/test/RebalancerClient.cumulativeRebalancing.ts
+++ b/test/RebalancerClient.cumulativeRebalancing.ts
@@ -789,6 +789,37 @@ describe("RebalancerClient.cumulativeRebalancing", () => {
     expect(pendingRebalances[CHAIN_B][USDT]).to.equal(amount(USDT, "2"));
   });
 
+  it("Treats an adapter whose pending-rebalance read fails as empty instead of throwing", async function () {
+    const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
+      [USDC]: buildTarget(USDC, "50", "40", 0, { [CHAIN_A]: 0, [CHAIN_B]: 0 }),
+      [USDT]: buildTarget(USDT, "50", "40", 0, { [CHAIN_A]: 0 }),
+    };
+    const baseSigner = ethers.Wallet.createRandom();
+    const adapter1 = new MockRebalancerAdapter(baseSigner);
+    const adapter2 = new MockRebalancerAdapter(baseSigner);
+    adapter1.setPendingRebalances({
+      [CHAIN_A]: {
+        [USDC]: amount(USDC, "5"),
+      },
+    });
+    adapter2.setPendingRebalancesError(new Error("HttpRequestError: The operation was aborted due to timeout"));
+    const rebalancerClient = await createClient(
+      cumulativeTargetBalances,
+      { adapter1, adapter2 },
+      [makeRoute(CHAIN_A, CHAIN_A, USDT, USDC, "adapter1")],
+      {},
+      {},
+      baseSigner
+    );
+
+    const pendingRebalances = await rebalancerClient.getPendingRebalances(
+      EvmAddress.from(await rebalancerClient.baseSigner.getAddress())
+    );
+
+    expect(pendingRebalances[CHAIN_A][USDC]).to.equal(amount(USDC, "5"));
+    expect(pendingRebalances[CHAIN_B]).to.be.undefined;
+  });
+
   it("Returns pending rebalances without cross-token or cross-chain merging", async function () {
     const cumulativeTargetBalances: CumulativeTargetBalanceConfig = {
       [USDC]: buildTarget(USDC, "50", "40", 0, { [CHAIN_A]: 0 }),
@@ -912,6 +943,7 @@ class MockRebalancerAdapter implements RebalancerAdapter {
   public initializeRebalanceResultMapping: { [route: string]: BigNumber } = {};
   private pendingOrders: string[] | undefined;
   private pendingRebalances: { [chainId: number]: { [token: string]: BigNumber } } = {};
+  private pendingRebalancesError: Error | undefined;
   readonly baseSigner: Signer;
 
   constructor(baseSigner: Signer) {
@@ -943,6 +975,9 @@ class MockRebalancerAdapter implements RebalancerAdapter {
   }
 
   getPendingRebalances(): Promise<{ [chainId: number]: { [token: string]: BigNumber } }> {
+    if (this.pendingRebalancesError !== undefined) {
+      return Promise.reject(this.pendingRebalancesError);
+    }
     return Promise.resolve(this.pendingRebalances);
   }
 
@@ -956,6 +991,10 @@ class MockRebalancerAdapter implements RebalancerAdapter {
 
   setPendingRebalances(pendingRebalances: { [chainId: number]: { [token: string]: BigNumber } }): void {
     this.pendingRebalances = pendingRebalances;
+  }
+
+  setPendingRebalancesError(error: Error): void {
+    this.pendingRebalancesError = error;
   }
 
   setEstimatedCost(route: RebalanceRoute, cost: BigNumber): void {


### PR DESCRIPTION
## Context

Since ~12:22 UTC today (2026-07-19), Hyperliquid's `userNonFundingLedgerUpdates` info query has been timing out (each call already retries 3x internally). The resulting `HttpRequestError` propagated out of `BaseRebalancerClient.getPendingRebalances` → `InventoryClient.update` and aborted every consumer's run: **relayer primary/secondary, fast-relayer-rebalancer, relayer-sweeper, and inventory-manager all crash-looped and mainnet fills stopped**. There is no config-level way to disable an adapter — all four adapters are constructed unconditionally on mainnet and `getPendingRebalances` queries every adapter regardless of configured routes.

Slack incident thread: T90K0AL22/C098EUCH7UJ/1784464575.769979

## Change

- `BaseRebalancerClient.getPendingRebalances` now catches per-adapter errors, logs a warning naming the failed adapter, and treats it as contributing no pending rebalances for that pass. One adapter's upstream outage no longer fails the aggregate read.
- Test: adapter that rejects its pending-rebalance read is treated as empty; healthy adapters still aggregate.
- Docs: noted the failure-isolation semantics in `src/rebalancer/README.md` and `docs/rebalancer-mode-adapter-architecture.md`.

## Trade-off

While an adapter's dependency is down, its in-flight rebalances are invisible to virtual-balance accounting, so repayment-chain choices can be slightly off until it recovers. That undercount is preferable to zero fills. Flagging severity choice for review: the skip is logged at `warn` (matches existing degradation logging in the HL adapter, avoids re-spamming the error notification path every run) — happy to bump to `error` if you want it paging.

## Verification

- `yarn hardhat test test/RebalancerClient.cumulativeRebalancing.ts` — 22 passing (includes new test)
- `yarn typecheck`, eslint + prettier on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)