### PR TITLE
fix(hyperliquid): honor SEND_TRANSACTIONS in HyperliquidExecutor

### DIFF
--- a/src/hyperliquid/HyperliquidExecutor.ts
+++ b/src/hyperliquid/HyperliquidExecutor.ts
@@ -302,7 +302,7 @@ export class HyperliquidExecutor {
         this.finalizeLimitOrders(pair.baseToken, pair.finalToken, quoteNonces, outputAmounts);
       }
     });
-    await this.clients.multiCallerClient.executeTxnQueues();
+    await this.clients.multiCallerClient.executeTxnQueues(!this.config.sendingTransactionsEnabled);
   }
 
   /*
@@ -386,7 +386,7 @@ export class HyperliquidExecutor {
         taskResult,
       });
       if (this.clients.multiCallerClient.transactionCount() !== 0) {
-        await this.clients.multiCallerClient.executeTxnQueues();
+        await this.clients.multiCallerClient.executeTxnQueues(!this.config.sendingTransactionsEnabled);
       }
     }
   }


### PR DESCRIPTION
## Motivation

The `zion-across-hyperliquid-executor` deployment was configured with `SEND_TRANSACTIONS=false` (UMAprotocol/bot-configs#4104), but the bot kept submitting transactions on-chain. Reported in Slack by @pxrl and @bmzig.

## Cause

`CommonConfig` parses `SEND_TRANSACTIONS` into `sendingTransactionsEnabled`, and every other bot passes it through to `MultiCallerClient.executeTxnQueues(simulate)` (e.g. the finalizer's `!submitFinalizationTransactions`, the rebalancer adapters' `simMode`). The HyperliquidExecutor never consulted the flag — both of its `executeTxnQueues()` call sites used the default `simulate = false`, so the flag was silently ignored:

- `processTasks()` (executor loop: place/cancel limit orders)
- `finalizeSwapFlows()` (finalizer: settle swap flows)

## Fix

Pass `!this.config.sendingTransactionsEnabled` as the `simulate` argument at both call sites. With `SEND_TRANSACTIONS=false` the bot now simulates the queued transactions and logs the results instead of submitting them, matching the behavior of the other bots.

No doc updates needed: this makes the module conform to the already-documented `SEND_TRANSACTIONS` convention; there is no `src/hyperliquid/README.md`.

## Testing

- `tsc --noEmit`, `eslint`, and `prettier --check` pass on the touched file.
- No existing unit tests cover `src/hyperliquid/`; behavior change is limited to forwarding the existing flag into `MultiCallerClient`'s well-tested simulate path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)