### PR TITLE
Require exact poolRebalanceLeafCount in bundle validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.123",
     "@across-protocol/contracts": "5.0.24",
-    "@across-protocol/sdk": "4.4.13",
+    "@across-protocol/sdk": "4.4.14",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1058,9 +1058,17 @@ export class Dataworker {
     };
 
     // Compare against the leaf count committed at proposal time, not the live unclaimed count (which decrements
-    // as leaves execute). The reconstructed root must contain exactly the proposed number of leaves.
-    const proposedPoolRebalanceLeafCount =
-      this.clients.hubPoolClient.getLatestProposedRootBundle().poolRebalanceLeafCount;
+    // as leaves execute). Look up the proposal matching the root bundle under validation rather than assuming it's
+    // the latest proposal, since this function can validate historical bundles (e.g. via the validateRootBundle
+    // script). The reconstructed root must contain exactly the proposed number of leaves.
+    const matchingProposal = this.clients.hubPoolClient
+      .getProposedRootBundles()
+      .find((proposal) => proposal.blockNumber === rootBundle.proposalBlockNumber);
+    assert(
+      isDefined(matchingProposal),
+      "validateRootBundle: no proposal found at rootBundle.proposalBlockNumber; increase HubPoolClient lookback"
+    );
+    const proposedPoolRebalanceLeafCount = matchingProposal.poolRebalanceLeafCount;
 
     if (
       expectedPoolRebalanceRoot.leaves.length !== proposedPoolRebalanceLeafCount ||
@@ -1097,6 +1105,7 @@ export class Dataworker {
         expectedSlowRelayRoot: expectedSlowRelayRoot.tree.getHexRoot(),
         pendingRoot: rootBundle.poolRebalanceRoot,
         pendingPoolRebalanceLeafCount: rootBundle.unclaimedPoolRebalanceLeafCount,
+        proposedPoolRebalanceLeafCount,
       });
     } else if (expectedRelayerRefundRoot.tree.getHexRoot() !== rootBundle.relayerRefundRoot) {
       this.logger.debug({

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1057,11 +1057,13 @@ export class Dataworker {
       slowRelayTree: expectedSlowRelayRoot,
     };
 
+    // Compare against the leaf count committed at proposal time, not the live unclaimed count (which decrements
+    // as leaves execute). The reconstructed root must contain exactly the proposed number of leaves.
+    const proposedPoolRebalanceLeafCount =
+      this.clients.hubPoolClient.getLatestProposedRootBundle().poolRebalanceLeafCount;
+
     if (
-      // Its ok if there are fewer unclaimed leaves than in the reconstructed root, because some of the leaves
-      // might already have been executed, but its an issue if the reconstructed root expects fewer leaves than there
-      // are left to execute because it means that the unclaimed count can never drop to 0.
-      expectedPoolRebalanceRoot.leaves.length < rootBundle.unclaimedPoolRebalanceLeafCount ||
+      expectedPoolRebalanceRoot.leaves.length !== proposedPoolRebalanceLeafCount ||
       expectedPoolRebalanceRoot.tree.getHexRoot() !== rootBundle.poolRebalanceRoot
     ) {
       this.logger.debug({

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -651,8 +651,6 @@ export class Dataworker {
       hubPoolChainId,
       widestPossibleExpectedBlockRange,
       pendingRootBundle,
-      // The pending root bundle is always constructed from the most recent proposal (see HubPoolClient.update).
-      this.clients.hubPoolClient.getLatestProposedRootBundle(),
       spokePoolClients,
       earliestBlocksInSpokePoolClients
     );
@@ -818,10 +816,6 @@ export class Dataworker {
     hubPoolChainId: number,
     widestPossibleExpectedBlockRange: number[][],
     rootBundle: PendingRootBundle,
-    // The ProposeRootBundle event that rootBundle was constructed from. Passed in explicitly because the caller
-    // knows unambiguously which proposal it is validating; an event lookup here couldn't distinguish multiple
-    // proposals landing in the same block (e.g. propose, dispute, re-propose).
-    proposal: ProposedRootBundle,
     spokePoolClients: { [chainId: number]: SpokePoolClient },
     earliestBlocksInSpokePoolClients: { [chainId: number]: number },
     loadDataFromArweave = false
@@ -1065,7 +1059,7 @@ export class Dataworker {
 
     // Compare against the leaf count committed at proposal time, not the live unclaimed count (which decrements
     // as leaves execute). The reconstructed root must contain exactly the proposed number of leaves.
-    const proposedPoolRebalanceLeafCount = proposal.poolRebalanceLeafCount;
+    const proposedPoolRebalanceLeafCount = rootBundle.poolRebalanceLeafCount;
 
     if (
       expectedPoolRebalanceRoot.leaves.length !== proposedPoolRebalanceLeafCount ||
@@ -1587,8 +1581,6 @@ export class Dataworker {
       hubPoolChainId,
       widestPossibleExpectedBlockRange,
       pendingRootBundle,
-      // The pending root bundle is always constructed from the most recent proposal (see HubPoolClient.update).
-      this.clients.hubPoolClient.getLatestProposedRootBundle(),
       spokePoolClients,
       earliestBlocksInSpokePoolClients,
       this.config.loadArweaveData ?? true // Load data from arweave when executing leaves for speed.

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -651,6 +651,8 @@ export class Dataworker {
       hubPoolChainId,
       widestPossibleExpectedBlockRange,
       pendingRootBundle,
+      // The pending root bundle is always constructed from the most recent proposal (see HubPoolClient.update).
+      this.clients.hubPoolClient.getLatestProposedRootBundle(),
       spokePoolClients,
       earliestBlocksInSpokePoolClients
     );
@@ -816,6 +818,10 @@ export class Dataworker {
     hubPoolChainId: number,
     widestPossibleExpectedBlockRange: number[][],
     rootBundle: PendingRootBundle,
+    // The ProposeRootBundle event that rootBundle was constructed from. Passed in explicitly because the caller
+    // knows unambiguously which proposal it is validating; an event lookup here couldn't distinguish multiple
+    // proposals landing in the same block (e.g. propose, dispute, re-propose).
+    proposal: ProposedRootBundle,
     spokePoolClients: { [chainId: number]: SpokePoolClient },
     earliestBlocksInSpokePoolClients: { [chainId: number]: number },
     loadDataFromArweave = false
@@ -1058,17 +1064,8 @@ export class Dataworker {
     };
 
     // Compare against the leaf count committed at proposal time, not the live unclaimed count (which decrements
-    // as leaves execute). Look up the proposal matching the root bundle under validation rather than assuming it's
-    // the latest proposal, since this function can validate historical bundles (e.g. via the validateRootBundle
-    // script). The reconstructed root must contain exactly the proposed number of leaves.
-    const matchingProposal = this.clients.hubPoolClient
-      .getProposedRootBundles()
-      .find((proposal) => proposal.blockNumber === rootBundle.proposalBlockNumber);
-    assert(
-      isDefined(matchingProposal),
-      "validateRootBundle: no proposal found at rootBundle.proposalBlockNumber; increase HubPoolClient lookback"
-    );
-    const proposedPoolRebalanceLeafCount = matchingProposal.poolRebalanceLeafCount;
+    // as leaves execute). The reconstructed root must contain exactly the proposed number of leaves.
+    const proposedPoolRebalanceLeafCount = proposal.poolRebalanceLeafCount;
 
     if (
       expectedPoolRebalanceRoot.leaves.length !== proposedPoolRebalanceLeafCount ||
@@ -1591,6 +1588,8 @@ export class Dataworker {
       hubPoolChainId,
       widestPossibleExpectedBlockRange,
       pendingRootBundle,
+      // The pending root bundle is always constructed from the most recent proposal (see HubPoolClient.update).
+      this.clients.hubPoolClient.getLatestProposedRootBundle(),
       spokePoolClients,
       earliestBlocksInSpokePoolClients,
       this.config.loadArweaveData ?? true // Load data from arweave when executing leaves for speed.

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1101,7 +1101,6 @@ export class Dataworker {
         }),
         expectedSlowRelayRoot: expectedSlowRelayRoot.tree.getHexRoot(),
         pendingRoot: rootBundle.poolRebalanceRoot,
-        pendingPoolRebalanceLeafCount: rootBundle.unclaimedPoolRebalanceLeafCount,
         proposedPoolRebalanceLeafCount,
       });
     } else if (expectedRelayerRefundRoot.tree.getHexRoot() !== rootBundle.relayerRefundRoot) {

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1057,12 +1057,10 @@ export class Dataworker {
       slowRelayTree: expectedSlowRelayRoot,
     };
 
-    // Compare against the leaf count committed at proposal time, not the live unclaimed count (which decrements
-    // as leaves execute). The reconstructed root must contain exactly the proposed number of leaves.
-    const proposedPoolRebalanceLeafCount = rootBundle.poolRebalanceLeafCount;
-
     if (
-      expectedPoolRebalanceRoot.leaves.length !== proposedPoolRebalanceLeafCount ||
+      // Compare against the leaf count committed at proposal time, not the live unclaimed count (which decrements
+      // as leaves execute). The reconstructed root must contain exactly the proposed number of leaves.
+      expectedPoolRebalanceRoot.leaves.length !== rootBundle.poolRebalanceLeafCount ||
       expectedPoolRebalanceRoot.tree.getHexRoot() !== rootBundle.poolRebalanceRoot
     ) {
       this.logger.debug({
@@ -1095,7 +1093,7 @@ export class Dataworker {
         }),
         expectedSlowRelayRoot: expectedSlowRelayRoot.tree.getHexRoot(),
         pendingRoot: rootBundle.poolRebalanceRoot,
-        proposedPoolRebalanceLeafCount,
+        proposedPoolRebalanceLeafCount: rootBundle.poolRebalanceLeafCount,
       });
     } else if (expectedRelayerRefundRoot.tree.getHexRoot() !== rootBundle.relayerRefundRoot) {
       this.logger.debug({

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -185,6 +185,7 @@ export async function validate(_logger: winston.Logger, baseSigner: Signer): Pro
     config.hubPoolChainId,
     bundleImpliedBlockRanges,
     rootBundle,
+    precedingProposeRootBundleEvent,
     spokePoolClients,
     fromBlocks
   );

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -120,6 +120,7 @@ export async function validate(_logger: winston.Logger, baseSigner: Signer): Pro
     relayerRefundRoot: precedingProposeRootBundleEvent.relayerRefundRoot,
     slowRelayRoot: precedingProposeRootBundleEvent.slowRelayRoot,
     proposer: precedingProposeRootBundleEvent.proposer,
+    poolRebalanceLeafCount: precedingProposeRootBundleEvent.poolRebalanceLeafCount,
     unclaimedPoolRebalanceLeafCount: precedingProposeRootBundleEvent.poolRebalanceLeafCount,
     challengePeriodEndTimestamp: precedingProposeRootBundleEvent.challengePeriodEndTimestamp,
     bundleEvaluationBlockNumbers: precedingProposeRootBundleEvent.bundleEvaluationBlockNumbers.map((x) => x.toNumber()),
@@ -185,7 +186,6 @@ export async function validate(_logger: winston.Logger, baseSigner: Signer): Pro
     config.hubPoolChainId,
     bundleImpliedBlockRanges,
     rootBundle,
-    precedingProposeRootBundleEvent,
     spokePoolClients,
     fromBlocks
   );

--- a/test/Dataworker.validateRootBundle.ts
+++ b/test/Dataworker.validateRootBundle.ts
@@ -319,6 +319,60 @@ describe("Dataworker: Validate pending root bundle", function () {
     expect(spy.getCall(-2).lastArg.message).to.equal("Unexpected slow relay root, submitting dispute");
     await multiCallerClient.executeTxnQueues();
   });
+  it("Disputes a proposal that under-reports the pool rebalance leaf count", async function () {
+    // Regression test: a proposer that submits the correct roots but a poolRebalanceLeafCount lower than the
+    // number of leaves in the pool rebalance root leaves the excess leaves permanently unexecutable. The
+    // validator must dispute this (UMIP-157 "Determining the Result" requires an exact leaf count match).
+    await updateAllClients();
+
+    // Deposit on the origin chain and fill on the destination chain so the bundle spans two chains and the
+    // pool rebalance root therefore contains more than one leaf.
+    const deposit = await depositV3(
+      spokePool_1,
+      destinationChainId,
+      depositor,
+      erc20_1.address,
+      amountToDeposit,
+      erc20_2.address,
+      amountToDeposit
+    );
+    await updateAllClients();
+    await fillV3Relay(spokePool_2, deposit, depositor, destinationChainId);
+    for (let i = 0; i < BUNDLE_END_BLOCK_BUFFER; i++) {
+      await hre.network.provider.send("evm_mine");
+    }
+    await updateAllClients();
+
+    const blockRange = dataworkerInstance.chainIdListForBundleEvaluationBlockNumbers.map((chainId) => [
+      0,
+      spokePoolClients[chainId].latestHeightSearched,
+    ]);
+    const poolRebalanceRoot = await dataworkerInstance.buildPoolRebalanceRoot(blockRange, spokePoolClients);
+    const relayerRefundRoot = await dataworkerInstance.buildRelayerRefundRoot(
+      blockRange,
+      spokePoolClients,
+      poolRebalanceRoot.leaves,
+      poolRebalanceRoot.runningBalances
+    );
+    const slowRelayRoot = await dataworkerInstance.buildSlowRelayRoot(blockRange, spokePoolClients);
+
+    // Precondition: the undercount only strands leaves when there is more than one to begin with.
+    expect(poolRebalanceRoot.leaves.length).to.be.greaterThan(1);
+
+    // Propose the correct roots but report one fewer pool rebalance leaf than the root actually contains.
+    await l1Token_1.approve(hubPool.address, MAX_UINT_VAL); // Approve the proposal bond.
+    await hubPool.proposeRootBundle(
+      blockRange.map((range) => range[1]),
+      poolRebalanceRoot.leaves.length - 1,
+      poolRebalanceRoot.tree.getHexRoot(),
+      relayerRefundRoot.tree.getHexRoot(),
+      slowRelayRoot.tree.getHexRoot()
+    );
+    await updateAllClients();
+    await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
+    expect(spy.getCall(-2).lastArg.message).to.equal("Unexpected pool rebalance root, submitting dispute");
+    await multiCallerClient.executeTxnQueues();
+  });
   it("Validates root bundle with large bundleEvaluationBlockNumbers", async function () {
     await updateAllClients();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,10 +34,10 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.4.13":
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.4.13.tgz#cd8c831ee4a6dea0e5bd864d8ac0af8dabc72c72"
-  integrity sha512-yarX5BTB3WhoWOL3abmOotug4YgddVk7VkNYgAe5hQhQL6lVrEz2hv9g36RUllCHE5Il9SyfsV4bs6xQT/hCzA==
+"@across-protocol/sdk@4.4.14":
+  version "4.4.14"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.4.14.tgz#404fb77e7c604fe64228ab72a492f401f0744f41"
+  integrity sha512-ooC4yMEO9iPImgYhz2VVytbRRwTi+O+BHqN2ZGxQ6UP/b+b2t51+aiK7E0MYNJMnBPcb94NE8d9NjZu09NgcUw==
   dependencies:
     "@across-protocol/constants" "^3.1.123"
     "@across-protocol/contracts" "5.0.24"


### PR DESCRIPTION
`validateRootBundle` compared the reconstructed pool rebalance root's leaf count against the live `unclaimedPoolRebalanceLeafCount` with `<`. That counter decrements as leaves execute, so the bound had to stay lenient — meaning it only rejected counts that were too high, never too low.

Compare against the immutable proposed `poolRebalanceLeafCount` instead and require exact equality. Correct in both callers (pre-liveness dispute path and post-liveness execute path, where the live counter has already decremented); no change for well-formed bundles, where reconstructed count == proposed count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)