### PR TITLE
feat: Support Tron origins on the v3 deposit-execute path

### DIFF
--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -140,8 +140,8 @@ export interface DepositAddressExecuteResponse {
   /** The API's re-derived deposit address; must match the funded address from the indexer. */
   depositAddress: string;
   executeTx: {
-    /** "tron" for Tron-origin executes; `to` is 0x-hex on both ecosystems. */
-    ecosystem: "evm" | "tron";
+    /** "tvm" for Tron-origin executes; `to` is 0x-hex on both ecosystems. */
+    ecosystem: "evm" | "tvm";
     chainId: number;
     to: string;
     data: string;

--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -103,10 +103,14 @@ export interface DepositAddressExecuteRequest {
     chainId: number;
     address: string;
   };
-  /** The withdraw "user" identity committed at deposit-address creation (the refund address). */
+  /**
+   * The withdraw "user" identity committed at deposit-address creation (the refund address).
+   * Origin-chain-native encoding: 0x-hex on EVM, base58 on Tron.
+   */
   userAddress: string;
   /** Input amount as a decimal (or 0x-hex) bigint string. */
   amount: string;
+  /** Origin-chain-native encoding, like `userAddress`. */
   executionFeeRecipient: string;
   /** Bot-priced payout, deducted from the bridged amount. Omitted => 0. */
   executionFee?: string;
@@ -136,7 +140,8 @@ export interface DepositAddressExecuteResponse {
   /** The API's re-derived deposit address; must match the funded address from the indexer. */
   depositAddress: string;
   executeTx: {
-    ecosystem: "evm";
+    /** "tvm" for Tron-origin executes; `to` is 0x-hex on both ecosystems. */
+    ecosystem: "evm" | "tvm";
     chainId: number;
     to: string;
     data: string;

--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -140,8 +140,8 @@ export interface DepositAddressExecuteResponse {
   /** The API's re-derived deposit address; must match the funded address from the indexer. */
   depositAddress: string;
   executeTx: {
-    /** "tvm" for Tron-origin executes; `to` is 0x-hex on both ecosystems. */
-    ecosystem: "evm" | "tvm";
+    /** "tron" for Tron-origin executes; `to` is 0x-hex on both ecosystems. */
+    ecosystem: "evm" | "tron";
     chainId: number;
     to: string;
     data: string;

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -1194,7 +1194,7 @@ export class DepositAddressHandler {
       });
       return false;
     }
-    const expectedEcosystem = chainIsTvm(originChainId) ? "tron" : "evm";
+    const expectedEcosystem = chainIsTvm(originChainId) ? "tvm" : "evm";
     if (executeTx.ecosystem !== expectedEcosystem) {
       this.logger.warn({
         ...logContext,

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -26,6 +26,9 @@ import {
   TransactionReceipt,
   getCurrentTime,
   isHttpError,
+  chainIsEvm,
+  chainIsTvm,
+  getEthersCompatibleAddress,
 } from "../utils";
 import { getRedisCache, RedisCacheInterface } from "../cache/Redis";
 import {
@@ -76,6 +79,15 @@ const HEARTBEAT_TIMEOUT_MS = 5_000;
 // Warn on every Nth consecutive heartbeat failure (i.e. once per N ticks during a sustained
 // outage, rather than once per tick or once ever).
 const HEARTBEAT_FAILURE_WARN_THRESHOLD = 10;
+
+/**
+ * Account namespace expected for addresses living on `chainId`; undefined = chain family the v3
+ * execute path does not support. Note zkSync-family chains are EVM here, so a `zksync`-namespaced
+ * message is skipped — same outcome as before this helper existed.
+ */
+function expectedNamespaceForChain(chainId: number): "evm" | "tron" | undefined {
+  return chainIsTvm(chainId) ? "tron" : chainIsEvm(chainId) ? "evm" : undefined;
+}
 
 /**
  * Independent relayer bot which processes EIP-3009 signatures into deposits and corresponding fills.
@@ -1031,14 +1043,21 @@ export class DepositAddressHandler {
     // unexpected throw must not strand the depositKey, since the next poll would silently skip it.
     let executeCommitted = false;
     try {
-      // The execute endpoint identity (userAddress) must be an EVM address; non-EVM identities
-      // cannot be executed through this path.
-      if (depositAddressNamespace !== "evm" || refundAddress.namespace !== "evm") {
+      // The execute endpoint identity (userAddress) must be native to the origin chain's family
+      // (evm ⇒ 0x-hex, tron ⇒ base58). A cross-family namespace (e.g. tron on an EVM chain) is a
+      // data anomaly; other families (e.g. svm) are not supported through this path.
+      const expectedNamespace = expectedNamespaceForChain(originChainId);
+      if (
+        !isDefined(expectedNamespace) ||
+        depositAddressNamespace !== expectedNamespace ||
+        refundAddress.namespace !== expectedNamespace
+      ) {
         this.logger.warn({
           at: "DepositAddressHandler#initiateDepositV3",
           message: "Skipping v3 deposit: unsupported account namespace",
           depositAddressNamespace,
           refundAddressNamespace: refundAddress.namespace,
+          expectedNamespace: expectedNamespace ?? "unsupported chain family",
           depositAddress,
           refTxHash,
           chainId: originChainId,
@@ -1155,7 +1174,11 @@ export class DepositAddressHandler {
       chainId: originChainId,
     };
 
-    if (executeResponse.depositAddress.toLowerCase() !== depositAddress.toLowerCase()) {
+    // Compare canonically: base58 is case-sensitive, so map both sides through the 0x-hex form
+    // (no-op on EVM, where this degrades to the previous lowercase compare). Also accepts a
+    // hex-encoded response for a base58-funded address.
+    const canonicalAddress = (address: string) => getEthersCompatibleAddress(originChainId, address).toLowerCase();
+    if (canonicalAddress(executeResponse.depositAddress) !== canonicalAddress(depositAddress)) {
       this.logger.warn({
         ...logContext,
         message: "Skipping execute: API-derived deposit address does not match funded deposit address",
@@ -1168,6 +1191,16 @@ export class DepositAddressHandler {
         ...logContext,
         message: "Skipping execute: execute tx chainId does not match origin chainId",
         executeTxChainId: executeTx.chainId,
+      });
+      return false;
+    }
+    const expectedEcosystem = chainIsTvm(originChainId) ? "tvm" : "evm";
+    if (executeTx.ecosystem !== expectedEcosystem) {
+      this.logger.warn({
+        ...logContext,
+        message: "Skipping execute: execute tx ecosystem does not match origin chain family",
+        executeTxEcosystem: executeTx.ecosystem,
+        expectedEcosystem,
       });
       return false;
     }
@@ -1206,6 +1239,7 @@ export class DepositAddressHandler {
       isDefined(integratorId) && INTEGRATOR_ID_REGEX.test(integratorId),
       "DepositAddressHandler: _getExecuteTx requires a validated integratorId"
     );
+    const originChainId = Number(erc20Transfer.chainId);
     const request = {
       destination: {
         token: {
@@ -1214,18 +1248,23 @@ export class DepositAddressHandler {
         },
         recipient: routeParams.recipient.address,
       },
-      originChainId: Number(erc20Transfer.chainId),
+      originChainId,
+      // The funding token is relayed verbatim from the indexer, which serves origin-chain-native
+      // encodings (base58 on Tron) — exactly what the execute endpoint expects for origin fields.
       ...(this.config.enableExecuteInputToken
         ? {
             inputToken: {
-              chainId: Number(erc20Transfer.chainId),
+              chainId: originChainId,
               address: erc20Transfer.contractAddress,
             },
           }
         : {}),
       userAddress: refundAddress.address,
       amount: erc20Transfer.amount,
-      executionFeeRecipient: this.signerAddress.toNative(),
+      // The API expects origin-chain-native encoding (base58 on Tron). The bot's Tron account is
+      // the same key re-encoded — TVM submission reuses the EVM private key — so re-encoding the
+      // signer address per origin chain keeps the fee recipient the bot itself on every family.
+      executionFeeRecipient: toAddressType(this.signerAddress.toNative(), originChainId).toNative(),
       integratorId,
       // Provenance reference to the inbound funding transfer. When accepted, the API folds this into a
       // Multicall3 bundle that emits a version-2 provenance blob, giving the indexer an on-chain
@@ -1235,7 +1274,7 @@ export class DepositAddressHandler {
       ...(this.config.enableExecuteErc20Transfer
         ? {
             erc20Transfer: {
-              chainId: Number(erc20Transfer.chainId),
+              chainId: originChainId,
               blockNumber: erc20Transfer.blockNumber,
               transactionHash: erc20Transfer.transactionHash,
               logIndex: erc20Transfer.logIndex,
@@ -1511,8 +1550,14 @@ export class DepositAddressHandler {
   }
 
   private getExecuteContract(address: string, originChainId: number, useDispatcher: boolean): Contract {
-    const contract = new Contract(address, []);
-    return useDispatcher ? contract : contract.connect(this.baseSigner.connect(this.providersByChain[originChainId]));
+    // The API returns a 0x-hex `to` on both ecosystems today; convert defensively in case a TVM
+    // response ever carries base58. The dispatcher case connects the provider only — simulation
+    // and TVM submission read `contract.provider`, while the dispatcher attaches its own signer
+    // at dispatch time.
+    const contract = new Contract(getEthersCompatibleAddress(originChainId, address), []);
+    return useDispatcher
+      ? contract.connect(this.providersByChain[originChainId])
+      : contract.connect(this.baseSigner.connect(this.providersByChain[originChainId]));
   }
 
   /**
@@ -1529,14 +1574,17 @@ export class DepositAddressHandler {
    * @notice Returns the deposit address's balance of `token` on `chainId`. Native transfers are
    * indexed with the sentinel token address, which has no contract — read those via
    * `provider.getBalance` instead of `balanceOf` (which reverts on the sentinel).
+   * Tron providers speak eth-JSON-RPC, so base58 inputs (un-normalized v3 messages) are converted
+   * to 0x-hex first; hex inputs pass through unchanged.
    */
   private async getDepositAddressBalance(chainId: number, token: string, depositAddress: string): Promise<BigNumber> {
     const provider = this.providersByChain[chainId];
     assert(isDefined(provider), `Provider not found for chain ${chainId}`);
+    const depositAddressHex = getEthersCompatibleAddress(chainId, depositAddress);
     if (isNativeTokenSentinel(token)) {
-      return provider.getBalance(depositAddress);
+      return provider.getBalance(depositAddressHex);
     }
-    return new Contract(token, ERC20_ABI, provider).balanceOf(depositAddress);
+    return new Contract(getEthersCompatibleAddress(chainId, token), ERC20_ABI, provider).balanceOf(depositAddressHex);
   }
 
   /*
@@ -1557,7 +1605,8 @@ export class DepositAddressHandler {
     // normalizeDepositAddressMessage dereferences those unconditionally — a single bad message
     // would throw and sink the whole batch, starving supported messages in the same response.
     // Only top-level fields are safe to read here. v3 items keep their own shape and are passed
-    // through un-normalized (the v3 execute path is EVM-only and guards namespaces itself).
+    // through un-normalized (the v3 execute path guards namespaces itself and consumes Tron
+    // fields in native base58, converting to 0x-hex only at on-chain call boundaries).
     return apiResponseData
       .filter((message) => {
         const { version } = message;

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -1194,7 +1194,7 @@ export class DepositAddressHandler {
       });
       return false;
     }
-    const expectedEcosystem = chainIsTvm(originChainId) ? "tvm" : "evm";
+    const expectedEcosystem = chainIsTvm(originChainId) ? "tron" : "evm";
     if (executeTx.ecosystem !== expectedEcosystem) {
       this.logger.warn({
         ...logContext,

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -127,7 +127,7 @@ read by the execute path — the API re-derives them, so they are carried for di
 (728126428) to `RELAYER_ORIGIN_CHAINS`, which also provisions the provider and dedup sets. v3
 messages stay un-normalized, so Tron fields flow **base58 end-to-end to the quote-api**
 (`userAddress`, `inputToken.address`; the bot re-encodes its own `executionFeeRecipient` to base58
-via `toAddressType`). The API responds with `executeTx.ecosystem: "tron"`, a **0x-hex `to`** (the
+via `toAddressType`). The API responds with `executeTx.ecosystem: "tvm"`, a **0x-hex `to`** (the
 RPC-facing format), and the `depositAddress` echoed in base58; the bot validates the ecosystem
 against the chain family and compares deposit addresses canonically (base58 → hex) since base58 is
 case-sensitive. On-chain reads (`getDepositAddressBalance`) and receipt-log matching

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -100,8 +100,9 @@ The flow (`initiateDepositV3`):
 
 1. Filter on `relayerOriginChains` and dedup against the same Redis/in-memory sets as v1 (the dedup
    scheme is keyed on `erc20Transfer.transactionHash` / `depositKey`, shared across versions).
-2. Skip non-`evm` `depositAddressNamespace` / `refundAddress.namespace` (the execute identity must
-   be an EVM address).
+2. Skip when `depositAddressNamespace` / `refundAddress.namespace` don't match the origin chain's
+   family (`evm` ⇒ EVM chains, `tron` ⇒ Tron; other families, and cross-family anomalies like a
+   `tron` namespace on an EVM chainId, are skipped with a warn).
 3. Skip when the `integrator.integratorId` is absent or not 2-byte hex (warned, no API call) —
    mirrors the namespace guard. No funded v3 addresses exist pre-integrator, so a missing/malformed
    id is a data anomaly; sending it would only derive a different, unfunded address.
@@ -120,6 +121,21 @@ The flow (`initiateDepositV3`):
 
 The v3 message's `counterfactualMaterials`/`initialRoot`/`salt` are relayed by the indexer but not
 read by the execute path — the API re-derives them, so they are carried for diagnostics only.
+
+**Tron origins.** The v3 execute path also supports Tron-funded deposit addresses
+(`depositAddressNamespace: "tron"`). No dedicated gate: Tron activates by adding its chainId
+(728126428) to `RELAYER_ORIGIN_CHAINS`, which also provisions the provider and dedup sets. v3
+messages stay un-normalized, so Tron fields flow **base58 end-to-end to the quote-api**
+(`userAddress`, `inputToken.address`; the bot re-encodes its own `executionFeeRecipient` to base58
+via `toAddressType`). The API responds with `executeTx.ecosystem: "tvm"`, a **0x-hex `to`** (the
+RPC-facing format), and the `depositAddress` echoed in base58; the bot validates the ecosystem
+against the chain family and compares deposit addresses canonically (base58 → hex) since base58 is
+case-sensitive. On-chain reads (`getDepositAddressBalance`) and receipt-log matching
+(`buildDepositExecutedPayload`) convert base58 → 0x-hex via `getEthersCompatibleAddress` because
+Tron providers speak eth-JSON-RPC. Submission reuses the existing TVM path in `TransactionClient`
+(`_runTransactionTvm`, raw calldata, TRX `feeLimit`); the bot signer's key doubles as its Tron
+account, which must hold TRX for fees. Tron refund-withdraws remain unsupported (the v3 withdraw
+path is still EVM-only).
 
 ## v3 refund-withdraw flow
 

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -127,7 +127,7 @@ read by the execute path — the API re-derives them, so they are carried for di
 (728126428) to `RELAYER_ORIGIN_CHAINS`, which also provisions the provider and dedup sets. v3
 messages stay un-normalized, so Tron fields flow **base58 end-to-end to the quote-api**
 (`userAddress`, `inputToken.address`; the bot re-encodes its own `executionFeeRecipient` to base58
-via `toAddressType`). The API responds with `executeTx.ecosystem: "tvm"`, a **0x-hex `to`** (the
+via `toAddressType`). The API responds with `executeTx.ecosystem: "tron"`, a **0x-hex `to`** (the
 RPC-facing format), and the `depositAddress` echoed in base58; the bot validates the ecosystem
 against the chain family and compares deposit addresses canonically (base58 → hex) since base58 is
 case-sensitive. On-chain reads (`getDepositAddressBalance`) and receipt-log matching

--- a/src/deposit-address/withdrawPayload.ts
+++ b/src/deposit-address/withdrawPayload.ts
@@ -1,5 +1,5 @@
 import { AnyDepositAddressMessage, DepositAddressMessageV3, isDepositAddressMessageV3 } from "../interfaces";
-import { isDefined, isNativeTokenSentinel, TransactionReceipt, utils } from "../utils";
+import { getEthersCompatibleAddress, isDefined, isNativeTokenSentinel, TransactionReceipt, utils } from "../utils";
 
 export const ERC20_TRANSFER_TOPIC = utils.id("Transfer(address,address,uint256)");
 
@@ -148,9 +148,16 @@ export function buildDepositExecutedPayload(
   depositMessage: DepositAddressMessageV3
 ): DepositExecutedPayload | undefined {
   const { erc20Transfer, depositAddress } = depositMessage;
-  const token = erc20Transfer.contractAddress;
+  const chainId = Number(erc20Transfer.chainId);
+  // v3 messages arrive un-normalized, so Tron fields are base58 — but receipt logs (eth-JSON-RPC)
+  // are 0x-hex, and hexZeroPad throws outright on base58. Convert before matching; no-op on EVM.
+  const token = getEthersCompatibleAddress(chainId, erc20Transfer.contractAddress);
 
-  const transferLog = findLastTransferFromDepositAddress(receipt, token, depositAddress);
+  const transferLog = findLastTransferFromDepositAddress(
+    receipt,
+    token,
+    getEthersCompatibleAddress(chainId, depositAddress)
+  );
   if (!isDefined(transferLog)) {
     return undefined;
   }

--- a/test/DepositAddressHandler.publish.ts
+++ b/test/DepositAddressHandler.publish.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { utils, TransactionReceipt } from "../src/utils";
+import { CHAIN_IDs, getEthersCompatibleAddress, utils, TransactionReceipt } from "../src/utils";
 import { DepositAddressMessage, DepositAddressMessageV3 } from "../src/interfaces/DepositAddress";
 import {
   buildDepositExecutedPayload,
@@ -329,6 +329,55 @@ describe("buildDepositExecutedPayload", function () {
     ]);
     const payload = buildDepositExecutedPayload(receipt, depositMessageV3());
     expect(payload?.data.logIndex).to.equal(2);
+  });
+
+  // v3 Tron messages arrive un-normalized (base58 token/depositAddress, un-prefixed tx hash), while
+  // receipt logs from the eth-JSON-RPC provider are 0x-hex — the builder converts before matching.
+  describe("with a base58 Tron message", function () {
+    const TRON_DEPOSIT_ADDRESS = "TRhLhFckPaeCtFyrUBJRK6p9LhRtbS7Pa5";
+    const TRON_REFUND_ADDRESS = "TQ4T4DgHoezYBTRoZPCspsSgRw38Ni9prA";
+    const TRON_TOKEN = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+    const TRON_TX_HASH = "3b699036b64d765dea6a9103c33793d343381bab361b3e96051e56de2d174247";
+    const TOKEN_HEX = getEthersCompatibleAddress(CHAIN_IDs.TRON, TRON_TOKEN);
+    const DEPOSIT_ADDRESS_HEX = getEthersCompatibleAddress(CHAIN_IDs.TRON, TRON_DEPOSIT_ADDRESS);
+
+    function tronDepositMessageV3(): DepositAddressMessageV3 {
+      const message = depositMessageV3();
+      message.depositAddress = TRON_DEPOSIT_ADDRESS;
+      message.refundAddress = { namespace: "tron", address: TRON_REFUND_ADDRESS };
+      message.depositAddressNamespace = "tron";
+      message.erc20Transfer = {
+        ...message.erc20Transfer,
+        chainId: String(CHAIN_IDs.TRON),
+        from: TRON_REFUND_ADDRESS,
+        to: TRON_DEPOSIT_ADDRESS,
+        contractAddress: TRON_TOKEN,
+        transactionHash: TRON_TX_HASH,
+      };
+      return message;
+    }
+
+    it("matches hex receipt logs against the converted base58 fields", function () {
+      const receipt = fakeReceipt([
+        {
+          address: TOKEN_HEX,
+          topics: [ERC20_TRANSFER_TOPIC, topicAddress(DEPOSIT_ADDRESS_HEX), topicAddress(SPOKE_POOL)],
+        },
+      ]);
+      const payload = buildDepositExecutedPayload(receipt, tronDepositMessageV3());
+      expect(payload).to.not.be.undefined;
+      expect(payload?.data.chainId).to.equal(CHAIN_IDs.TRON);
+      expect(payload?.data.logIndex).to.equal(0);
+      // Inbound tx hash is relayed verbatim (un-prefixed), preserving the indexer's row key.
+      expect(payload?.data.erc20Transfer.txHash).to.equal(TRON_TX_HASH);
+    });
+
+    it("returns undefined (does not throw on base58) when no log matches", function () {
+      const receipt = fakeReceipt([
+        { address: TOKEN_HEX, topics: [ERC20_TRANSFER_TOPIC, topicAddress(FEE_RECIPIENT), topicAddress(SPOKE_POOL)] },
+      ]);
+      expect(buildDepositExecutedPayload(receipt, tronDepositMessageV3())).to.be.undefined;
+    });
   });
 });
 

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -717,9 +717,9 @@ describe("DepositAddressHandler._validateExecuteResponse guards", function () {
     expect(validate(executeResponse({ signatureDeadline: getCurrentTime() + 30 }))).to.equal(false);
   });
 
-  it("rejects a tron-ecosystem response for an EVM origin", function () {
+  it("rejects a tvm-ecosystem response for an EVM origin", function () {
     const response = executeResponse();
-    response.executeTx.ecosystem = "tron";
+    response.executeTx.ecosystem = "tvm";
     expect(validate(response)).to.equal(false);
     expect(warnStub.calledOnce).to.equal(true);
   });
@@ -741,11 +741,11 @@ describe("DepositAddressHandler._validateExecuteResponse for Tron origins", func
   const message = tronDepositMessageV3();
   const originChainId = Number(message.erc20Transfer.chainId);
 
-  /** Mirrors the quote-api Tron response contract: base58 depositAddress echo, "tron", 0x-hex `to`. */
+  /** Mirrors the live quote-api Tron response: base58 depositAddress echo, "tvm", 0x-hex `to`. */
   function executeResponse(overrides: Partial<DepositAddressExecuteResponse> = {}): DepositAddressExecuteResponse {
     return {
       depositAddress: TRON_DEPOSIT_ADDRESS,
-      executeTx: { ecosystem: "tron", chainId: originChainId, to: TRON_FACTORY, data: "0x", value: "0" },
+      executeTx: { ecosystem: "tvm", chainId: originChainId, to: TRON_FACTORY, data: "0x", value: "0" },
       signer: SIGNER,
       signatureDeadline: getCurrentTime() + 600,
       isPlaceholder: false,

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -1,6 +1,17 @@
 import sinon from "sinon";
 import { expect } from "chai";
-import { EvmAddress, getCurrentTime, HttpError, Signer, toBN, TransactionReceipt, utils, winston } from "../src/utils";
+import {
+  CHAIN_IDs,
+  EvmAddress,
+  getCurrentTime,
+  HttpError,
+  Signer,
+  toAddressType,
+  toBN,
+  TransactionReceipt,
+  utils,
+  winston,
+} from "../src/utils";
 import { DepositAddressMessage, DepositAddressMessageV3 } from "../src/interfaces/DepositAddress";
 import { DepositAddressExecuteResponse, DepositAddressSignWithdrawResponse } from "../src/clients";
 import { DepositAddressHandler } from "../src/deposit-address/DepositAddressHandler";
@@ -15,6 +26,13 @@ const TOKEN = "0x000000000000000000000000000000000000DEAD";
 const OUTPUT_TOKEN = "0x0000000000000000000000000000000000005678";
 const RECIPIENT = "0x0000000000000000000000000000000000001111";
 const IMPL = "0x000000000000000000000000000000000000A4A4";
+
+// Tron-origin v3 sample fields (indexer verbatim: base58 addresses, un-prefixed tx hash).
+const TRON_DEPOSIT_ADDRESS = "TRhLhFckPaeCtFyrUBJRK6p9LhRtbS7Pa5";
+const TRON_REFUND_ADDRESS = "TQ4T4DgHoezYBTRoZPCspsSgRw38Ni9prA";
+const TRON_TOKEN = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+const TRON_TX_HASH = "3b699036b64d765dea6a9103c33793d343381bab361b3e96051e56de2d174247";
+const TRON_FACTORY = "0xce892B16B4D486e26c869bCb8475b087f4469A48";
 
 // The 12 params the deposit-execute quote sent before executionFee support — the legacy request shape.
 const BASE_PARAM_KEYS = [
@@ -141,6 +159,36 @@ function depositMessageV3(overrides: Partial<DepositAddressMessageV3> = {}): Dep
     },
     ...overrides,
   };
+}
+
+/**
+ * v3 Tron-origin correct_transfer message mirroring the indexer sample: base58 addresses,
+ * un-prefixed transaction hash, `tron` namespaces, EVM destination.
+ */
+function tronDepositMessageV3(overrides: Partial<DepositAddressMessageV3> = {}): DepositAddressMessageV3 {
+  return depositMessageV3({
+    depositAddress: TRON_DEPOSIT_ADDRESS,
+    routeParams: {
+      outputToken: OUTPUT_TOKEN,
+      destinationChainId: String(CHAIN_IDs.BASE),
+      recipient: { namespace: "evm", address: RECIPIENT },
+    },
+    refundAddress: { namespace: "tron", address: TRON_REFUND_ADDRESS },
+    depositAddressNamespace: "tron",
+    integrator: { name: "test-integrator", integratorId: "0x00e6" },
+    erc20Transfer: {
+      chainId: String(CHAIN_IDs.TRON),
+      blockNumber: 84_665_484,
+      logIndex: 55,
+      from: TRON_REFUND_ADDRESS,
+      to: TRON_DEPOSIT_ADDRESS,
+      amount: "25000000",
+      contractAddress: TRON_TOKEN,
+      transactionHash: TRON_TX_HASH,
+      transferClassification: "correct_transfer",
+    },
+    ...overrides,
+  });
 }
 
 describe("DepositAddressHandler._getSwapApiQuote params", function () {
@@ -461,6 +509,104 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
     expect(result).to.equal(undefined);
     expect(executeStub.callCount).to.equal(4); // initial attempt + 3 retries
   });
+
+  it("sends origin-native Tron encodings: base58 userAddress verbatim, base58 executionFeeRecipient", async function () {
+    await (handler as unknown as Internals)._getExecuteTx(tronDepositMessageV3());
+    expect(executeStub.calledOnce).to.equal(true);
+    const expectedFeeRecipient = toAddressType(SIGNER, CHAIN_IDs.TRON).toNative();
+    // Sanity: the fee recipient really is re-encoded, not the signer's 0x form.
+    expect(expectedFeeRecipient).to.not.equal(SIGNER);
+    expect(executeStub.firstCall.args[0]).to.deep.equal({
+      destination: {
+        token: { chainId: CHAIN_IDs.BASE, address: OUTPUT_TOKEN },
+        recipient: RECIPIENT,
+      },
+      originChainId: CHAIN_IDs.TRON,
+      userAddress: TRON_REFUND_ADDRESS,
+      amount: "25000000",
+      executionFeeRecipient: expectedFeeRecipient,
+      integratorId: "0x00e6",
+    });
+  });
+
+  it("relays base58 inputToken and the un-prefixed provenance hash verbatim when both gates are on", async function () {
+    const config = handler.config as unknown as {
+      enableExecuteInputToken: boolean;
+      enableExecuteErc20Transfer: boolean;
+    };
+    config.enableExecuteInputToken = true;
+    config.enableExecuteErc20Transfer = true;
+    await (handler as unknown as Internals)._getExecuteTx(tronDepositMessageV3());
+    expect(executeStub.calledOnce).to.equal(true);
+    const request = executeStub.firstCall.args[0] as Record<string, unknown>;
+    expect(request.inputToken).to.deep.equal({ chainId: CHAIN_IDs.TRON, address: TRON_TOKEN });
+    expect(request.erc20Transfer).to.deep.equal({
+      chainId: CHAIN_IDs.TRON,
+      blockNumber: 84_665_484,
+      transactionHash: TRON_TX_HASH,
+      logIndex: 55,
+    });
+  });
+});
+
+describe("DepositAddressHandler.initiateDepositV3 namespace guard", function () {
+  let handler: DepositAddressHandler;
+  let executeStub: sinon.SinonStub;
+  let warnStub: sinon.SinonStub;
+
+  type Internals = { initiateDepositV3: (m: DepositAddressMessageV3) => Promise<void> };
+
+  function makeHandler(originChainId: number): void {
+    const config = { relayerOriginChains: [originChainId] } as unknown as DepositAddressHandlerConfig;
+    warnStub = sinon.stub();
+    const logger = { warn: warnStub, debug: sinon.stub() } as unknown as winston.Logger;
+    handler = new DepositAddressHandler(logger, config, {} as unknown as Signer, []);
+    (handler as unknown as { _signerAddress: EvmAddress })._signerAddress = EvmAddress.from(SIGNER);
+    // Resolving undefined makes _getExecuteTx retry then bail with a warn — reaching the endpoint
+    // at all is the proof that the namespace guard opened.
+    executeStub = sinon.stub().resolves(undefined);
+    (handler as unknown as { api: { executeDepositAddress: sinon.SinonStub } }).api = {
+      executeDepositAddress: executeStub,
+    };
+    (handler as unknown as { observedExecutedDeposits: Record<number, Set<string>> }).observedExecutedDeposits = {
+      [originChainId]: new Set<string>(),
+    };
+    // The balance check sits between the namespace guard and the API call; make it pass.
+    (handler as unknown as { getDepositAddressBalance: sinon.SinonStub }).getDepositAddressBalance = sinon
+      .stub()
+      .resolves(toBN("25000000"));
+  }
+
+  afterEach(() => sinon.restore());
+
+  it("skips an svm-namespaced message without calling the execute endpoint", async function () {
+    makeHandler(42161);
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3({ depositAddressNamespace: "svm" }));
+    expect(executeStub.notCalled).to.equal(true);
+    expect(warnStub.calledOnce).to.equal(true);
+  });
+
+  it("skips a tron-namespaced message on an EVM origin chain (cross-family anomaly)", async function () {
+    makeHandler(42161);
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3({ depositAddressNamespace: "tron" }));
+    expect(executeStub.notCalled).to.equal(true);
+    expect(warnStub.calledOnce).to.equal(true);
+  });
+
+  it("skips a Tron-origin message whose refund namespace does not match the chain family", async function () {
+    makeHandler(CHAIN_IDs.TRON);
+    await (handler as unknown as Internals).initiateDepositV3(
+      tronDepositMessageV3({ refundAddress: { namespace: "evm", address: REFUND_ADDRESS } })
+    );
+    expect(executeStub.notCalled).to.equal(true);
+    expect(warnStub.calledOnce).to.equal(true);
+  });
+
+  it("lets a tron-namespaced message on the Tron chain through to the execute endpoint", async function () {
+    makeHandler(CHAIN_IDs.TRON);
+    await (handler as unknown as Internals).initiateDepositV3(tronDepositMessageV3());
+    expect(executeStub.called).to.equal(true);
+  });
 });
 
 describe("DepositAddressHandler.initiateDepositV3 integratorId guard", function () {
@@ -569,6 +715,78 @@ describe("DepositAddressHandler._validateExecuteResponse guards", function () {
 
   it("rejects responses whose signature deadline is too close to expiry", function () {
     expect(validate(executeResponse({ signatureDeadline: getCurrentTime() + 30 }))).to.equal(false);
+  });
+
+  it("rejects a tvm-ecosystem response for an EVM origin", function () {
+    const response = executeResponse();
+    response.executeTx.ecosystem = "tvm";
+    expect(validate(response)).to.equal(false);
+    expect(warnStub.calledOnce).to.equal(true);
+  });
+});
+
+describe("DepositAddressHandler._validateExecuteResponse for Tron origins", function () {
+  let handler: DepositAddressHandler;
+  let warnStub: sinon.SinonStub;
+
+  type Internals = {
+    _validateExecuteResponse: (
+      r: DepositAddressExecuteResponse,
+      m: DepositAddressMessageV3,
+      originChainId: number,
+      depositKey: string
+    ) => boolean;
+  };
+
+  const message = tronDepositMessageV3();
+  const originChainId = Number(message.erc20Transfer.chainId);
+
+  /** Mirrors the live quote-api Tron response: base58 depositAddress echo, "tvm", 0x-hex `to`. */
+  function executeResponse(overrides: Partial<DepositAddressExecuteResponse> = {}): DepositAddressExecuteResponse {
+    return {
+      depositAddress: TRON_DEPOSIT_ADDRESS,
+      executeTx: { ecosystem: "tvm", chainId: originChainId, to: TRON_FACTORY, data: "0x", value: "0" },
+      signer: SIGNER,
+      signatureDeadline: getCurrentTime() + 600,
+      isPlaceholder: false,
+      ...overrides,
+    };
+  }
+
+  function validate(response: DepositAddressExecuteResponse): boolean {
+    return (handler as unknown as Internals)._validateExecuteResponse(response, message, originChainId, "key");
+  }
+
+  beforeEach(function () {
+    const config = {} as unknown as DepositAddressHandlerConfig;
+    warnStub = sinon.stub();
+    const logger = { warn: warnStub } as unknown as winston.Logger;
+    handler = new DepositAddressHandler(logger, config, {} as unknown as Signer, []);
+  });
+
+  afterEach(() => sinon.restore());
+
+  it("accepts a base58 depositAddress echo", function () {
+    expect(validate(executeResponse())).to.equal(true);
+    expect(warnStub.notCalled).to.equal(true);
+  });
+
+  it("accepts the 0x-hex encoding of the funded base58 address", function () {
+    const hexDepositAddress = toAddressType(TRON_DEPOSIT_ADDRESS, originChainId).toEvmAddress();
+    expect(validate(executeResponse({ depositAddress: hexDepositAddress }))).to.equal(true);
+    expect(warnStub.notCalled).to.equal(true);
+  });
+
+  it("rejects a different base58 depositAddress", function () {
+    expect(validate(executeResponse({ depositAddress: TRON_REFUND_ADDRESS }))).to.equal(false);
+    expect(warnStub.calledOnce).to.equal(true);
+  });
+
+  it("rejects an evm-ecosystem response for a Tron origin", function () {
+    const response = executeResponse();
+    response.executeTx.ecosystem = "evm";
+    expect(validate(response)).to.equal(false);
+    expect(warnStub.calledOnce).to.equal(true);
   });
 });
 

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -717,9 +717,9 @@ describe("DepositAddressHandler._validateExecuteResponse guards", function () {
     expect(validate(executeResponse({ signatureDeadline: getCurrentTime() + 30 }))).to.equal(false);
   });
 
-  it("rejects a tvm-ecosystem response for an EVM origin", function () {
+  it("rejects a tron-ecosystem response for an EVM origin", function () {
     const response = executeResponse();
-    response.executeTx.ecosystem = "tvm";
+    response.executeTx.ecosystem = "tron";
     expect(validate(response)).to.equal(false);
     expect(warnStub.calledOnce).to.equal(true);
   });
@@ -741,11 +741,11 @@ describe("DepositAddressHandler._validateExecuteResponse for Tron origins", func
   const message = tronDepositMessageV3();
   const originChainId = Number(message.erc20Transfer.chainId);
 
-  /** Mirrors the live quote-api Tron response: base58 depositAddress echo, "tvm", 0x-hex `to`. */
+  /** Mirrors the quote-api Tron response contract: base58 depositAddress echo, "tron", 0x-hex `to`. */
   function executeResponse(overrides: Partial<DepositAddressExecuteResponse> = {}): DepositAddressExecuteResponse {
     return {
       depositAddress: TRON_DEPOSIT_ADDRESS,
-      executeTx: { ecosystem: "tvm", chainId: originChainId, to: TRON_FACTORY, data: "0x", value: "0" },
+      executeTx: { ecosystem: "tron", chainId: originChainId, to: TRON_FACTORY, data: "0x", value: "0" },
       signer: SIGNER,
       signatureDeadline: getCurrentTime() + 600,
       isPlaceholder: false,


### PR DESCRIPTION
## Summary

Adds Tron (TVM) support to the deposit-address bot's **v3 deposit-execute path**. The bot stays a thin submitter — the quote-api builds all calldata; the bot relays funding context, validates the response, and submits through the existing TVM path in `TransactionClient`.

- **Namespace guard** (`initiateDepositV3`) now validates namespaces against the origin chain's family (`evm` ⇒ EVM chains, `tron` ⇒ Tron). svm and cross-family anomalies (e.g. a `tron` namespace on an EVM chainId) keep skipping with a warn.
- **On-chain reads and log matching convert base58 → 0x-hex** via `getEthersCompatibleAddress`: `getDepositAddressBalance` (Tron providers speak eth-JSON-RPC) and `buildDepositExecutedPayload` (`hexZeroPad` throws on base58 *after* the execute is committed, which would have rejected the whole poll batch).
- **`_getExecuteTx`** re-encodes `executionFeeRecipient` to the origin-native form (base58 on Tron; the TVM submitter reuses the same EVM key, so the fee recipient stays the bot). All other Tron fields relay verbatim from the indexer.
- **`_validateExecuteResponse`** compares deposit addresses canonically through the hex form (base58 is case-sensitive; a hex echo of the same address also passes) and requires `executeTx.ecosystem` to match the chain family (`"tvm"` on Tron).
- **`getExecuteContract`** now connects the provider in dispatcher mode — raw-tx simulation (`willSucceed`) and `_runTransactionTvm` both read `contract.provider`, which was previously null in that mode — and defensively hex-converts the target address.
- `DepositAddressExecuteResponse.executeTx.ecosystem` widened to `"evm" | "tvm"`.

Out of scope: the v3 refund-withdraw path stays EVM-only (Tron mis_routes keep being skipped).

## Rollout

- No new env gate: add `728126428` to `RELAYER_ORIGIN_CHAINS` to activate (providers + dedup sets are provisioned from that list).
- The bot signer's derived Tron account must hold TRX for fees (default feeLimit 100 TRX, `TVM_GAS_LIMIT` to override).
- Prod runs deposit executions with `ENABLE_EXECUTE_ERC20_TRANSFER_METADATA=true`, so provenance is on-chain and no `deposit_executed` Pub/Sub is published; the payload-builder fix is a safety net for other gate combinations.

## Verification

- 74 tests passing, including 12 new Tron cases (namespace guard, request mapping, response validation, payload builder). Lint clean.
- Probed the quote-api preview (`deposit-addresses/execute`) with the exact request the new code builds: HTTP 200, `ecosystem: "tvm"`, 0x-hex `to`, base58 `depositAddress` echo, base58 `userAddress`/`executionFeeRecipient` accepted.
- Pre-existing `tsc` errors on master (`poolRebalanceLeafCount` in dataworker/scripts vs installed SDK) are unrelated; no errors in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

