### PR TITLE
chore(monitor): Remove unused MONITOR_REPORT_NON_LP_TOKENS option

### DIFF
--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -41,7 +41,6 @@ import {
   isSVMSpokePoolClient,
   toAddressType,
   Address,
-  EvmAddress,
   chainIsTvm,
   SvmAddress,
   assert,
@@ -89,7 +88,6 @@ export class Monitor {
   private spokePoolsBlocks: Record<number, { startingBlock: number | undefined; endingBlock: number | undefined }> = {};
   private balanceCache: { [chainId: number]: { [token: string]: { [account: string]: BigNumber } } } = {};
   private decimals: { [chainId: number]: { [token: string]: number } } = {};
-  private additionalL1Tokens: L1Token[] = [];
   // Chains for each spoke pool client.
   public monitorChains: number[];
   // Chains that we care about inventory manager activity on, so doesn't include Ethereum which doesn't
@@ -114,20 +112,12 @@ export class Monitor {
       monitorChains: this.monitorChains,
       crossChainAdapterSupportedChains: this.crossChainAdapterSupportedChains,
     });
-    this.additionalL1Tokens = monitorConfig.additionalL1NonLpTokens.map((l1Token) => {
-      const l1TokenInfo = this.getTokenInfo(EvmAddress.from(l1Token), this.clients.hubPoolClient.chainId);
-      assert(l1TokenInfo.address.isEVM());
-      return {
-        ...l1TokenInfo,
-        address: l1TokenInfo.address,
-      };
-    });
     this.l1Tokens = this.clients.hubPoolClient.getL1Tokens();
     this.bundleDataApproxClient = new BundleDataApproxClient(
       this.clients.spokePoolClients,
       this.clients.hubPoolClient,
       this.monitorChains,
-      [...this.l1Tokens, ...this.additionalL1Tokens].map(({ address }) => address),
+      this.l1Tokens.map(({ address }) => address),
       this.logger
     );
   }
@@ -406,7 +396,7 @@ export class Monitor {
   async reportRelayerBalances(): Promise<void> {
     const hubChainId = this.clients.hubPoolClient.chainId;
     const relayers = this.monitorConfig.monitoredRelayers;
-    const allL1Tokens = [...this.l1Tokens, ...this.additionalL1Tokens];
+    const allL1Tokens = this.l1Tokens;
 
     // Fetch pending rebalances once for all relayers.
 

--- a/src/monitor/MonitorConfig.ts
+++ b/src/monitor/MonitorConfig.ts
@@ -1,15 +1,7 @@
 import winston from "winston";
 import { array, create, number, object, optional, record, string, union } from "superstruct";
 import { CommonConfig, ProcessEnv } from "../common";
-import {
-  CHAIN_IDs,
-  getNativeTokenAddressForChain,
-  isDefined,
-  resolveAcrossToken,
-  Address,
-  toAddressType,
-  parseJson,
-} from "../utils";
+import { CHAIN_IDs, getNativeTokenAddressForChain, isDefined, Address, toAddressType, parseJson } from "../utils";
 
 const MonitoredBalances2Schema = record(
   string(),
@@ -67,7 +59,6 @@ export class MonitorConfig extends CommonConfig {
     account: Address;
     token: Address;
   }[] = [];
-  readonly additionalL1NonLpTokens: string[] = [];
   readonly binanceWithdrawWarnThreshold: number;
   readonly binanceWithdrawAlertThreshold: number;
   readonly hyperliquidOrderMaximumLifetime: number;
@@ -90,7 +81,6 @@ export class MonitorConfig extends CommonConfig {
       MONITORED_BALANCES,
       MONITORED_BALANCES_2,
       STUCK_REBALANCES_ENABLED,
-      MONITOR_REPORT_NON_LP_TOKENS,
       BUNDLES_COUNT,
       BINANCE_WITHDRAW_WARN_THRESHOLD,
       BINANCE_WITHDRAW_ALERT_THRESHOLD,
@@ -119,10 +109,6 @@ export class MonitorConfig extends CommonConfig {
     this.monitoredRelayers = parseAddressesOptional(MONITORED_RELAYERS);
     this.knownV1Addresses = parseAddressesOptional(KNOWN_V1_ADDRESSES);
     this.bundlesCount = Number(BUNDLES_COUNT ?? 4);
-    this.additionalL1NonLpTokens = parseJson
-      .stringArray(MONITOR_REPORT_NON_LP_TOKENS)
-      .map((token) => resolveAcrossToken(token, CHAIN_IDs.MAINNET))
-      .filter(isDefined);
 
     this.binanceWithdrawWarnThreshold = Number(BINANCE_WITHDRAW_WARN_THRESHOLD ?? 1);
     this.binanceWithdrawAlertThreshold = Number(BINANCE_WITHDRAW_ALERT_THRESHOLD ?? 1);


### PR DESCRIPTION
## Why

`MONITOR_REPORT_NON_LP_TOKENS` no longer has any consumers: its last use (CAKE on `zion-across-reporter`) was removed in UMAprotocol/bot-configs#4209 after the CAKE/BSC sunset. The env var now always parses to an empty array, making `additionalL1Tokens` dead plumbing.

## What

- `src/monitor/MonitorConfig.ts`: drop the `MONITOR_REPORT_NON_LP_TOKENS` env destructure, the `additionalL1NonLpTokens` property + parsing, and the now-unused `resolveAcrossToken` import.
- `src/monitor/Monitor.ts`: drop the `additionalL1Tokens` field, its population in the constructor, and its two spreads into the reported token lists (now just `this.l1Tokens`); remove the now-unused `EvmAddress` import.

Net -24 lines, no behavior change for any deployed config.

## Verification

- `yarn typecheck` clean
- `eslint` + `prettier` clean on both files
- `hardhat test test/Monitor.ts`: 3 passing

Requested by Paul in Slack ([thread](https://umaproject.slack.com/archives/C03JLFNQNDV/p1784556126946889)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)