### PR TITLE
fix(deposit-address): concurrent handover — continuous service, no replayed executions

### DIFF
--- a/src/cache/Redis.ts
+++ b/src/cache/Redis.ts
@@ -11,10 +11,15 @@ export interface RedisCacheInterface extends interfaces.CachingMechanismInterfac
   decr(key: string): Promise<number>;
   decrBy(key: string, amount: number): Promise<number>;
   del(key: string): Promise<number>;
+  expire(key: string, seconds: number): Promise<boolean>;
   releaseLock(key: string, token: string): Promise<boolean>;
   renewLock(key: string, token: string, ttlMs: number): Promise<boolean>;
   incr(key: string): Promise<number>;
   incrBy(key: string, amount: number): Promise<number>;
+  sAdd(key: string, value: string): Promise<number>;
+  sIsMember(key: string, value: string): Promise<boolean>;
+  sMembers(key: string): Promise<string[]>;
+  sRem(key: string, value: string): Promise<number>;
   ttl(key: string): Promise<number | undefined>;
 }
 
@@ -110,8 +115,16 @@ export class RedisCache implements RedisCacheInterface {
     return this.client.sAdd(this.getNamespacedKey(key), value);
   }
 
+  async sIsMember(key: string, value: string): Promise<boolean> {
+    return Boolean(await this.client.sIsMember(this.getNamespacedKey(key), value));
+  }
+
   sMembers(key: string): Promise<string[]> {
     return this.client.sMembers(this.getNamespacedKey(key));
+  }
+
+  async expire(key: string, seconds: number): Promise<boolean> {
+    return Boolean(await this.client.expire(this.getNamespacedKey(key), seconds));
   }
 
   sRem(key: string, value: string): Promise<number> {

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -11,7 +11,7 @@ import {
   forEachAsync,
   getProvider,
   Contract,
-  delay,
+  abortableDelay,
   sendAndConfirmTransaction,
   getCounterfactualDepositFactory,
   buildDeployTx,
@@ -242,11 +242,6 @@ export class DepositAddressHandler {
       this.observedExecutedWithdraws[chainId] = new Set<string>();
     });
 
-    // Establish bot instance and take over. The predecessor keeps draining its in-flight
-    // executions concurrently — service is continuous. Replay safety does not depend on it
-    // being done: every fund-moving broadcast is guarded by the per-transfer pending-execution
-    // lock and a committed-set re-check under that lock (see preBroadcastCheckpoint), and the
-    // committed sets are re-read from Redis every poll tick.
     this.instanceCoordinator = new InstanceCoordinator(
       this.logger,
       this.redisCache,
@@ -254,8 +249,12 @@ export class DepositAddressHandler {
       this.config.runIdentifier,
       this.abortController
     );
-    await this.instanceCoordinator.initiateHandover();
 
+    // Load state BEFORE taking the lease: staleness is harmless (the committed sets are re-read
+    // from Redis every poll tick), and ordering the lease last shrinks the window in which a
+    // SIGHUP/disconnect leaves this instance holding a lease it will never poll on — that would
+    // make a healthy predecessor cede for nothing, leaving no handler running until the next
+    // external restart.
     this.executedDepositTxHashes = await this._loadPersistedSet(
       this.getExecutedDepositsRedisKey(),
       this.getLegacyExecutedDepositsRedisKey()
@@ -275,6 +274,21 @@ export class DepositAddressHandler {
       executedWithdraws: this.executedWithdrawKeys.size,
       terminallySkippedWithdraws: this.terminallySkippedWithdrawKeys.size,
     });
+
+    // A shutdown observed during boot cedes WITHOUT taking the lease (the entrypoint checks
+    // `aborted` and skips polling); only the lease-write itself remains as an unavoidable
+    // sub-second window. Taking over is otherwise safe while the predecessor keeps draining
+    // concurrently — service is continuous, and replay safety does not depend on the drain:
+    // every fund-moving broadcast is guarded by the per-transfer pending-execution lock and a
+    // committed-set re-check under that lock (see preBroadcastCheckpoint).
+    if (this.abortController.signal.aborted) {
+      this.logger.warn({
+        at: "DepositAddressHandler#initialize",
+        message: "Shutdown observed during initialization; ceding without taking the instance lease.",
+      });
+      return;
+    }
+    await this.instanceCoordinator.initiateHandover();
 
     this.initialized = true;
   }
@@ -446,10 +460,14 @@ export class DepositAddressHandler {
       inFlightTicks: this.inFlightTicks.size,
     });
     let timedOut = false;
+    const timeoutScope = new AbortController();
     await Promise.race([
       Promise.allSettled([...this.inFlightTicks]),
-      delay(timeoutSeconds).then(() => (timedOut = true)),
+      abortableDelay(timeoutSeconds, timeoutScope.signal).then(() => (timedOut = !timeoutScope.signal.aborted)),
     ]);
