### PR TITLE
improve(clients): track upcoming refunds only for configured relayers

### DIFF
--- a/src/clients/BundleDataApproxClient.ts
+++ b/src/clients/BundleDataApproxClient.ts
@@ -19,18 +19,18 @@ import { Address, bnZero } from "../utils/SDKUtils";
 import { HubPoolClient } from "./HubPoolClient";
 
 export type BundleDataState = {
+  // Deposit tracking was removed when its last consumer went away, but the field is retained (exported empty)
+  // so the serialized shape stays compatible across relayer versions.
   upcomingDeposits: { [l1Token: string]: { [chainId: number]: BigNumber } };
   upcomingRefunds: { [l1Token: string]: { [chainId: number]: { [relayer: string]: BigNumber } } };
 };
 
-// This client is used to approximate running balances and the refunds and deposits for a given L1 token. Running balances
-// can easily be estimated by taking the last validated running balance for a chain and subtracting the total deposit amount
-// on that chain since the last validated end block and adding the total refund amount on that chain since the last validated
-// end block.
+// This client approximates the upcoming refunds owed to a set of tracked relayers for a given L1 token:
+// every fill sent by a tracked relayer since the last executed bundle is assumed to be valid and refunded
+// on its selected repayment chain. Fills from other relayers are ignored.
 export class BundleDataApproxClient {
   private upcomingRefunds: { [l1Token: string]: { [chainId: number]: { [relayer: string]: BigNumber } } } | undefined =
     undefined;
-  private upcomingDeposits: { [l1Token: string]: { [chainId: number]: BigNumber } } | undefined = undefined;
   private readonly spokePoolManager: SpokePoolManager;
 
   private readonly protocolChainIdIndices: number[];
@@ -39,6 +39,7 @@ export class BundleDataApproxClient {
     private readonly hubPoolClient: HubPoolClient,
     private readonly chainIdList: number[],
     private readonly l1Tokens: Address[],
+    private readonly relayers: Address[],
     private readonly logger: winston.Logger
   ) {
     this.spokePoolManager = new SpokePoolManager(logger, spokePoolClients);
@@ -50,12 +51,9 @@ export class BundleDataApproxClient {
    * @returns BundleData(Approx)Client state. This can be subsequently ingested by BundleDataApproxClient.import().
    */
   export(): BundleDataState {
-    const { upcomingDeposits, upcomingRefunds } = this;
-    assert(
-      isDefined(upcomingDeposits) && isDefined(upcomingRefunds),
-      "BundleDataApproxClient#export: client not initialized"
-    );
-    return { upcomingDeposits, upcomingRefunds };
+    const { upcomingRefunds } = this;
+    assert(isDefined(upcomingRefunds), "BundleDataApproxClient#export: client not initialized");
+    return { upcomingDeposits: {}, upcomingRefunds };
   }
 
   /**
@@ -64,14 +62,12 @@ export class BundleDataApproxClient {
    * @returns void
    */
   import(state: BundleDataState): void {
-    const { upcomingDeposits, upcomingRefunds } = state;
-    this.upcomingDeposits = upcomingDeposits;
-    this.upcomingRefunds = upcomingRefunds;
+    this.upcomingRefunds = state.upcomingRefunds;
   }
 
   /**
-   * Return sum of refunds for all fills sent after the fromBlocks.
-   * Makes a simple assumption that all fills that were sent by this relayer after the last executed bundle
+   * Return sum of refunds for all tracked relayers' fills sent after the fromBlocks.
+   * Makes a simple assumption that all fills that were sent by a tracked relayer after the last executed bundle
    * are valid and will be refunded on the repayment chain selected.
    * @param l1Token L1 token to get refunds for all inventory-equivalent L2 tokens on each chain.
    * @param fromBlocks 2D block mapping indexed by [referenceChainId][fillChainId]. For refund counting, each fill
@@ -93,6 +89,11 @@ export class BundleDataApproxClient {
       }
       spokePoolClient.getFills().forEach((fill) => {
         const { inputAmount: _refundAmount, originChainId, repaymentChainId, relayer, inputToken, blockNumber } = fill;
+        // Only tracked relayers' refunds are of interest; skip everyone else's fills.
+        if (!this.relayers.some((trackedRelayer) => trackedRelayer.eq(relayer))) {
+          return;
+        }
+
         // Filter based on the repayment chain's execution state: a fill on chain X with repayment on
         // chain Y should only be excluded when chain Y's refund leaf has been executed.
         if (blockNumber < (fromBlocks[repaymentChainId]?.[chainId] ?? 0)) {
@@ -123,16 +124,13 @@ export class BundleDataApproxClient {
     return refundsForChain;
   }
 
-  // For each chain, find the last executed (or relayed) bundle and return a 2D mapping of start blocks:
+  // For each chain, find the last executed bundle and return a 2D mapping of start blocks:
   // result[chainId][c] = the start block on chain c derived from the last executed bundle on chainId.
   // This 2D structure is needed because a bundle executed on chain A may not yet be relayed to chain B
   // (due to cross-chain propagation delays), so the correct start block for counting fills depends on
   // which chain's execution state is being used as the reference. For refunds, the reference chain is
-  // the repayment chain; for deposits, it is the deposit's own chain (the diagonal: result[chainId][chainId]).
-  protected getUnexecutedBundleStartBlocks(
-    l1Token: Address,
-    requireExecution: boolean
-  ): { [chainId: number]: { [chainId: number]: number } } {
+  // the repayment chain.
+  protected getUnexecutedBundleStartBlocks(l1Token: Address): { [chainId: number]: { [chainId: number]: number } } {
     assert(l1Token.isEVM());
     return Object.fromEntries(
       this.chainIdList.map((chainId) => {
@@ -143,12 +141,6 @@ export class BundleDataApproxClient {
         const lastRelayedRootToChain = spokePoolClient.getRootBundleRelays().findLast((relay) => {
           if (!isDefined(relay)) {
             return false;
-          }
-
-          // If we don't require execution verification, return the last relayed root bundle directly.
-          // This is used for deposit counting where the boundary is bundle validation/relay, not leaf execution.
-          if (!requireExecution) {
-            return true;
           }
 
           const l2Tokens = getInventoryBalanceContributorTokens(l1Token, chainId, this.hubPoolClient.chainId);
@@ -205,62 +197,9 @@ export class BundleDataApproxClient {
   }
 
   private getApproximateUpcomingRefunds(l1Token: Address): ReturnType<typeof this.getApproximateRefundsForToken> {
-    const fromBlocks = this.getUnexecutedBundleStartBlocks(l1Token, true);
+    const fromBlocks = this.getUnexecutedBundleStartBlocks(l1Token);
     const refundsForChain = this.getApproximateRefundsForToken(l1Token, fromBlocks);
     return refundsForChain;
-  }
-
-  /**
-   * Return sum of deposits for all deposits sent after the fromBlocks.
-   * @param l1Token L1 token to get deposits for all inventory-equivalent L2 tokens on each chain.
-   * @param fromBlocks 2D block mapping indexed by [referenceChainId][depositChainId]. For deposit counting,
-   * only the diagonal is used: fromBlocks[chainId][chainId], since deposits are counted per origin chain.
-   * @returns Deposits grouped by chain. Deposits are denominated in L1 token decimals.
-   */
-  private getApproximateDepositsForToken(
-    l1Token: Address,
-    fromBlocks: { [chainId: number]: { [chainId: number]: number } }
-  ): { [chainId: number]: BigNumber } {
-    const depositsForChain: { [chainId: number]: BigNumber } = {};
-    for (const chainId of this.chainIdList) {
-      depositsForChain[chainId] ??= bnZero;
-      const spokePoolClient = this.spokePoolManager.getClient(chainId);
-      if (!isDefined(spokePoolClient)) {
-        continue;
-      }
-      spokePoolClient
-        .getDeposits()
-        .filter((deposit) => {
-          if (deposit.blockNumber < (fromBlocks[chainId]?.[chainId] ?? 0)) {
-            return false;
-          }
-          // We are ok to group together deposits for inventory-equivalent tokens because these approximate
-          // deposits and refunds are usually computed and summed together to approximate running balances. So we should
-          // use the same methodology for equating input and l1 tokens as we do in the getApproximateRefundsForToken method.
-          const expectedL1Token = this.getL1TokenAddress(deposit.inputToken, deposit.originChainId);
-          if (!isDefined(expectedL1Token)) {
-            return false;
-          }
-          return l1Token.eq(expectedL1Token);
-        })
-        .forEach((deposit) => {
-          const depositAmount = ConvertDecimals(
-            getTokenInfo(deposit.inputToken, deposit.originChainId).decimals,
-            getTokenInfo(l1Token, this.hubPoolClient.chainId).decimals
-          )(deposit.inputAmount);
-          depositsForChain[chainId] = depositsForChain[chainId].add(depositAmount);
-        });
-    }
-    return depositsForChain;
-  }
-
-  private getApproximateUpcomingDepositsForToken(
-    l1Token: Address
-  ): ReturnType<typeof this.getApproximateDepositsForToken> {
-    // Deposits don't need to be executed following a root bundle validation so we pass in `false` for `requireExecution`.
-    const fromBlocks = this.getUnexecutedBundleStartBlocks(l1Token, false);
-    const depositsForChain = this.getApproximateDepositsForToken(l1Token, fromBlocks);
-    return depositsForChain;
   }
 
   protected getL1TokenAddress(l2Token: Address, chainId: number): Address | undefined {
@@ -273,17 +212,14 @@ export class BundleDataApproxClient {
 
   initialize(): void {
     this.upcomingRefunds = {};
-    this.upcomingDeposits = {};
     for (const l1Token of this.l1Tokens) {
       this.upcomingRefunds[l1Token.toNative()] = this.getApproximateUpcomingRefunds(l1Token);
-      this.upcomingDeposits[l1Token.toNative()] = this.getApproximateUpcomingDepositsForToken(l1Token);
     }
     this.logger.debug({
       at: "BundleDataApproxClient#initialize",
       message: "Initialized BundleDataApproxClient",
       l1Tokens: this.l1Tokens.map((l1Token) => l1Token.toNative()),
       upcomingRefunds: this.upcomingRefunds,
-      upcomingDeposits: this.upcomingDeposits,
     });
   }
 
@@ -292,7 +228,8 @@ export class BundleDataApproxClient {
    * Refunds are denominated in L1 token decimals.
    * @param chainId Chain ID to get refunds for.
    * @param l1Token L1 token to get refunds for.
-   * @param relayer Optional relayer to get refunds for. If not provided, returns the sum of refunds for all relayers.
+   * @param relayer Optional relayer to get refunds for. If not provided, returns the sum of refunds for all tracked
+   * relayers. Refunds are only tracked for the relayers supplied at construction; other relayers return zero.
    * @returns Refunds for the given L1 token on the given chain for all inventory-equivalent L2 tokens on that chain. Refunds are denominated in L1 token decimals.
    */
   getUpcomingRefunds(chainId: number, l1Token: Address, relayer?: Address): BigNumber {
@@ -310,23 +247,5 @@ export class BundleDataApproxClient {
       (acc, curr) => acc.add(curr),
       bnZero
     );
-  }
-
-  /**
-   * Return deposits for a given L1 token on a given chain for all inventory-equivalent L2 tokens on that chain.
-   * Deposits are denominated in L1 token decimals.
-   * @param chainId Chain ID to get deposits for.
-   * @param l1Token L1 token to get deposits for.
-   * @returns Deposits for the given L1 token on the given chain for all inventory-equivalent L2 tokens on that chain. Deposits are denominated in L1 token decimals.
-   */
-  getUpcomingDeposits(chainId: number, l1Token: Address): BigNumber {
-    assert(
-      isDefined(this.upcomingDeposits),
-      "BundleDataApproxClient#getUpcomingDeposits: Upcoming deposits not initialized"
-    );
-    if (!this.upcomingDeposits[l1Token.toNative()]) {
-      return bnZero;
-    }
-    return this.upcomingDeposits[l1Token.toNative()][chainId] ?? bnZero;
   }
 }

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -136,6 +136,7 @@ export class InventoryClient {
       this.hubPoolClient,
       this.chainIdList,
       Array.from(allL1Tokens.values()).map((l1Token) => EvmAddress.from(l1Token)),
+      [this.relayer],
       this.logger
     );
   }

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -128,6 +128,7 @@ export class Monitor {
       this.clients.hubPoolClient,
       this.monitorChains,
       [...this.l1Tokens, ...this.additionalL1Tokens].map(({ address }) => address),
+      this.monitorConfig.monitoredRelayers,
       this.logger
     );
   }

--- a/test/BundleDataApproxClient.ts
+++ b/test/BundleDataApproxClient.ts
@@ -27,7 +27,7 @@ import { MockBundleDataApproxClient, MockConfigStoreClient, MockHubPoolClient, M
 import { interfaces } from "@across-protocol/sdk";
 import { ProposedRootBundle, RootBundleRelayWithBlock } from "../src/interfaces";
 
-describe("BundleDataApproxClient: Accounting for unexecuted, upcoming relayer refunds and deposits", function () {
+describe("BundleDataApproxClient: Accounting for unexecuted, upcoming relayer refunds", function () {
   const { MAINNET, OPTIMISM, BSC, POLYGON } = CHAIN_IDs;
   const enabledChainIds = [MAINNET, OPTIMISM, BSC];
   const mainnetWeth = TOKEN_SYMBOLS_MAP.WETH.addresses[MAINNET];
@@ -106,6 +106,7 @@ describe("BundleDataApproxClient: Accounting for unexecuted, upcoming relayer re
       hubPoolClient,
       enabledChainIds,
       [toAddressType(mainnetWeth, MAINNET), toAddressType(mainnetUsdc, MAINNET)],
+      [relayer],
       spyLogger
     );
     (bundleDataClient as MockBundleDataApproxClient).setTokenMapping({
@@ -176,35 +177,6 @@ describe("BundleDataApproxClient: Accounting for unexecuted, upcoming relayer re
     return newEvent;
   }
 
-  async function generateDeposit(
-    inputTokenSymbol: "USDC" | "WETH",
-    inputChainId: number,
-    inputAmount = toWei(1)
-  ): Promise<interfaces.Log> {
-    const spokePoolClient = spokePoolClients[inputChainId];
-    const newEvent = (spokePoolClient as unknown as MockSpokePoolClient).deposit({
-      inputToken: toAddressType(
-        inputTokenSymbol === "USDC" ? l2TokensForUsdc[inputChainId] : l2TokensForWeth[inputChainId],
-        inputChainId
-      ),
-      inputAmount,
-      depositor: toAddressType(owner.address, inputChainId),
-      recipient: toAddressType(owner.address, inputChainId),
-      outputToken: toAddressType(randomAddress(), inputChainId),
-      outputAmount: inputAmount,
-      quoteTimestamp: getCurrentTime(),
-      fillDeadline: getCurrentTime() + 14400,
-      exclusivityDeadline: getCurrentTime() + 14400,
-      exclusiveRelayer: toAddressType(owner.address, inputChainId),
-      originChainId: inputChainId,
-      blockNumber: spokePoolClient.latestHeightSearched,
-      txnIndex: 0,
-      logIndex: 0,
-    } as interfaces.DepositWithBlock);
-    await spokePoolClient.update(["FundsDeposited"]);
-    return newEvent;
-  }
-
   describe("getApproximateRefundsForToken", function () {
     // Helper to create 2D fromBlocks where every [repaymentChain][fillChain] has the same value.
     function uniformFromBlocks(
@@ -255,13 +227,11 @@ describe("BundleDataApproxClient: Accounting for unexecuted, upcoming relayer re
       const fill1 = await generateFill("WETH", MAINNET, MAINNET, owner.address);
       const fill2 = await generateFill("WETH", MAINNET, OPTIMISM, owner.address);
       const fill3 = await generateFill("USDC", MAINNET, MAINNET, owner.address, toBNWei(1, 6));
-      // Send a fill for a different relayer:
-      const fill4 = await generateFill("WETH", MAINNET, MAINNET, randomAddress());
+      // Send a fill for an untracked relayer; it produces no refunds for the tracked relayer set.
+      await generateFill("WETH", MAINNET, MAINNET, randomAddress());
       bundleDataClient.initialize();
       expect(bundleDataClient.getUpcomingRefunds(MAINNET, l1Weth, relayer)).to.equal(fill1.args.inputAmount);
-      expect(bundleDataClient.getUpcomingRefunds(MAINNET, l1Weth)).to.equal(
-        fill1.args.inputAmount.add(fill4.args.inputAmount)
-      );
+      expect(bundleDataClient.getUpcomingRefunds(MAINNET, l1Weth)).to.equal(fill1.args.inputAmount);
       expect(bundleDataClient.getUpcomingRefunds(OPTIMISM, l1Weth)).to.equal(fill2.args.inputAmount);
       expect(bundleDataClient.getUpcomingRefunds(MAINNET, l1Usdc)).to.equal(fill3.args.inputAmount);
       expect(bundleDataClient.getUpcomingRefunds(BSC, l1Weth)).to.equal(bnZero);
@@ -270,29 +240,20 @@ describe("BundleDataApproxClient: Accounting for unexecuted, upcoming relayer re
       );
       expect(bundleDataClient.getUpcomingRefunds(OPTIMISM, l1Usdc)).to.equal(bnZero);
     });
-  });
 
-  describe("getUpcomingDeposits", function () {
-    it("Must be initialized before use", async function () {
-      expect(() => bundleDataClient.getUpcomingDeposits(MAINNET, l1Weth)).to.throw(/not initialized/);
-    });
-    it("Returns the upcoming deposits for a given L1 token", async function () {
-      const deposit1 = await generateDeposit("WETH", MAINNET);
-      const deposit2 = await generateDeposit("USDC", MAINNET);
-      const deposit3 = await generateDeposit("WETH", OPTIMISM);
+    it("Ignores fills from untracked relayers", async function () {
+      await generateFill("WETH", MAINNET, MAINNET, randomAddress());
+      await generateFill("WETH", MAINNET, OPTIMISM, randomAddress());
       bundleDataClient.initialize();
-      expect(bundleDataClient.getUpcomingDeposits(MAINNET, l1Weth)).to.equal(deposit1.args.inputAmount);
-      expect(bundleDataClient.getUpcomingDeposits(OPTIMISM, l1Weth)).to.equal(deposit3.args.inputAmount);
-      expect(bundleDataClient.getUpcomingDeposits(MAINNET, l1Usdc)).to.equal(deposit2.args.inputAmount);
-      expect(bundleDataClient.getUpcomingDeposits(OPTIMISM, l1Usdc)).to.equal(bnZero);
-      expect(bundleDataClient.getUpcomingRefunds(BSC, l1Weth)).to.equal(bnZero);
+      expect(bundleDataClient.getUpcomingRefunds(MAINNET, l1Weth)).to.equal(bnZero);
+      expect(bundleDataClient.getUpcomingRefunds(OPTIMISM, l1Weth)).to.equal(bnZero);
     });
   });
 
   describe("Aggregates balances across multiple inventory contributor tokens", function () {
     // Test that when two different L2 tokens on the same chain both map to the same L1 token
-    // (e.g. USDC.e and native USDC both mapping to L1 USDC on Optimism), getUpcomingRefunds and
-    // getUpcomingDeposits correctly aggregate balances from both contributor tokens.
+    // (e.g. USDC.e and native USDC both mapping to L1 USDC on Optimism), getUpcomingRefunds
+    // correctly aggregates balances from both contributor tokens.
     const nativeUsdcOnOptimism = TOKEN_SYMBOLS_MAP.USDC.addresses[OPTIMISM];
 
     beforeEach(function () {
@@ -358,40 +319,6 @@ describe("BundleDataApproxClient: Accounting for unexecuted, upcoming relayer re
       const totalRefunds = bundleDataClient.getUpcomingRefunds(OPTIMISM, l1Usdc);
       expect(totalRefunds).to.equal(fillAmount1.add(fillAmount2));
     });
-
-    it("getUpcomingDeposits aggregates deposits from both contributor tokens", async function () {
-      const depositAmount1 = toBNWei(200, 6);
-      const depositAmount2 = toBNWei(75, 6);
-
-      // Deposit with the primary USDC.e token on Optimism.
-      await generateDeposit("USDC", OPTIMISM, depositAmount1);
-
-      // Deposit with the second contributor token on Optimism.
-      const spokePoolClient = spokePoolClients[OPTIMISM];
-      (spokePoolClient as unknown as MockSpokePoolClient).deposit({
-        inputToken: toAddressType(nativeUsdcOnOptimism, OPTIMISM),
-        inputAmount: depositAmount2,
-        depositor: toAddressType(owner.address, OPTIMISM),
-        recipient: toAddressType(owner.address, OPTIMISM),
-        outputToken: toAddressType(randomAddress(), OPTIMISM),
-        outputAmount: depositAmount2,
-        quoteTimestamp: getCurrentTime(),
-        fillDeadline: getCurrentTime() + 14400,
-        exclusivityDeadline: getCurrentTime() + 14400,
-        exclusiveRelayer: toAddressType(owner.address, OPTIMISM),
-        originChainId: OPTIMISM,
-        blockNumber: spokePoolClient.latestHeightSearched,
-        txnIndex: 0,
-        logIndex: 1,
-      } as interfaces.DepositWithBlock);
-      await spokePoolClient.update(["FundsDeposited"]);
-
-      bundleDataClient.initialize();
-
-      // Deposits should aggregate both deposit amounts.
-      const totalDeposits = bundleDataClient.getUpcomingDeposits(OPTIMISM, l1Usdc);
-      expect(totalDeposits).to.equal(depositAmount1.add(depositAmount2));
-    });
   });
 
   describe("Cross-chain refund counting with relay delay", function () {
@@ -409,6 +336,7 @@ describe("BundleDataApproxClient: Accounting for unexecuted, upcoming relayer re
         hubPoolClient,
         enabledChainIds,
         [toAddressType(mainnetWeth, MAINNET)],
+        [relayer],
         spyLogger
       );
       (bundleDataClient as MockBundleDataApproxClient).setTokenMapping({
@@ -501,10 +429,7 @@ describe("BundleDataApproxClient: Accounting for unexecuted, upcoming relayer re
       configStoreClient.setAvailableChains([MAINNET, OPTIMISM, BSC]);
 
       // When there are no RootBundleRelay/ProposedRootBundle events, returns 0 for all chains.
-      const defaultFromBlocks = (bundleDataClient as MockBundleDataApproxClient).getUnexecutedBundleStartBlocks(
-        l1Weth,
-        true
-      );
+      const defaultFromBlocks = (bundleDataClient as MockBundleDataApproxClient).getUnexecutedBundleStartBlocks(l1Weth);
       expect(defaultFromBlocks[MAINNET][MAINNET]).to.equal(0);
       expect(defaultFromBlocks[OPTIMISM][OPTIMISM]).to.equal(0);
       expect(defaultFromBlocks[BSC][BSC]).to.equal(0);
@@ -537,7 +462,7 @@ describe("BundleDataApproxClient: Accounting for unexecuted, upcoming relayer re
         txnRef: "0x",
       });
 
-      const fromBlocks1 = (bundleDataClient as MockBundleDataApproxClient).getUnexecutedBundleStartBlocks(l1Weth, true);
+      const fromBlocks1 = (bundleDataClient as MockBundleDataApproxClient).getUnexecutedBundleStartBlocks(l1Weth);
 
       // Only the spoke pool clients that saw the RootBundleRelay events should have non-zero fromBlocks.
       // The MAINNET entry returns end blocks for all chains from the matched bundle.

--- a/test/mocks/MockBundleDataApproxClient.ts
+++ b/test/mocks/MockBundleDataApproxClient.ts
@@ -33,10 +33,7 @@ export class MockBundleDataApproxClient extends BundleDataApproxClient {
   }
 
   // Expose for unit testing
-  override getUnexecutedBundleStartBlocks(
-    l1Token: Address,
-    requireExecution: boolean
-  ): { [chainId: number]: { [chainId: number]: number } } {
-    return super.getUnexecutedBundleStartBlocks(l1Token, requireExecution);
+  override getUnexecutedBundleStartBlocks(l1Token: Address): { [chainId: number]: { [chainId: number]: number } } {
+    return super.getUnexecutedBundleStartBlocks(l1Token);
   }
 }


### PR DESCRIPTION
## Motivation

Prerequisite to #3598, split out per Paul in Slack.

#3602 (remove spoke pool running-balance reporter) deleted the last consumer that needed all-relayer refund sums from `BundleDataApproxClient`. Every remaining consumer queries a relayer that is known at construction time: `InventoryClient` always queries its own relayer, and the Monitor queries each of its configured `MONITORED_RELAYERS`. Tracking every relayer on every spoke is now wasted work — and #3598 is about to make the per-fill bookkeeping heavier (repayment-chain/token resolution per fill), so shrinking the fill set first keeps that PR cheap.

## Changes

- `BundleDataApproxClient` takes the set of relayers to track and skips all other relayers' fills. `InventoryClient` passes `[this.relayer]`; the Monitor passes `monitoredRelayers`. Internal per-relayer keying is unchanged (the Monitor tracks several relayers).
- Remove upcoming-deposits tracking outright: `getUpcomingDeposits` lost its only consumer in #3602. The serialized `BundleDataState` shape is **unchanged** — `upcomingDeposits` is exported empty — so Redis handover state remains compatible with older/newer relayer versions in both directions. The inventory cache key embeds the relayer address (`InventoryClient#getInventoryCacheKey`), so imported state always belongs to the same, tracked relayer.
- `getUnexecutedBundleStartBlocks` drops the `requireExecution` parameter; the non-execution path existed only for deposit counting.

No README/AGENTS updates needed: internal client behavior only; `src/clients/README.md` describes the refund-tracking role, which is unchanged.

## Testing

- `yarn hardhat test test/BundleDataApproxClient.ts test/InventoryClient.InventoryRebalance.ts test/InventoryClient.RefundChain.ts test/Monitor.ts test/Rebalancer.loadCumulativeModeBalances.ts test/JussiGraph.buildGraph.ts` — 109 passing
- New test: fills from untracked relayers are ignored; existing all-relayer sum test updated to the tracked-set semantics
- `yarn build`, eslint + prettier clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)