### PR TITLE
chore: drop disabled tokens from SUPPORTED_TOKENS rebalance routes

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -26,7 +26,6 @@ const { AddressZero: ZERO_ADDRESS } = ethersConstants;
 import {
   BaseBridgeAdapter,
   OpStackDefaultERC20Bridge,
-  SnxOptimismBridge,
   DaiOptimismBridge,
   UsdcTokenSplitterBridge,
   OpStackWethBridge,
@@ -346,10 +345,10 @@ export const spokesThatHoldNativeTokens = resolveNativeTokenSpokes();
 
 // A mapping of L2 chain IDs to an array of tokens Across supports on that chain.
 export const SUPPORTED_TOKENS: { [chainId: number]: string[] } = {
-  [CHAIN_IDs.ARBITRUM]: ["USDC", "USDT", "WETH", "DAI", "WBTC", "UMA", "BAL", "ACX", "POOL", "ezETH"],
+  [CHAIN_IDs.ARBITRUM]: ["USDC", "USDT", "WETH", "DAI", "WBTC", "ezETH"],
   [CHAIN_IDs.ARC]: ["USDC"],
   [CHAIN_IDs.AVALANCHE]: ["USDC", "USDT"],
-  [CHAIN_IDs.BASE]: ["BAL", "DAI", "ETH", "WETH", "USDC", "USDT", "POOL", "VLR", "ezETH"],
+  [CHAIN_IDs.BASE]: ["DAI", "ETH", "WETH", "USDC", "USDT", "ezETH"],
   [CHAIN_IDs.BLAST]: ["DAI", "WBTC", "WETH", "ezETH"],
   [CHAIN_IDs.BSC]: ["CAKE", "WBNB", "USDC", "USDT", "WETH"],
   [CHAIN_IDs.HYPEREVM]: ["USDC", "USDT"],
@@ -360,30 +359,16 @@ export const SUPPORTED_TOKENS: { [chainId: number]: string[] } = {
   [CHAIN_IDs.MEGAETH]: ["WETH", "USDT"],
   [CHAIN_IDs.MODE]: ["ETH", "WETH", "USDC", "USDT", "WBTC", "ezETH"],
   [CHAIN_IDs.MONAD]: ["USDC", "USDT"], // @TODO: Add WBTC after its added to the chain token list
-  [CHAIN_IDs.OPTIMISM]: [
-    "DAI",
-    "SNX",
-    "BAL",
-    "WETH",
-    "USDC",
-    "POOL",
-    "USDT",
-    "WBTC",
-    "WLD",
-    "UMA",
-    "ACX",
-    "VLR",
-    "ezETH",
-  ],
+  [CHAIN_IDs.OPTIMISM]: ["DAI", "WETH", "USDC", "USDT", "WBTC", "WLD", "ezETH"],
   [CHAIN_IDs.PLASMA]: ["USDT", "WETH"],
-  [CHAIN_IDs.POLYGON]: ["USDC", "USDT", "WETH", "DAI", "WBTC", "UMA", "BAL", "ACX", "POOL"],
+  [CHAIN_IDs.POLYGON]: ["USDC", "USDT", "WETH", "DAI", "WBTC"],
   [CHAIN_IDs.SOLANA]: ["USDC"],
   [CHAIN_IDs.SONEIUM]: ["WETH", "USDC"],
   [CHAIN_IDs.ROBINHOOD]: ["WETH", "USDC"],
   [CHAIN_IDs.TEMPO]: ["USDC"],
   [CHAIN_IDs.TRON]: ["USDT"],
   [CHAIN_IDs.UNICHAIN]: ["ETH", "WETH", "USDC", "USDT", "ezETH"],
-  [CHAIN_IDs.WORLD_CHAIN]: ["WETH", "WBTC", "USDC", "WLD", "POOL"],
+  [CHAIN_IDs.WORLD_CHAIN]: ["WETH", "WBTC", "USDC", "WLD"],
   [CHAIN_IDs.ZK_SYNC]: ["USDC", "USDT", "WETH", "WBTC", "DAI"],
   [CHAIN_IDs.ZORA]: ["USDC", "WETH"],
 
@@ -541,7 +526,6 @@ export const CUSTOM_BRIDGE: Record<number, Record<string, L1BridgeConstructor<Ba
     // [TOKEN_SYMBOLS_MAP.WBTC.addresses[CHAIN_IDs.MAINNET]]: OFTBridge,
   },
   [CHAIN_IDs.OPTIMISM]: {
-    [TOKEN_SYMBOLS_MAP.SNX.addresses[CHAIN_IDs.MAINNET]]: SnxOptimismBridge,
     [TOKEN_SYMBOLS_MAP.DAI.addresses[CHAIN_IDs.MAINNET]]: DaiOptimismBridge,
     [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: UsdcTokenSplitterBridge,
     [TOKEN_SYMBOLS_MAP.WETH.addresses[CHAIN_IDs.MAINNET]]: OpStackWethBridge,

--- a/test/generic-adapters/AdapterManager.SendTokensCrossChain.ts
+++ b/test/generic-adapters/AdapterManager.SendTokensCrossChain.ts
@@ -39,7 +39,7 @@ let adapterManager: AdapterManager;
 let l1AtomicDepositor: FakeContract;
 
 // Optimism contracts
-let l1OptimismBridge: FakeContract, l1OptimismDaiBridge: FakeContract, l1OptimismSnxBridge: FakeContract;
+let l1OptimismBridge: FakeContract, l1OptimismDaiBridge: FakeContract;
 
 // Polygon contracts
 let l1PolygonRootChainManager: FakeContract;
@@ -60,8 +60,6 @@ const mainnetTokens = {
   weth: TOKEN_SYMBOLS_MAP.WETH.addresses[CHAIN_IDs.MAINNET],
   dai: TOKEN_SYMBOLS_MAP.DAI.addresses[CHAIN_IDs.MAINNET],
   wbtc: TOKEN_SYMBOLS_MAP.WBTC.addresses[CHAIN_IDs.MAINNET],
-  snx: TOKEN_SYMBOLS_MAP.SNX.addresses[CHAIN_IDs.MAINNET],
-  bal: TOKEN_SYMBOLS_MAP.BAL.addresses[CHAIN_IDs.MAINNET],
 } as const;
 
 describe("AdapterManager: Send tokens cross-chain", function () {
@@ -109,12 +107,12 @@ describe("AdapterManager: Send tokens cross-chain", function () {
     await adapterManager.sendTokenCrossChain(
       toAddressType(relayer.address, CHAIN_IDs.MAINNET),
       chainId,
-      toAddressType(mainnetTokens.bal, CHAIN_IDs.MAINNET),
+      toAddressType(mainnetTokens.wbtc, CHAIN_IDs.MAINNET),
       amountToSend
     );
     expect(l1OptimismBridge.depositERC20).to.have.been.calledWith(
-      mainnetTokens.bal, // l1 token
-      getL2TokenAddresses(mainnetTokens.bal)[chainId], // l2 token
+      mainnetTokens.wbtc, // l1 token
+      getL2TokenAddresses(mainnetTokens.wbtc)[chainId], // l2 token
       amountToSend, // amount
       l2Gas, // l2Gas
       "0x" // data
@@ -134,17 +132,6 @@ describe("AdapterManager: Send tokens cross-chain", function () {
       amountToSend, // amount
       l2Gas, // l2Gas
       "0x" // data
-    );
-
-    await adapterManager.sendTokenCrossChain(
-      toAddressType(relayer.address, CHAIN_IDs.MAINNET),
-      chainId,
-      toAddressType(mainnetTokens.snx, CHAIN_IDs.MAINNET),
-      amountToSend
-    );
-    expect(l1OptimismSnxBridge.depositTo).to.have.been.calledWith(
-      relayer.address, // to
-      amountToSend // amount
     );
 
     // Non- ERC20 tokens:
@@ -378,20 +365,6 @@ describe("AdapterManager: Send tokens cross-chain", function () {
       "0x" // data
     );
 
-    await adapterManager.sendTokenCrossChain(
-      toAddressType(relayer.address, CHAIN_IDs.MAINNET),
-      chainId,
-      toAddressType(mainnetTokens.bal, CHAIN_IDs.MAINNET),
-      amountToSend
-    );
-    expect(l1BaseBridge.depositERC20).to.have.been.calledWith(
-      mainnetTokens.bal, // l1 token
-      getL2TokenAddresses(mainnetTokens.bal)[chainId], // l2 token
-      amountToSend, // amount
-      l2Gas, // l2Gas
-      "0x" // data
-    );
-
     // DAI should not be a custom token on base.
     await adapterManager.sendTokenCrossChain(
       toAddressType(relayer.address, CHAIN_IDs.MAINNET),
@@ -466,7 +439,6 @@ async function constructChainSpecificFakes() {
   // Optimism contracts
   l1OptimismBridge = await makeFake("ovmStandardBridge_10", CONTRACT_ADDRESSES[1].ovmStandardBridge_10.address);
   l1OptimismDaiBridge = await makeFake("daiOptimismBridge", CONTRACT_ADDRESSES[1].daiOptimismBridge.address);
-  l1OptimismSnxBridge = await makeFake("snxOptimismBridge", CONTRACT_ADDRESSES[1].snxOptimismBridge.address);
 
   // Polygon contracts
   l1PolygonRootChainManager = await makeFake(


### PR DESCRIPTION
## What

Removes recently disabled tokens from `SUPPORTED_TOKENS` in `src/common/Constants.ts`, so the rebalancer/inventory clients stop constructing bridges and tracking inventory for routes Across no longer serves:

- **Arbitrum**: UMA, BAL, ACX, POOL
- **Optimism**: SNX, BAL, POOL, UMA, ACX, VLR
- **Polygon**: UMA, BAL, ACX, POOL
- **Base**: BAL, POOL, VLR
- **World Chain**: POOL

Also removes the now-unreachable `SnxOptimismBridge` entry from `CUSTOM_BRIDGE[OPTIMISM]` (SNX on Optimism was its only route) and its import.

## Why these tokens

All six were sunset from Across routes in quote-api: SNX reverted to swapped token 2026-05-12 (across-protocol/quote-api#2698), BAL/POOL/VLR dropped 2026-05-13 (across-protocol/quote-api#2700), ACX/UMA sunset 2026-07-03 (across-protocol/quote-api#2813). None of these token/chain pairs appear in the live `/api/available-routes` response today.

## Funds check (per token/chain pair, before removal)

`balanceOf` checked on-chain for both the active relayer `0x07aE8551Be970cB1cCa11Dd7a11F47Ae82e70E67` and the legacy relayer `0x428AB2BA90Eba0a4Be7aF34C9Ac451ab061AC010`: **zero for all 18 removed token/chain pairs on both addresses** (checked 2026-07-19).

Indexer cross-check: the last fill in any of these tokens was 2026-07-06 (UMA/ACX, 13 days ago), so no repayments are still in flight. Residual SpokePool balances in these tokens were already swept by the June 2026 stuck-token recovery (`scripts/recoveries/2026-06-accounting/`).

## Deliberately NOT removed

- **ezETH** — also has no live routes, but the legacy relayer still holds ezETH on Blast (0.014), Linea (0.034), Mode (0.033) and Unichain (0.091), and removal would orphan the dedicated `HyperlaneXERC20Bridge` wiring across ~15 chain entries. Worth a follow-up once those balances are swept.
- **WBNB (BSC)** — no live routes, but both relayer addresses still hold WBNB (0.010 / 0.040).

## Tests

- `AdapterManager.SendTokensCrossChain.ts`: removed the SNX custom-bridge assertion and the redundant BAL canonical-bridge blocks; the Optimism canonical-ERC20 case now uses WBTC (still supported). Base keeps its DAI canonical case.
- `tsc --noEmit` clean; `hardhat test` on the four generic-adapter suites: 35 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)