### PR TITLE
chore: Enable Gasless on Unichain, Monad, MegaETH, Plasma, Ink and Linea

### DIFF
--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -273,6 +273,13 @@ export const CONTRACT_ADDRESSES: {
       address: "0x647aFB7d935Ff0aaE4F0DdEfE0499d13AdE69178",
       abi: SPONSORED_CCTP_DST_PERIPHERY_ABI,
     },
+    spokePoolPeriphery: {
+      abi: SPOKE_POOL_PERIPHERY_ABI,
+    },
+    permit2: {
+      address: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+      abi: PERMIT2_ABI,
+    },
   },
   [CHAIN_IDs.OPTIMISM]: {
     daiOptimismBridge: {
@@ -420,6 +427,13 @@ export const CONTRACT_ADDRESSES: {
     nativeToken: {
       address: "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
     },
+    spokePoolPeriphery: {
+      abi: SPOKE_POOL_PERIPHERY_ABI,
+    },
+    permit2: {
+      address: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+      abi: PERMIT2_ABI,
+    },
   },
   [CHAIN_IDs.SOLANA]: {
     cctpTokenMessenger: {
@@ -548,6 +562,22 @@ export const CONTRACT_ADDRESSES: {
     nativeToken: {
       address: "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
     },
+    spokePoolPeriphery: {
+      abi: SPOKE_POOL_PERIPHERY_ABI,
+    },
+    permit2: {
+      address: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+      abi: PERMIT2_ABI,
+    },
+  },
+  [CHAIN_IDs.PLASMA]: {
+    spokePoolPeriphery: {
+      abi: SPOKE_POOL_PERIPHERY_ABI,
+    },
+    permit2: {
+      address: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+      abi: PERMIT2_ABI,
+    },
   },
   [CHAIN_IDs.INK]: {
     ovmStandardBridge: {
@@ -568,6 +598,13 @@ export const CONTRACT_ADDRESSES: {
     sponsoredCCTPDstPeriphery: {
       address: "0x087B70E43BF01359678E7b927bbAC76D175F3293",
       abi: SPONSORED_CCTP_DST_PERIPHERY_ABI,
+    },
+    spokePoolPeriphery: {
+      abi: SPOKE_POOL_PERIPHERY_ABI,
+    },
+    permit2: {
+      address: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+      abi: PERMIT2_ABI,
     },
   },
   [CHAIN_IDs.BLAST]: {
@@ -714,6 +751,13 @@ export const CONTRACT_ADDRESSES: {
     },
     nativeToken: {
       address: "0x0000000000000000000000000000000000000000",
+    },
+    spokePoolPeriphery: {
+      abi: SPOKE_POOL_PERIPHERY_ABI,
+    },
+    permit2: {
+      address: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+      abi: PERMIT2_ABI,
     },
   },
   [CHAIN_IDs.TRON]: {


### PR DESCRIPTION
## What

Adds `spokePoolPeriphery` and `permit2` entries to `CONTRACT_ADDRESSES` for six chains:

| Chain ID | Name | Block |
| --- | --- | --- |
| 130 | Unichain | existing, entries appended |
| 143 | Monad | existing, entries appended |
| 4326 | MegaETH | existing, entries appended |
| 9745 | Plasma | **new block** (chain had none) |
| 57073 | Ink | existing, entries appended |
| 59144 | Linea | existing, entries appended |

Entries follow the existing pattern (see Avalanche, #3571): `spokePoolPeriphery` is abi-only (address resolves via `getDeployedAddress("SpokePoolPeriphery", chainId)`), `permit2` uses the canonical address.

## Why

UMAprotocol/bot-configs#4221 added these six chains to the sandbox gasless relayers' origin/destination lists. The gasless relayer requires both entries for every configured origin chain (`GaslessRelayer#initialize` → `getSpokePoolPeriphery` / `getPermit2`), so both `zion-across-gasless-relayer-test` and `zion-across-gasless-relayer-general-test` have been exiting at init since 2026-07-24 10:00 UTC with:

```
AssertionError [ERR_ASSERTION]: Missing CONTRACT_ADDRESSES abi: 130/spokePoolPeriphery
```

## Verification

- `SpokePoolPeriphery` is present in the pinned `@across-protocol/contracts@5.0.24` deployment metadata for all six chains (`0x10D8b8DaA26d307489803e10477De69C0492B610`), so no dependency bump is needed.
- Verified on-chain via `eth_getCode` on each chain's public RPC: SpokePoolPeriphery and canonical Permit2 (`0x000000000022D473030F116dDEE9F6B43aC78BA3`) both have identical deterministic bytecode on all six chains.
- Smoke-tested the failing init path (`getSpokePoolPeriphery` + `getPermit2`) for the full 13-chain sandbox config, including the chain-999 override/exclusion — all resolve.
- `yarn typecheck` and prettier pass.

No README/AGENTS.md updates needed: this is a pure data addition and `src/gasless/README.md` already documents the periphery/permit2 requirements generically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)