+    // Cancel the timeout timer: a plain delay would keep the event loop alive for the full
+    // timeout after a clean drain, holding up process exit on healthy handovers.
+    timeoutScope.abort();
     if (timedOut) {
       this.logger.warn({
         at: "DepositAddressHandler#drainInFlightWork",
@@ -467,7 +485,29 @@ export class DepositAddressHandler {
   }
 
   private async evaluateDepositAddresses(): Promise<void> {
+    // Capture prune candidates before anything async: only a member already known when the
+    // indexer snapshot below is taken may be pruned against that snapshot. A member imported by
+    // this tick's refresh can have been committed by a concurrently-running instance AFTER the
+    // snapshot was taken — its absence from the snapshot proves nothing, and pruning it would
+    // re-open the replay window. It becomes prunable one tick later, when the snapshot postdates
+    // its commit.
+    const pruneCandidates = {
+      executedDeposits: new Set(this.executedDepositTxHashes),
+      executedWithdraws: new Set(this.executedWithdrawKeys),
+      terminallySkipped: new Set(this.terminallySkippedWithdrawKeys),
+    };
+
     const depositMessages = await this._queryIndexerApi();
+    // A failed poll is not an empty snapshot: there is nothing to execute, and pruning against
+    // it would SREM every committed member from Redis — durably dropping replay protection on a
+    // transient indexer outage. Skip the whole tick.
+    if (!isDefined(depositMessages)) {
+      this.logger.warn({
+        at: "DepositAddressHandler#evaluateDepositAddresses",
+        message: "Indexer poll failed; skipping tick (no refresh, prune, or executions)",
+      });
+      return;
+    }
 
     // Refresh the in-memory committed views from Redis so executions committed by a concurrently
     // running instance (e.g. the predecessor draining through a handover) are respected within
@@ -483,12 +523,19 @@ export class DepositAddressHandler {
     const depositKeysFromIndexer = new Set(depositMessages.map((m) => getDepositKey(m)));
     await this._prunePersistedSet(
       this.executedDepositTxHashes,
+      pruneCandidates.executedDeposits,
       refTxHashesFromIndexer,
       this.getExecutedDepositsRedisKey()
     );
-    await this._prunePersistedSet(this.executedWithdrawKeys, depositKeysFromIndexer, this.getWithdrawnKeysRedisKey());
+    await this._prunePersistedSet(
+      this.executedWithdrawKeys,
+      pruneCandidates.executedWithdraws,
+      depositKeysFromIndexer,
+      this.getWithdrawnKeysRedisKey()
+    );
     await this._prunePersistedSet(
       this.terminallySkippedWithdrawKeys,
+      pruneCandidates.terminallySkipped,
       depositKeysFromIndexer,
       this.getSkippedWithdrawKeysRedisKey()
     );
@@ -519,11 +566,21 @@ export class DepositAddressHandler {
     }
   }
 
-  /** Removes members the indexer no longer returns from both the in-memory set and Redis. */
-  private async _prunePersistedSet(memory: Set<string>, current: Set<string>, redisKey: string): Promise<void> {
+  /**
+   * Removes members the indexer no longer returns from both the in-memory set and Redis. Only
+   * `candidates` (the members known before the tick's indexer snapshot) are considered: a member
+   * that entered `memory` via this tick's refresh may postdate the snapshot, so its absence from
+   * it is meaningless — see evaluateDepositAddresses.
+   */
+  private async _prunePersistedSet(
+    memory: Set<string>,
+    candidates: Set<string>,
+    current: Set<string>,
+    redisKey: string
+  ): Promise<void> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
     const { redisCache } = this;
-    for (const member of [...memory]) {
+    for (const member of candidates) {
       if (!current.has(member)) {
         memory.delete(member);
         await redisCache.sRem(redisKey, member);
@@ -579,6 +636,8 @@ export class DepositAddressHandler {
    *      instance defers the transfer (it may have a broadcast in flight).
    *   3. Re-check the committed set under the lock: the other instance may have committed and
    *      released between this tick's refresh and now.
+   *   4. Re-check the abort signal after the Redis round-trips: a handover/shutdown can land
+   *      while the acquire is pending, and the process may already be past its drain wait.
    * MUST be awaited immediately before every fund-moving broadcast: if this instance then dies
    * before committing, the held lock is what stands between the successor and a replayed
    * execution. Returns false when the caller must NOT broadcast; fails closed on Redis errors.
@@ -622,6 +681,21 @@ export class DepositAddressHandler {
           committedMember,
         });
         await redisCache.releaseLock(pendingKey, runIdentifier);
+        return false;
+      }
+      // Re-check after the Redis round-trips: an abort that lands while the acquire/re-check is
+      // pending must not proceed — the drain wait may have already timed out and the process may
+      // be tearing down, so a broadcast now risks dying between broadcast and commit (an
+      // untracked execution, the exact replay window the lock exists to close). Nothing was
+      // broadcast, so releasing the just-acquired lock is safe and spares the successor the TTL
+      // defer.
+      if (this.abortController.signal.aborted) {
+        await redisCache.releaseLock(pendingKey, runIdentifier);
+        this.logger.debug({
+          at,
+          message: "Skipping broadcast: handover/shutdown observed while acquiring the pending-execution lock",
+          depositKey,
+        });
         return false;
       }
       return true;
@@ -876,7 +950,12 @@ export class DepositAddressHandler {
       // instances off it until its TTL — a double-send is worse).
       this.executedWithdrawKeys.add(depositKey);
       withdrawCommitted = true;
-      await this._persistCommitted(this.getWithdrawnKeysRedisKey(), depositKey);
+      await this._persistCommitted(
+        this.getWithdrawnKeysRedisKey(),
+        this.getLegacyWithdrawnKeysRedisKey(),
+        this.executedWithdrawKeys,
+        depositKey
+      );
       await this.releasePendingExecution(depositKey);
       await this._publishWithdrawExecuted(receipt, depositMessage);
     } finally {
@@ -936,12 +1015,26 @@ export class DepositAddressHandler {
    * Commits a single member to a persisted committed set. SADD is atomic per member, so
    * concurrent commits from two instances never lose an entry (unlike the previous whole-blob
    * SET). The key's TTL is refreshed on every commit.
+   *
+   * Rollback safety during the v2 rollout: a previous build reads only the legacy blob key, so
+   * an execution recorded only in the v2 set would be replayable after a rollback. Mirror the
+   * (post-refresh, union-merged) in-memory view into the legacy key on every commit. The mirror
+   * keeps the old last-writer-wins semantics, so a concurrent-writer race can drop the OTHER
+   * instance's newest member from the blob — but never from the authoritative v2 set; accepted
+   * for the rollout window. TODO: drop the mirror (and `memory`/`legacyRedisKey` params) once
+   * the v2 rollout has settled past the rollback horizon.
    */
-  private async _persistCommitted(redisKey: string, member: string): Promise<void> {
+  private async _persistCommitted(
+    redisKey: string,
+    legacyRedisKey: string,
+    memory: Set<string>,
+    member: string
+  ): Promise<void> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
     const { redisCache } = this;
     await redisCache.sAdd(redisKey, member);
     await redisCache.expire(redisKey, PERSISTED_SET_EXPIRY);
+    await redisCache.set(legacyRedisKey, JSON.stringify([...memory]), PERSISTED_SET_EXPIRY);
   }
 
   /**
@@ -1261,7 +1354,12 @@ export class DepositAddressHandler {
 
     // Commit to Redis immediately so a concurrently-running instance cannot miss this execute.
     this.executedDepositTxHashes.add(refTxHash);
-    await this._persistCommitted(this.getExecutedDepositsRedisKey(), refTxHash);
+    await this._persistCommitted(
+      this.getExecutedDepositsRedisKey(),
+      this.getLegacyExecutedDepositsRedisKey(),
+      this.executedDepositTxHashes,
+      refTxHash
+    );
     await this.releasePendingExecution(depositKey);
   }
 
@@ -1423,7 +1521,12 @@ export class DepositAddressHandler {
       // concurrently-running instance cannot miss this execute.
       this.executedDepositTxHashes.add(refTxHash);
       executeCommitted = true;
-      await this._persistCommitted(this.getExecutedDepositsRedisKey(), refTxHash);
+      await this._persistCommitted(
+        this.getExecutedDepositsRedisKey(),
+        this.getLegacyExecutedDepositsRedisKey(),
+        this.executedDepositTxHashes,
+        refTxHash
+      );
       await this.releasePendingExecution(depositKey);
       await this._publishDepositExecuted(depositReceipt, depositMessage);
     } finally {
@@ -1770,7 +1873,12 @@ export class DepositAddressHandler {
       // instances off it until its TTL — a double-send is worse).
       this.executedWithdrawKeys.add(depositKey);
       withdrawCommitted = true;
-      await this._persistCommitted(this.getWithdrawnKeysRedisKey(), depositKey);
+      await this._persistCommitted(
+        this.getWithdrawnKeysRedisKey(),
+        this.getLegacyWithdrawnKeysRedisKey(),
+        this.executedWithdrawKeys,
+        depositKey
+      );
       await this.releasePendingExecution(depositKey);
       await this._publishWithdrawExecuted(receipt, depositMessage);
     } finally {
@@ -1815,7 +1923,12 @@ export class DepositAddressHandler {
       // unpriceable. Persist the skip so it survives handover and is not re-attempted on later polls.
       if (isHttpError(err) && err.status === 422) {
         this.terminallySkippedWithdrawKeys.add(depositKey);
-        await this._persistCommitted(this.getSkippedWithdrawKeysRedisKey(), depositKey);
+        await this._persistCommitted(
+          this.getSkippedWithdrawKeysRedisKey(),
+          this.getLegacySkippedWithdrawKeysRedisKey(),
+          this.terminallySkippedWithdrawKeys,
+          depositKey
+        );
         this.logger.warn({
           at: "DepositAddressHandler#_getSignedWithdrawV3",
           message: "Skipping withdraw permanently: quote-api returned terminal 422",
@@ -1865,8 +1978,11 @@ export class DepositAddressHandler {
 
   /*
    * @notice Queries the Indexer API for all pending deposit addresses transactions. By default, do not retry since this endpoing is being polled.
+   * Returns undefined (NOT an empty array) when the poll fails after retries: the caller must be
+   * able to tell "the indexer returned nothing" from "the indexer was unreachable" — pruning the
+   * committed sets against the latter would delete every replay guard.
    */
-  private async _queryIndexerApi(retriesRemaining = 3): Promise<AnyDepositAddressMessage[]> {
+  private async _queryIndexerApi(retriesRemaining = 3): Promise<AnyDepositAddressMessage[] | undefined> {
     let apiResponseData: AnyDepositAddressMessage[] | undefined = undefined;
     try {
       apiResponseData = await this.indexerApi.get<AnyDepositAddressMessage[]>(this.config.indexerApiEndpoint, {});
@@ -1874,7 +1990,7 @@ export class DepositAddressHandler {
       // Error log should have been emitted in IndexerApiClient.
     }
     if (!isDefined(apiResponseData)) {
-      return retriesRemaining > 0 ? this._queryIndexerApi(--retriesRemaining) : [];
+      return retriesRemaining > 0 ? this._queryIndexerApi(--retriesRemaining) : undefined;
     }
     // Drop unsupported message versions BEFORE normalization. Unsupported payloads (e.g. v2) may
     // not carry the v1 shape (routeParams/erc20Transfer/counterfactualMaterials), and

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -627,8 +627,9 @@ export class DepositAddressHandler {
   /**
    * Guards a fund-moving broadcast: bails when a handover was observed mid-message (the
    * successor re-evaluates from scratch — a broadcast from a ceding instance is how replays
-   * happen), then atomically acquires the pending-execution marker. Returns false when the
-   * caller must NOT broadcast.
+   * happen), then atomically acquires the pending-execution marker. The abort signal is checked
+   * on both sides of the acquisition, since the Redis write itself can straddle the handover.
+   * Returns false when the caller must NOT broadcast.
    */
   private async preBroadcastCheckpoint(depositKey: string, at: string): Promise<boolean> {
     if (this.abortController.signal.aborted) {
@@ -656,6 +657,19 @@ export class DepositAddressHandler {
         message: "Skipping broadcast: failed to persist pending-execution marker",
         depositKey,
         err: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }
+    // Re-check after the acquisition: a slow Redis write can outlive the drain timeout, and by
+    // then the successor has been signalled to start — a broadcast from this instance now would
+    // be invisible to the successor's already-loaded state. Nothing was broadcast yet, so
+    // releasing the just-acquired marker is safe and spares the successor the TTL defer.
+    if (this.abortController.signal.aborted) {
+      await this.clearPendingExecution(depositKey);
+      this.logger.debug({
+        at,
+        message: "Skipping broadcast: handover/shutdown observed while persisting the pending-execution marker",
+        depositKey,
       });
       return false;
     }

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -430,11 +430,42 @@ export class DepositAddressHandler {
    * so a broadcast tx gets confirmed and committed to Redis rather than orphaned — while the
    * successor is already running concurrently. The per-transfer pending-execution locks keep
    * the successor off anything still draining here.
+   *
+   * The drain is two-phase. Past the expected window (HANDOVER_DRAIN_TIMEOUT) it warns for ops
+   * visibility but keeps waiting — up to the pending-execution lock TTL — rather than returning:
+   * returning tears down this process's Redis clients under a tick that may sit between
+   * broadcast and commit, and a tx that confirms after that teardown leaves no committed record.
+   * Its lock then expires and the successor can replay the transfer against fresh funds (the
+   * 2026-07-20 incident's exact shape). The successor is already serving, so the only cost of
+   * lingering is an old process that lives a little longer.
    */
   public async waitForDisconnect(): Promise<void> {
     await this.instanceCoordinator.subscribe();
     this.abortController.abort();
-    await this.drainInFlightWork(HANDOVER_DRAIN_TIMEOUT);
+    const drained = await this.drainInFlightWork(HANDOVER_DRAIN_TIMEOUT);
+    if (!drained) {
+      this.logger.warn({
+        at: "DepositAddressHandler#waitForDisconnect",
+        message:
+          "In-flight work did not settle within the expected drain window; holding Redis open up to the lock TTL so a late-confirming broadcast can still commit.",
+        inFlightTicks: this.inFlightTicks.size,
+        expectedDrainSeconds: HANDOVER_DRAIN_TIMEOUT,
+      });
+      const stillNotDrained = !(await this.drainInFlightWork(PENDING_EXECUTION_EXPIRY - HANDOVER_DRAIN_TIMEOUT));
+      if (stillNotDrained) {
+        // Past the lock TTL a commit no longer beats the successor's next acquire attempt, so
+        // there is nothing left to protect by lingering. This should never happen — it means an
+        // RPC/API call has hung for the full TTL without settling.
+        this.logger.error({
+          at: "DepositAddressHandler#waitForDisconnect",
+          message:
+            "In-flight work still unsettled after the pending-execution lock TTL; exiting. Any broadcast in that work is now unguarded — reconcile manually.",
+          inFlightTicks: this.inFlightTicks.size,
+          totalWaitSeconds: PENDING_EXECUTION_EXPIRY,
+          notificationPath: "across-bot-error",
+        });
+      }
+    }
   }
 
   /** Registers a poll tick for handover draining. Returns a chained promise so scheduleTask's
@@ -445,19 +476,21 @@ export class DepositAddressHandler {
   }
 
   /**
-   * Waits (bounded) for in-flight poll ticks to settle after the abort signal fired. A tick that
-   * has broadcast a tx commits the executed member and releases its pending-execution lock as it
-   * settles; exiting before that leaves the transfer lock-deferred on the successor until the
-   * lock's TTL expires.
+   * Waits (bounded) for in-flight poll ticks to settle after the abort signal fired, returning
+   * false on timeout. A tick that has broadcast a tx commits the executed member and releases
+   * its pending-execution lock as it settles; exiting before that leaves the transfer
+   * lock-deferred on the successor until the lock's TTL expires — and, worse, uncommitted if the
+   * tx confirms after this process's Redis clients are gone (see waitForDisconnect).
    */
-  private async drainInFlightWork(timeoutSeconds: number): Promise<void> {
+  private async drainInFlightWork(timeoutSeconds: number): Promise<boolean> {
     if (this.inFlightTicks.size === 0) {
-      return;
+      return true;
     }
     this.logger.debug({
       at: "DepositAddressHandler#drainInFlightWork",
       message: "Draining in-flight poll ticks before ceding",
       inFlightTicks: this.inFlightTicks.size,
+      timeoutSeconds,
     });
     let timedOut = false;
     const timeoutScope = new AbortController();
@@ -468,20 +501,13 @@ export class DepositAddressHandler {
     // Cancel the timeout timer: a plain delay would keep the event loop alive for the full
     // timeout after a clean drain, holding up process exit on healthy handovers.
     timeoutScope.abort();
-    if (timedOut) {
-      this.logger.warn({
-        at: "DepositAddressHandler#drainInFlightWork",
-        message:
-          "In-flight work did not settle within the drain timeout; exiting anyway. Pending-execution locks keep the successor off any broadcast still in flight.",
-        inFlightTicks: this.inFlightTicks.size,
-        timeoutSeconds,
-      });
-    } else {
+    if (!timedOut) {
       this.logger.debug({
         at: "DepositAddressHandler#drainInFlightWork",
         message: "Drained all in-flight poll ticks",
       });
     }
+    return !timedOut;
   }
 
   private async evaluateDepositAddresses(): Promise<void> {
@@ -593,16 +619,21 @@ export class DepositAddressHandler {
   }
 
   /**
-   * Returns true when another instance holds the pending-execution lock for this depositKey —
-   * a cheap early skip ahead of the balance/quote work. The authoritative exclusion is the
-   * atomic acquire in preBroadcastCheckpoint; locks held by this instance don't defer it (its
-   * in-memory in-flight sets are strictly better informed, and blocking on our own lock would
-   * stall the normal retry path after a failed submit).
+   * Returns true when ANY instance — this one included — holds the pending-execution lock for
+   * this depositKey; a cheap early skip ahead of the balance/quote work. The authoritative
+   * exclusion is the atomic acquire in preBroadcastCheckpoint.
+   *
+   * Own locks defer too: the only way this instance re-encounters its own live lock is after an
+   * unknown-outcome submit (a "failed" sendAndConfirm may still have broadcast — see the
+   * failed-submit branches), and retrying while that tx may be pending in the mempool is how the
+   * same sweep gets submitted twice. Every known-not-broadcast failure path either never
+   * acquires the lock (it fails before the checkpoint) or releases it, so deferring on own locks
+   * stalls nothing legitimate.
    */
-  private async hasForeignPendingExecution(depositKey: string): Promise<boolean> {
+  private async hasPendingExecution(depositKey: string): Promise<boolean> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
     const owner = await this.redisCache.get<string>(this.getPendingExecutionRedisKey(depositKey));
-    return isDefined(owner) && owner !== this.config.runIdentifier;
+    return isDefined(owner);
   }
 
   /**
@@ -631,9 +662,11 @@ export class DepositAddressHandler {
    * any time, even while two instances run concurrently through a handover:
    *   1. Bail when a handover/shutdown was observed mid-message — the successor is already
    *      running and re-evaluates the transfer fresh.
-   *   2. Atomically acquire the transfer's pending-execution lock (SET NX). A token-guarded
-   *      renew covers this instance's own retries after a failed submit; a lock held by another
-   *      instance defers the transfer (it may have a broadcast in flight).
+   *   2. Atomically acquire the transfer's pending-execution lock (SET NX). ANY existing lock
+   *      defers the transfer — a foreign one means the other instance may have a broadcast in
+   *      flight; an own one only survives an unknown-outcome submit, whose tx may equally still
+   *      land (retrying against it is how the same sweep gets submitted twice). The TTL bounds
+   *      the deferral.
    *   3. Re-check the committed set under the lock: the other instance may have committed and
    *      released between this tick's refresh and now.
    *   4. Re-check the abort signal after the Redis round-trips: a handover/shutdown can land
@@ -662,13 +695,13 @@ export class DepositAddressHandler {
     const { runIdentifier } = this.config;
     const ttlMs = PENDING_EXECUTION_EXPIRY * 1000;
     try {
-      const acquired =
-        (await redisCache.acquireLock(pendingKey, runIdentifier, ttlMs)) ||
-        (await redisCache.renewLock(pendingKey, runIdentifier, ttlMs));
+      // SET NX only — deliberately NO own-token renew: an own lock that still exists here stems
+      // from an unknown-outcome submit and must defer like any other (see hasPendingExecution).
+      const acquired = await redisCache.acquireLock(pendingKey, runIdentifier, ttlMs);
       if (!acquired) {
         this.logger.debug({
           at,
-          message: "Skipping broadcast: pending-execution lock held by another instance",
+          message: "Skipping broadcast: pending-execution lock already held (foreign instance, or own unknown-outcome submit)",
           depositKey,
         });
         return false;
@@ -825,12 +858,13 @@ export class DepositAddressHandler {
       return;
     }
 
-    // Defer while another instance holds this transfer's pending-execution lock (it crashed or
-    // is still draining a broadcast); the lock expires via TTL if that instance never resolves it.
-    if (await this.hasForeignPendingExecution(depositKey)) {
+    // Defer while any instance holds this transfer's pending-execution lock — a foreign one
+    // (crashed, or still draining a broadcast) or our own left by an unknown-outcome submit; the
+    // lock expires via TTL if its owner never resolves it.
+    if (await this.hasPendingExecution(depositKey)) {
       this.logger.debug({
         at: "DepositAddressHandler#initiateWithdraw",
-        message: "Skipping withdraw: pending-execution lock held by another instance",
+        message: "Skipping withdraw: pending-execution lock held (foreign instance, or own unknown-outcome submit)",
         refTxHash,
         depositKey,
       });
@@ -933,7 +967,8 @@ export class DepositAddressHandler {
       const receipt = await this.sendAndConfirm(withdrawTx, useDispatcher);
       if (!isDefined(receipt)) {
         // Pending-execution lock intentionally kept: the tx may still have broadcast
-        // (confirmation failure), so let the TTL expire it rather than invite a replay.
+        // (confirmation failure), so let the TTL expire it rather than invite a replay. The lock
+        // defers ALL retries — this instance's included — until the outcome window has passed.
         this.logger.warn({
           at: "DepositAddressHandler#initiateWithdraw",
           message: "Failed to submit withdraw tx",
@@ -1199,12 +1234,13 @@ export class DepositAddressHandler {
       return;
     }
 
-    // Defer while another instance holds this transfer's pending-execution lock (it crashed or
-    // is still draining a broadcast); the lock expires via TTL if that instance never resolves it.
-    if (await this.hasForeignPendingExecution(depositKey)) {
+    // Defer while any instance holds this transfer's pending-execution lock — a foreign one
+    // (crashed, or still draining a broadcast) or our own left by an unknown-outcome submit; the
+    // lock expires via TTL if its owner never resolves it.
+    if (await this.hasPendingExecution(depositKey)) {
       this.logger.debug({
         at: "DepositAddressHandler#initiateDeposit",
-        message: "Skipping deposit: pending-execution lock held by another instance",
+        message: "Skipping deposit: pending-execution lock held (foreign instance, or own unknown-outcome submit)",
         refTxHash,
         depositKey,
       });
@@ -1338,7 +1374,8 @@ export class DepositAddressHandler {
 
     if (!depositReceipt) {
       // Pending-execution lock intentionally kept: the tx may still have broadcast
-      // (confirmation failure), so let the TTL expire it rather than invite a replay.
+      // (confirmation failure), so let the TTL expire it rather than invite a replay. The lock
+      // defers ALL retries — this instance's included — until the outcome window has passed.
       this.logger.warn({
         at: "DepositAddressHandler#initiateDeposit",
         message: "Failed to submit execute tx",
@@ -1393,12 +1430,13 @@ export class DepositAddressHandler {
       return;
     }
 
-    // Defer while another instance holds this transfer's pending-execution lock (it crashed or
-    // is still draining a broadcast); the lock expires via TTL if that instance never resolves it.
-    if (await this.hasForeignPendingExecution(depositKey)) {
+    // Defer while any instance holds this transfer's pending-execution lock — a foreign one
+    // (crashed, or still draining a broadcast) or our own left by an unknown-outcome submit; the
+    // lock expires via TTL if its owner never resolves it.
+    if (await this.hasPendingExecution(depositKey)) {
       this.logger.debug({
         at: "DepositAddressHandler#initiateDepositV3",
-        message: "Skipping deposit: pending-execution lock held by another instance",
+        message: "Skipping deposit: pending-execution lock held (foreign instance, or own unknown-outcome submit)",
         refTxHash,
         depositKey,
       });
@@ -1504,7 +1542,8 @@ export class DepositAddressHandler {
       const depositReceipt = await this.sendAndConfirm(executeTx, useDispatcher);
       if (!isDefined(depositReceipt)) {
         // Pending-execution lock intentionally kept: the tx may still have broadcast
-        // (confirmation failure), so let the TTL expire it rather than invite a replay.
+        // (confirmation failure), so let the TTL expire it rather than invite a replay. The lock
+        // defers ALL retries — this instance's included — until the outcome window has passed.
         this.logger.warn({
           at: "DepositAddressHandler#initiateDepositV3",
           message: "Failed to submit execute tx",
@@ -1709,12 +1748,13 @@ export class DepositAddressHandler {
       return;
     }
 
-    // Defer while another instance holds this transfer's pending-execution lock (it crashed or
-    // is still draining a broadcast); the lock expires via TTL if that instance never resolves it.
-    if (await this.hasForeignPendingExecution(depositKey)) {
+    // Defer while any instance holds this transfer's pending-execution lock — a foreign one
+    // (crashed, or still draining a broadcast) or our own left by an unknown-outcome submit; the
+    // lock expires via TTL if its owner never resolves it.
+    if (await this.hasPendingExecution(depositKey)) {
       this.logger.debug({
         at: "DepositAddressHandler#initiateWithdrawV3",
-        message: "Skipping withdraw: pending-execution lock held by another instance",
+        message: "Skipping withdraw: pending-execution lock held (foreign instance, or own unknown-outcome submit)",
         refTxHash,
         depositKey,
       });
@@ -1856,7 +1896,8 @@ export class DepositAddressHandler {
       const receipt = await this.sendAndConfirm(withdrawTx, useDispatcher);
       if (!isDefined(receipt)) {
         // Pending-execution lock intentionally kept: the tx may still have broadcast
-        // (confirmation failure), so let the TTL expire it rather than invite a replay.
+        // (confirmation failure), so let the TTL expire it rather than invite a replay. The lock
+        // defers ALL retries — this instance's included — until the outcome window has passed.
         this.logger.warn({
           at: "DepositAddressHandler#initiateWithdrawV3",
           message: "Failed to submit withdraw tx",

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -81,30 +81,31 @@ const HEARTBEAT_FAILURE_WARN_THRESHOLD = 10;
 
 /**
  * Max seconds the outgoing instance waits, after observing a handover, for in-flight poll ticks
- * to settle (tx confirmation + Redis persist of the executed marker) before signalling drained.
- * An execution abandoned between broadcast and persist is exactly how a successor comes to
- * replay a sweep (2026-07-20 duplicate-sweep incident), so this errs long; the pending-execution
- * marker still covers anything that outlives the drain.
+ * to settle (tx confirmation + Redis commit of the executed member) before exiting. The
+ * successor runs concurrently from the moment it takes the lease — service is continuous — so
+ * this only bounds how long the old process lingers to finish work it already broadcast. An
+ * execution abandoned between broadcast and commit is exactly how a successor comes to replay a
+ * sweep (2026-07-20 duplicate-sweep incident), so this errs long; the pending-execution lock
+ * still covers anything that outlives the drain.
  */
 const HANDOVER_DRAIN_TIMEOUT = 90;
 
 /**
- * Max seconds the incoming instance waits for its predecessor's drained signal before loading
- * persisted state and starting to poll. Must exceed HANDOVER_DRAIN_TIMEOUT plus the
- * predecessor's ~1s handover-detection latency so a live predecessor always beats the timeout;
- * the timeout only bites when the predecessor crashed (or predates this protocol).
- */
-const HANDOVER_TAKEOVER_TIMEOUT = 120;
-
-/**
- * TTL (seconds) on a pending-execution marker, written to Redis immediately before every
- * fund-moving broadcast and cleared once the confirmed execution is persisted. A marker written
- * by another instance defers this instance's execution of that transfer, so the TTL bounds how
- * long a transfer stays deferred when its broadcast outcome is unknown (instance crashed
- * mid-flight, or confirmation failed after a possible broadcast). Sized to comfortably outlive
+ * TTL (seconds) on a per-transfer pending-execution lock, acquired atomically (SET NX)
+ * immediately before every fund-moving broadcast and released once the confirmed execution is
+ * committed. The lock is what lets two instances run concurrently through a handover without
+ * ever executing the same transfer twice; the TTL bounds how long a transfer stays deferred
+ * when the lock holder dies with the broadcast outcome unknown. Sized to comfortably outlive
  * any broadcast→confirmation window; a deferred sweep is recoverable, a double-spend is not.
  */
 const PENDING_EXECUTION_EXPIRY = 900;
+
+/**
+ * TTL (seconds) on the persisted committed-execution sets, refreshed on every write. Only
+ * relevant after a bot is decommissioned (live sets are rewritten constantly); must comfortably
+ * exceed the indexer's message redelivery horizon.
+ */
+const PERSISTED_SET_EXPIRY = 14 * 24 * 60 * 60;
 
 /**
  * Independent relayer bot which processes EIP-3009 signatures into deposits and corresponding fills.
@@ -116,9 +117,9 @@ export class DepositAddressHandler {
   private consecutiveHeartbeatFailures = 0;
 
   /**
-   * True once a handover/shutdown has been observed — including during initialize(), which cedes
-   * without loading state when the abort fires (or a newer instance takes the lease) while it is
-   * blocked on the predecessor drain. The caller must not start polling in that case.
+   * True once a handover/shutdown has been observed — including during initialize() (SIGHUP or
+   * process disconnect while it boots). The entrypoint checks this and must not start polling
+   * from an already-ceded instance.
    */
   public get aborted(): boolean {
     return this.abortController.signal.aborted;
@@ -241,10 +242,11 @@ export class DepositAddressHandler {
       this.observedExecutedWithdraws[chainId] = new Set<string>();
     });
 
-    // Establish bot instance and take over. Wait for the predecessor to finish draining its
-    // in-flight executions (it persists their executed markers as part of the drain) BEFORE
-    // loading the persisted sets — loading earlier races the predecessor's final persist and is
-    // how a swept transfer gets replayed (2026-07-20 duplicate-sweep incident).
+    // Establish bot instance and take over. The predecessor keeps draining its in-flight
+    // executions concurrently — service is continuous. Replay safety does not depend on it
+    // being done: every fund-moving broadcast is guarded by the per-transfer pending-execution
+    // lock and a committed-set re-check under that lock (see preBroadcastCheckpoint), and the
+    // committed sets are re-read from Redis every poll tick.
     this.instanceCoordinator = new InstanceCoordinator(
       this.logger,
       this.redisCache,
@@ -252,158 +254,104 @@ export class DepositAddressHandler {
       this.config.runIdentifier,
       this.abortController
     );
-    const predecessor = await this.instanceCoordinator.initiateHandover();
-    // Heartbeat while blocked on the predecessor: it stops its own watchdog the moment it
-    // observes this takeover, and this wait can exceed the ~60s Checkly alert window — a healthy
-    // handover must not page as a dead bot.
-    const drainWaitHeartbeat = new AbortController();
-    scheduleTask(() => this.kickWatchdog(), this.config.watchdogInterval, drainWaitHeartbeat.signal);
-    let predecessorDrained: boolean;
-    try {
-      predecessorDrained = await this.instanceCoordinator.waitForPredecessorDrain(
-        predecessor,
-        HANDOVER_TAKEOVER_TIMEOUT
-      );
-    } finally {
-      drainWaitHeartbeat.abort();
-    }
-    // waitForPredecessorDrain also returns false when this handler's own abort signal fires
-    // (SIGHUP/disconnect during the wait). That is a shutdown, not a takeover timeout: cede
-    // without loading state — the caller checks `aborted` and must not start polling.
-    if (this.abortController.signal.aborted) {
-      this.logger.debug({
-        at: "DepositAddressHandler#initialize",
-        message: "Shutdown observed while waiting for predecessor drain; ceding without starting.",
-        predecessor,
-      });
-      return;
-    }
-    if (!predecessorDrained) {
-      this.logger.warn({
-        at: "DepositAddressHandler#initialize",
-        message:
-          "Predecessor instance did not signal drained; proceeding. Pending-execution markers still defer any broadcast it left in flight.",
-        predecessor,
-        timeoutSeconds: HANDOVER_TAKEOVER_TIMEOUT,
-      });
-    }
-    // A newer instance may have taken the lease while this one was blocked here; polling would
-    // then run executions from a stale instance until waitForDisconnect's next 1s subscribe poll
-    // notices the newer lease. Cede immediately instead.
-    if (!(await this.instanceCoordinator.isActiveInstance())) {
-      this.logger.warn({
-        at: "DepositAddressHandler#initialize",
-        message: "Another instance took over while waiting for predecessor drain; ceding without starting.",
-        predecessor,
-      });
-      this.abortController.abort();
-      return;
-    }
+    await this.instanceCoordinator.initiateHandover();
 
-    await this._loadExecutedDepositsFromRedis();
-    await this._loadWithdrawnKeysFromRedis();
-    await this._loadSkippedWithdrawKeysFromRedis();
+    this.executedDepositTxHashes = await this._loadPersistedSet(
+      this.getExecutedDepositsRedisKey(),
+      this.getLegacyExecutedDepositsRedisKey()
+    );
+    this.executedWithdrawKeys = await this._loadPersistedSet(
+      this.getWithdrawnKeysRedisKey(),
+      this.getLegacyWithdrawnKeysRedisKey()
+    );
+    this.terminallySkippedWithdrawKeys = await this._loadPersistedSet(
+      this.getSkippedWithdrawKeysRedisKey(),
+      this.getLegacySkippedWithdrawKeysRedisKey()
+    );
+    this.logger.debug({
+      at: "DepositAddressHandler#initialize",
+      message: "Loaded persisted execution state from Redis",
+      executedDeposits: this.executedDepositTxHashes.size,
+      executedWithdraws: this.executedWithdrawKeys.size,
+      terminallySkippedWithdraws: this.terminallySkippedWithdrawKeys.size,
+    });
 
     this.initialized = true;
   }
 
+  // The committed sets are native Redis sets (atomic per-member SADD/SREM) so two instances
+  // running concurrently through a handover can both write without lost updates — the previous
+  // whole-JSON-blob writes would clobber each other. The legacy (blob) keys are read once for
+  // migration; see _loadPersistedSet.
   private getExecutedDepositsRedisKey(): string {
+    return `deposit-address:executed:${this.config.botIdentifier}:v2`;
+  }
+
+  private getLegacyExecutedDepositsRedisKey(): string {
     return `deposit-address:executed:${this.config.botIdentifier}`;
   }
 
   private getWithdrawnKeysRedisKey(): string {
+    return `deposit-address:withdrawn-deposit-keys:${this.config.botIdentifier}:v2`;
+  }
+
+  private getLegacyWithdrawnKeysRedisKey(): string {
     return `deposit-address:withdrawn-deposit-keys:${this.config.botIdentifier}`;
   }
 
   private getSkippedWithdrawKeysRedisKey(): string {
+    return `deposit-address:skipped-withdraw-keys:${this.config.botIdentifier}:v2`;
+  }
+
+  private getLegacySkippedWithdrawKeysRedisKey(): string {
     return `deposit-address:skipped-withdraw-keys:${this.config.botIdentifier}`;
   }
 
-  /** Loads executed deposit tx hashes from Redis (e.g. after handover). */
-  private async _loadExecutedDepositsFromRedis(): Promise<void> {
+  /**
+   * Loads a persisted committed set (native Redis set under the v2 key), migrating from the
+   * legacy JSON-array key when the v2 set is empty (first boot on this format, or a set fully
+   * pruned since). The legacy key is left in place for rollback; it expires via its own TTL, and
+   * any stale entries it re-seeds are pruned again within one poll.
+   */
+  private async _loadPersistedSet(redisKey: string, legacyRedisKey: string): Promise<Set<string>> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
     const { redisCache } = this;
-    const redisKey = this.getExecutedDepositsRedisKey();
-    const raw = await redisCache.get<string>(redisKey);
-    let arr: string[] = [];
+    const members = new Set(await redisCache.sMembers(redisKey));
+    if (members.size > 0) {
+      return members;
+    }
+
+    const raw = await redisCache.get<string>(legacyRedisKey);
+    if (!raw) {
+      return members;
+    }
+    let legacyMembers: string[] = [];
     try {
-      if (raw) {
-        arr = parseJson.stringArray(raw);
-      }
+      legacyMembers = parseJson.stringArray(raw);
     } catch (err) {
       this.logger.error({
-        at: "DepositAddressHandler#_loadExecutedDepositsFromRedis",
-        message: "Failed to parse executed deposits from Redis, using empty set",
-        redisKey,
+        at: "DepositAddressHandler#_loadPersistedSet",
+        message: "Failed to parse legacy persisted set from Redis",
+        redisKey: legacyRedisKey,
         err: err instanceof Error ? err.message : String(err),
       });
-
       throw err;
     }
-    this.executedDepositTxHashes = new Set(arr);
-    this.logger.debug({
-      at: "DepositAddressHandler#_loadExecutedDepositsFromRedis",
-      message: "Loaded executed deposit tx hashes from Redis",
-      count: this.executedDepositTxHashes.size,
-    });
-  }
-
-  /** Loads executed refund-withdraw depositKeys from Redis (e.g. after handover). */
-  private async _loadWithdrawnKeysFromRedis(): Promise<void> {
-    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
-    const { redisCache } = this;
-    const redisKey = this.getWithdrawnKeysRedisKey();
-    const raw = await redisCache.get<string>(redisKey);
-    let arr: string[] = [];
-    try {
-      if (raw) {
-        arr = parseJson.stringArray(raw);
-      }
-    } catch (err) {
-      this.logger.error({
-        at: "DepositAddressHandler#_loadWithdrawnKeysFromRedis",
-        message: "Failed to parse withdrawn deposit keys from Redis, using empty set",
-        redisKey,
-        err: err instanceof Error ? err.message : String(err),
-      });
-
-      throw err;
+    for (const member of legacyMembers) {
+      await redisCache.sAdd(redisKey, member);
+      members.add(member);
     }
-    this.executedWithdrawKeys = new Set(arr);
-    this.logger.debug({
-      at: "DepositAddressHandler#_loadWithdrawnKeysFromRedis",
-      message: "Loaded executed withdraw deposit keys from Redis",
-      count: this.executedWithdrawKeys.size,
-    });
-  }
-
-  /** Loads terminally-skipped (422) refund-withdraw depositKeys from Redis (e.g. after handover). */
-  private async _loadSkippedWithdrawKeysFromRedis(): Promise<void> {
-    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
-    const { redisCache } = this;
-    const redisKey = this.getSkippedWithdrawKeysRedisKey();
-    const raw = await redisCache.get<string>(redisKey);
-    let arr: string[] = [];
-    try {
-      if (raw) {
-        arr = parseJson.stringArray(raw);
-      }
-    } catch (err) {
-      this.logger.error({
-        at: "DepositAddressHandler#_loadSkippedWithdrawKeysFromRedis",
-        message: "Failed to parse skipped withdraw keys from Redis, using empty set",
-        redisKey,
-        err: err instanceof Error ? err.message : String(err),
-      });
-
-      throw err;
+    if (members.size > 0) {
+      await redisCache.expire(redisKey, PERSISTED_SET_EXPIRY);
     }
-    this.terminallySkippedWithdrawKeys = new Set(arr);
     this.logger.debug({
-      at: "DepositAddressHandler#_loadSkippedWithdrawKeysFromRedis",
-      message: "Loaded terminally-skipped withdraw deposit keys from Redis",
-      count: this.terminallySkippedWithdrawKeys.size,
+      at: "DepositAddressHandler#_loadPersistedSet",
+      message: "Migrated legacy persisted set to native Redis set",
+      legacyRedisKey,
+      redisKey,
+      count: members.size,
     });
+    return members;
   }
 
   /*
@@ -464,24 +412,15 @@ export class DepositAddressHandler {
 
   /*
    * @notice Utility function which tells the relayer when a handoff has occurred.
-   * Calls the abort controller once a handoff is observed, then drains in-flight executions
-   * (so a broadcast tx gets confirmed and its executed marker persisted rather than orphaned)
-   * and signals the successor that it is safe to load state and start polling.
+   * Calls the abort controller once a handoff is observed, then drains in-flight executions —
+   * so a broadcast tx gets confirmed and committed to Redis rather than orphaned — while the
+   * successor is already running concurrently. The per-transfer pending-execution locks keep
+   * the successor off anything still draining here.
    */
   public async waitForDisconnect(): Promise<void> {
     await this.instanceCoordinator.subscribe();
     this.abortController.abort();
     await this.drainInFlightWork(HANDOVER_DRAIN_TIMEOUT);
-    try {
-      await this.instanceCoordinator.signalDrained();
-    } catch (err) {
-      // The successor times out and proceeds; pending-execution markers still guard replays.
-      this.logger.error({
-        at: "DepositAddressHandler#waitForDisconnect",
-        message: "Failed to signal drained to successor",
-        err: err instanceof Error ? err.message : String(err),
-      });
-    }
   }
 
   /** Registers a poll tick for handover draining. Returns a chained promise so scheduleTask's
@@ -493,8 +432,9 @@ export class DepositAddressHandler {
 
   /**
    * Waits (bounded) for in-flight poll ticks to settle after the abort signal fired. A tick that
-   * has broadcast a tx persists its executed marker and clears its pending marker as it settles;
-   * exiting before that is what turns a handover into a replayed execution.
+   * has broadcast a tx commits the executed member and releases its pending-execution lock as it
+   * settles; exiting before that leaves the transfer lock-deferred on the successor until the
+   * lock's TTL expires.
    */
   private async drainInFlightWork(timeoutSeconds: number): Promise<void> {
     if (this.inFlightTicks.size === 0) {
@@ -514,7 +454,7 @@ export class DepositAddressHandler {
       this.logger.warn({
         at: "DepositAddressHandler#drainInFlightWork",
         message:
-          "In-flight work did not settle within the drain timeout; ceding anyway. Pending-execution markers defer the successor from any broadcast still in flight.",
+          "In-flight work did not settle within the drain timeout; exiting anyway. Pending-execution locks keep the successor off any broadcast still in flight.",
         inFlightTicks: this.inFlightTicks.size,
         timeoutSeconds,
       });
@@ -529,30 +469,34 @@ export class DepositAddressHandler {
   private async evaluateDepositAddresses(): Promise<void> {
     const depositMessages = await this._queryIndexerApi();
 
-    // We want to remove all executed deposits from the in-memory set if they are not returned by the indexer.
+    // Refresh the in-memory committed views from Redis so executions committed by a concurrently
+    // running instance (e.g. the predecessor draining through a handover) are respected within
+    // one tick. Union with in-memory: a locally committed entry whose Redis write failed must
+    // never be dropped.
+    await this._refreshPersistedSets();
+
+    // We want to remove all executed deposits from the sets if they are not returned by the indexer.
     // This is because the indexer will stop sending the deposit once it has been "expired" (internal TTL).
     // So there is no point of keeping them in Redis after Indexer API stops returning them.
+    // SREM is atomic per member, so concurrent pruning by two instances loses nothing.
     const refTxHashesFromIndexer = new Set(depositMessages.map((m) => m.erc20Transfer.transactionHash));
     const depositKeysFromIndexer = new Set(depositMessages.map((m) => getDepositKey(m)));
-    for (const tx of [...this.executedDepositTxHashes]) {
-      if (!refTxHashesFromIndexer.has(tx)) {
-        this.executedDepositTxHashes.delete(tx);
-      }
-    }
-    for (const key of [...this.executedWithdrawKeys]) {
-      if (!depositKeysFromIndexer.has(key)) {
-        this.executedWithdrawKeys.delete(key);
-      }
-    }
-    for (const key of [...this.terminallySkippedWithdrawKeys]) {
-      if (!depositKeysFromIndexer.has(key)) {
-        this.terminallySkippedWithdrawKeys.delete(key);
-      }
-    }
+    await this._prunePersistedSet(
+      this.executedDepositTxHashes,
+      refTxHashesFromIndexer,
+      this.getExecutedDepositsRedisKey()
+    );
+    await this._prunePersistedSet(this.executedWithdrawKeys, depositKeysFromIndexer, this.getWithdrawnKeysRedisKey());
+    await this._prunePersistedSet(
+      this.terminallySkippedWithdrawKeys,
+      depositKeysFromIndexer,
+      this.getSkippedWithdrawKeysRedisKey()
+    );
 
     await forEachAsync(depositMessages, async (depositMessage) => {
       // Once a handover/shutdown is observed, initiate no new executions — in-flight ones are
-      // drained by waitForDisconnect; anything not yet started belongs to the successor.
+      // drained by waitForDisconnect; anything not yet started belongs to the successor, which
+      // is already running.
       if (this.abortController.signal.aborted) {
         return;
       }
@@ -560,19 +504,43 @@ export class DepositAddressHandler {
     });
   }
 
+  /** Merges the persisted committed sets from Redis into the in-memory views (union). */
+  private async _refreshPersistedSets(): Promise<void> {
+    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    const { redisCache } = this;
+    for (const member of await redisCache.sMembers(this.getExecutedDepositsRedisKey())) {
+      this.executedDepositTxHashes.add(member);
+    }
+    for (const member of await redisCache.sMembers(this.getWithdrawnKeysRedisKey())) {
+      this.executedWithdrawKeys.add(member);
+    }
+    for (const member of await redisCache.sMembers(this.getSkippedWithdrawKeysRedisKey())) {
+      this.terminallySkippedWithdrawKeys.add(member);
+    }
+  }
+
+  /** Removes members the indexer no longer returns from both the in-memory set and Redis. */
+  private async _prunePersistedSet(memory: Set<string>, current: Set<string>, redisKey: string): Promise<void> {
+    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    const { redisCache } = this;
+    for (const member of [...memory]) {
+      if (!current.has(member)) {
+        memory.delete(member);
+        await redisCache.sRem(redisKey, member);
+      }
+    }
+  }
+
   private getPendingExecutionRedisKey(depositKey: string): string {
     return `deposit-address:pending-execution:${this.config.botIdentifier}:${depositKey}`;
   }
 
   /**
-   * Returns true when another instance has recorded a pending (possibly still in-flight)
-   * fund-moving broadcast for this depositKey. Markers written by this instance don't defer it:
-   * its in-memory in-flight sets are strictly better informed, and blocking on our own marker
-   * would stall the normal retry path after a failed submit.
-   *
-   * Advisory pre-filter only — it saves the API/chain reads that follow, but a concurrent
-   * instance can write its marker after this read. The authoritative guard is the atomic
-   * acquisition in preBroadcastCheckpoint.
+   * Returns true when another instance holds the pending-execution lock for this depositKey —
+   * a cheap early skip ahead of the balance/quote work. The authoritative exclusion is the
+   * atomic acquire in preBroadcastCheckpoint; locks held by this instance don't defer it (its
+   * in-memory in-flight sets are strictly better informed, and blocking on our own lock would
+   * stall the normal retry path after a failed submit).
    */
   private async hasForeignPendingExecution(depositKey: string): Promise<boolean> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
@@ -581,43 +549,20 @@ export class DepositAddressHandler {
   }
 
   /**
-   * Atomically acquires the pending-execution marker; returns false when another instance owns
-   * it, in which case the caller must NOT broadcast. MUST be awaited immediately before every
-   * fund-moving broadcast: if this instance dies between broadcast and persisting the executed
-   * marker, the marker is the only thing standing between the successor and a replayed execution,
-   * and two live instances racing the same transfer (overlapping replacement starts, or a
-   * takeover timeout while the old process still runs) must not both proceed past it.
-   *
-   * SET NX first; on conflict, re-take the marker only if it is already this instance's own — a
-   * failed submit intentionally leaves the marker in place (see clearPendingExecution), so the
-   * same-instance retry path must be able to re-acquire it.
-   */
-  private async acquirePendingExecution(depositKey: string): Promise<boolean> {
-    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
-    const redisKey = this.getPendingExecutionRedisKey(depositKey);
-    const ttlMs = PENDING_EXECUTION_EXPIRY * 1000;
-    return (
-      (await this.redisCache.acquireLock(redisKey, this.config.runIdentifier, ttlMs)) ||
-      (await this.redisCache.renewLock(redisKey, this.config.runIdentifier, ttlMs))
-    );
-  }
-
-  /**
-   * Releases the pending-execution marker after the confirmed execution has been persisted to the
-   * executed set. Ownership-checked (compare-and-delete): if this instance's marker expired
-   * mid-flight and another instance has since acquired the key, that marker is left intact.
-   * Best-effort: on failure the marker expires via its TTL. Never call this after a failed
+   * Releases this instance's pending-execution lock after the confirmed execution has been
+   * committed to the persisted set. Token-guarded (never deletes another instance's lock) and
+   * best-effort: on failure the lock expires via its TTL. Never call this after a failed
    * submit — a "failed" sendAndConfirm may still have broadcast (confirmation failure), so the
-   * marker must outlive it.
+   * lock must outlive it.
    */
-  private async clearPendingExecution(depositKey: string): Promise<void> {
+  private async releasePendingExecution(depositKey: string): Promise<void> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
     try {
       await this.redisCache.releaseLock(this.getPendingExecutionRedisKey(depositKey), this.config.runIdentifier);
     } catch (err) {
       this.logger.warn({
-        at: "DepositAddressHandler#clearPendingExecution",
-        message: "Failed to clear pending-execution marker; it will expire via TTL",
+        at: "DepositAddressHandler#releasePendingExecution",
+        message: "Failed to release pending-execution lock; it will expire via TTL",
         depositKey,
         err: err instanceof Error ? err.message : String(err),
       });
@@ -625,12 +570,27 @@ export class DepositAddressHandler {
   }
 
   /**
-   * Guards a fund-moving broadcast: bails when a handover was observed mid-message (the
-   * successor re-evaluates from scratch — a broadcast from a ceding instance is how replays
-   * happen), then atomically acquires the pending-execution marker. Returns false when the
-   * caller must NOT broadcast.
+   * Guards a fund-moving broadcast so at most one instance can be executing a given transfer at
+   * any time, even while two instances run concurrently through a handover:
+   *   1. Bail when a handover/shutdown was observed mid-message — the successor is already
+   *      running and re-evaluates the transfer fresh.
+   *   2. Atomically acquire the transfer's pending-execution lock (SET NX). A token-guarded
+   *      renew covers this instance's own retries after a failed submit; a lock held by another
+   *      instance defers the transfer (it may have a broadcast in flight).
+   *   3. Re-check the committed set under the lock: the other instance may have committed and
+   *      released between this tick's refresh and now.
+   * MUST be awaited immediately before every fund-moving broadcast: if this instance then dies
+   * before committing, the held lock is what stands between the successor and a replayed
+   * execution. Returns false when the caller must NOT broadcast; fails closed on Redis errors.
    */
-  private async preBroadcastCheckpoint(depositKey: string, at: string): Promise<boolean> {
+  private async preBroadcastCheckpoint(
+    depositKey: string,
+    committedSetKey: string,
+    committedMember: string,
+    at: string
+  ): Promise<boolean> {
+    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    const { redisCache } = this;
     if (this.abortController.signal.aborted) {
       this.logger.debug({
         at,
@@ -639,27 +599,41 @@ export class DepositAddressHandler {
       });
       return false;
     }
+    const pendingKey = this.getPendingExecutionRedisKey(depositKey);
+    const { runIdentifier } = this.config;
+    const ttlMs = PENDING_EXECUTION_EXPIRY * 1000;
     try {
-      // Atomic: two live instances can both pass the earlier hasForeignPendingExecution read for
-      // the same transfer; only the one that wins the marker may broadcast.
-      if (!(await this.acquirePendingExecution(depositKey))) {
+      const acquired =
+        (await redisCache.acquireLock(pendingKey, runIdentifier, ttlMs)) ||
+        (await redisCache.renewLock(pendingKey, runIdentifier, ttlMs));
+      if (!acquired) {
         this.logger.debug({
           at,
-          message: "Skipping broadcast: pending-execution marker acquired by another instance",
+          message: "Skipping broadcast: pending-execution lock held by another instance",
           depositKey,
         });
         return false;
       }
+      if (await redisCache.sIsMember(committedSetKey, committedMember)) {
+        this.logger.debug({
+          at,
+          message: "Skipping broadcast: transfer already committed by another instance",
+          depositKey,
+          committedMember,
+        });
+        await redisCache.releaseLock(pendingKey, runIdentifier);
+        return false;
+      }
+      return true;
     } catch (err) {
       this.logger.warn({
         at,
-        message: "Skipping broadcast: failed to persist pending-execution marker",
+        message: "Skipping broadcast: pre-broadcast checkpoint failed",
         depositKey,
         err: err instanceof Error ? err.message : String(err),
       });
       return false;
     }
-    return true;
   }
 
   /** Thin wrapper over sendAndConfirmTransaction so unit tests can stub the broadcast. */
@@ -777,12 +751,12 @@ export class DepositAddressHandler {
       return;
     }
 
-    // Defer while another instance may have a broadcast in flight for this transfer (it crashed
-    // or is still draining); the marker expires via TTL if that instance never resolves it.
+    // Defer while another instance holds this transfer's pending-execution lock (it crashed or
+    // is still draining a broadcast); the lock expires via TTL if that instance never resolves it.
     if (await this.hasForeignPendingExecution(depositKey)) {
       this.logger.debug({
         at: "DepositAddressHandler#initiateWithdraw",
-        message: "Skipping withdraw: pending-execution marker held by another instance",
+        message: "Skipping withdraw: pending-execution lock held by another instance",
         refTxHash,
         depositKey,
       });
@@ -872,13 +846,20 @@ export class DepositAddressHandler {
         )} (classification: ${erc20Transfer.transferClassification}, bundledDeploy: ${signed.bundledDeploy})`,
       };
 
-      if (!(await this.preBroadcastCheckpoint(depositKey, "DepositAddressHandler#initiateWithdraw"))) {
+      if (
+        !(await this.preBroadcastCheckpoint(
+          depositKey,
+          this.getWithdrawnKeysRedisKey(),
+          depositKey,
+          "DepositAddressHandler#initiateWithdraw"
+        ))
+      ) {
         return;
       }
       const receipt = await this.sendAndConfirm(withdrawTx, useDispatcher);
       if (!isDefined(receipt)) {
-        // Pending marker intentionally left: the tx may still have broadcast (confirmation
-        // failure), so let the TTL expire it rather than invite a cross-instance replay.
+        // Pending-execution lock intentionally kept: the tx may still have broadcast
+        // (confirmation failure), so let the TTL expire it rather than invite a replay.
         this.logger.warn({
           at: "DepositAddressHandler#initiateWithdraw",
           message: "Failed to submit withdraw tx",
@@ -891,11 +872,12 @@ export class DepositAddressHandler {
       }
 
       // The withdraw is on-chain; keep the in-flight lock and never re-attempt this depositKey,
-      // even if the Redis persist below throws (handover may miss it, but a double-send is worse).
+      // even if the Redis commit below throws (the held pending-execution lock then keeps other
+      // instances off it until its TTL — a double-send is worse).
       this.executedWithdrawKeys.add(depositKey);
       withdrawCommitted = true;
-      await this._persistWithdrawnKeysRedis();
-      await this.clearPendingExecution(depositKey);
+      await this._persistCommitted(this.getWithdrawnKeysRedisKey(), depositKey);
+      await this.releasePendingExecution(depositKey);
       await this._publishWithdrawExecuted(receipt, depositMessage);
     } finally {
       if (!withdrawCommitted) {
@@ -951,30 +933,15 @@ export class DepositAddressHandler {
   }
 
   /**
-   * Overwrites Redis key with the full executedDepositTxHashes set (single SET; value is JSON array).
-   * Called at start of each poll (after filtering) and after each successful execute.
+   * Commits a single member to a persisted committed set. SADD is atomic per member, so
+   * concurrent commits from two instances never lose an entry (unlike the previous whole-blob
+   * SET). The key's TTL is refreshed on every commit.
    */
-  private async _persistExecutedDepositsRedis(): Promise<void> {
+  private async _persistCommitted(redisKey: string, member: string): Promise<void> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
     const { redisCache } = this;
-    const redisKey = this.getExecutedDepositsRedisKey();
-    await redisCache.set(redisKey, JSON.stringify([...this.executedDepositTxHashes]));
-  }
-
-  /** Same pattern as `_persistExecutedDepositsRedis` but for refund-withdraw deposit keys. */
-  private async _persistWithdrawnKeysRedis(): Promise<void> {
-    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
-    const { redisCache } = this;
-    const redisKey = this.getWithdrawnKeysRedisKey();
-    await redisCache.set(redisKey, JSON.stringify([...this.executedWithdrawKeys]));
-  }
-
-  /** Same pattern as `_persistWithdrawnKeysRedis` but for terminally-skipped (422) withdraw keys. */
-  private async _persistSkippedWithdrawKeysRedis(): Promise<void> {
-    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
-    const { redisCache } = this;
-    const redisKey = this.getSkippedWithdrawKeysRedisKey();
-    await redisCache.set(redisKey, JSON.stringify([...this.terminallySkippedWithdrawKeys]));
+    await redisCache.sAdd(redisKey, member);
+    await redisCache.expire(redisKey, PERSISTED_SET_EXPIRY);
   }
 
   /**
@@ -1139,12 +1106,12 @@ export class DepositAddressHandler {
       return;
     }
 
-    // Defer while another instance may have a broadcast in flight for this transfer (it crashed
-    // or is still draining); the marker expires via TTL if that instance never resolves it.
+    // Defer while another instance holds this transfer's pending-execution lock (it crashed or
+    // is still draining a broadcast); the lock expires via TTL if that instance never resolves it.
     if (await this.hasForeignPendingExecution(depositKey)) {
       this.logger.debug({
         at: "DepositAddressHandler#initiateDeposit",
-        message: "Skipping deposit: pending-execution marker held by another instance",
+        message: "Skipping deposit: pending-execution lock held by another instance",
         refTxHash,
         depositKey,
       });
@@ -1263,15 +1230,22 @@ export class DepositAddressHandler {
       )} (cctpExecutionFee: ${cctpExecutionFee}, spokePoolExecutionFee: ${spokePoolExecutionFee})`,
     };
 
-    if (!(await this.preBroadcastCheckpoint(depositKey, "DepositAddressHandler#initiateDeposit"))) {
+    if (
+      !(await this.preBroadcastCheckpoint(
+        depositKey,
+        this.getExecutedDepositsRedisKey(),
+        refTxHash,
+        "DepositAddressHandler#initiateDeposit"
+      ))
+    ) {
       this.observedExecutedDeposits[originChainId].delete(depositKey);
       return;
     }
     const depositReceipt = await this.sendAndConfirm(executeTx, useDispatcher);
 
     if (!depositReceipt) {
-      // Pending marker intentionally left: the tx may still have broadcast (confirmation
-      // failure), so let the TTL expire it rather than invite a cross-instance replay.
+      // Pending-execution lock intentionally kept: the tx may still have broadcast
+      // (confirmation failure), so let the TTL expire it rather than invite a replay.
       this.logger.warn({
         at: "DepositAddressHandler#initiateDeposit",
         message: "Failed to submit execute tx",
@@ -1285,10 +1259,10 @@ export class DepositAddressHandler {
       return;
     }
 
-    // Persist full set to Redis immediately so handover cannot miss this execute.
+    // Commit to Redis immediately so a concurrently-running instance cannot miss this execute.
     this.executedDepositTxHashes.add(refTxHash);
-    await this._persistExecutedDepositsRedis();
-    await this.clearPendingExecution(depositKey);
+    await this._persistCommitted(this.getExecutedDepositsRedisKey(), refTxHash);
+    await this.releasePendingExecution(depositKey);
   }
 
   /**
@@ -1321,12 +1295,12 @@ export class DepositAddressHandler {
       return;
     }
 
-    // Defer while another instance may have a broadcast in flight for this transfer (it crashed
-    // or is still draining); the marker expires via TTL if that instance never resolves it.
+    // Defer while another instance holds this transfer's pending-execution lock (it crashed or
+    // is still draining a broadcast); the lock expires via TTL if that instance never resolves it.
     if (await this.hasForeignPendingExecution(depositKey)) {
       this.logger.debug({
         at: "DepositAddressHandler#initiateDepositV3",
-        message: "Skipping deposit: pending-execution marker held by another instance",
+        message: "Skipping deposit: pending-execution lock held by another instance",
         refTxHash,
         depositKey,
       });
@@ -1419,13 +1393,20 @@ export class DepositAddressHandler {
         )}, using deposit address ${blockExplorerLink(depositAddress, originChainId)}`,
       };
 
-      if (!(await this.preBroadcastCheckpoint(depositKey, "DepositAddressHandler#initiateDepositV3"))) {
+      if (
+        !(await this.preBroadcastCheckpoint(
+          depositKey,
+          this.getExecutedDepositsRedisKey(),
+          refTxHash,
+          "DepositAddressHandler#initiateDepositV3"
+        ))
+      ) {
         return;
       }
       const depositReceipt = await this.sendAndConfirm(executeTx, useDispatcher);
       if (!isDefined(depositReceipt)) {
-        // Pending marker intentionally left: the tx may still have broadcast (confirmation
-        // failure), so let the TTL expire it rather than invite a cross-instance replay.
+        // Pending-execution lock intentionally kept: the tx may still have broadcast
+        // (confirmation failure), so let the TTL expire it rather than invite a replay.
         this.logger.warn({
           at: "DepositAddressHandler#initiateDepositV3",
           message: "Failed to submit execute tx",
@@ -1438,12 +1419,12 @@ export class DepositAddressHandler {
         return;
       }
 
-      // The execute is on-chain; keep the in-flight lock and persist to Redis immediately so
-      // handover cannot miss this execute.
+      // The execute is on-chain; keep the in-flight lock and commit to Redis immediately so a
+      // concurrently-running instance cannot miss this execute.
       this.executedDepositTxHashes.add(refTxHash);
       executeCommitted = true;
-      await this._persistExecutedDepositsRedis();
-      await this.clearPendingExecution(depositKey);
+      await this._persistCommitted(this.getExecutedDepositsRedisKey(), refTxHash);
+      await this.releasePendingExecution(depositKey);
       await this._publishDepositExecuted(depositReceipt, depositMessage);
     } finally {
       if (!executeCommitted) {
@@ -1625,12 +1606,12 @@ export class DepositAddressHandler {
       return;
     }
 
-    // Defer while another instance may have a broadcast in flight for this transfer (it crashed
-    // or is still draining); the marker expires via TTL if that instance never resolves it.
+    // Defer while another instance holds this transfer's pending-execution lock (it crashed or
+    // is still draining a broadcast); the lock expires via TTL if that instance never resolves it.
     if (await this.hasForeignPendingExecution(depositKey)) {
       this.logger.debug({
         at: "DepositAddressHandler#initiateWithdrawV3",
-        message: "Skipping withdraw: pending-execution marker held by another instance",
+        message: "Skipping withdraw: pending-execution lock held by another instance",
         refTxHash,
         depositKey,
       });
@@ -1759,13 +1740,20 @@ export class DepositAddressHandler {
         }, bundledDeploy: ${signed.bundledDeploy})`,
       };
 
-      if (!(await this.preBroadcastCheckpoint(depositKey, "DepositAddressHandler#initiateWithdrawV3"))) {
+      if (
+        !(await this.preBroadcastCheckpoint(
+          depositKey,
+          this.getWithdrawnKeysRedisKey(),
+          depositKey,
+          "DepositAddressHandler#initiateWithdrawV3"
+        ))
+      ) {
         return;
       }
       const receipt = await this.sendAndConfirm(withdrawTx, useDispatcher);
       if (!isDefined(receipt)) {
-        // Pending marker intentionally left: the tx may still have broadcast (confirmation
-        // failure), so let the TTL expire it rather than invite a cross-instance replay.
+        // Pending-execution lock intentionally kept: the tx may still have broadcast
+        // (confirmation failure), so let the TTL expire it rather than invite a replay.
         this.logger.warn({
           at: "DepositAddressHandler#initiateWithdrawV3",
           message: "Failed to submit withdraw tx",
@@ -1778,11 +1766,12 @@ export class DepositAddressHandler {
       }
 
       // The withdraw is on-chain; keep the in-flight lock and never re-attempt this depositKey,
-      // even if the Redis persist below throws (handover may miss it, but a double-send is worse).
+      // even if the Redis commit below throws (the held pending-execution lock then keeps other
+      // instances off it until its TTL — a double-send is worse).
       this.executedWithdrawKeys.add(depositKey);
       withdrawCommitted = true;
-      await this._persistWithdrawnKeysRedis();
-      await this.clearPendingExecution(depositKey);
+      await this._persistCommitted(this.getWithdrawnKeysRedisKey(), depositKey);
+      await this.releasePendingExecution(depositKey);
       await this._publishWithdrawExecuted(receipt, depositMessage);
     } finally {
       if (!withdrawCommitted) {
@@ -1826,7 +1815,7 @@ export class DepositAddressHandler {
       // unpriceable. Persist the skip so it survives handover and is not re-attempted on later polls.
       if (isHttpError(err) && err.status === 422) {
         this.terminallySkippedWithdrawKeys.add(depositKey);
-        await this._persistSkippedWithdrawKeysRedis();
+        await this._persistCommitted(this.getSkippedWithdrawKeysRedisKey(), depositKey);
         this.logger.warn({
           at: "DepositAddressHandler#_getSignedWithdrawV3",
           message: "Skipping withdraw permanently: quote-api returned terminal 422",

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -11,6 +11,7 @@ import {
   forEachAsync,
   getProvider,
   Contract,
+  delay,
   sendAndConfirmTransaction,
   getCounterfactualDepositFactory,
   buildDeployTx,
@@ -37,6 +38,7 @@ import {
 } from "../interfaces";
 import {
   AcrossSwapApiClient,
+  AugmentedTransaction,
   TransactionClient,
   SwapApiResponse,
   SignedWithdrawResponse,
@@ -78,6 +80,33 @@ const HEARTBEAT_TIMEOUT_MS = 5_000;
 const HEARTBEAT_FAILURE_WARN_THRESHOLD = 10;
 
 /**
+ * Max seconds the outgoing instance waits, after observing a handover, for in-flight poll ticks
+ * to settle (tx confirmation + Redis persist of the executed marker) before signalling drained.
+ * An execution abandoned between broadcast and persist is exactly how a successor comes to
+ * replay a sweep (2026-07-20 duplicate-sweep incident), so this errs long; the pending-execution
+ * marker still covers anything that outlives the drain.
+ */
+const HANDOVER_DRAIN_TIMEOUT = 90;
+
+/**
+ * Max seconds the incoming instance waits for its predecessor's drained signal before loading
+ * persisted state and starting to poll. Must exceed HANDOVER_DRAIN_TIMEOUT plus the
+ * predecessor's ~1s handover-detection latency so a live predecessor always beats the timeout;
+ * the timeout only bites when the predecessor crashed (or predates this protocol).
+ */
+const HANDOVER_TAKEOVER_TIMEOUT = 120;
+
+/**
+ * TTL (seconds) on a pending-execution marker, written to Redis immediately before every
+ * fund-moving broadcast and cleared once the confirmed execution is persisted. A marker written
+ * by another instance defers this instance's execution of that transfer, so the TTL bounds how
+ * long a transfer stays deferred when its broadcast outcome is unknown (instance crashed
+ * mid-flight, or confirmation failed after a possible broadcast). Sized to comfortably outlive
+ * any broadcast→confirmation window; a deferred sweep is recoverable, a double-spend is not.
+ */
+const PENDING_EXECUTION_EXPIRY = 900;
+
+/**
  * Independent relayer bot which processes EIP-3009 signatures into deposits and corresponding fills.
  */
 export class DepositAddressHandler {
@@ -99,6 +128,12 @@ export class DepositAddressHandler {
   }
 
   private providersByChain: { [chainId: number]: Provider } = {};
+
+  /**
+   * Poll ticks currently in flight. On handover the outgoing instance must not exit while one of
+   * these may still be between broadcast and Redis persist — see drainInFlightWork().
+   */
+  private inFlightTicks: Set<Promise<unknown>> = new Set();
 
   /** Per chainId: set of deposit keys already executed (like gasless depositNonces). */
   private observedExecutedDeposits: { [chainId: number]: Set<string> } = {};
@@ -197,7 +232,10 @@ export class DepositAddressHandler {
       this.observedExecutedWithdraws[chainId] = new Set<string>();
     });
 
-    // Establish bot instance and take over. First thing after handover: load persisted executed deposits from Redis.
+    // Establish bot instance and take over. Wait for the predecessor to finish draining its
+    // in-flight executions (it persists their executed markers as part of the drain) BEFORE
+    // loading the persisted sets — loading earlier races the predecessor's final persist and is
+    // how a swept transfer gets replayed (2026-07-20 duplicate-sweep incident).
     this.instanceCoordinator = new InstanceCoordinator(
       this.logger,
       this.redisCache,
@@ -205,7 +243,20 @@ export class DepositAddressHandler {
       this.config.runIdentifier,
       this.abortController
     );
-    await this.instanceCoordinator.initiateHandover();
+    const predecessor = await this.instanceCoordinator.initiateHandover();
+    const predecessorDrained = await this.instanceCoordinator.waitForPredecessorDrain(
+      predecessor,
+      HANDOVER_TAKEOVER_TIMEOUT
+    );
+    if (!predecessorDrained) {
+      this.logger.warn({
+        at: "DepositAddressHandler#initialize",
+        message:
+          "Predecessor instance did not signal drained; proceeding. Pending-execution markers still defer any broadcast it left in flight.",
+        predecessor,
+        timeoutSeconds: HANDOVER_TAKEOVER_TIMEOUT,
+      });
+    }
 
     await this._loadExecutedDepositsFromRedis();
     await this._loadWithdrawnKeysFromRedis();
@@ -318,7 +369,7 @@ export class DepositAddressHandler {
    */
   public pollAndExecute(): void {
     scheduleTask(
-      () => this.evaluateDepositAddresses(),
+      () => this.trackTick(this.evaluateDepositAddresses()),
       this.config.indexerPollingInterval,
       this.abortController.signal,
       // A rejected poll skips the whole batch for that tick; without this log the failure is
@@ -371,11 +422,66 @@ export class DepositAddressHandler {
 
   /*
    * @notice Utility function which tells the relayer when a handoff has occurred.
-   * Calls the abort controller and settles this function's promise once a handoff is observed.
+   * Calls the abort controller once a handoff is observed, then drains in-flight executions
+   * (so a broadcast tx gets confirmed and its executed marker persisted rather than orphaned)
+   * and signals the successor that it is safe to load state and start polling.
    */
   public async waitForDisconnect(): Promise<void> {
     await this.instanceCoordinator.subscribe();
     this.abortController.abort();
+    await this.drainInFlightWork(HANDOVER_DRAIN_TIMEOUT);
+    try {
+      await this.instanceCoordinator.signalDrained();
+    } catch (err) {
+      // The successor times out and proceeds; pending-execution markers still guard replays.
+      this.logger.error({
+        at: "DepositAddressHandler#waitForDisconnect",
+        message: "Failed to signal drained to successor",
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /** Registers a poll tick for handover draining. Returns a chained promise so scheduleTask's
+   * rejection handling still applies; the raw tick is what drainInFlightWork awaits. */
+  private trackTick(tick: Promise<unknown>): Promise<unknown> {
+    this.inFlightTicks.add(tick);
+    return tick.finally(() => this.inFlightTicks.delete(tick));
+  }
+
+  /**
+   * Waits (bounded) for in-flight poll ticks to settle after the abort signal fired. A tick that
+   * has broadcast a tx persists its executed marker and clears its pending marker as it settles;
+   * exiting before that is what turns a handover into a replayed execution.
+   */
+  private async drainInFlightWork(timeoutSeconds: number): Promise<void> {
+    if (this.inFlightTicks.size === 0) {
+      return;
+    }
+    this.logger.debug({
+      at: "DepositAddressHandler#drainInFlightWork",
+      message: "Draining in-flight poll ticks before ceding",
+      inFlightTicks: this.inFlightTicks.size,
+    });
+    let timedOut = false;
+    await Promise.race([
+      Promise.allSettled([...this.inFlightTicks]),
+      delay(timeoutSeconds).then(() => (timedOut = true)),
+    ]);
+    if (timedOut) {
+      this.logger.warn({
+        at: "DepositAddressHandler#drainInFlightWork",
+        message:
+          "In-flight work did not settle within the drain timeout; ceding anyway. Pending-execution markers defer the successor from any broadcast still in flight.",
+        inFlightTicks: this.inFlightTicks.size,
+        timeoutSeconds,
+      });
+    } else {
+      this.logger.debug({
+        at: "DepositAddressHandler#drainInFlightWork",
+        message: "Drained all in-flight poll ticks",
+      });
+    }
   }
 
   private async evaluateDepositAddresses(): Promise<void> {
@@ -403,8 +509,98 @@ export class DepositAddressHandler {
     }
 
     await forEachAsync(depositMessages, async (depositMessage) => {
+      // Once a handover/shutdown is observed, initiate no new executions — in-flight ones are
+      // drained by waitForDisconnect; anything not yet started belongs to the successor.
+      if (this.abortController.signal.aborted) {
+        return;
+      }
       await this.processExecution(depositMessage);
     });
+  }
+
+  private getPendingExecutionRedisKey(depositKey: string): string {
+    return `deposit-address:pending-execution:${this.config.botIdentifier}:${depositKey}`;
+  }
+
+  /**
+   * Returns true when another instance has recorded a pending (possibly still in-flight)
+   * fund-moving broadcast for this depositKey. Markers written by this instance don't defer it:
+   * its in-memory in-flight sets are strictly better informed, and blocking on our own marker
+   * would stall the normal retry path after a failed submit.
+   */
+  private async hasForeignPendingExecution(depositKey: string): Promise<boolean> {
+    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    const owner = await this.redisCache.get<string>(this.getPendingExecutionRedisKey(depositKey));
+    return isDefined(owner) && owner !== this.config.runIdentifier;
+  }
+
+  /**
+   * Persists the pending-execution marker. MUST be awaited immediately before every fund-moving
+   * broadcast: if this instance dies between broadcast and persisting the executed marker, the
+   * marker is the only thing standing between the successor and a replayed execution. A failure
+   * here must abort the broadcast attempt (callers return without submitting).
+   */
+  private async markPendingExecution(depositKey: string): Promise<void> {
+    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    await this.redisCache.set(
+      this.getPendingExecutionRedisKey(depositKey),
+      this.config.runIdentifier,
+      PENDING_EXECUTION_EXPIRY
+    );
+  }
+
+  /**
+   * Clears the pending-execution marker after the confirmed execution has been persisted to the
+   * executed set. Best-effort: on failure the marker expires via its TTL. Never call this after
+   * a failed submit — a "failed" sendAndConfirm may still have broadcast (confirmation failure),
+   * so the marker must outlive it.
+   */
+  private async clearPendingExecution(depositKey: string): Promise<void> {
+    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    try {
+      await this.redisCache.del(this.getPendingExecutionRedisKey(depositKey));
+    } catch (err) {
+      this.logger.warn({
+        at: "DepositAddressHandler#clearPendingExecution",
+        message: "Failed to clear pending-execution marker; it will expire via TTL",
+        depositKey,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Guards a fund-moving broadcast: bails when a handover was observed mid-message (the
+   * successor re-evaluates from scratch — a broadcast from a ceding instance is how replays
+   * happen), then persists the pending-execution marker. Returns false when the caller must NOT
+   * broadcast.
+   */
+  private async preBroadcastCheckpoint(depositKey: string, at: string): Promise<boolean> {
+    if (this.abortController.signal.aborted) {
+      this.logger.debug({
+        at,
+        message: "Skipping broadcast: handover/shutdown observed, leaving execution to the successor",
+        depositKey,
+      });
+      return false;
+    }
+    try {
+      await this.markPendingExecution(depositKey);
+    } catch (err) {
+      this.logger.warn({
+        at,
+        message: "Skipping broadcast: failed to persist pending-execution marker",
+        depositKey,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }
+    return true;
+  }
+
+  /** Thin wrapper over sendAndConfirmTransaction so unit tests can stub the broadcast. */
+  protected sendAndConfirm(tx: AugmentedTransaction, useDispatcher: boolean): Promise<TransactionReceipt | undefined> {
+    return sendAndConfirmTransaction(tx, this.transactionClient, useDispatcher);
   }
 
   /**
@@ -517,6 +713,18 @@ export class DepositAddressHandler {
       return;
     }
 
+    // Defer while another instance may have a broadcast in flight for this transfer (it crashed
+    // or is still draining); the marker expires via TTL if that instance never resolves it.
+    if (await this.hasForeignPendingExecution(depositKey)) {
+      this.logger.debug({
+        at: "DepositAddressHandler#initiateWithdraw",
+        message: "Skipping withdraw: pending-execution marker held by another instance",
+        refTxHash,
+        depositKey,
+      });
+      return;
+    }
+
     if (this.observedExecutedWithdraws[chainId]?.has(depositKey)) {
       return;
     }
@@ -600,8 +808,13 @@ export class DepositAddressHandler {
         )} (classification: ${erc20Transfer.transferClassification}, bundledDeploy: ${signed.bundledDeploy})`,
       };
 
-      const receipt = await sendAndConfirmTransaction(withdrawTx, this.transactionClient, useDispatcher);
+      if (!(await this.preBroadcastCheckpoint(depositKey, "DepositAddressHandler#initiateWithdraw"))) {
+        return;
+      }
+      const receipt = await this.sendAndConfirm(withdrawTx, useDispatcher);
       if (!isDefined(receipt)) {
+        // Pending marker intentionally left: the tx may still have broadcast (confirmation
+        // failure), so let the TTL expire it rather than invite a cross-instance replay.
         this.logger.warn({
           at: "DepositAddressHandler#initiateWithdraw",
           message: "Failed to submit withdraw tx",
@@ -618,6 +831,7 @@ export class DepositAddressHandler {
       this.executedWithdrawKeys.add(depositKey);
       withdrawCommitted = true;
       await this._persistWithdrawnKeysRedis();
+      await this.clearPendingExecution(depositKey);
       await this._publishWithdrawExecuted(receipt, depositMessage);
     } finally {
       if (!withdrawCommitted) {
@@ -861,6 +1075,18 @@ export class DepositAddressHandler {
       return;
     }
 
+    // Defer while another instance may have a broadcast in flight for this transfer (it crashed
+    // or is still draining); the marker expires via TTL if that instance never resolves it.
+    if (await this.hasForeignPendingExecution(depositKey)) {
+      this.logger.debug({
+        at: "DepositAddressHandler#initiateDeposit",
+        message: "Skipping deposit: pending-execution marker held by another instance",
+        refTxHash,
+        depositKey,
+      });
+      return;
+    }
+
     if (this.observedExecutedDeposits[originChainId]?.has(depositKey)) {
       return;
     }
@@ -926,7 +1152,9 @@ export class DepositAddressHandler {
         )}`,
       };
 
-      const deployReceipt = await sendAndConfirmTransaction(deployTx, this.transactionClient, useDispatcher);
+      // No pending-execution marker for the deploy: it moves no funds and a replay is guarded
+      // by the isContractDeployed check (at worst a reverted no-op).
+      const deployReceipt = await this.sendAndConfirm(deployTx, useDispatcher);
       if (!isDefined(deployReceipt)) {
         this.observedExecutedDeposits[originChainId].delete(depositKey);
         this.logger.warn({
@@ -971,9 +1199,15 @@ export class DepositAddressHandler {
       )} (cctpExecutionFee: ${cctpExecutionFee}, spokePoolExecutionFee: ${spokePoolExecutionFee})`,
     };
 
-    const depositReceipt = await sendAndConfirmTransaction(executeTx, this.transactionClient, useDispatcher);
+    if (!(await this.preBroadcastCheckpoint(depositKey, "DepositAddressHandler#initiateDeposit"))) {
+      this.observedExecutedDeposits[originChainId].delete(depositKey);
+      return;
+    }
+    const depositReceipt = await this.sendAndConfirm(executeTx, useDispatcher);
 
     if (!depositReceipt) {
+      // Pending marker intentionally left: the tx may still have broadcast (confirmation
+      // failure), so let the TTL expire it rather than invite a cross-instance replay.
       this.logger.warn({
         at: "DepositAddressHandler#initiateDeposit",
         message: "Failed to submit execute tx",
@@ -990,6 +1224,7 @@ export class DepositAddressHandler {
     // Persist full set to Redis immediately so handover cannot miss this execute.
     this.executedDepositTxHashes.add(refTxHash);
     await this._persistExecutedDepositsRedis();
+    await this.clearPendingExecution(depositKey);
   }
 
   /**
@@ -1016,6 +1251,18 @@ export class DepositAddressHandler {
       this.logger.debug({
         at: "DepositAddressHandler#initiateDepositV3",
         message: "Skipping already executed deposit (found in Redis)",
+        refTxHash,
+        depositKey,
+      });
+      return;
+    }
+
+    // Defer while another instance may have a broadcast in flight for this transfer (it crashed
+    // or is still draining); the marker expires via TTL if that instance never resolves it.
+    if (await this.hasForeignPendingExecution(depositKey)) {
+      this.logger.debug({
+        at: "DepositAddressHandler#initiateDepositV3",
+        message: "Skipping deposit: pending-execution marker held by another instance",
         refTxHash,
         depositKey,
       });
@@ -1108,8 +1355,13 @@ export class DepositAddressHandler {
         )}, using deposit address ${blockExplorerLink(depositAddress, originChainId)}`,
       };
 
-      const depositReceipt = await sendAndConfirmTransaction(executeTx, this.transactionClient, useDispatcher);
+      if (!(await this.preBroadcastCheckpoint(depositKey, "DepositAddressHandler#initiateDepositV3"))) {
+        return;
+      }
+      const depositReceipt = await this.sendAndConfirm(executeTx, useDispatcher);
       if (!isDefined(depositReceipt)) {
+        // Pending marker intentionally left: the tx may still have broadcast (confirmation
+        // failure), so let the TTL expire it rather than invite a cross-instance replay.
         this.logger.warn({
           at: "DepositAddressHandler#initiateDepositV3",
           message: "Failed to submit execute tx",
@@ -1127,6 +1379,7 @@ export class DepositAddressHandler {
       this.executedDepositTxHashes.add(refTxHash);
       executeCommitted = true;
       await this._persistExecutedDepositsRedis();
+      await this.clearPendingExecution(depositKey);
       await this._publishDepositExecuted(depositReceipt, depositMessage);
     } finally {
       if (!executeCommitted) {
@@ -1308,6 +1561,18 @@ export class DepositAddressHandler {
       return;
     }
 
+    // Defer while another instance may have a broadcast in flight for this transfer (it crashed
+    // or is still draining); the marker expires via TTL if that instance never resolves it.
+    if (await this.hasForeignPendingExecution(depositKey)) {
+      this.logger.debug({
+        at: "DepositAddressHandler#initiateWithdrawV3",
+        message: "Skipping withdraw: pending-execution marker held by another instance",
+        refTxHash,
+        depositKey,
+      });
+      return;
+    }
+
     if (this.observedExecutedWithdraws[chainId]?.has(depositKey)) {
       return;
     }
@@ -1430,8 +1695,13 @@ export class DepositAddressHandler {
         }, bundledDeploy: ${signed.bundledDeploy})`,
       };
 
-      const receipt = await sendAndConfirmTransaction(withdrawTx, this.transactionClient, useDispatcher);
+      if (!(await this.preBroadcastCheckpoint(depositKey, "DepositAddressHandler#initiateWithdrawV3"))) {
+        return;
+      }
+      const receipt = await this.sendAndConfirm(withdrawTx, useDispatcher);
       if (!isDefined(receipt)) {
+        // Pending marker intentionally left: the tx may still have broadcast (confirmation
+        // failure), so let the TTL expire it rather than invite a cross-instance replay.
         this.logger.warn({
           at: "DepositAddressHandler#initiateWithdrawV3",
           message: "Failed to submit withdraw tx",
@@ -1448,6 +1718,7 @@ export class DepositAddressHandler {
       this.executedWithdrawKeys.add(depositKey);
       withdrawCommitted = true;
       await this._persistWithdrawnKeysRedis();
+      await this.clearPendingExecution(depositKey);
       await this._publishWithdrawExecuted(receipt, depositMessage);
     } finally {
       if (!withdrawCommitted) {

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -115,6 +115,15 @@ export class DepositAddressHandler {
   private initialized = false;
   private consecutiveHeartbeatFailures = 0;
 
+  /**
+   * True once a handover/shutdown has been observed — including during initialize(), which cedes
+   * without loading state when the abort fires (or a newer instance takes the lease) while it is
+   * blocked on the predecessor drain. The caller must not start polling in that case.
+   */
+  public get aborted(): boolean {
+    return this.abortController.signal.aborted;
+  }
+
   // instanceCoordinator is populated by initialize(); reads pre-init throw, writes go through the setter.
   private get instanceCoordinator(): InstanceCoordinator {
     assert(
@@ -244,10 +253,31 @@ export class DepositAddressHandler {
       this.abortController
     );
     const predecessor = await this.instanceCoordinator.initiateHandover();
-    const predecessorDrained = await this.instanceCoordinator.waitForPredecessorDrain(
-      predecessor,
-      HANDOVER_TAKEOVER_TIMEOUT
-    );
+    // Heartbeat while blocked on the predecessor: it stops its own watchdog the moment it
+    // observes this takeover, and this wait can exceed the ~60s Checkly alert window — a healthy
+    // handover must not page as a dead bot.
+    const drainWaitHeartbeat = new AbortController();
+    scheduleTask(() => this.kickWatchdog(), this.config.watchdogInterval, drainWaitHeartbeat.signal);
+    let predecessorDrained: boolean;
+    try {
+      predecessorDrained = await this.instanceCoordinator.waitForPredecessorDrain(
+        predecessor,
+        HANDOVER_TAKEOVER_TIMEOUT
+      );
+    } finally {
+      drainWaitHeartbeat.abort();
+    }
+    // waitForPredecessorDrain also returns false when this handler's own abort signal fires
+    // (SIGHUP/disconnect during the wait). That is a shutdown, not a takeover timeout: cede
+    // without loading state — the caller checks `aborted` and must not start polling.
+    if (this.abortController.signal.aborted) {
+      this.logger.debug({
+        at: "DepositAddressHandler#initialize",
+        message: "Shutdown observed while waiting for predecessor drain; ceding without starting.",
+        predecessor,
+      });
+      return;
+    }
     if (!predecessorDrained) {
       this.logger.warn({
         at: "DepositAddressHandler#initialize",
@@ -256,6 +286,18 @@ export class DepositAddressHandler {
         predecessor,
         timeoutSeconds: HANDOVER_TAKEOVER_TIMEOUT,
       });
+    }
+    // A newer instance may have taken the lease while this one was blocked here; polling would
+    // then run executions from a stale instance until waitForDisconnect's next 1s subscribe poll
+    // notices the newer lease. Cede immediately instead.
+    if (!(await this.instanceCoordinator.isActiveInstance())) {
+      this.logger.warn({
+        at: "DepositAddressHandler#initialize",
+        message: "Another instance took over while waiting for predecessor drain; ceding without starting.",
+        predecessor,
+      });
+      this.abortController.abort();
+      return;
     }
 
     await this._loadExecutedDepositsFromRedis();
@@ -527,6 +569,10 @@ export class DepositAddressHandler {
    * fund-moving broadcast for this depositKey. Markers written by this instance don't defer it:
    * its in-memory in-flight sets are strictly better informed, and blocking on our own marker
    * would stall the normal retry path after a failed submit.
+   *
+   * Advisory pre-filter only — it saves the API/chain reads that follow, but a concurrent
+   * instance can write its marker after this read. The authoritative guard is the atomic
+   * acquisition in preBroadcastCheckpoint.
    */
   private async hasForeignPendingExecution(depositKey: string): Promise<boolean> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
@@ -535,30 +581,39 @@ export class DepositAddressHandler {
   }
 
   /**
-   * Persists the pending-execution marker. MUST be awaited immediately before every fund-moving
-   * broadcast: if this instance dies between broadcast and persisting the executed marker, the
-   * marker is the only thing standing between the successor and a replayed execution. A failure
-   * here must abort the broadcast attempt (callers return without submitting).
+   * Atomically acquires the pending-execution marker; returns false when another instance owns
+   * it, in which case the caller must NOT broadcast. MUST be awaited immediately before every
+   * fund-moving broadcast: if this instance dies between broadcast and persisting the executed
+   * marker, the marker is the only thing standing between the successor and a replayed execution,
+   * and two live instances racing the same transfer (overlapping replacement starts, or a
+   * takeover timeout while the old process still runs) must not both proceed past it.
+   *
+   * SET NX first; on conflict, re-take the marker only if it is already this instance's own — a
+   * failed submit intentionally leaves the marker in place (see clearPendingExecution), so the
+   * same-instance retry path must be able to re-acquire it.
    */
-  private async markPendingExecution(depositKey: string): Promise<void> {
+  private async acquirePendingExecution(depositKey: string): Promise<boolean> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
-    await this.redisCache.set(
-      this.getPendingExecutionRedisKey(depositKey),
-      this.config.runIdentifier,
-      PENDING_EXECUTION_EXPIRY
+    const redisKey = this.getPendingExecutionRedisKey(depositKey);
+    const ttlMs = PENDING_EXECUTION_EXPIRY * 1000;
+    return (
+      (await this.redisCache.acquireLock(redisKey, this.config.runIdentifier, ttlMs)) ||
+      (await this.redisCache.renewLock(redisKey, this.config.runIdentifier, ttlMs))
     );
   }
 
   /**
-   * Clears the pending-execution marker after the confirmed execution has been persisted to the
-   * executed set. Best-effort: on failure the marker expires via its TTL. Never call this after
-   * a failed submit — a "failed" sendAndConfirm may still have broadcast (confirmation failure),
-   * so the marker must outlive it.
+   * Releases the pending-execution marker after the confirmed execution has been persisted to the
+   * executed set. Ownership-checked (compare-and-delete): if this instance's marker expired
+   * mid-flight and another instance has since acquired the key, that marker is left intact.
+   * Best-effort: on failure the marker expires via its TTL. Never call this after a failed
+   * submit — a "failed" sendAndConfirm may still have broadcast (confirmation failure), so the
+   * marker must outlive it.
    */
   private async clearPendingExecution(depositKey: string): Promise<void> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
     try {
-      await this.redisCache.del(this.getPendingExecutionRedisKey(depositKey));
+      await this.redisCache.releaseLock(this.getPendingExecutionRedisKey(depositKey), this.config.runIdentifier);
     } catch (err) {
       this.logger.warn({
         at: "DepositAddressHandler#clearPendingExecution",
@@ -572,8 +627,8 @@ export class DepositAddressHandler {
   /**
    * Guards a fund-moving broadcast: bails when a handover was observed mid-message (the
    * successor re-evaluates from scratch — a broadcast from a ceding instance is how replays
-   * happen), then persists the pending-execution marker. Returns false when the caller must NOT
-   * broadcast.
+   * happen), then atomically acquires the pending-execution marker. Returns false when the
+   * caller must NOT broadcast.
    */
   private async preBroadcastCheckpoint(depositKey: string, at: string): Promise<boolean> {
     if (this.abortController.signal.aborted) {
@@ -585,7 +640,16 @@ export class DepositAddressHandler {
       return false;
     }
     try {
-      await this.markPendingExecution(depositKey);
+      // Atomic: two live instances can both pass the earlier hasForeignPendingExecution read for
+      // the same transfer; only the one that wins the marker may broadcast.
+      if (!(await this.acquirePendingExecution(depositKey))) {
+        this.logger.debug({
+          at,
+          message: "Skipping broadcast: pending-execution marker acquired by another instance",
+          depositKey,
+        });
+        return false;
+      }
     } catch (err) {
       this.logger.warn({
         at,

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -12,7 +12,9 @@ import {
   getProvider,
   Contract,
   abortableDelay,
-  sendAndConfirmTransaction,
+  submitTransaction,
+  dispatchTransaction,
+  TransactionResponse,
   getCounterfactualDepositFactory,
   buildDeployTx,
   toBN,
@@ -101,6 +103,14 @@ const HANDOVER_DRAIN_TIMEOUT = 90;
 const PENDING_EXECUTION_EXPIRY = 900;
 
 /**
+ * Interval (seconds) between renewals of held pending-execution locks while the outgoing
+ * instance drains in-flight work. Locks are TTL'd from their acquisition, not from the
+ * handover, so a broadcast already in flight for most of the TTL would otherwise lose its lock
+ * mid-drain. Each renewal restores the full TTL; TTL/3 leaves two missed renewals of slack.
+ */
+const PENDING_LOCK_RENEWAL_INTERVAL = PENDING_EXECUTION_EXPIRY / 3;
+
+/**
  * TTL (seconds) on the persisted committed-execution sets, refreshed on every write. Only
  * relevant after a bot is decommissioned (live sets are rewritten constantly); must comfortably
  * exceed the indexer's message redelivery horizon.
@@ -144,6 +154,13 @@ export class DepositAddressHandler {
    * these may still be between broadcast and Redis persist — see drainInFlightWork().
    */
   private inFlightTicks: Set<Promise<unknown>> = new Set();
+
+  /**
+   * depositKeys whose pending-execution lock this instance currently holds — added on acquire,
+   * removed on every release path. A key whose submit outcome is unknown stays here (its lock is
+   * deliberately kept), so a drain can renew exactly the locks that guard possible broadcasts.
+   */
+  private heldPendingLocks: Set<string> = new Set();
 
   /** Per chainId: set of deposit keys already executed (like gasless depositNonces). */
   private observedExecutedDeposits: { [chainId: number]: Set<string> } = {};
@@ -322,18 +339,18 @@ export class DepositAddressHandler {
   }
 
   /**
-   * Loads a persisted committed set (native Redis set under the v2 key), migrating from the
-   * legacy JSON-array key when the v2 set is empty (first boot on this format, or a set fully
-   * pruned since). The legacy key is left in place for rollback; it expires via its own TTL, and
-   * any stale entries it re-seeds are pruned again within one poll.
+   * Loads a persisted committed set (native Redis set under the v2 key), union-merging the
+   * legacy JSON-array key into it on EVERY boot — not only when the v2 set is empty. After a
+   * rollback, the previous build commits executions only to the legacy key while the v2 set
+   * (still populated, 14d TTL) sits stale; skipping the merge on re-upgrade would drop those
+   * legacy-only commits forever and make them replayable. The same holds for an interrupted
+   * first migration. The legacy key is left in place for rollback; any stale entries it re-seeds
+   * are pruned again within one poll.
    */
   private async _loadPersistedSet(redisKey: string, legacyRedisKey: string): Promise<Set<string>> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
     const { redisCache } = this;
     const members = new Set(await redisCache.sMembers(redisKey));
-    if (members.size > 0) {
-      return members;
-    }
 
     const raw = await redisCache.get<string>(legacyRedisKey);
     if (!raw) {
@@ -351,20 +368,22 @@ export class DepositAddressHandler {
       });
       throw err;
     }
-    for (const member of legacyMembers) {
+    const missing = legacyMembers.filter((member) => !members.has(member));
+    for (const member of missing) {
       await redisCache.sAdd(redisKey, member);
       members.add(member);
     }
-    if (members.size > 0) {
+    if (missing.length > 0) {
       await redisCache.expire(redisKey, PERSISTED_SET_EXPIRY);
+      this.logger.debug({
+        at: "DepositAddressHandler#_loadPersistedSet",
+        message: "Merged legacy persisted-set members into the native Redis set",
+        legacyRedisKey,
+        redisKey,
+        merged: missing.length,
+        total: members.size,
+      });
     }
-    this.logger.debug({
-      at: "DepositAddressHandler#_loadPersistedSet",
-      message: "Migrated legacy persisted set to native Redis set",
-      legacyRedisKey,
-      redisKey,
-      count: members.size,
-    });
     return members;
   }
 
@@ -432,39 +451,55 @@ export class DepositAddressHandler {
    * the successor off anything still draining here.
    *
    * The drain is two-phase. Past the expected window (HANDOVER_DRAIN_TIMEOUT) it warns for ops
-   * visibility but keeps waiting — up to the pending-execution lock TTL — rather than returning:
-   * returning tears down this process's Redis clients under a tick that may sit between
-   * broadcast and commit, and a tx that confirms after that teardown leaves no committed record.
-   * Its lock then expires and the successor can replay the transfer against fresh funds (the
-   * 2026-07-20 incident's exact shape). The successor is already serving, so the only cost of
-   * lingering is an old process that lives a little longer.
+   * visibility but keeps waiting — up to one full pending-execution lock TTL — rather than
+   * returning: returning tears down this process's Redis clients under a tick that may sit
+   * between broadcast and commit, and a tx that confirms after that teardown leaves no committed
+   * record. Its lock then expires and the successor can replay the transfer against fresh funds
+   * (the 2026-07-20 incident's exact shape). The successor is already serving, so the only cost
+   * of lingering is an old process that lives a little longer.
+   *
+   * Held locks are renewed throughout the drain (immediately, then on an interval): each lock's
+   * TTL runs from ITS acquisition, not from the handover, so a broadcast already in flight for
+   * most of the TTL would otherwise lose its lock mid-drain — and the successor would acquire
+   * the expired key against a still-empty committed set and double-submit. The final renewal
+   * also leaves any unresolved lock a full TTL of successor deferral after this process exits.
    */
   public async waitForDisconnect(): Promise<void> {
     await this.instanceCoordinator.subscribe();
     this.abortController.abort();
-    const drained = await this.drainInFlightWork(HANDOVER_DRAIN_TIMEOUT);
-    if (!drained) {
-      this.logger.warn({
-        at: "DepositAddressHandler#waitForDisconnect",
-        message:
-          "In-flight work did not settle within the expected drain window; holding Redis open up to the lock TTL so a late-confirming broadcast can still commit.",
-        inFlightTicks: this.inFlightTicks.size,
-        expectedDrainSeconds: HANDOVER_DRAIN_TIMEOUT,
-      });
-      const stillNotDrained = !(await this.drainInFlightWork(PENDING_EXECUTION_EXPIRY - HANDOVER_DRAIN_TIMEOUT));
-      if (stillNotDrained) {
-        // Past the lock TTL a commit no longer beats the successor's next acquire attempt, so
-        // there is nothing left to protect by lingering. This should never happen — it means an
-        // RPC/API call has hung for the full TTL without settling.
-        this.logger.error({
+    await this.renewHeldPendingLocks();
+    const lockRenewal = new AbortController();
+    scheduleTask(() => this.renewHeldPendingLocks(), PENDING_LOCK_RENEWAL_INTERVAL, lockRenewal.signal);
+    try {
+      const drained = await this.drainInFlightWork(HANDOVER_DRAIN_TIMEOUT);
+      if (!drained) {
+        this.logger.warn({
           at: "DepositAddressHandler#waitForDisconnect",
           message:
-            "In-flight work still unsettled after the pending-execution lock TTL; exiting. Any broadcast in that work is now unguarded — reconcile manually.",
+            "In-flight work did not settle within the expected drain window; holding Redis open up to the lock TTL so a late-confirming broadcast can still commit.",
           inFlightTicks: this.inFlightTicks.size,
-          totalWaitSeconds: PENDING_EXECUTION_EXPIRY,
-          notificationPath: "across-bot-error",
+          expectedDrainSeconds: HANDOVER_DRAIN_TIMEOUT,
         });
+        const stillNotDrained = !(await this.drainInFlightWork(PENDING_EXECUTION_EXPIRY - HANDOVER_DRAIN_TIMEOUT));
+        if (stillNotDrained) {
+          // This should never happen — it means an RPC/API call has hung for a full lock TTL
+          // without settling. Exit rather than linger forever; the final renewal below keeps the
+          // successor deferred from any possible broadcast for one more TTL.
+          this.logger.error({
+            at: "DepositAddressHandler#waitForDisconnect",
+            message:
+              "In-flight work still unsettled after a full pending-execution lock TTL; exiting. Any broadcast in that work stays lock-deferred for one more TTL — reconcile manually.",
+            inFlightTicks: this.inFlightTicks.size,
+            totalWaitSeconds: PENDING_EXECUTION_EXPIRY,
+            notificationPath: "across-bot-error",
+          });
+        }
       }
+    } finally {
+      lockRenewal.abort();
+      // One last renewal so whatever remains unresolved defers the successor for a full TTL
+      // from NOW, not from whenever the renewal interval last fired.
+      await this.renewHeldPendingLocks();
     }
   }
 
@@ -645,6 +680,7 @@ export class DepositAddressHandler {
    */
   private async releasePendingExecution(depositKey: string): Promise<void> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    this.heldPendingLocks.delete(depositKey);
     try {
       await this.redisCache.releaseLock(this.getPendingExecutionRedisKey(depositKey), this.config.runIdentifier);
     } catch (err) {
@@ -654,6 +690,32 @@ export class DepositAddressHandler {
         depositKey,
         err: err instanceof Error ? err.message : String(err),
       });
+    }
+  }
+
+  /**
+   * Renews (token-guarded, best-effort) every pending-execution lock this instance still holds,
+   * restoring the full TTL. Only invoked while draining through a handover: locks are TTL'd from
+   * their acquisition, so a broadcast already in flight for most of the TTL would otherwise lose
+   * its lock mid-drain — the successor then acquires the expired key against a still-empty
+   * committed set and can double-submit the sweep. In steady state the original TTL comfortably
+   * outlives a broadcast→confirmation window, so no renewal runs.
+   */
+  private async renewHeldPendingLocks(): Promise<void> {
+    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    const { redisCache } = this;
+    const ttlMs = PENDING_EXECUTION_EXPIRY * 1000;
+    for (const depositKey of [...this.heldPendingLocks]) {
+      try {
+        await redisCache.renewLock(this.getPendingExecutionRedisKey(depositKey), this.config.runIdentifier, ttlMs);
+      } catch (err) {
+        this.logger.warn({
+          at: "DepositAddressHandler#renewHeldPendingLocks",
+          message: "Failed to renew held pending-execution lock; it keeps whatever TTL remains",
+          depositKey,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
   }
 
@@ -706,6 +768,7 @@ export class DepositAddressHandler {
         });
         return false;
       }
+      this.heldPendingLocks.add(depositKey);
       if (await redisCache.sIsMember(committedSetKey, committedMember)) {
         this.logger.debug({
           at,
@@ -713,6 +776,7 @@ export class DepositAddressHandler {
           depositKey,
           committedMember,
         });
+        this.heldPendingLocks.delete(depositKey);
         await redisCache.releaseLock(pendingKey, runIdentifier);
         return false;
       }
@@ -723,6 +787,7 @@ export class DepositAddressHandler {
       // broadcast, so releasing the just-acquired lock is safe and spares the successor the TTL
       // defer.
       if (this.abortController.signal.aborted) {
+        this.heldPendingLocks.delete(depositKey);
         await redisCache.releaseLock(pendingKey, runIdentifier);
         this.logger.debug({
           at,
@@ -743,9 +808,38 @@ export class DepositAddressHandler {
     }
   }
 
-  /** Thin wrapper over sendAndConfirmTransaction so unit tests can stub the broadcast. */
-  protected sendAndConfirm(tx: AugmentedTransaction, useDispatcher: boolean): Promise<TransactionReceipt | undefined> {
-    return sendAndConfirmTransaction(tx, this.transactionClient, useDispatcher);
+  /**
+   * Thin wrapper over the submit/confirm pipeline (mirrors sendAndConfirmTransaction) so unit
+   * tests can stub the broadcast — and so failures classify. Pre-flight simulation failures
+   * throw before anything is signed or sent, so a caller holding the pending-execution lock may
+   * safely release it and keep the fast retry path (`mayHaveBroadcast: false`). Everything past
+   * simulation — a submit/dispatch throw, or a confirmation failure — may have reached the
+   * network and reports `mayHaveBroadcast: true`. Classification matches the simulation error
+   * message from TransactionUtils; if that message ever changes upstream, this degrades in the
+   * safe direction (a no-broadcast failure gets deferred, never the reverse).
+   */
+  protected async sendAndConfirm(
+    tx: AugmentedTransaction,
+    useDispatcher: boolean
+  ): Promise<{ receipt: TransactionReceipt | undefined; mayHaveBroadcast: boolean }> {
+    const txWithConfirmation: AugmentedTransaction = { ...tx, ensureConfirmation: true };
+    let txResponse: TransactionResponse | undefined;
+    try {
+      txResponse = useDispatcher
+        ? await dispatchTransaction(txWithConfirmation, this.transactionClient)
+        : await submitTransaction(txWithConfirmation, this.transactionClient);
+    } catch (err) {
+      const knownNoBroadcast = err instanceof Error && err.message.startsWith("Failed to simulate");
+      return { receipt: undefined, mayHaveBroadcast: !knownNoBroadcast };
+    }
+    if (!isDefined(txResponse)) {
+      return { receipt: undefined, mayHaveBroadcast: true };
+    }
+    try {
+      return { receipt: await txResponse.wait(), mayHaveBroadcast: true };
+    } catch {
+      return { receipt: undefined, mayHaveBroadcast: true };
+    }
   }
 
   /**
@@ -964,14 +1058,20 @@ export class DepositAddressHandler {
       ) {
         return;
       }
-      const receipt = await this.sendAndConfirm(withdrawTx, useDispatcher);
+      const { receipt, mayHaveBroadcast } = await this.sendAndConfirm(withdrawTx, useDispatcher);
       if (!isDefined(receipt)) {
-        // Pending-execution lock intentionally kept: the tx may still have broadcast
-        // (confirmation failure), so let the TTL expire it rather than invite a replay. The lock
-        // defers ALL retries — this instance's included — until the outcome window has passed.
+        if (!mayHaveBroadcast) {
+          // Pre-flight simulation failed before anything was signed or sent: release the lock so
+          // the normal fast retry path applies on the next poll.
+          await this.releasePendingExecution(depositKey);
+        }
+        // Otherwise the lock is intentionally kept: the tx may still have broadcast (confirmation
+        // failure), so let the TTL expire it rather than invite a replay — it defers ALL retries,
+        // this instance's included, until the outcome window has passed.
         this.logger.warn({
           at: "DepositAddressHandler#initiateWithdraw",
           message: "Failed to submit withdraw tx",
+          mayHaveBroadcast,
           depositKey,
           refTxHash,
           depositAddress,
@@ -1314,7 +1414,7 @@ export class DepositAddressHandler {
 
       // No pending-execution marker for the deploy: it moves no funds and a replay is guarded
       // by the isContractDeployed check (at worst a reverted no-op).
-      const deployReceipt = await this.sendAndConfirm(deployTx, useDispatcher);
+      const { receipt: deployReceipt } = await this.sendAndConfirm(deployTx, useDispatcher);
       if (!isDefined(deployReceipt)) {
         this.observedExecutedDeposits[originChainId].delete(depositKey);
         this.logger.warn({
@@ -1370,15 +1470,21 @@ export class DepositAddressHandler {
       this.observedExecutedDeposits[originChainId].delete(depositKey);
       return;
     }
-    const depositReceipt = await this.sendAndConfirm(executeTx, useDispatcher);
+    const { receipt: depositReceipt, mayHaveBroadcast } = await this.sendAndConfirm(executeTx, useDispatcher);
 
     if (!depositReceipt) {
-      // Pending-execution lock intentionally kept: the tx may still have broadcast
-      // (confirmation failure), so let the TTL expire it rather than invite a replay. The lock
-      // defers ALL retries — this instance's included — until the outcome window has passed.
+      if (!mayHaveBroadcast) {
+        // Pre-flight simulation failed before anything was signed or sent: release the lock so
+        // the normal fast retry path applies on the next poll.
+        await this.releasePendingExecution(depositKey);
+      }
+      // Otherwise the lock is intentionally kept: the tx may still have broadcast (confirmation
+      // failure), so let the TTL expire it rather than invite a replay — it defers ALL retries,
+      // this instance's included, until the outcome window has passed.
       this.logger.warn({
         at: "DepositAddressHandler#initiateDeposit",
         message: "Failed to submit execute tx",
+        mayHaveBroadcast,
         depositKey,
         executeTx: {
           ...executeTx,
@@ -1539,14 +1645,20 @@ export class DepositAddressHandler {
       ) {
         return;
       }
-      const depositReceipt = await this.sendAndConfirm(executeTx, useDispatcher);
+      const { receipt: depositReceipt, mayHaveBroadcast } = await this.sendAndConfirm(executeTx, useDispatcher);
       if (!isDefined(depositReceipt)) {
-        // Pending-execution lock intentionally kept: the tx may still have broadcast
-        // (confirmation failure), so let the TTL expire it rather than invite a replay. The lock
-        // defers ALL retries — this instance's included — until the outcome window has passed.
+        if (!mayHaveBroadcast) {
+          // Pre-flight simulation failed before anything was signed or sent: release the lock so
+          // the normal fast retry path applies on the next poll.
+          await this.releasePendingExecution(depositKey);
+        }
+        // Otherwise the lock is intentionally kept: the tx may still have broadcast (confirmation
+        // failure), so let the TTL expire it rather than invite a replay — it defers ALL retries,
+        // this instance's included, until the outcome window has passed.
         this.logger.warn({
           at: "DepositAddressHandler#initiateDepositV3",
           message: "Failed to submit execute tx",
+          mayHaveBroadcast,
           depositKey,
           executeTx: {
             ...executeTx,
@@ -1893,14 +2005,20 @@ export class DepositAddressHandler {
       ) {
         return;
       }
-      const receipt = await this.sendAndConfirm(withdrawTx, useDispatcher);
+      const { receipt, mayHaveBroadcast } = await this.sendAndConfirm(withdrawTx, useDispatcher);
       if (!isDefined(receipt)) {
-        // Pending-execution lock intentionally kept: the tx may still have broadcast
-        // (confirmation failure), so let the TTL expire it rather than invite a replay. The lock
-        // defers ALL retries — this instance's included — until the outcome window has passed.
+        if (!mayHaveBroadcast) {
+          // Pre-flight simulation failed before anything was signed or sent: release the lock so
+          // the normal fast retry path applies on the next poll.
+          await this.releasePendingExecution(depositKey);
+        }
+        // Otherwise the lock is intentionally kept: the tx may still have broadcast (confirmation
+        // failure), so let the TTL expire it rather than invite a replay — it defers ALL retries,
+        // this instance's included, until the outcome window has passed.
         this.logger.warn({
           at: "DepositAddressHandler#initiateWithdrawV3",
           message: "Failed to submit withdraw tx",
+          mayHaveBroadcast,
           depositKey,
           refTxHash,
           depositAddress,

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -61,7 +61,10 @@ Three mechanisms close the window:
    same-instance retry path after a failed submit is unaffected — and refuses to broadcast unless
    it wins the marker. Acquisition being atomic means two live instances racing the same transfer
    (overlapping replacement starts, or a takeover timeout while the old process still runs) cannot
-   both broadcast. The marker is released (compare-and-delete on ownership, never a blind DEL)
+   both broadcast. The abort signal is checked on both sides of the acquisition: a marker write
+   that straddles the handover (a slow write can outlive the predecessor's drain timeout, after
+   which the successor has been signalled to start) is released and the broadcast skipped. The
+   marker is otherwise released (compare-and-delete on ownership, never a blind DEL)
    only after the confirmed execution has been persisted to the executed set. Every
    execute/withdraw path also defers early on a transfer whose marker is held by **another**
    instance, saving the API/chain reads; after a failed submit the marker is intentionally left to

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -46,7 +46,10 @@ Three mechanisms make the overlap safe:
    transfer; a token-guarded renew covers this instance's own retries, so the same-instance retry
    path is unaffected. Under the lock, the handler re-checks the committed set (`SISMEMBER`)
    before broadcasting — catching an execution the other instance committed and released between
-   this tick's refresh and now. The lock is released only after the confirmed execution is
+   this tick's refresh and now — and re-checks the abort signal, since a handover/shutdown can
+   land while the acquire round-trip is pending (nothing was broadcast, so the just-acquired lock
+   is released rather than left to defer the successor for the full TTL). The lock is released
+   only after the confirmed execution is
    committed; after a failed submit it is intentionally left to expire via TTL, since a "failed"
    send may still have broadcast. Consequence: if an instance dies mid-flight, the successor
    defers that one transfer for up to 15 minutes instead of risking a replay — a deferred sweep
@@ -56,7 +59,15 @@ Three mechanisms make the overlap safe:
    Redis sets written with per-member `SADD`/`SREM` (atomic — two writers never clobber each
    other, unlike the previous whole-JSON-blob `SET`s), committed immediately after each confirmed
    execution, and re-read (union-merged) into memory at the start of every poll tick so one
-   instance's commits reach the other within a tick.
+   instance's commits reach the other within a tick. Pruning (once the indexer stops returning a
+   message) is snapshot-disciplined: only members already known **before** the tick's indexer
+   snapshot are prune candidates — a member imported by the tick's own refresh may have been
+   committed after the snapshot, so its absence from it proves nothing; it becomes prunable one
+   tick later. A failed indexer poll skips the tick entirely (no refresh, prune, or executions):
+   an outage must never be mistaken for an empty snapshot, which would `SREM` every replay guard.
+   For rollback safety during the v2 rollout, every commit also mirrors the in-memory view into
+   the legacy JSON-blob key that previous builds read; the mirror is transitional and goes away
+   once the rollout settles.
 3. **Drain on the way out.** On observing a handover (or SIGHUP), the outgoing instance aborts
    new work — the poll loop initiates no new executions once the abort signal fires, and a
    pre-broadcast abort check bails mid-message — then waits up to `HANDOVER_DRAIN_TIMEOUT` (90s)
@@ -64,7 +75,10 @@ Three mechanisms make the overlap safe:
    orphaned. Its locks keep the successor off those transfers while it drains; if it dies
    instead, the lock TTL bounds the deferral. A shutdown observed while still inside
    `initialize()` cedes before polling ever starts (the entrypoint checks `relayer.aborted`, and
-   `scheduleTask` refuses to schedule on an already-aborted signal).
+   `scheduleTask` refuses to schedule on an already-aborted signal) — and cedes **without taking
+   the instance lease**, which is deliberately the last step of `initialize()`: an aborted boot
+   that grabbed the lease would make a healthy predecessor exit for nothing, leaving no handler
+   running until the next external restart.
 
 ## Indexer message classification
 

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -19,7 +19,7 @@ The deposit-address handler polls the across-indexer for ERC-20 transfers that h
    warning log to aid diagnosis when the alert fires. Pings stop on handover/shutdown with the
    rest of the handler.
 5. Handover via Redis (`InstanceCoordinator`) — exits cleanly when another instance takes over,
-   after draining in-flight executions (see "Handover alignment" below).
+   after draining in-flight executions (see "Concurrent handover" below).
 
 Poll-loop failures are never silent: `pollAndExecute` passes an error handler to `scheduleTask`, so
 a rejected `evaluateDepositAddresses` tick (which skips that whole batch) is logged at error level
@@ -27,49 +27,44 @@ instead of being swallowed by the scheduler.
 
 Cleanup in the `finally` block closes the Pub/Sub publisher and Redis clients.
 
-## Handover alignment (no replayed executions)
+## Concurrent handover (continuous service, no replayed executions)
 
-Instances rotate every few minutes; the danger window is an execution that has broadcast but not
-yet confirmed + persisted its executed marker when the rotation happens. An instance that exits
-inside that window leaves no record of the broadcast, so its successor replays the sweep once the
-balance check passes again — with fresh funds at the address, that is a double-spend (2026-07-20
-duplicate-sweep incident: a handover orphaned a confirmed 10 USDC sweep, the replacement replayed
-it against the next 20 USDC deposit, and the residual 10 USDC deadlocked at the deposit address).
+Instances rotate every few minutes. The incoming instance starts polling the moment it takes the
+Redis lease — it does **not** wait for its predecessor — so sweep service is continuous through a
+rotation. The outgoing instance keeps draining its in-flight executions concurrently. Two
+instances therefore overlap by design, and replay safety is enforced per transfer rather than by
+serializing the handover (the danger being a double-spend: the 2026-07-20 duplicate-sweep
+incident replayed an orphaned 10 USDC sweep against the next 20 USDC deposit and deadlocked the
+remainder at the deposit address).
 
-Three mechanisms close the window:
+Three mechanisms make the overlap safe:
 
-1. **Drain before ceding (outgoing instance).** On observing a handover (or SIGHUP), the instance
-   aborts new work — the poll loop initiates no new executions once the abort signal fires — then
-   waits up to `HANDOVER_DRAIN_TIMEOUT` (90s) for in-flight poll ticks to settle, so a broadcast
-   tx gets confirmed and its executed marker persisted rather than orphaned. It then signals
-   "drained" through the `InstanceCoordinator` (`<botIdentifier>:drained` in Redis) and exits.
-2. **Wait before starting (incoming instance).** After taking the lease, the new instance waits up
-   to `HANDOVER_TAKEOVER_TIMEOUT` (120s) for its specific predecessor's drained signal **before**
-   loading the persisted sets — loading earlier races the predecessor's final persist. On timeout
-   (predecessor crashed, or predates this protocol) it proceeds with a warning; the markers below
-   still guard anything left in flight. While it waits it kicks the watchdog heartbeat on the
-   usual interval (the predecessor stops its own the moment it observes the takeover), so a slow
-   but healthy handover never pages as a dead bot. The wait has two cede paths: if the instance's
-   own abort signal fired during the wait (SIGHUP/disconnect), or if the lease is no longer held
-   by this instance afterwards (a newer instance took over mid-wait), `initialize()` returns
-   without loading state, the entrypoint skips polling entirely (`relayer.aborted`), and the
-   instance signals drained on its way out so its own successor is not left waiting.
-3. **Pending-execution markers (crash safety).** Immediately before every fund-moving broadcast
-   the handler **atomically acquires** `deposit-address:pending-execution:<botIdentifier>:<depositKey>`
-   (value: the acquiring instance's run identifier, TTL `PENDING_EXECUTION_EXPIRY` = 15 min) via
-   SET NX — falling back to re-taking a marker it already owns (compare-and-expire), so the
-   same-instance retry path after a failed submit is unaffected — and refuses to broadcast unless
-   it wins the marker. Acquisition being atomic means two live instances racing the same transfer
-   (overlapping replacement starts, or a takeover timeout while the old process still runs) cannot
-   both broadcast. The marker is released (compare-and-delete on ownership, never a blind DEL)
-   only after the confirmed execution has been persisted to the executed set. Every
-   execute/withdraw path also defers early on a transfer whose marker is held by **another**
-   instance, saving the API/chain reads; after a failed submit the marker is intentionally left to
-   expire via TTL, since a "failed" send may still have broadcast. Consequence: if an instance
-   dies mid-flight, the successor defers that transfer for up to 15 minutes instead of risking a
-   replay — a deferred sweep is recoverable, a double-spend is not. The deploy tx on the v1
-   deposit path carries no marker: it moves no funds and replays are guarded by the
-   `isContractDeployed` check.
+1. **Per-transfer pending-execution locks.** Immediately before every fund-moving broadcast the
+   handler atomically acquires `deposit-address:pending-execution:<botIdentifier>:<depositKey>`
+   (SET NX; value: the acquiring instance's run identifier, TTL `PENDING_EXECUTION_EXPIRY` =
+   15 min) and refuses to broadcast without it. A lock held by **another** instance defers the
+   transfer; a token-guarded renew covers this instance's own retries, so the same-instance retry
+   path is unaffected. Under the lock, the handler re-checks the committed set (`SISMEMBER`)
+   before broadcasting — catching an execution the other instance committed and released between
+   this tick's refresh and now. The lock is released only after the confirmed execution is
+   committed; after a failed submit it is intentionally left to expire via TTL, since a "failed"
+   send may still have broadcast. Consequence: if an instance dies mid-flight, the successor
+   defers that one transfer for up to 15 minutes instead of risking a replay — a deferred sweep
+   is recoverable, a double-spend is not. The deploy tx on the v1 deposit path carries no lock:
+   it moves no funds and replays are guarded by the `isContractDeployed` check.
+2. **Concurrency-safe committed sets.** The executed/withdrawn/terminal-skip sets are native
+   Redis sets written with per-member `SADD`/`SREM` (atomic — two writers never clobber each
+   other, unlike the previous whole-JSON-blob `SET`s), committed immediately after each confirmed
+   execution, and re-read (union-merged) into memory at the start of every poll tick so one
+   instance's commits reach the other within a tick.
+3. **Drain on the way out.** On observing a handover (or SIGHUP), the outgoing instance aborts
+   new work — the poll loop initiates no new executions once the abort signal fires, and a
+   pre-broadcast abort check bails mid-message — then waits up to `HANDOVER_DRAIN_TIMEOUT` (90s)
+   for in-flight poll ticks to settle, so a broadcast tx gets confirmed and committed rather than
+   orphaned. Its locks keep the successor off those transfers while it drains; if it dies
+   instead, the lock TTL bounds the deferral. A shutdown observed while still inside
+   `initialize()` cedes before polling ever starts (the entrypoint checks `relayer.aborted`, and
+   `scheduleTask` refuses to schedule on an already-aborted signal).
 
 ## Indexer message classification
 
@@ -225,15 +220,17 @@ neither validates nor skips: the deposit address is already deployed from explic
 
 ## Redis persistence
 
-Three sets persist across runs so handover does not double-spend, double-refund, or re-attempt a terminally-skipped refund:
+Three sets persist across runs so handover does not double-spend, double-refund, or re-attempt a terminally-skipped refund. They are **native Redis sets** (per-member `SADD`/`SREM`, safe for two concurrent writer instances):
 
-- `deposit-address:executed:<botIdentifier>` — set of `erc20Transfer.transactionHash` for successfully executed deposits.
-- `deposit-address:withdrawn-deposit-keys:<botIdentifier>` — set of `depositKey` (`depositAddress:transactionHash`) for successfully executed refund withdraws.
-- `deposit-address:skipped-withdraw-keys:<botIdentifier>` — set of `depositKey` for v3 refund withdraws the quote-api rejected with a terminal 422 (`GAS_EXCEEDS_REFUND` / `UNPRICEABLE_REFUND_TOKEN`); never re-attempted.
+- `deposit-address:executed:<botIdentifier>:v2` — set of `erc20Transfer.transactionHash` for successfully executed deposits.
+- `deposit-address:withdrawn-deposit-keys:<botIdentifier>:v2` — set of `depositKey` (`depositAddress:transactionHash`) for successfully executed refund withdraws.
+- `deposit-address:skipped-withdraw-keys:<botIdentifier>:v2` — set of `depositKey` for v3 refund withdraws the quote-api rejected with a terminal 422 (`GAS_EXCEEDS_REFUND` / `UNPRICEABLE_REFUND_TOKEN`); never re-attempted.
 
-On each poll, entries whose source messages are no longer returned by the indexer are pruned — the indexer has its own TTL and stops returning expired messages.
+On boot, an empty `:v2` set is seeded from the legacy JSON-blob key of the same name without the suffix (pre-migration format); the legacy key is left in place for rollback and expires via its own TTL. Set keys refresh a 14-day TTL (`PERSISTED_SET_EXPIRY`) on every commit.
 
-Additionally, per-transfer `deposit-address:pending-execution:<botIdentifier>:<depositKey>` keys (self-expiring, no pruning needed) mark possibly-in-flight broadcasts across instances — see "Handover alignment" above.
+On each poll the sets are re-read from Redis (union-merged into memory, so a concurrent instance's commits are picked up within a tick) and entries whose source messages are no longer returned by the indexer are pruned from memory and Redis — the indexer has its own TTL and stops returning expired messages.
+
+Additionally, per-transfer `deposit-address:pending-execution:<botIdentifier>:<depositKey>` lock keys (self-expiring, no pruning needed) serialize possibly-in-flight broadcasts across instances — see "Concurrent handover" above.
 
 ## Refund-withdraw flow (high level)
 

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -46,8 +46,10 @@ Three mechanisms make the overlap safe:
    foreign one means the other instance may have a broadcast in flight, and an own one only
    survives an unknown-outcome submit (a "failed" `sendAndConfirm` may still have broadcast), so
    retrying against it could submit the same sweep twice while the first tx sits in the mempool.
-   Known-not-broadcast failures never hold a lock (they fail before the checkpoint acquires it),
-   so their fast retry path is unaffected. Under the lock, the handler re-checks the committed
+   Known-no-broadcast failures keep their fast retry path: most fail before the checkpoint ever
+   acquires the lock, and a pre-flight simulation failure inside the submit pipeline (which
+   throws before anything is signed or sent) releases the just-acquired lock immediately —
+   classification errs toward deferral, never toward fast-retrying a possible broadcast. Under the lock, the handler re-checks the committed
    set (`SISMEMBER`)
    before broadcasting — catching an execution the other instance committed and released between
    this tick's refresh and now — and re-checks the abort signal, since a handover/shutdown can
@@ -77,9 +79,13 @@ Three mechanisms make the overlap safe:
    pre-broadcast abort check bails mid-message — then waits for in-flight poll ticks to settle,
    so a broadcast tx gets confirmed and committed rather than orphaned. The wait is two-phase:
    past the expected window (`HANDOVER_DRAIN_TIMEOUT`, 90s) it warns but keeps the process — and
-   its Redis clients — alive up to the pending-execution lock TTL, because exiting would tear
-   Redis down under a tick sitting between broadcast and commit, and a tx confirming after that
-   leaves no committed record for the successor once the lock expires. The successor is already
+   its Redis clients — alive up to one full pending-execution lock TTL, because exiting would
+   tear Redis down under a tick sitting between broadcast and commit, and a tx confirming after
+   that leaves no committed record for the successor once the lock expires. Held locks are
+   renewed throughout the drain (immediately, then every TTL/3): each lock's TTL runs from its
+   acquisition, not from the handover, so a broadcast already in flight for most of the TTL
+   would otherwise lose its lock mid-drain; the final renewal on the way out also leaves any
+   unresolved lock a full TTL of successor deferral. The successor is already
    serving, so a lingering old process costs nothing. Its locks keep the successor off those
    transfers while it drains; if it dies
    instead, the lock TTL bounds the deferral. A shutdown observed while still inside
@@ -249,7 +255,7 @@ Three sets persist across runs so handover does not double-spend, double-refund,
 - `deposit-address:withdrawn-deposit-keys:<botIdentifier>:v2` — set of `depositKey` (`depositAddress:transactionHash`) for successfully executed refund withdraws.
 - `deposit-address:skipped-withdraw-keys:<botIdentifier>:v2` — set of `depositKey` for v3 refund withdraws the quote-api rejected with a terminal 422 (`GAS_EXCEEDS_REFUND` / `UNPRICEABLE_REFUND_TOKEN`); never re-attempted.
 
-On boot, an empty `:v2` set is seeded from the legacy JSON-blob key of the same name without the suffix (pre-migration format); the legacy key is left in place for rollback and expires via its own TTL. Set keys refresh a 14-day TTL (`PERSISTED_SET_EXPIRY`) on every commit.
+On every boot, the legacy JSON-blob key of the same name without the suffix (pre-migration format) is union-merged into the `:v2` set — not only when the set is empty: after a rollback, the legacy build commits only to the blob, and those members would otherwise be lost on re-upgrade. The legacy key is left in place for rollback (each commit mirrors the in-memory view into it) and expires via its own TTL. Set keys refresh a 14-day TTL (`PERSISTED_SET_EXPIRY`) on every commit.
 
 On each poll the sets are re-read from Redis (union-merged into memory, so a concurrent instance's commits are picked up within a tick) and entries whose source messages are no longer returned by the indexer are pruned from memory and Redis — the indexer has its own TTL and stops returning expired messages.
 

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -18,13 +18,47 @@ The deposit-address handler polls the across-indexer for ERC-20 transfers that h
    per request), but every 10th consecutive failure — including non-2xx responses — emits a
    warning log to aid diagnosis when the alert fires. Pings stop on handover/shutdown with the
    rest of the handler.
-5. Handover via Redis (`InstanceCoordinator`) — exits cleanly when another instance takes over.
+5. Handover via Redis (`InstanceCoordinator`) — exits cleanly when another instance takes over,
+   after draining in-flight executions (see "Handover alignment" below).
 
 Poll-loop failures are never silent: `pollAndExecute` passes an error handler to `scheduleTask`, so
 a rejected `evaluateDepositAddresses` tick (which skips that whole batch) is logged at error level
 instead of being swallowed by the scheduler.
 
 Cleanup in the `finally` block closes the Pub/Sub publisher and Redis clients.
+
+## Handover alignment (no replayed executions)
+
+Instances rotate every few minutes; the danger window is an execution that has broadcast but not
+yet confirmed + persisted its executed marker when the rotation happens. An instance that exits
+inside that window leaves no record of the broadcast, so its successor replays the sweep once the
+balance check passes again — with fresh funds at the address, that is a double-spend (2026-07-20
+duplicate-sweep incident: a handover orphaned a confirmed 10 USDC sweep, the replacement replayed
+it against the next 20 USDC deposit, and the residual 10 USDC deadlocked at the deposit address).
+
+Three mechanisms close the window:
+
+1. **Drain before ceding (outgoing instance).** On observing a handover (or SIGHUP), the instance
+   aborts new work — the poll loop initiates no new executions once the abort signal fires — then
+   waits up to `HANDOVER_DRAIN_TIMEOUT` (90s) for in-flight poll ticks to settle, so a broadcast
+   tx gets confirmed and its executed marker persisted rather than orphaned. It then signals
+   "drained" through the `InstanceCoordinator` (`<botIdentifier>:drained` in Redis) and exits.
+2. **Wait before starting (incoming instance).** After taking the lease, the new instance waits up
+   to `HANDOVER_TAKEOVER_TIMEOUT` (120s) for its specific predecessor's drained signal **before**
+   loading the persisted sets — loading earlier races the predecessor's final persist. On timeout
+   (predecessor crashed, or predates this protocol) it proceeds with a warning; the markers below
+   still guard anything left in flight.
+3. **Pending-execution markers (crash safety).** Immediately before every fund-moving broadcast
+   the handler persists `deposit-address:pending-execution:<botIdentifier>:<depositKey>` (value:
+   the writing instance's run identifier, TTL `PENDING_EXECUTION_EXPIRY` = 15 min) and refuses to
+   broadcast if that persist fails. The marker is deleted only after the confirmed execution has
+   been persisted to the executed set. Every execute/withdraw path defers a transfer whose marker
+   is held by **another** instance (own markers don't block, so the normal same-instance retry
+   path is unaffected); after a failed submit the marker is intentionally left to expire via TTL,
+   since a "failed" send may still have broadcast. Consequence: if an instance dies mid-flight,
+   the successor defers that transfer for up to 15 minutes instead of risking a replay — a
+   deferred sweep is recoverable, a double-spend is not. The deploy tx on the v1 deposit path
+   carries no marker: it moves no funds and replays are guarded by the `isContractDeployed` check.
 
 ## Indexer message classification
 
@@ -187,6 +221,8 @@ Three sets persist across runs so handover does not double-spend, double-refund,
 - `deposit-address:skipped-withdraw-keys:<botIdentifier>` — set of `depositKey` for v3 refund withdraws the quote-api rejected with a terminal 422 (`GAS_EXCEEDS_REFUND` / `UNPRICEABLE_REFUND_TOKEN`); never re-attempted.
 
 On each poll, entries whose source messages are no longer returned by the indexer are pruned — the indexer has its own TTL and stops returning expired messages.
+
+Additionally, per-transfer `deposit-address:pending-execution:<botIdentifier>:<depositKey>` keys (self-expiring, no pruning needed) mark possibly-in-flight broadcasts across instances — see "Handover alignment" above.
 
 ## Refund-withdraw flow (high level)
 

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -47,18 +47,29 @@ Three mechanisms close the window:
    to `HANDOVER_TAKEOVER_TIMEOUT` (120s) for its specific predecessor's drained signal **before**
    loading the persisted sets — loading earlier races the predecessor's final persist. On timeout
    (predecessor crashed, or predates this protocol) it proceeds with a warning; the markers below
-   still guard anything left in flight.
+   still guard anything left in flight. While it waits it kicks the watchdog heartbeat on the
+   usual interval (the predecessor stops its own the moment it observes the takeover), so a slow
+   but healthy handover never pages as a dead bot. The wait has two cede paths: if the instance's
+   own abort signal fired during the wait (SIGHUP/disconnect), or if the lease is no longer held
+   by this instance afterwards (a newer instance took over mid-wait), `initialize()` returns
+   without loading state, the entrypoint skips polling entirely (`relayer.aborted`), and the
+   instance signals drained on its way out so its own successor is not left waiting.
 3. **Pending-execution markers (crash safety).** Immediately before every fund-moving broadcast
-   the handler persists `deposit-address:pending-execution:<botIdentifier>:<depositKey>` (value:
-   the writing instance's run identifier, TTL `PENDING_EXECUTION_EXPIRY` = 15 min) and refuses to
-   broadcast if that persist fails. The marker is deleted only after the confirmed execution has
-   been persisted to the executed set. Every execute/withdraw path defers a transfer whose marker
-   is held by **another** instance (own markers don't block, so the normal same-instance retry
-   path is unaffected); after a failed submit the marker is intentionally left to expire via TTL,
-   since a "failed" send may still have broadcast. Consequence: if an instance dies mid-flight,
-   the successor defers that transfer for up to 15 minutes instead of risking a replay — a
-   deferred sweep is recoverable, a double-spend is not. The deploy tx on the v1 deposit path
-   carries no marker: it moves no funds and replays are guarded by the `isContractDeployed` check.
+   the handler **atomically acquires** `deposit-address:pending-execution:<botIdentifier>:<depositKey>`
+   (value: the acquiring instance's run identifier, TTL `PENDING_EXECUTION_EXPIRY` = 15 min) via
+   SET NX — falling back to re-taking a marker it already owns (compare-and-expire), so the
+   same-instance retry path after a failed submit is unaffected — and refuses to broadcast unless
+   it wins the marker. Acquisition being atomic means two live instances racing the same transfer
+   (overlapping replacement starts, or a takeover timeout while the old process still runs) cannot
+   both broadcast. The marker is released (compare-and-delete on ownership, never a blind DEL)
+   only after the confirmed execution has been persisted to the executed set. Every
+   execute/withdraw path also defers early on a transfer whose marker is held by **another**
+   instance, saving the API/chain reads; after a failed submit the marker is intentionally left to
+   expire via TTL, since a "failed" send may still have broadcast. Consequence: if an instance
+   dies mid-flight, the successor defers that transfer for up to 15 minutes instead of risking a
+   replay — a deferred sweep is recoverable, a double-spend is not. The deploy tx on the v1
+   deposit path carries no marker: it moves no funds and replays are guarded by the
+   `isContractDeployed` check.
 
 ## Indexer message classification
 

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -42,17 +42,21 @@ Three mechanisms make the overlap safe:
 1. **Per-transfer pending-execution locks.** Immediately before every fund-moving broadcast the
    handler atomically acquires `deposit-address:pending-execution:<botIdentifier>:<depositKey>`
    (SET NX; value: the acquiring instance's run identifier, TTL `PENDING_EXECUTION_EXPIRY` =
-   15 min) and refuses to broadcast without it. A lock held by **another** instance defers the
-   transfer; a token-guarded renew covers this instance's own retries, so the same-instance retry
-   path is unaffected. Under the lock, the handler re-checks the committed set (`SISMEMBER`)
+   15 min) and refuses to broadcast without it. **Any** existing lock defers the transfer — a
+   foreign one means the other instance may have a broadcast in flight, and an own one only
+   survives an unknown-outcome submit (a "failed" `sendAndConfirm` may still have broadcast), so
+   retrying against it could submit the same sweep twice while the first tx sits in the mempool.
+   Known-not-broadcast failures never hold a lock (they fail before the checkpoint acquires it),
+   so their fast retry path is unaffected. Under the lock, the handler re-checks the committed
+   set (`SISMEMBER`)
    before broadcasting — catching an execution the other instance committed and released between
    this tick's refresh and now — and re-checks the abort signal, since a handover/shutdown can
    land while the acquire round-trip is pending (nothing was broadcast, so the just-acquired lock
    is released rather than left to defer the successor for the full TTL). The lock is released
    only after the confirmed execution is
-   committed; after a failed submit it is intentionally left to expire via TTL, since a "failed"
-   send may still have broadcast. Consequence: if an instance dies mid-flight, the successor
-   defers that one transfer for up to 15 minutes instead of risking a replay — a deferred sweep
+   committed; after a failed submit it is intentionally left to expire via TTL. Consequence: if
+   an instance dies mid-flight (or a submit outcome is unknown), the transfer is deferred for up
+   to 15 minutes instead of risking a replay — a deferred sweep
    is recoverable, a double-spend is not. The deploy tx on the v1 deposit path carries no lock:
    it moves no funds and replays are guarded by the `isContractDeployed` check.
 2. **Concurrency-safe committed sets.** The executed/withdrawn/terminal-skip sets are native
@@ -70,9 +74,14 @@ Three mechanisms make the overlap safe:
    once the rollout settles.
 3. **Drain on the way out.** On observing a handover (or SIGHUP), the outgoing instance aborts
    new work — the poll loop initiates no new executions once the abort signal fires, and a
-   pre-broadcast abort check bails mid-message — then waits up to `HANDOVER_DRAIN_TIMEOUT` (90s)
-   for in-flight poll ticks to settle, so a broadcast tx gets confirmed and committed rather than
-   orphaned. Its locks keep the successor off those transfers while it drains; if it dies
+   pre-broadcast abort check bails mid-message — then waits for in-flight poll ticks to settle,
+   so a broadcast tx gets confirmed and committed rather than orphaned. The wait is two-phase:
+   past the expected window (`HANDOVER_DRAIN_TIMEOUT`, 90s) it warns but keeps the process — and
+   its Redis clients — alive up to the pending-execution lock TTL, because exiting would tear
+   Redis down under a tick sitting between broadcast and commit, and a tx confirming after that
+   leaves no committed record for the successor once the lock expires. The successor is already
+   serving, so a lingering old process costs nothing. Its locks keep the successor off those
+   transfers while it drains; if it dies
    instead, the lock TTL bounds the deferral. A shutdown observed while still inside
    `initialize()` cedes before polling ever starts (the entrypoint checks `relayer.aborted`, and
    `scheduleTask` refuses to schedule on an already-aborted signal) — and cedes **without taking

--- a/src/deposit-address/index.ts
+++ b/src/deposit-address/index.ts
@@ -13,15 +13,26 @@ export async function runDepositAddressHandler(_logger: winston.Logger, baseSign
   await relayer.initialize();
 
   try {
-    logger[startupLogLevel(config)]({
-      at: "DepositAddressHandler#index",
-      message: "Deposit address handler started",
-      config,
-    });
     const start = Date.now();
 
-    // Start the API polling.
-    relayer.pollAndExecute();
+    // initialize() cedes without loading state when a shutdown or a newer instance is observed
+    // while it waits for the predecessor drain; a stale instance must not start polling. It still
+    // falls through to waitForDisconnect below so its drained signal reaches any successor.
+    if (relayer.aborted) {
+      logger.debug({
+        at: "DepositAddressHandler#index",
+        message: "Handler ceded during initialization; exiting without polling.",
+      });
+    } else {
+      logger[startupLogLevel(config)]({
+        at: "DepositAddressHandler#index",
+        message: "Deposit address handler started",
+        config,
+      });
+
+      // Start the API polling.
+      relayer.pollAndExecute();
+    }
 
     // Wait for the handover to complete.
     await relayer.waitForDisconnect();

--- a/src/deposit-address/index.ts
+++ b/src/deposit-address/index.ts
@@ -15,9 +15,9 @@ export async function runDepositAddressHandler(_logger: winston.Logger, baseSign
   try {
     const start = Date.now();
 
-    // initialize() cedes without loading state when a shutdown or a newer instance is observed
-    // while it waits for the predecessor drain; a stale instance must not start polling. It still
-    // falls through to waitForDisconnect below so its drained signal reaches any successor.
+    // A shutdown (SIGHUP/disconnect) observed during initialize() means this instance already
+    // ceded; it must not start polling. It still falls through to waitForDisconnect below so any
+    // in-flight work drains before exit.
     if (relayer.aborted) {
       logger.debug({
         at: "DepositAddressHandler#index",

--- a/src/utils/InstanceCoordinator.ts
+++ b/src/utils/InstanceCoordinator.ts
@@ -1,5 +1,10 @@
-import { delay, winston } from "./";
+import { delay, isDefined, winston } from "./";
 import { RedisCacheInterface } from "../cache/Redis";
+
+// Lifetime of the drained signal. Only consumed by the immediate successor (which matches the
+// signal against the specific predecessor it took over from), so it just needs to outlive the
+// takeover wait; match the instance lease for symmetry.
+const DRAINED_SIGNAL_EXPIRY = 1200;
 
 export class InstanceCoordinator {
   constructor(
@@ -10,6 +15,10 @@ export class InstanceCoordinator {
     private readonly abortController: AbortController,
     public readonly instanceExpiry = 1200
   ) {}
+
+  private getDrainedKey(): string {
+    return `${this.identifier}:drained`;
+  }
 
   async getActiveInstance(): Promise<string | undefined> {
     return (await this.redis.get<string>(this.identifier)) ?? undefined;
@@ -23,7 +32,12 @@ export class InstanceCoordinator {
     return (await this.getActiveInstance()) === this.instance;
   }
 
-  async initiateHandover(): Promise<void> {
+  /**
+   * Takes over as the active instance. Returns the previously-active instance (undefined on a
+   * cold start / expired lease) so the caller can wait for its drained signal via
+   * waitForPredecessorDrain before starting work of its own.
+   */
+  async initiateHandover(): Promise<string | undefined> {
     const activeInstance = await this.getActiveInstance();
     this.logger.debug({
       at: "Coordinator::initiateHandover",
@@ -31,6 +45,65 @@ export class InstanceCoordinator {
     });
 
     await this.setActiveInstance();
+    return activeInstance;
+  }
+
+  /**
+   * Signals that this instance has finished draining in-flight work after ceding (or on
+   * shutdown). The successor blocks on this signal in waitForPredecessorDrain, so it must only
+   * be emitted once all in-flight executions have settled and their state is persisted.
+   */
+  async signalDrained(): Promise<void> {
+    await this.redis.set(this.getDrainedKey(), this.instance, DRAINED_SIGNAL_EXPIRY);
+    this.logger.debug({
+      at: "Coordinator::signalDrained",
+      message: `Signalled drained for ${this.identifier} instance ${this.instance}.`,
+    });
+  }
+
+  /**
+   * Waits until `predecessor` (the instance returned by initiateHandover) signals it has drained
+   * its in-flight work, so this instance does not act on state the predecessor is still writing.
+   * Resolves true when the signal is observed; false on timeout, abort, or sustained Redis
+   * errors — callers should proceed in that case (the predecessor may have crashed) and rely on
+   * per-execution guards for anything it left in flight. Returns immediately when there is no
+   * predecessor (cold start).
+   */
+  async waitForPredecessorDrain(predecessor: string | undefined, timeoutSeconds: number): Promise<boolean> {
+    if (!isDefined(predecessor) || predecessor === this.instance) {
+      return true;
+    }
+
+    const maxConsecutiveErrors = 10;
+    let consecutiveErrors = 0;
+    const deadline = Date.now() + timeoutSeconds * 1000;
+    do {
+      try {
+        if ((await this.redis.get<string>(this.getDrainedKey())) === predecessor) {
+          this.logger.debug({
+            at: "Coordinator::waitForPredecessorDrain",
+            message: `Predecessor ${this.identifier} instance ${predecessor} signalled drained.`,
+          });
+          return true;
+        }
+        consecutiveErrors = 0;
+      } catch (err) {
+        if (++consecutiveErrors >= maxConsecutiveErrors) {
+          this.logger.error({
+            at: "Coordinator::waitForPredecessorDrain",
+            message: "Redis unreachable while waiting for predecessor drain; proceeding.",
+            err: String(err),
+          });
+          return false;
+        }
+      }
+      if (Date.now() >= deadline || this.abortController.signal.aborted) {
+        break;
+      }
+      await delay(1);
+    } while (!this.abortController.signal.aborted);
+
+    return false;
   }
 
   // Poor-man's subscription - just poll on a 1s interval.

--- a/src/utils/InstanceCoordinator.ts
+++ b/src/utils/InstanceCoordinator.ts
@@ -1,10 +1,5 @@
-import { delay, isDefined, winston } from "./";
+import { delay, winston } from "./";
 import { RedisCacheInterface } from "../cache/Redis";
-
-// Lifetime of the drained signal. Only consumed by the immediate successor (which matches the
-// signal against the specific predecessor it took over from), so it just needs to outlive the
-// takeover wait; match the instance lease for symmetry.
-const DRAINED_SIGNAL_EXPIRY = 1200;
 
 export class InstanceCoordinator {
   constructor(
@@ -15,10 +10,6 @@ export class InstanceCoordinator {
     private readonly abortController: AbortController,
     public readonly instanceExpiry = 1200
   ) {}
-
-  private getDrainedKey(): string {
-    return `${this.identifier}:drained`;
-  }
 
   async getActiveInstance(): Promise<string | undefined> {
     return (await this.redis.get<string>(this.identifier)) ?? undefined;
@@ -32,12 +23,7 @@ export class InstanceCoordinator {
     return (await this.getActiveInstance()) === this.instance;
   }
 
-  /**
-   * Takes over as the active instance. Returns the previously-active instance (undefined on a
-   * cold start / expired lease) so the caller can wait for its drained signal via
-   * waitForPredecessorDrain before starting work of its own.
-   */
-  async initiateHandover(): Promise<string | undefined> {
+  async initiateHandover(): Promise<void> {
     const activeInstance = await this.getActiveInstance();
     this.logger.debug({
       at: "Coordinator::initiateHandover",
@@ -45,65 +31,6 @@ export class InstanceCoordinator {
     });
 
     await this.setActiveInstance();
-    return activeInstance;
-  }
-
-  /**
-   * Signals that this instance has finished draining in-flight work after ceding (or on
-   * shutdown). The successor blocks on this signal in waitForPredecessorDrain, so it must only
-   * be emitted once all in-flight executions have settled and their state is persisted.
-   */
-  async signalDrained(): Promise<void> {
-    await this.redis.set(this.getDrainedKey(), this.instance, DRAINED_SIGNAL_EXPIRY);
-    this.logger.debug({
-      at: "Coordinator::signalDrained",
-      message: `Signalled drained for ${this.identifier} instance ${this.instance}.`,
-    });
-  }
-
-  /**
-   * Waits until `predecessor` (the instance returned by initiateHandover) signals it has drained
-   * its in-flight work, so this instance does not act on state the predecessor is still writing.
-   * Resolves true when the signal is observed; false on timeout, abort, or sustained Redis
-   * errors — callers should proceed in that case (the predecessor may have crashed) and rely on
-   * per-execution guards for anything it left in flight. Returns immediately when there is no
-   * predecessor (cold start).
-   */
-  async waitForPredecessorDrain(predecessor: string | undefined, timeoutSeconds: number): Promise<boolean> {
-    if (!isDefined(predecessor) || predecessor === this.instance) {
-      return true;
-    }
-
-    const maxConsecutiveErrors = 10;
-    let consecutiveErrors = 0;
-    const deadline = Date.now() + timeoutSeconds * 1000;
-    do {
-      try {
-        if ((await this.redis.get<string>(this.getDrainedKey())) === predecessor) {
-          this.logger.debug({
-            at: "Coordinator::waitForPredecessorDrain",
-            message: `Predecessor ${this.identifier} instance ${predecessor} signalled drained.`,
-          });
-          return true;
-        }
-        consecutiveErrors = 0;
-      } catch (err) {
-        if (++consecutiveErrors >= maxConsecutiveErrors) {
-          this.logger.error({
-            at: "Coordinator::waitForPredecessorDrain",
-            message: "Redis unreachable while waiting for predecessor drain; proceeding.",
-            err: String(err),
-          });
-          return false;
-        }
-      }
-      if (Date.now() >= deadline || this.abortController.signal.aborted) {
-        break;
-      }
-      await delay(1);
-    } while (!this.abortController.signal.aborted);
-
-    return false;
   }
 
   // Poor-man's subscription - just poll on a 1s interval.

--- a/src/utils/Tasks.ts
+++ b/src/utils/Tasks.ts
@@ -52,6 +52,11 @@ export function scheduleTask(
   signal: AbortSignal,
   onError?: (err: unknown) => void
 ): void {
+  // A signal that aborted in the past never fires "abort" again, so the interval would never be
+  // cleared when scheduling starts after shutdown was already observed. Schedule nothing instead.
+  if (signal.aborted) {
+    return;
+  }
   const timer = setInterval(fireAndForget(task, onError), interval * 1000);
   signal.addEventListener("abort", () => clearInterval(timer));
 }

--- a/test/DepositAddressHandler.handover.ts
+++ b/test/DepositAddressHandler.handover.ts
@@ -176,7 +176,7 @@ type HandlerInternals = {
   initiateWithdraw: (m: DepositAddressMessage) => Promise<void>;
   evaluateDepositAddresses: () => Promise<void>;
   trackTick: (tick: Promise<unknown>) => Promise<unknown>;
-  drainInFlightWork: (timeoutSeconds: number) => Promise<void>;
+  drainInFlightWork: (timeoutSeconds: number) => Promise<boolean>;
   waitForDisconnect: () => Promise<void>;
   observedExecutedDeposits: { [chainId: number]: Set<string> };
   executedDepositTxHashes: Set<string>;
@@ -250,17 +250,20 @@ describe("DepositAddressHandler pending-execution locks", function () {
     expect(redis.store.get(pendingKey(message))).to.equal(OTHER_INSTANCE);
   });
 
-  it("does not defer on its own lock (normal retry path renews it)", async function () {
-    const { internals, redis, sendStub } = buildHandler();
+  it("defers on its own lock: an own lock only survives an unknown-outcome submit", async function () {
+    const { internals, redis, sendStub, executeTxStub } = buildHandler();
     const message = depositMessageV3();
     redis.store.set(pendingKey(message), RUN_IDENTIFIER);
 
     await internals.initiateDepositV3(message);
 
-    expect(sendStub.calledOnce).to.equal(true);
+    // Retrying while our own possibly-broadcast tx may still land is how a sweep double-submits.
+    expect(executeTxStub.notCalled).to.equal(true);
+    expect(sendStub.notCalled).to.equal(true);
+    expect(redis.store.get(pendingKey(message))).to.equal(RUN_IDENTIFIER);
   });
 
-  it("keeps the lock on a failed submit and still allows this instance to retry", async function () {
+  it("keeps the lock on a failed submit, defers retries until the TTL clears it", async function () {
     const { internals, redis, sendStub } = buildHandler();
     const message = depositMessageV3();
     sendStub.resolves(undefined);
@@ -270,9 +273,17 @@ describe("DepositAddressHandler pending-execution locks", function () {
     // A failed sendAndConfirm may still have broadcast; the lock must outlive it (TTL cleanup).
     expect(redis.store.get(pendingKey(message))).to.equal(RUN_IDENTIFIER);
     expect(redis.sets.has(EXECUTED_KEY)).to.equal(false);
-    // The in-flight lock was released, and the own pending lock renews rather than blocks.
+
+    // While the lock stands, this instance's own retry defers like anyone else's.
+    await internals.initiateDepositV3(message);
+    expect(sendStub.calledOnce).to.equal(true);
+
+    // Once the TTL expires the lock, the retry proceeds.
+    redis.store.delete(pendingKey(message));
+    sendStub.resolves(fakeReceipt());
     await internals.initiateDepositV3(message);
     expect(sendStub.calledTwice).to.equal(true);
+    expect(redis.sets.get(EXECUTED_KEY)?.has(message.erc20Transfer.transactionHash)).to.equal(true);
   });
 
   it("does not broadcast when another instance acquires the lock after the early foreign check", async function () {
@@ -512,7 +523,23 @@ describe("DepositAddressHandler handover draining", function () {
   it("drainInFlightWork gives up after the timeout when a tick never settles", async function () {
     const { internals } = buildHandler();
     void internals.trackTick(new Promise(() => undefined));
-    await internals.drainInFlightWork(0);
+    expect(await internals.drainInFlightWork(0)).to.equal(false);
+  });
+
+  it("waitForDisconnect holds Redis open past the expected drain window for a slow tick", async function () {
+    const { handler, internals } = buildHandler();
+    const coordinator = { subscribe: sinon.stub().resolves(OTHER_INSTANCE) };
+    // First (expected) drain window times out — the tick is still between broadcast and commit;
+    // the second phase must keep waiting up to the pending-execution lock TTL instead of
+    // returning and letting the entrypoint tear Redis down under the tick.
+    const drainStub = sinon.stub().onFirstCall().resolves(false).onSecondCall().resolves(true);
+    Object.assign(handler, { _instanceCoordinator: coordinator, drainInFlightWork: drainStub });
+
+    await internals.waitForDisconnect();
+
+    expect(drainStub.calledTwice).to.equal(true);
+    expect(drainStub.firstCall.args[0]).to.equal(90); // HANDOVER_DRAIN_TIMEOUT
+    expect(drainStub.secondCall.args[0]).to.equal(810); // PENDING_EXECUTION_EXPIRY - HANDOVER_DRAIN_TIMEOUT
   });
 
   it("waitForDisconnect aborts, then drains in-flight work before resolving", async function () {

--- a/test/DepositAddressHandler.handover.ts
+++ b/test/DepositAddressHandler.handover.ts
@@ -18,7 +18,7 @@ const EXECUTE_TARGET = "0x0000000000000000000000000000000000005900";
 const V3_CHAIN = 42161;
 const V1_CHAIN = 1;
 
-/** Minimal in-memory stand-in for the Redis ops the handler uses (get/set/del). */
+/** Minimal in-memory stand-in for the Redis ops the handler uses (get/set/locks). */
 class FakeRedis {
   store = new Map<string, string>();
 
@@ -33,6 +33,26 @@ class FakeRedis {
 
   async del(key: string): Promise<number> {
     return this.store.delete(key) ? 1 : 0;
+  }
+
+  /** SET NX semantics; TTLs are not modelled. */
+  async acquireLock(key: string, token: string, _ttlMs: number): Promise<boolean> {
+    if (this.store.has(key)) {
+      return false;
+    }
+    this.store.set(key, token);
+    return true;
+  }
+
+  async renewLock(key: string, token: string, _ttlMs: number): Promise<boolean> {
+    return this.store.get(key) === token;
+  }
+
+  async releaseLock(key: string, token: string): Promise<boolean> {
+    if (this.store.get(key) !== token) {
+      return false;
+    }
+    return this.store.delete(key);
   }
 }
 
@@ -236,6 +256,42 @@ describe("DepositAddressHandler pending-execution markers", function () {
     expect(sendStub.notCalled).to.equal(true);
     expect(redis.store.has(pendingKey(message))).to.equal(false);
     expect(internals.observedExecutedDeposits[V3_CHAIN].size).to.equal(0);
+  });
+
+  it("does not broadcast when another instance acquires the marker after the early foreign check", async function () {
+    const { internals, redis, sendStub, executeTxStub } = buildHandler();
+    const message = depositMessageV3();
+    // The early hasForeignPendingExecution read passes (no marker yet); the other instance's
+    // marker lands while this instance is fetching calldata, i.e. before the pre-broadcast
+    // checkpoint. The atomic acquisition must lose and skip the broadcast.
+    executeTxStub.callsFake(async () => {
+      redis.store.set(pendingKey(message), OTHER_INSTANCE);
+      return executeResponse();
+    });
+
+    await internals.initiateDepositV3(message);
+
+    expect(sendStub.notCalled).to.equal(true);
+    expect(redis.store.get(pendingKey(message))).to.equal(OTHER_INSTANCE);
+    // The in-flight lock was released so the transfer is re-evaluated on later polls.
+    expect(internals.observedExecutedDeposits[V3_CHAIN].size).to.equal(0);
+  });
+
+  it("does not clear a marker another instance acquired after this instance's expired mid-flight", async function () {
+    const { internals, redis, sendStub } = buildHandler();
+    const message = depositMessageV3();
+
+    sendStub.callsFake(async () => {
+      // Simulate the marker TTL expiring during a slow confirmation, with another instance then
+      // acquiring the key. The ownership-checked release must leave that marker intact.
+      redis.store.set(pendingKey(message), OTHER_INSTANCE);
+      return fakeReceipt();
+    });
+
+    await internals.initiateDepositV3(message);
+
+    expect(redis.store.get(executedKey())).to.contain(message.erc20Transfer.transactionHash);
+    expect(redis.store.get(pendingKey(message))).to.equal(OTHER_INSTANCE);
   });
 
   it("defers the v1 refund-withdraw path on a foreign marker before any chain reads", async function () {

--- a/test/DepositAddressHandler.handover.ts
+++ b/test/DepositAddressHandler.handover.ts
@@ -1,0 +1,315 @@
+import sinon from "sinon";
+import { expect } from "chai";
+import { getCurrentTime, getDepositKey, Signer, toBN, TransactionReceipt, winston } from "../src/utils";
+import { DepositAddressMessage, DepositAddressMessageV3 } from "../src/interfaces/DepositAddress";
+import { DepositAddressExecuteResponse } from "../src/clients";
+import { DepositAddressHandler } from "../src/deposit-address/DepositAddressHandler";
+import { DepositAddressHandlerConfig } from "../src/deposit-address/DepositAddressHandlerConfig";
+
+const BOT_IDENTIFIER = "test-deposit-address-handler";
+const RUN_IDENTIFIER = "instance-a";
+const OTHER_INSTANCE = "instance-b";
+const DEPOSIT_ADDRESS = "0x000000000000000000000000000000000000C0DE";
+const REFUND_ADDRESS = "0x0000000000000000000000000000000000002222";
+const TOKEN = "0x000000000000000000000000000000000000DEAD";
+const OUTPUT_TOKEN = "0x0000000000000000000000000000000000005678";
+const RECIPIENT = "0x0000000000000000000000000000000000001111";
+const EXECUTE_TARGET = "0x0000000000000000000000000000000000005900";
+const V3_CHAIN = 42161;
+const V1_CHAIN = 1;
+
+/** Minimal in-memory stand-in for the Redis ops the handler uses (get/set/del). */
+class FakeRedis {
+  store = new Map<string, string>();
+
+  async get<T>(key: string): Promise<T | null> {
+    return (this.store.get(key) ?? null) as T | null;
+  }
+
+  async set<T>(key: string, val: T): Promise<string> {
+    this.store.set(key, String(val));
+    return "OK";
+  }
+
+  async del(key: string): Promise<number> {
+    return this.store.delete(key) ? 1 : 0;
+  }
+}
+
+function pendingKey(message: DepositAddressMessage | DepositAddressMessageV3): string {
+  return `deposit-address:pending-execution:${BOT_IDENTIFIER}:${getDepositKey(message)}`;
+}
+
+function executedKey(): string {
+  return `deposit-address:executed:${BOT_IDENTIFIER}`;
+}
+
+function fakeReceipt(): TransactionReceipt {
+  return { transactionHash: "0x" + "9".repeat(64), blockNumber: 1_234_567, logs: [] } as unknown as TransactionReceipt;
+}
+
+function depositMessageV3(): DepositAddressMessageV3 {
+  return {
+    depositAddress: DEPOSIT_ADDRESS,
+    version: 3,
+    salt: "0x" + "0".repeat(64),
+    initialRoot: "0x" + "2".repeat(64),
+    counterfactualBeaconContractAddress: "0x000000000000000000000000000000000000B1B1",
+    counterfactualFactoryContractAddress: "0x000000000000000000000000000000000000B2B2",
+    adminWithdrawManagerContractAddress: "0x000000000000000000000000000000000000B3B3",
+    shouldSponsorAccountCreation: false,
+    counterfactualMaterials: [],
+    routeParams: {
+      outputToken: OUTPUT_TOKEN,
+      destinationChainId: "1337",
+      recipient: { namespace: "evm", address: RECIPIENT },
+    },
+    refundAddress: { namespace: "evm", address: REFUND_ADDRESS },
+    depositAddressNamespace: "evm",
+    integrator: { name: "test-integrator", integratorId: "0xdead" },
+    erc20Transfer: {
+      chainId: String(V3_CHAIN),
+      blockNumber: 1_000_000,
+      logIndex: 4,
+      from: REFUND_ADDRESS,
+      to: DEPOSIT_ADDRESS,
+      amount: "5000",
+      contractAddress: TOKEN,
+      transactionHash: "0x" + "3".repeat(64),
+      transferClassification: "correct_transfer",
+    },
+  };
+}
+
+function withdrawMessageV1(): DepositAddressMessage {
+  return {
+    depositAddress: DEPOSIT_ADDRESS,
+    paramsHash: "0x" + "0".repeat(64),
+    salt: "0x" + "0".repeat(64),
+    counterfactualDepositContractAddress: "0x000000000000000000000000000000000000A1A1",
+    counterfactualFactoryContractAddress: "0x000000000000000000000000000000000000A2A2",
+    adminWithdrawManagerContractAddress: "0x000000000000000000000000000000000000A3A3",
+    shouldSponsorAccountCreation: false,
+    counterfactualMaterials: undefined,
+    routeParams: {
+      inputToken: TOKEN,
+      outputToken: OUTPUT_TOKEN,
+      originChainId: String(V1_CHAIN),
+      destinationChainId: "10",
+      recipient: RECIPIENT,
+      refundAddress: REFUND_ADDRESS,
+    },
+    erc20Transfer: {
+      chainId: String(V1_CHAIN),
+      blockNumber: 1_000_000,
+      logIndex: 4,
+      from: REFUND_ADDRESS,
+      to: DEPOSIT_ADDRESS,
+      amount: "5000",
+      contractAddress: TOKEN,
+      transactionHash: "0x" + "1".repeat(64),
+      transferClassification: "mis_route",
+    },
+  };
+}
+
+function executeResponse(): DepositAddressExecuteResponse {
+  return {
+    depositAddress: DEPOSIT_ADDRESS,
+    isPlaceholder: false,
+    signatureDeadline: getCurrentTime() + 300,
+    executeTx: { to: EXECUTE_TARGET, data: "0x", value: "0", chainId: V3_CHAIN },
+  } as unknown as DepositAddressExecuteResponse;
+}
+
+type HandlerInternals = {
+  redisCache: FakeRedis;
+  abortController: AbortController;
+  initiateDepositV3: (m: DepositAddressMessageV3) => Promise<void>;
+  initiateWithdraw: (m: DepositAddressMessage) => Promise<void>;
+  evaluateDepositAddresses: () => Promise<void>;
+  trackTick: (tick: Promise<unknown>) => Promise<unknown>;
+  drainInFlightWork: (timeoutSeconds: number) => Promise<void>;
+  waitForDisconnect: () => Promise<void>;
+  observedExecutedDeposits: { [chainId: number]: Set<string> };
+};
+
+function buildHandler(): {
+  handler: DepositAddressHandler;
+  internals: HandlerInternals;
+  redis: FakeRedis;
+  sendStub: sinon.SinonStub;
+  executeTxStub: sinon.SinonStub;
+} {
+  const config = {
+    botIdentifier: BOT_IDENTIFIER,
+    runIdentifier: RUN_IDENTIFIER,
+    relayerOriginChains: [V1_CHAIN, V3_CHAIN],
+    withdrawEnabled: true,
+    enableV3Withdrawals: true,
+  } as unknown as DepositAddressHandlerConfig;
+  const logger = { debug: sinon.stub(), warn: sinon.stub(), error: sinon.stub() } as unknown as winston.Logger;
+  // A non-empty signer list selects the dispatcher path, keeping getExecuteContract from
+  // dereferencing real providers; the broadcast itself is stubbed via sendAndConfirm.
+  const handler = new DepositAddressHandler(logger, config, {} as unknown as Signer, [{} as unknown as Signer]);
+
+  const redis = new FakeRedis();
+  const sendStub = sinon.stub().resolves(fakeReceipt());
+  const executeTxStub = sinon.stub().resolves(executeResponse());
+  const balanceStub = sinon.stub().resolves(toBN("5000"));
+  Object.assign(handler, {
+    redisCache: redis,
+    observedExecutedDeposits: { [V1_CHAIN]: new Set(), [V3_CHAIN]: new Set() },
+    observedExecutedWithdraws: { [V1_CHAIN]: new Set(), [V3_CHAIN]: new Set() },
+    sendAndConfirm: sendStub,
+    _getExecuteTx: executeTxStub,
+    getDepositAddressBalance: balanceStub,
+  });
+  return { handler, internals: handler as unknown as HandlerInternals, redis, sendStub, executeTxStub };
+}
+
+describe("DepositAddressHandler pending-execution markers", function () {
+  afterEach(() => sinon.restore());
+
+  it("writes the marker before broadcasting and clears it after persisting the executed marker", async function () {
+    const { internals, redis, sendStub } = buildHandler();
+    const message = depositMessageV3();
+
+    sendStub.callsFake(async () => {
+      // At broadcast time the pending marker must already be persisted under this instance.
+      expect(redis.store.get(pendingKey(message))).to.equal(RUN_IDENTIFIER);
+      return fakeReceipt();
+    });
+
+    await internals.initiateDepositV3(message);
+
+    expect(sendStub.calledOnce).to.equal(true);
+    expect(redis.store.has(pendingKey(message))).to.equal(false);
+    expect(redis.store.get(executedKey())).to.contain(message.erc20Transfer.transactionHash);
+  });
+
+  it("defers execution while another instance holds the pending marker", async function () {
+    const { internals, redis, sendStub, executeTxStub } = buildHandler();
+    const message = depositMessageV3();
+    redis.store.set(pendingKey(message), OTHER_INSTANCE);
+
+    await internals.initiateDepositV3(message);
+
+    expect(executeTxStub.notCalled).to.equal(true);
+    expect(sendStub.notCalled).to.equal(true);
+    // The marker was not consumed: the deferral holds until the owner clears it or the TTL expires.
+    expect(redis.store.get(pendingKey(message))).to.equal(OTHER_INSTANCE);
+  });
+
+  it("does not defer on its own marker (normal retry path)", async function () {
+    const { internals, redis, sendStub } = buildHandler();
+    const message = depositMessageV3();
+    redis.store.set(pendingKey(message), RUN_IDENTIFIER);
+
+    await internals.initiateDepositV3(message);
+
+    expect(sendStub.calledOnce).to.equal(true);
+  });
+
+  it("keeps the marker on a failed submit and still allows this instance to retry", async function () {
+    const { internals, redis, sendStub } = buildHandler();
+    const message = depositMessageV3();
+    sendStub.resolves(undefined);
+
+    await internals.initiateDepositV3(message);
+
+    // A failed sendAndConfirm may still have broadcast; the marker must outlive it (TTL cleanup).
+    expect(redis.store.get(pendingKey(message))).to.equal(RUN_IDENTIFIER);
+    expect(redis.store.has(executedKey())).to.equal(false);
+    // The in-flight lock was released, and the own marker does not block the retry.
+    await internals.initiateDepositV3(message);
+    expect(sendStub.calledTwice).to.equal(true);
+  });
+
+  it("skips the broadcast without writing a marker when a handover was observed mid-message", async function () {
+    const { internals, redis, sendStub } = buildHandler();
+    const message = depositMessageV3();
+    internals.abortController.abort();
+
+    await internals.initiateDepositV3(message);
+
+    expect(sendStub.notCalled).to.equal(true);
+    expect(redis.store.has(pendingKey(message))).to.equal(false);
+    expect(internals.observedExecutedDeposits[V3_CHAIN].size).to.equal(0);
+  });
+
+  it("defers the v1 refund-withdraw path on a foreign marker before any chain reads", async function () {
+    const { handler, internals, redis, sendStub } = buildHandler();
+    const message = withdrawMessageV1();
+    redis.store.set(pendingKey(message), OTHER_INSTANCE);
+    const balanceStub = (handler as unknown as { getDepositAddressBalance: sinon.SinonStub }).getDepositAddressBalance;
+
+    await internals.initiateWithdraw(message);
+
+    expect(balanceStub.notCalled).to.equal(true);
+    expect(sendStub.notCalled).to.equal(true);
+  });
+});
+
+describe("DepositAddressHandler handover draining", function () {
+  afterEach(() => sinon.restore());
+
+  it("stops initiating executions once aborted", async function () {
+    const { handler, internals } = buildHandler();
+    const processStub = sinon.stub().resolves();
+    Object.assign(handler, {
+      _queryIndexerApi: sinon.stub().resolves([depositMessageV3()]),
+      processExecution: processStub,
+    });
+    internals.abortController.abort();
+
+    await internals.evaluateDepositAddresses();
+
+    expect(processStub.notCalled).to.equal(true);
+  });
+
+  it("drainInFlightWork waits for in-flight ticks to settle", async function () {
+    const { internals } = buildHandler();
+    let resolveTick: (() => void) | undefined;
+    void internals.trackTick(new Promise<void>((resolve) => (resolveTick = resolve)));
+
+    let drained = false;
+    const drain = internals.drainInFlightWork(5).then(() => (drained = true));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(drained).to.equal(false);
+
+    resolveTick?.();
+    await drain;
+    expect(drained).to.equal(true);
+  });
+
+  it("drainInFlightWork gives up after the timeout when a tick never settles", async function () {
+    const { internals } = buildHandler();
+    void internals.trackTick(new Promise(() => undefined));
+    await internals.drainInFlightWork(0);
+  });
+
+  it("waitForDisconnect aborts, drains in-flight work, then signals drained", async function () {
+    const { handler, internals } = buildHandler();
+    const events: string[] = [];
+    const coordinator = {
+      subscribe: sinon.stub().resolves(OTHER_INSTANCE),
+      signalDrained: sinon.stub().callsFake(async () => void events.push("drained")),
+    };
+    Object.assign(handler, { _instanceCoordinator: coordinator });
+
+    void internals.trackTick(
+      new Promise<void>((resolve) =>
+        setTimeout(() => {
+          events.push("tickSettled");
+          resolve();
+        }, 20)
+      )
+    );
+
+    await internals.waitForDisconnect();
+
+    expect(internals.abortController.signal.aborted).to.equal(true);
+    expect(events).to.deep.equal(["tickSettled", "drained"]);
+  });
+});

--- a/test/DepositAddressHandler.handover.ts
+++ b/test/DepositAddressHandler.handover.ts
@@ -246,6 +246,28 @@ describe("DepositAddressHandler pending-execution markers", function () {
     expect(sendStub.calledTwice).to.equal(true);
   });
 
+  it("skips the broadcast and releases the marker when a handover lands during the marker write", async function () {
+    const { internals, redis, sendStub } = buildHandler();
+    const message = depositMessageV3();
+    // The initial abort check passes; the handover is observed while the marker write is in
+    // flight (a slow write can outlive the predecessor's drain timeout, after which the
+    // successor has already been signalled to start). The post-acquisition re-check must bail.
+    const realAcquire = redis.acquireLock.bind(redis);
+    redis.acquireLock = async (key: string, token: string, ttlMs: number) => {
+      const acquired = await realAcquire(key, token, ttlMs);
+      internals.abortController.abort();
+      return acquired;
+    };
+
+    await internals.initiateDepositV3(message);
+
+    expect(sendStub.notCalled).to.equal(true);
+    // Nothing was broadcast, so the just-acquired marker is released rather than left to defer
+    // the successor for the full TTL.
+    expect(redis.store.has(pendingKey(message))).to.equal(false);
+    expect(redis.store.has(executedKey())).to.equal(false);
+  });
+
   it("skips the broadcast without writing a marker when a handover was observed mid-message", async function () {
     const { internals, redis, sendStub } = buildHandler();
     const message = depositMessageV3();

--- a/test/DepositAddressHandler.handover.ts
+++ b/test/DepositAddressHandler.handover.ts
@@ -180,6 +180,7 @@ type HandlerInternals = {
   waitForDisconnect: () => Promise<void>;
   observedExecutedDeposits: { [chainId: number]: Set<string> };
   executedDepositTxHashes: Set<string>;
+  heldPendingLocks: Set<string>;
   _loadPersistedSet: (redisKey: string, legacyRedisKey: string) => Promise<Set<string>>;
 };
 
@@ -203,7 +204,7 @@ function buildHandler(): {
   const handler = new DepositAddressHandler(logger, config, {} as unknown as Signer, [{} as unknown as Signer]);
 
   const redis = new FakeRedis();
-  const sendStub = sinon.stub().resolves(fakeReceipt());
+  const sendStub = sinon.stub().resolves({ receipt: fakeReceipt(), mayHaveBroadcast: true });
   const executeTxStub = sinon.stub().resolves(executeResponse());
   const balanceStub = sinon.stub().resolves(toBN("5000"));
   Object.assign(handler, {
@@ -227,7 +228,7 @@ describe("DepositAddressHandler pending-execution locks", function () {
     sendStub.callsFake(async () => {
       // At broadcast time the pending-execution lock must be held under this instance's token.
       expect(redis.store.get(pendingKey(message))).to.equal(RUN_IDENTIFIER);
-      return fakeReceipt();
+      return { receipt: fakeReceipt(), mayHaveBroadcast: true };
     });
 
     await internals.initiateDepositV3(message);
@@ -266,7 +267,7 @@ describe("DepositAddressHandler pending-execution locks", function () {
   it("keeps the lock on a failed submit, defers retries until the TTL clears it", async function () {
     const { internals, redis, sendStub } = buildHandler();
     const message = depositMessageV3();
-    sendStub.resolves(undefined);
+    sendStub.resolves({ receipt: undefined, mayHaveBroadcast: true });
 
     await internals.initiateDepositV3(message);
 
@@ -280,7 +281,25 @@ describe("DepositAddressHandler pending-execution locks", function () {
 
     // Once the TTL expires the lock, the retry proceeds.
     redis.store.delete(pendingKey(message));
-    sendStub.resolves(fakeReceipt());
+    sendStub.resolves({ receipt: fakeReceipt(), mayHaveBroadcast: true });
+    await internals.initiateDepositV3(message);
+    expect(sendStub.calledTwice).to.equal(true);
+    expect(redis.sets.get(EXECUTED_KEY)?.has(message.erc20Transfer.transactionHash)).to.equal(true);
+  });
+
+  it("releases the lock and keeps the fast retry path on a known no-broadcast failure", async function () {
+    const { internals, redis, sendStub } = buildHandler();
+    const message = depositMessageV3();
+    // Pre-flight simulation failed before anything was signed or sent.
+    sendStub.resolves({ receipt: undefined, mayHaveBroadcast: false });
+
+    await internals.initiateDepositV3(message);
+
+    expect(redis.store.has(pendingKey(message))).to.equal(false);
+    expect(redis.sets.has(EXECUTED_KEY)).to.equal(false);
+
+    // The next poll retries immediately — no TTL deferral for a provably-unsent tx.
+    sendStub.resolves({ receipt: fakeReceipt(), mayHaveBroadcast: true });
     await internals.initiateDepositV3(message);
     expect(sendStub.calledTwice).to.equal(true);
     expect(redis.sets.get(EXECUTED_KEY)?.has(message.erc20Transfer.transactionHash)).to.equal(true);
@@ -311,7 +330,7 @@ describe("DepositAddressHandler pending-execution locks", function () {
     sendStub.callsFake(async () => {
       // Simulate TTL expiry + re-acquisition by the other instance while the tx confirms.
       redis.store.set(pendingKey(message), OTHER_INSTANCE);
-      return fakeReceipt();
+      return { receipt: fakeReceipt(), mayHaveBroadcast: true };
     });
 
     await internals.initiateDepositV3(message);
@@ -477,14 +496,18 @@ describe("DepositAddressHandler committed-set refresh, prune and migration", fun
     expect(redis.store.has(LEGACY_EXECUTED_KEY)).to.equal(true);
   });
 
-  it("prefers the native set over the legacy blob once it is populated", async function () {
+  it("merges legacy-only members into a populated native set (rollback recovery)", async function () {
     const { internals, redis } = buildHandler();
+    // The v2 set is already populated (pre-rollback commits); the legacy blob carries a member
+    // committed by the rolled-back build that exists nowhere else. Skipping the merge would make
+    // that execution replayable.
     redis.sets.set(EXECUTED_KEY, new Set(["0xccc"]));
-    redis.store.set(LEGACY_EXECUTED_KEY, JSON.stringify(["0xaaa"]));
+    redis.store.set(LEGACY_EXECUTED_KEY, JSON.stringify(["0xaaa", "0xccc"]));
 
     const loaded = await internals._loadPersistedSet(EXECUTED_KEY, LEGACY_EXECUTED_KEY);
 
-    expect([...loaded]).to.deep.equal(["0xccc"]);
+    expect([...loaded].sort()).to.deep.equal(["0xaaa", "0xccc"]);
+    expect([...(redis.sets.get(EXECUTED_KEY) ?? [])].sort()).to.deep.equal(["0xaaa", "0xccc"]);
   });
 });
 
@@ -524,6 +547,26 @@ describe("DepositAddressHandler handover draining", function () {
     const { internals } = buildHandler();
     void internals.trackTick(new Promise(() => undefined));
     expect(await internals.drainInFlightWork(0)).to.equal(false);
+  });
+
+  it("waitForDisconnect renews held pending-execution locks while draining", async function () {
+    const { handler, internals, redis } = buildHandler();
+    const message = depositMessageV3();
+    const coordinator = { subscribe: sinon.stub().resolves(OTHER_INSTANCE) };
+    Object.assign(handler, { _instanceCoordinator: coordinator });
+    // An unknown-outcome submit left this lock held (and tracked) before the handover; its TTL
+    // runs from acquisition, so the drain must renew it or the successor could acquire the
+    // expired key mid-drain.
+    redis.store.set(pendingKey(message), RUN_IDENTIFIER);
+    internals.heldPendingLocks.add(getDepositKey(message));
+    const renewSpy = sinon.spy(redis, "renewLock");
+
+    await internals.waitForDisconnect();
+
+    // Renewed immediately at drain start and once more on the way out.
+    expect(renewSpy.callCount).to.be.greaterThanOrEqual(2);
+    expect(renewSpy.firstCall.args[0]).to.equal(pendingKey(message));
+    expect(renewSpy.firstCall.args[1]).to.equal(RUN_IDENTIFIER);
   });
 
   it("waitForDisconnect holds Redis open past the expected drain window for a slow tick", async function () {

--- a/test/DepositAddressHandler.handover.ts
+++ b/test/DepositAddressHandler.handover.ts
@@ -324,6 +324,28 @@ describe("DepositAddressHandler pending-execution locks", function () {
     expect(redis.store.has(pendingKey(message))).to.equal(false);
   });
 
+  it("skips the broadcast and releases the lock when a handover lands during the acquire round-trip", async function () {
+    const { internals, redis, sendStub } = buildHandler();
+    const message = depositMessageV3();
+    // The checkpoint's initial abort check passes; the handover is observed while the lock
+    // acquire is in flight (e.g. the drain wait has already timed out and the process is about
+    // to tear down). The post-acquisition re-check must bail rather than broadcast.
+    const realAcquire = redis.acquireLock.bind(redis);
+    redis.acquireLock = async (key: string, token: string) => {
+      const acquired = await realAcquire(key, token);
+      internals.abortController.abort();
+      return acquired;
+    };
+
+    await internals.initiateDepositV3(message);
+
+    expect(sendStub.notCalled).to.equal(true);
+    // Nothing was broadcast, so the just-acquired lock is released rather than left to defer the
+    // successor for the full TTL.
+    expect(redis.store.has(pendingKey(message))).to.equal(false);
+    expect(redis.sets.has(EXECUTED_KEY)).to.equal(false);
+  });
+
   it("skips the broadcast without taking the lock when a handover was observed mid-message", async function () {
     const { internals, redis, sendStub } = buildHandler();
     const message = depositMessageV3();
@@ -376,6 +398,60 @@ describe("DepositAddressHandler committed-set refresh, prune and migration", fun
 
     expect(internals.executedDepositTxHashes.has(stale)).to.equal(false);
     expect(redis.sets.get(EXECUTED_KEY)?.has(stale)).to.equal(false);
+  });
+
+  it("does not prune a member imported by this tick's refresh (commit racing the snapshot)", async function () {
+    const { handler, internals, redis } = buildHandler();
+    const fresh = "0x" + "8".repeat(64);
+    // Committed by a concurrently-running instance AFTER this tick's indexer snapshot: present
+    // in Redis, absent from memory and from the snapshot. Absence from a snapshot that may
+    // predate the commit proves nothing — pruning it would re-open the replay window.
+    redis.sets.set(EXECUTED_KEY, new Set([fresh]));
+    Object.assign(handler, { _queryIndexerApi: sinon.stub().resolves([]) });
+
+    await internals.evaluateDepositAddresses();
+
+    expect(internals.executedDepositTxHashes.has(fresh)).to.equal(true);
+    expect(redis.sets.get(EXECUTED_KEY)?.has(fresh)).to.equal(true);
+
+    // One tick later the member predates the snapshot, so its absence is meaningful — pruned.
+    await internals.evaluateDepositAddresses();
+
+    expect(internals.executedDepositTxHashes.has(fresh)).to.equal(false);
+    expect(redis.sets.get(EXECUTED_KEY)?.has(fresh)).to.equal(false);
+  });
+
+  it("prunes nothing and processes nothing when the indexer poll fails", async function () {
+    const { handler, internals, redis } = buildHandler();
+    const member = "0x" + "9".repeat(64);
+    internals.executedDepositTxHashes.add(member);
+    redis.sets.set(EXECUTED_KEY, new Set([member]));
+    const processStub = sinon.stub().resolves();
+    // A failed poll resolves undefined — not an empty snapshot. Treating it as empty would SREM
+    // every committed member and durably drop replay protection on a transient outage.
+    Object.assign(handler, {
+      _queryIndexerApi: sinon.stub().resolves(undefined),
+      processExecution: processStub,
+    });
+
+    await internals.evaluateDepositAddresses();
+
+    expect(processStub.notCalled).to.equal(true);
+    expect(internals.executedDepositTxHashes.has(member)).to.equal(true);
+    expect(redis.sets.get(EXECUTED_KEY)?.has(member)).to.equal(true);
+  });
+
+  it("mirrors each commit into the legacy blob key for rollback", async function () {
+    const { internals, redis } = buildHandler();
+    const message = depositMessageV3();
+
+    await internals.initiateDepositV3(message);
+
+    // The authoritative v2 set and the legacy JSON blob (read by a rolled-back build) both carry
+    // the commit.
+    expect(redis.sets.get(EXECUTED_KEY)?.has(message.erc20Transfer.transactionHash)).to.equal(true);
+    const legacy = JSON.parse(redis.store.get(LEGACY_EXECUTED_KEY) ?? "[]") as string[];
+    expect(legacy).to.contain(message.erc20Transfer.transactionHash);
   });
 
   it("migrates the legacy JSON blob into the native set on first load", async function () {

--- a/test/DepositAddressHandler.handover.ts
+++ b/test/DepositAddressHandler.handover.ts
@@ -18,9 +18,13 @@ const EXECUTE_TARGET = "0x0000000000000000000000000000000000005900";
 const V3_CHAIN = 42161;
 const V1_CHAIN = 1;
 
-/** Minimal in-memory stand-in for the Redis ops the handler uses (get/set/locks). */
+/**
+ * Minimal in-memory stand-in for the Redis ops the handler uses: plain keys (get/set/del),
+ * native sets (sAdd/sRem/sMembers/sIsMember) and the token-guarded lock trio.
+ */
 class FakeRedis {
   store = new Map<string, string>();
+  sets = new Map<string, Set<string>>();
 
   async get<T>(key: string): Promise<T | null> {
     return (this.store.get(key) ?? null) as T | null;
@@ -35,8 +39,7 @@ class FakeRedis {
     return this.store.delete(key) ? 1 : 0;
   }
 
-  /** SET NX semantics; TTLs are not modelled. */
-  async acquireLock(key: string, token: string, _ttlMs: number): Promise<boolean> {
+  async acquireLock(key: string, token: string): Promise<boolean> {
     if (this.store.has(key)) {
       return false;
     }
@@ -44,15 +47,40 @@ class FakeRedis {
     return true;
   }
 
-  async renewLock(key: string, token: string, _ttlMs: number): Promise<boolean> {
+  async renewLock(key: string, token: string): Promise<boolean> {
     return this.store.get(key) === token;
   }
 
   async releaseLock(key: string, token: string): Promise<boolean> {
-    if (this.store.get(key) !== token) {
-      return false;
+    if (this.store.get(key) === token) {
+      this.store.delete(key);
+      return true;
     }
-    return this.store.delete(key);
+    return false;
+  }
+
+  async sAdd(key: string, value: string): Promise<number> {
+    const set = this.sets.get(key) ?? new Set<string>();
+    const added = set.has(value) ? 0 : 1;
+    set.add(value);
+    this.sets.set(key, set);
+    return added;
+  }
+
+  async sRem(key: string, value: string): Promise<number> {
+    return this.sets.get(key)?.delete(value) ? 1 : 0;
+  }
+
+  async sMembers(key: string): Promise<string[]> {
+    return [...(this.sets.get(key) ?? [])];
+  }
+
+  async sIsMember(key: string, value: string): Promise<boolean> {
+    return this.sets.get(key)?.has(value) ?? false;
+  }
+
+  async expire(): Promise<boolean> {
+    return true;
   }
 }
 
@@ -60,9 +88,8 @@ function pendingKey(message: DepositAddressMessage | DepositAddressMessageV3): s
   return `deposit-address:pending-execution:${BOT_IDENTIFIER}:${getDepositKey(message)}`;
 }
 
-function executedKey(): string {
-  return `deposit-address:executed:${BOT_IDENTIFIER}`;
-}
+const EXECUTED_KEY = `deposit-address:executed:${BOT_IDENTIFIER}:v2`;
+const LEGACY_EXECUTED_KEY = `deposit-address:executed:${BOT_IDENTIFIER}`;
 
 function fakeReceipt(): TransactionReceipt {
   return { transactionHash: "0x" + "9".repeat(64), blockNumber: 1_234_567, logs: [] } as unknown as TransactionReceipt;
@@ -152,6 +179,8 @@ type HandlerInternals = {
   drainInFlightWork: (timeoutSeconds: number) => Promise<void>;
   waitForDisconnect: () => Promise<void>;
   observedExecutedDeposits: { [chainId: number]: Set<string> };
+  executedDepositTxHashes: Set<string>;
+  _loadPersistedSet: (redisKey: string, legacyRedisKey: string) => Promise<Set<string>>;
 };
 
 function buildHandler(): {
@@ -188,15 +217,15 @@ function buildHandler(): {
   return { handler, internals: handler as unknown as HandlerInternals, redis, sendStub, executeTxStub };
 }
 
-describe("DepositAddressHandler pending-execution markers", function () {
+describe("DepositAddressHandler pending-execution locks", function () {
   afterEach(() => sinon.restore());
 
-  it("writes the marker before broadcasting and clears it after persisting the executed marker", async function () {
+  it("holds the lock during the broadcast, then commits the member and releases", async function () {
     const { internals, redis, sendStub } = buildHandler();
     const message = depositMessageV3();
 
     sendStub.callsFake(async () => {
-      // At broadcast time the pending marker must already be persisted under this instance.
+      // At broadcast time the pending-execution lock must be held under this instance's token.
       expect(redis.store.get(pendingKey(message))).to.equal(RUN_IDENTIFIER);
       return fakeReceipt();
     });
@@ -205,10 +234,10 @@ describe("DepositAddressHandler pending-execution markers", function () {
 
     expect(sendStub.calledOnce).to.equal(true);
     expect(redis.store.has(pendingKey(message))).to.equal(false);
-    expect(redis.store.get(executedKey())).to.contain(message.erc20Transfer.transactionHash);
+    expect(redis.sets.get(EXECUTED_KEY)?.has(message.erc20Transfer.transactionHash)).to.equal(true);
   });
 
-  it("defers execution while another instance holds the pending marker", async function () {
+  it("defers execution while another instance holds the lock", async function () {
     const { internals, redis, sendStub, executeTxStub } = buildHandler();
     const message = depositMessageV3();
     redis.store.set(pendingKey(message), OTHER_INSTANCE);
@@ -217,11 +246,11 @@ describe("DepositAddressHandler pending-execution markers", function () {
 
     expect(executeTxStub.notCalled).to.equal(true);
     expect(sendStub.notCalled).to.equal(true);
-    // The marker was not consumed: the deferral holds until the owner clears it or the TTL expires.
+    // The foreign lock is untouched: the deferral holds until the owner releases it or TTL expires.
     expect(redis.store.get(pendingKey(message))).to.equal(OTHER_INSTANCE);
   });
 
-  it("does not defer on its own marker (normal retry path)", async function () {
+  it("does not defer on its own lock (normal retry path renews it)", async function () {
     const { internals, redis, sendStub } = buildHandler();
     const message = depositMessageV3();
     redis.store.set(pendingKey(message), RUN_IDENTIFIER);
@@ -231,22 +260,71 @@ describe("DepositAddressHandler pending-execution markers", function () {
     expect(sendStub.calledOnce).to.equal(true);
   });
 
-  it("keeps the marker on a failed submit and still allows this instance to retry", async function () {
+  it("keeps the lock on a failed submit and still allows this instance to retry", async function () {
     const { internals, redis, sendStub } = buildHandler();
     const message = depositMessageV3();
     sendStub.resolves(undefined);
 
     await internals.initiateDepositV3(message);
 
-    // A failed sendAndConfirm may still have broadcast; the marker must outlive it (TTL cleanup).
+    // A failed sendAndConfirm may still have broadcast; the lock must outlive it (TTL cleanup).
     expect(redis.store.get(pendingKey(message))).to.equal(RUN_IDENTIFIER);
-    expect(redis.store.has(executedKey())).to.equal(false);
-    // The in-flight lock was released, and the own marker does not block the retry.
+    expect(redis.sets.has(EXECUTED_KEY)).to.equal(false);
+    // The in-flight lock was released, and the own pending lock renews rather than blocks.
     await internals.initiateDepositV3(message);
     expect(sendStub.calledTwice).to.equal(true);
   });
 
-  it("skips the broadcast without writing a marker when a handover was observed mid-message", async function () {
+  it("does not broadcast when another instance acquires the lock after the early foreign check", async function () {
+    // The early hasForeignPendingExecution read is advisory; a concurrent instance can take the
+    // lock between it and the checkpoint. The atomic acquire must lose and skip the broadcast.
+    const { internals, redis, sendStub, executeTxStub } = buildHandler();
+    const message = depositMessageV3();
+    executeTxStub.callsFake(async () => {
+      // Runs after the early check, before the checkpoint — the other instance wins the lock here.
+      redis.store.set(pendingKey(message), OTHER_INSTANCE);
+      return executeResponse();
+    });
+
+    await internals.initiateDepositV3(message);
+
+    expect(sendStub.notCalled).to.equal(true);
+    expect(redis.store.get(pendingKey(message))).to.equal(OTHER_INSTANCE);
+  });
+
+  it("does not release a lock another instance acquired after this instance's expired mid-flight", async function () {
+    // If the broadcast outlives the lock TTL and another instance re-acquires it, the token-guarded
+    // release after commit must leave the other instance's lock in place.
+    const { internals, redis, sendStub } = buildHandler();
+    const message = depositMessageV3();
+    sendStub.callsFake(async () => {
+      // Simulate TTL expiry + re-acquisition by the other instance while the tx confirms.
+      redis.store.set(pendingKey(message), OTHER_INSTANCE);
+      return fakeReceipt();
+    });
+
+    await internals.initiateDepositV3(message);
+
+    // The execution still commits (it is on-chain), but the foreign lock survives the release.
+    expect(redis.sets.get(EXECUTED_KEY)?.has(message.erc20Transfer.transactionHash)).to.equal(true);
+    expect(redis.store.get(pendingKey(message))).to.equal(OTHER_INSTANCE);
+  });
+
+  it("skips the broadcast when the transfer was committed by another instance under no lock", async function () {
+    // Simulates the race the committed-set re-check closes: the other instance committed and
+    // released its lock after this tick's refresh, so memory is stale and no lock is visible.
+    const { internals, redis, sendStub } = buildHandler();
+    const message = depositMessageV3();
+    redis.sets.set(EXECUTED_KEY, new Set([message.erc20Transfer.transactionHash]));
+
+    await internals.initiateDepositV3(message);
+
+    expect(sendStub.notCalled).to.equal(true);
+    // The checkpoint's probe lock was released again — nothing is left deferring the transfer.
+    expect(redis.store.has(pendingKey(message))).to.equal(false);
+  });
+
+  it("skips the broadcast without taking the lock when a handover was observed mid-message", async function () {
     const { internals, redis, sendStub } = buildHandler();
     const message = depositMessageV3();
     internals.abortController.abort();
@@ -258,43 +336,7 @@ describe("DepositAddressHandler pending-execution markers", function () {
     expect(internals.observedExecutedDeposits[V3_CHAIN].size).to.equal(0);
   });
 
-  it("does not broadcast when another instance acquires the marker after the early foreign check", async function () {
-    const { internals, redis, sendStub, executeTxStub } = buildHandler();
-    const message = depositMessageV3();
-    // The early hasForeignPendingExecution read passes (no marker yet); the other instance's
-    // marker lands while this instance is fetching calldata, i.e. before the pre-broadcast
-    // checkpoint. The atomic acquisition must lose and skip the broadcast.
-    executeTxStub.callsFake(async () => {
-      redis.store.set(pendingKey(message), OTHER_INSTANCE);
-      return executeResponse();
-    });
-
-    await internals.initiateDepositV3(message);
-
-    expect(sendStub.notCalled).to.equal(true);
-    expect(redis.store.get(pendingKey(message))).to.equal(OTHER_INSTANCE);
-    // The in-flight lock was released so the transfer is re-evaluated on later polls.
-    expect(internals.observedExecutedDeposits[V3_CHAIN].size).to.equal(0);
-  });
-
-  it("does not clear a marker another instance acquired after this instance's expired mid-flight", async function () {
-    const { internals, redis, sendStub } = buildHandler();
-    const message = depositMessageV3();
-
-    sendStub.callsFake(async () => {
-      // Simulate the marker TTL expiring during a slow confirmation, with another instance then
-      // acquiring the key. The ownership-checked release must leave that marker intact.
-      redis.store.set(pendingKey(message), OTHER_INSTANCE);
-      return fakeReceipt();
-    });
-
-    await internals.initiateDepositV3(message);
-
-    expect(redis.store.get(executedKey())).to.contain(message.erc20Transfer.transactionHash);
-    expect(redis.store.get(pendingKey(message))).to.equal(OTHER_INSTANCE);
-  });
-
-  it("defers the v1 refund-withdraw path on a foreign marker before any chain reads", async function () {
+  it("defers the v1 refund-withdraw path on a foreign lock before any chain reads", async function () {
     const { handler, internals, redis, sendStub } = buildHandler();
     const message = withdrawMessageV1();
     redis.store.set(pendingKey(message), OTHER_INSTANCE);
@@ -304,6 +346,58 @@ describe("DepositAddressHandler pending-execution markers", function () {
 
     expect(balanceStub.notCalled).to.equal(true);
     expect(sendStub.notCalled).to.equal(true);
+  });
+});
+
+describe("DepositAddressHandler committed-set refresh, prune and migration", function () {
+  afterEach(() => sinon.restore());
+
+  it("picks up commits from a concurrently-running instance within one tick", async function () {
+    const { handler, internals, redis, sendStub } = buildHandler();
+    const message = depositMessageV3();
+    // Committed by the other instance after this instance booted: present in Redis, not in memory.
+    redis.sets.set(EXECUTED_KEY, new Set([message.erc20Transfer.transactionHash]));
+    Object.assign(handler, { _queryIndexerApi: sinon.stub().resolves([message]) });
+
+    await internals.evaluateDepositAddresses();
+
+    expect(internals.executedDepositTxHashes.has(message.erc20Transfer.transactionHash)).to.equal(true);
+    expect(sendStub.notCalled).to.equal(true);
+  });
+
+  it("prunes members the indexer no longer returns from memory and Redis", async function () {
+    const { handler, internals, redis } = buildHandler();
+    const stale = "0x" + "7".repeat(64);
+    internals.executedDepositTxHashes.add(stale);
+    redis.sets.set(EXECUTED_KEY, new Set([stale]));
+    Object.assign(handler, { _queryIndexerApi: sinon.stub().resolves([]) });
+
+    await internals.evaluateDepositAddresses();
+
+    expect(internals.executedDepositTxHashes.has(stale)).to.equal(false);
+    expect(redis.sets.get(EXECUTED_KEY)?.has(stale)).to.equal(false);
+  });
+
+  it("migrates the legacy JSON blob into the native set on first load", async function () {
+    const { internals, redis } = buildHandler();
+    redis.store.set(LEGACY_EXECUTED_KEY, JSON.stringify(["0xaaa", "0xbbb"]));
+
+    const loaded = await internals._loadPersistedSet(EXECUTED_KEY, LEGACY_EXECUTED_KEY);
+
+    expect([...loaded].sort()).to.deep.equal(["0xaaa", "0xbbb"]);
+    expect([...(redis.sets.get(EXECUTED_KEY) ?? [])].sort()).to.deep.equal(["0xaaa", "0xbbb"]);
+    // The legacy key is left in place for rollback.
+    expect(redis.store.has(LEGACY_EXECUTED_KEY)).to.equal(true);
+  });
+
+  it("prefers the native set over the legacy blob once it is populated", async function () {
+    const { internals, redis } = buildHandler();
+    redis.sets.set(EXECUTED_KEY, new Set(["0xccc"]));
+    redis.store.set(LEGACY_EXECUTED_KEY, JSON.stringify(["0xaaa"]));
+
+    const loaded = await internals._loadPersistedSet(EXECUTED_KEY, LEGACY_EXECUTED_KEY);
+
+    expect([...loaded]).to.deep.equal(["0xccc"]);
   });
 });
 
@@ -345,19 +439,16 @@ describe("DepositAddressHandler handover draining", function () {
     await internals.drainInFlightWork(0);
   });
 
-  it("waitForDisconnect aborts, drains in-flight work, then signals drained", async function () {
+  it("waitForDisconnect aborts, then drains in-flight work before resolving", async function () {
     const { handler, internals } = buildHandler();
-    const events: string[] = [];
-    const coordinator = {
-      subscribe: sinon.stub().resolves(OTHER_INSTANCE),
-      signalDrained: sinon.stub().callsFake(async () => void events.push("drained")),
-    };
+    const coordinator = { subscribe: sinon.stub().resolves(OTHER_INSTANCE) };
     Object.assign(handler, { _instanceCoordinator: coordinator });
 
+    let tickSettled = false;
     void internals.trackTick(
       new Promise<void>((resolve) =>
         setTimeout(() => {
-          events.push("tickSettled");
+          tickSettled = true;
           resolve();
         }, 20)
       )
@@ -366,6 +457,6 @@ describe("DepositAddressHandler handover draining", function () {
     await internals.waitForDisconnect();
 
     expect(internals.abortController.signal.aborted).to.equal(true);
-    expect(events).to.deep.equal(["tickSettled", "drained"]);
+    expect(tickSettled).to.equal(true);
   });
 });

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -577,7 +577,7 @@ describe("DepositAddressHandler._validateExecuteResponse guards", function () {
 describe("DepositAddressHandler._getSignedWithdrawV3", function () {
   let handler: DepositAddressHandler;
   let signWithdrawStub: sinon.SinonStub;
-  let redisSetStub: sinon.SinonStub;
+  let redisSAddStub: sinon.SinonStub;
 
   type Internals = {
     _getSignedWithdrawV3: (
@@ -600,8 +600,12 @@ describe("DepositAddressHandler._getSignedWithdrawV3", function () {
     (handler as unknown as { api: { signWithdrawDepositAddressV3: sinon.SinonStub } }).api = {
       signWithdrawDepositAddressV3: signWithdrawStub,
     };
-    redisSetStub = sinon.stub().resolves();
-    (handler as unknown as { redisCache: { set: sinon.SinonStub } }).redisCache = { set: redisSetStub };
+    // The terminal-422 skip is committed via sAdd + expire (native Redis set).
+    redisSAddStub = sinon.stub().resolves(1);
+    (handler as unknown as { redisCache: unknown }).redisCache = {
+      sAdd: redisSAddStub,
+      expire: sinon.stub().resolves(true),
+    };
   });
 
   afterEach(() => sinon.restore());
@@ -635,7 +639,7 @@ describe("DepositAddressHandler._getSignedWithdrawV3", function () {
     expect(result).to.equal(undefined);
     expect(signWithdrawStub.callCount).to.equal(4); // initial attempt + 3 retries
     expect(internals().terminallySkippedWithdrawKeys.size).to.equal(0);
-    expect(redisSetStub.notCalled).to.equal(true);
+    expect(redisSAddStub.notCalled).to.equal(true);
   });
 
   it("treats a 422 as terminal: no retry, persists the skip key", async function () {
@@ -646,7 +650,7 @@ describe("DepositAddressHandler._getSignedWithdrawV3", function () {
     expect(signWithdrawStub.callCount).to.equal(1); // no retries on a terminal 422
     const depositKey = `${DEPOSIT_ADDRESS}:${message.erc20Transfer.transactionHash}`;
     expect(internals().terminallySkippedWithdrawKeys.has(depositKey)).to.equal(true);
-    expect(redisSetStub.calledOnce).to.equal(true);
+    expect(redisSAddStub.calledOnce).to.equal(true);
   });
 });
 

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -600,11 +600,13 @@ describe("DepositAddressHandler._getSignedWithdrawV3", function () {
     (handler as unknown as { api: { signWithdrawDepositAddressV3: sinon.SinonStub } }).api = {
       signWithdrawDepositAddressV3: signWithdrawStub,
     };
-    // The terminal-422 skip is committed via sAdd + expire (native Redis set).
+    // The terminal-422 skip is committed via sAdd + expire (native Redis set), with the legacy
+    // blob key mirrored via set for rollback safety.
     redisSAddStub = sinon.stub().resolves(1);
     (handler as unknown as { redisCache: unknown }).redisCache = {
       sAdd: redisSAddStub,
       expire: sinon.stub().resolves(true),
+      set: sinon.stub().resolves("OK"),
     };
   });
 

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -484,6 +484,8 @@ describe("DepositAddressHandler.initiateDepositV3 integratorId guard", function 
     (handler as unknown as { observedExecutedDeposits: Record<number, Set<string>> }).observedExecutedDeposits = {
       [originChainId]: new Set<string>(),
     };
+    // The pending-execution marker check reads Redis before the guard; no marker present.
+    (handler as unknown as { redisCache: unknown }).redisCache = { get: sinon.stub().resolves(null) };
   });
 
   afterEach(() => sinon.restore());
@@ -673,7 +675,11 @@ describe("DepositAddressHandler.initiateWithdrawV3 guards", function () {
     (handler as unknown as { observedExecutedWithdraws: Record<number, Set<string>> }).observedExecutedWithdraws = {
       [chainId]: new Set<string>(),
     };
-    (handler as unknown as { redisCache: { set: sinon.SinonStub } }).redisCache = { set: sinon.stub().resolves() };
+    // `get` serves the pending-execution marker check (no marker present).
+    (handler as unknown as { redisCache: unknown }).redisCache = {
+      get: sinon.stub().resolves(null),
+      set: sinon.stub().resolves(),
+    };
   }
 
   afterEach(() => sinon.restore());
@@ -770,6 +776,8 @@ describe("DepositAddressHandler.initiateWithdrawV3 balance check", function () {
     (handler as unknown as { providersByChain: Record<number, unknown> }).providersByChain = {
       [chainId]: { getBalance: getBalanceStub },
     };
+    // The pending-execution marker check reads Redis before the balance check; no marker present.
+    (handler as unknown as { redisCache: unknown }).redisCache = { get: sinon.stub().resolves(null) };
   });
 
   afterEach(() => sinon.restore());

--- a/test/InstanceCoordinator.ts
+++ b/test/InstanceCoordinator.ts
@@ -35,67 +35,19 @@ function makeCoordinator(
   );
 }
 
-describe("InstanceCoordinator handover drain protocol", function () {
+describe("InstanceCoordinator handover", function () {
   afterEach(() => sinon.restore());
 
-  it("initiateHandover returns undefined on a cold start and the predecessor on takeover", async function () {
+  it("initiateHandover makes this instance active and displaces the predecessor", async function () {
     const redis = new FakeRedis();
     const a = makeCoordinator(redis, "instance-a");
-    expect(await a.initiateHandover()).to.equal(undefined);
+    await a.initiateHandover();
     expect(await a.isActiveInstance()).to.equal(true);
 
     const b = makeCoordinator(redis, "instance-b");
-    expect(await b.initiateHandover()).to.equal("instance-a");
+    await b.initiateHandover();
     expect(await b.isActiveInstance()).to.equal(true);
     expect(await a.isActiveInstance()).to.equal(false);
-  });
-
-  it("waitForPredecessorDrain returns true immediately when there is no predecessor", async function () {
-    const redis = new FakeRedis();
-    const b = makeCoordinator(redis, "instance-b");
-    expect(await b.waitForPredecessorDrain(undefined, 0)).to.equal(true);
-  });
-
-  it("resolves true when the predecessor has already signalled drained", async function () {
-    const redis = new FakeRedis();
-    const a = makeCoordinator(redis, "instance-a");
-    const b = makeCoordinator(redis, "instance-b");
-    await a.initiateHandover();
-    await b.initiateHandover();
-    await a.signalDrained();
-    expect(await b.waitForPredecessorDrain("instance-a", 0)).to.equal(true);
-  });
-
-  it("resolves true when the drained signal arrives while waiting", async function () {
-    this.timeout(5000);
-    const redis = new FakeRedis();
-    const a = makeCoordinator(redis, "instance-a");
-    const b = makeCoordinator(redis, "instance-b");
-    const wait = b.waitForPredecessorDrain("instance-a", 3);
-    setTimeout(() => void a.signalDrained(), 200);
-    expect(await wait).to.equal(true);
-  });
-
-  it("returns false when the predecessor never signals within the timeout", async function () {
-    const redis = new FakeRedis();
-    const b = makeCoordinator(redis, "instance-b");
-    expect(await b.waitForPredecessorDrain("instance-a", 0)).to.equal(false);
-  });
-
-  it("ignores a drained signal from a different instance", async function () {
-    const redis = new FakeRedis();
-    const stale = makeCoordinator(redis, "instance-stale");
-    await stale.signalDrained();
-    const b = makeCoordinator(redis, "instance-b");
-    expect(await b.waitForPredecessorDrain("instance-a", 0)).to.equal(false);
-  });
-
-  it("returns false promptly when aborted", async function () {
-    const redis = new FakeRedis();
-    const abortController = new AbortController();
-    const b = makeCoordinator(redis, "instance-b", abortController);
-    abortController.abort();
-    // Timeout is far in the future; only the abort can end the wait quickly.
-    expect(await b.waitForPredecessorDrain("instance-a", 600)).to.equal(false);
+    expect(await b.getActiveInstance()).to.equal("instance-b");
   });
 });

--- a/test/InstanceCoordinator.ts
+++ b/test/InstanceCoordinator.ts
@@ -1,0 +1,101 @@
+import sinon from "sinon";
+import { expect } from "chai";
+import { winston } from "../src/utils";
+import { InstanceCoordinator } from "../src/utils/InstanceCoordinator";
+import { RedisCacheInterface } from "../src/cache/Redis";
+
+const IDENTIFIER = "test-deposit-address-handler";
+
+/** Minimal in-memory stand-in for the Redis ops the coordinator uses (get/set). */
+class FakeRedis {
+  store = new Map<string, string>();
+
+  async get<T>(key: string): Promise<T | null> {
+    return (this.store.get(key) ?? null) as T | null;
+  }
+
+  async set<T>(key: string, val: T): Promise<string> {
+    this.store.set(key, String(val));
+    return "OK";
+  }
+}
+
+function makeCoordinator(
+  redis: FakeRedis,
+  instance: string,
+  abortController = new AbortController()
+): InstanceCoordinator {
+  const logger = { debug: sinon.stub(), warn: sinon.stub(), error: sinon.stub() } as unknown as winston.Logger;
+  return new InstanceCoordinator(
+    logger,
+    redis as unknown as RedisCacheInterface,
+    IDENTIFIER,
+    instance,
+    abortController
+  );
+}
+
+describe("InstanceCoordinator handover drain protocol", function () {
+  afterEach(() => sinon.restore());
+
+  it("initiateHandover returns undefined on a cold start and the predecessor on takeover", async function () {
+    const redis = new FakeRedis();
+    const a = makeCoordinator(redis, "instance-a");
+    expect(await a.initiateHandover()).to.equal(undefined);
+    expect(await a.isActiveInstance()).to.equal(true);
+
+    const b = makeCoordinator(redis, "instance-b");
+    expect(await b.initiateHandover()).to.equal("instance-a");
+    expect(await b.isActiveInstance()).to.equal(true);
+    expect(await a.isActiveInstance()).to.equal(false);
+  });
+
+  it("waitForPredecessorDrain returns true immediately when there is no predecessor", async function () {
+    const redis = new FakeRedis();
+    const b = makeCoordinator(redis, "instance-b");
+    expect(await b.waitForPredecessorDrain(undefined, 0)).to.equal(true);
+  });
+
+  it("resolves true when the predecessor has already signalled drained", async function () {
+    const redis = new FakeRedis();
+    const a = makeCoordinator(redis, "instance-a");
+    const b = makeCoordinator(redis, "instance-b");
+    await a.initiateHandover();
+    await b.initiateHandover();
+    await a.signalDrained();
+    expect(await b.waitForPredecessorDrain("instance-a", 0)).to.equal(true);
+  });
+
+  it("resolves true when the drained signal arrives while waiting", async function () {
+    this.timeout(5000);
+    const redis = new FakeRedis();
+    const a = makeCoordinator(redis, "instance-a");
+    const b = makeCoordinator(redis, "instance-b");
+    const wait = b.waitForPredecessorDrain("instance-a", 3);
+    setTimeout(() => void a.signalDrained(), 200);
+    expect(await wait).to.equal(true);
+  });
+
+  it("returns false when the predecessor never signals within the timeout", async function () {
+    const redis = new FakeRedis();
+    const b = makeCoordinator(redis, "instance-b");
+    expect(await b.waitForPredecessorDrain("instance-a", 0)).to.equal(false);
+  });
+
+  it("ignores a drained signal from a different instance", async function () {
+    const redis = new FakeRedis();
+    const stale = makeCoordinator(redis, "instance-stale");
+    await stale.signalDrained();
+    const b = makeCoordinator(redis, "instance-b");
+    expect(await b.waitForPredecessorDrain("instance-a", 0)).to.equal(false);
+  });
+
+  it("returns false promptly when aborted", async function () {
+    const redis = new FakeRedis();
+    const abortController = new AbortController();
+    const b = makeCoordinator(redis, "instance-b", abortController);
+    abortController.abort();
+    // Timeout is far in the future; only the abort can end the wait quickly.
+    expect(await b.waitForPredecessorDrain("instance-a", 600)).to.equal(false);
+  });
+});

--- a/test/Tasks.ts
+++ b/test/Tasks.ts
@@ -1,6 +1,6 @@
 import { expect } from "./utils";
 
-import { abortableDelay, fireAndForget } from "../src/utils";
+import { abortableDelay, fireAndForget, scheduleTask } from "../src/utils";
 
 describe("Tasks", function () {
   describe("fireAndForget", function () {
@@ -42,6 +42,33 @@ describe("Tasks", function () {
       )();
       await flushMicrotasks();
       expect(seen).to.deep.equal([]);
+    });
+  });
+
+  describe("scheduleTask", function () {
+    const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    it("schedules nothing when the signal is already aborted", async function () {
+      // addEventListener("abort") never fires on a signal that aborted in the past, so an
+      // interval started here could never be cleared — scheduleTask must not start one.
+      const controller = new AbortController();
+      controller.abort();
+      let calls = 0;
+      scheduleTask(async () => void ++calls, 0.01, controller.signal);
+      await sleep(50);
+      expect(calls).to.equal(0);
+    });
+
+    it("runs until the signal aborts, then stops", async function () {
+      const controller = new AbortController();
+      let calls = 0;
+      scheduleTask(async () => void ++calls, 0.01, controller.signal);
+      await sleep(100);
+      controller.abort();
+      const callsAtAbort = calls;
+      expect(callsAtAbort).to.be.greaterThan(0);
+      await sleep(60);
+      expect(calls).to.equal(callsAtAbort);
     });
   });
 


### PR DESCRIPTION
## Context

2026-07-20 duplicate-sweep incident ([Slack thread](https://risklabs.slack.com/archives/C08E4H3FSRX/p1784509360110029)): an instance handover raced an in-flight sweep on `zion-across-persistent-address-handler`. The outgoing instance broadcast the sweep for a 10 USDC deposit, then observed the handover and exited ~1s before the tx confirmed — the executed marker was never written. The replacement replayed the sweep once the next (20 USDC) deposit re-funded the address, double-sweeping the first deposit and deadlocking the 10 USDC remainder until a manual sweep.

## Design (updated per review: continuous service)

The incoming instance starts polling **the moment it takes the lease** — no takeover wait — while the outgoing instance drains its in-flight executions concurrently. Two instances overlap by design; replay safety is per transfer:

**1. Per-transfer pending-execution locks.** Every fund-moving broadcast (v1/v3 deposit-execute, v1/v3 refund-withdraw) first atomically acquires `deposit-address:pending-execution:<botIdentifier>:<depositKey>` (SET NX, 15 min TTL; token-guarded renew covers this instance's own retries after a failed submit) and re-checks the committed set under the lock (`SISMEMBER`) before submitting — catching an execution the other instance committed and released after this tick's refresh. A lock held by another instance defers the transfer. The lock is released (token-guarded, never a blind DEL) only after the confirmed execution is committed; after a failed submit it is left to expire, since a "failed" send may still have broadcast. If an instance dies mid-flight, the successor defers that one transfer up to 15 min instead of risking a replay.

**2. Concurrency-safe committed sets.** The executed / withdrawn / terminal-skip sets move from whole-JSON-blob `SET`s (last-writer-wins → lost updates with two writers) to **native Redis sets** with per-member `SADD`/`SREM`, committed immediately after each confirmed execution and re-read (union-merged) into memory every poll tick — so one instance's commits reach the other within a tick. New `:v2` keys; empty v2 sets are seeded from the legacy blob keys on boot (legacy keys left in place for rollback).

**3. Drain on the way out.** On handover/SIGHUP the outgoing instance stops initiating new executions (poll-loop + pre-broadcast abort checks) and waits up to 90s for in-flight broadcasts to confirm and commit before exiting. Its locks keep the successor off those transfers while it drains.

**Handover latency: zero.** The successor polls immediately; only transfers actively in flight on the old instance are briefly deferred (lock-guarded), everything else executes without pause.

## Changes

- `src/deposit-address/DepositAddressHandler.ts` — lock-based `preBroadcastCheckpoint` (atomic acquire → committed re-check → broadcast), per-tick set refresh + prune, per-member commits, legacy-blob migration on load, drain on exit, `aborted` getter.
- `src/cache/Redis.ts` — `RedisCacheInterface` gains `expire` / `sAdd` / `sIsMember` / `sMembers` / `sRem` (implementations mostly pre-existing on `RedisCache`).
- `src/deposit-address/index.ts` — entrypoint skips polling when the handler ceded during initialize (still drains via `waitForDisconnect`).
- `src/utils/Tasks.ts` — `scheduleTask` schedules nothing on an already-aborted signal (listener would never fire, interval would leak).
- `src/utils/InstanceCoordinator.ts` — reverted to master; the earlier drained-signal/takeover-wait protocol is superseded by the lock-based concurrent model.
- `src/deposit-address/README.md` — "Concurrent handover" section + updated Redis persistence docs.
- Tests: lock lifecycle (held during broadcast, released after commit, kept on failed submit), foreign-lock deferral, own-lock renew, lock-acquired-after-early-check race, TTL-expiry/foreign-reacquire release guard, committed-under-no-lock re-check, per-tick refresh/prune, legacy migration, drain ordering, abort gating, `scheduleTask` abort semantics. 123 passing across the affected suites.

## Correctness argument (why no replay)

For any transfer, a broadcast requires holding the lock and having passed the committed-set re-check under it. Two instances cannot hold the lock simultaneously (SET NX). If the holder commits, its `SADD` lands **before** its lock release, so any later acquirer sees the committed member under the lock and skips. If the holder dies without committing, nobody else can broadcast until the lock TTL (15 min) expires — a bounded deferral, not a replay. The balance check remains as an additional independent guard.

## Rollout notes

- First deploy overlaps new code with the old (pre-lock) instance: the old instance takes no locks during its final drain, so that single rotation has the same (pre-existing) race as today. From the next rotation on, both sides are lock-guarded.
- Committed-set storage migrates automatically (blob → native set); rollback-safe (legacy keys untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)