### PR TITLE
fix(logging): pull in @risk-labs/logger 1.3.13 and single-path error reporting

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -91,6 +91,9 @@ if (require.main === module) {
     .catch(async (error) => {
       exitCode = 1;
       const stringifiedError = stringifyThrownValue(error);
+      // Raw console backstop: winston output is lost if the process exits while transports are backed up.
+      // eslint-disable-next-line no-console
+      console.error("There was an execution error!", stringifiedError);
       logger.error({
         at: cmd ?? "unknown process",
         message: "There was an execution error!",

--- a/index.ts
+++ b/index.ts
@@ -91,9 +91,6 @@ if (require.main === module) {
     .catch(async (error) => {
       exitCode = 1;
       const stringifiedError = stringifyThrownValue(error);
-      // Raw console backstop: winston output is lost if the process exits while transports are backed up.
-      // eslint-disable-next-line no-console
-      console.error("There was an execution error!", stringifiedError);
       logger.error({
         at: cmd ?? "unknown process",
         message: "There was an execution error!",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@maticnetwork/maticjs": "^3.6.0",
     "@maticnetwork/maticjs-ethers": "^1.0.3",
     "@nktkas/hyperliquid": "^0.25.9",
-    "@risk-labs/logger": "^1.3.11",
+    "@risk-labs/logger": "^1.3.13",
     "@risk-labs/serverless-orchestration": "^1.3.0",
     "@solana-program/address-lookup-table": "^0.7.0",
     "@solana-program/compute-budget": "^0.8.0",

--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -290,22 +290,22 @@ Runtime entrypoints in `src/rebalancer/`:
 
 ## Failure reporting
 
-When a rebalancer run throws, it is reported at two layers, each through two channels:
+When a rebalancer run throws, the error propagates through the entrypoint's `finally` (which disconnects the
+shared redis clients) to the top-level handler in the repo-root `index.ts`, which logs it once at ERROR
+(`"There was an execution error!"`, `across-error` notification path) and exits nonzero. The rebalancer
+entrypoints deliberately do not catch-and-log — the top-level handler is the single reporting path for all bot
+commands.
 
-1. The entrypoint catch blocks in `src/rebalancer/index.ts` emit a raw `console.error` and log the failure at
-   ERROR via winston (with the `across-error` notification path), then rethrow.
-2. The rethrown error propagates through the entrypoint's `finally` (which disconnects the shared redis clients)
-   into the top-level handler in the repo-root `index.ts`, which does the same (`"There was an execution
-   error!"`, also `across-error`) and exits nonzero.
-
-The duplication is deliberate: winston entries logged near process exit can vanish. When the Cloud Logging API
-transport degrades (hanging writes and 60s gax timeouts were observed in production during the 2026-07-24/25
-same-asset rebalancer crash-loop), its full write buffer backpressures the shared winston stream and pauses
-delivery to every transport — including stdout JSON — and `waitForLogger` cannot flush it, so entries buffered at
-that point are discarded when the process exits shortly after. Raw console output bypasses winston entirely and
-always reaches container logs, which is why each layer keeps the `console.error` alongside the winston call.
-Errors thrown before the entrypoint's try block (e.g. during client initialization) skip layer 1 and are
-reported by the top-level handler.
+That single report is only reliable if the logger cannot lose entries at process exit. During the 2026-07-24/25
+same-asset rebalancer crash-loop the top-level ERROR vanished from every sink: under `ENVIRONMENT=serverless`
+the logger writes to the Cloud Logging API over gRPC, and when those writes degrade (60s gax timeouts were
+observed), the transport's full write buffer backpressures the shared winston stream, pausing delivery to all
+transports — including stdout JSON. `waitForLogger` cannot flush that state (none of these transports expose
+`isFlushed`), so everything still buffered is discarded at `process.exit`. The fix is `ENVIRONMENT=serverless-gcp`
+(`@risk-labs/logger` >= 1.3.12, set on the spoke services in zion): it replaces the API transport with structured
+stdout logging ingested by the Cloud Run agent, leaving no network writes to hang or lose at exit. Logger 1.3.13
+additionally routes transport errors to the console when no PagerDuty transport is configured, so residual
+transport breakage is visible instead of silent.
 
 ## Interactions with Other Bots and Clients
 

--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -288,6 +288,24 @@ Runtime entrypoints in `src/rebalancer/`:
 - `runSameAssetRebalancer` (directional SameAsset operational path).
 - The runtime updates adapter status/sweeps first, then refreshes `TokenClient` balances before applying adapter-reported pending rebalance adjustments and evaluating new rebalances. The refresh is required because the sweeps and `updateRebalanceStatuses` calls submit OFT/CCTP/Hypercore transactions that leave the initial `TokenClient.update()` snapshot stale; without it, `rebalanceInventory` can size a new bridge against a pre-burn balance and crash on the underlying simulation revert.
 
+## Failure reporting
+
+When a rebalancer run throws, two layers report it:
+
+1. The entrypoint catch blocks in `src/rebalancer/index.ts` log the failure at ERROR via winston (with the
+   `across-error` notification path) and rethrow.
+2. The rethrown error propagates through the entrypoint's `finally` (which disconnects the shared redis clients)
+   into the top-level handler in the repo-root `index.ts`, which logs it again at ERROR (`"There was an execution
+   error!"`, also `across-error`) and exits nonzero.
+
+When both land this produces two ERROR records per failure. That duplication is deliberate: in production
+(observed during the 2026-07-24/25 same-asset rebalancer crash-loop) the top-level handler's ERROR entry emitted
+after the rebalancer's redis teardown never reached any log sink — neither the Cloud Logging API transport nor
+stdout JSON — across dozens of runs, while output emitted at catch time (before the teardown) landed every run.
+Errors thrown before the entrypoint's try block (e.g. during client initialization) skip layer 1 and are reported
+by the top-level handler, which works on that path. Do not remove the local catch-time logging as "redundant"
+until the top-level vanishing behavior is understood and fixed.
+
 ## Interactions with Other Bots and Clients
 
 ### InventoryClient

--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -290,21 +290,22 @@ Runtime entrypoints in `src/rebalancer/`:
 
 ## Failure reporting
 
-When a rebalancer run throws, two layers report it:
+When a rebalancer run throws, it is reported at two layers, each through two channels:
 
-1. The entrypoint catch blocks in `src/rebalancer/index.ts` log the failure at ERROR via winston (with the
-   `across-error` notification path) and rethrow.
+1. The entrypoint catch blocks in `src/rebalancer/index.ts` emit a raw `console.error` and log the failure at
+   ERROR via winston (with the `across-error` notification path), then rethrow.
 2. The rethrown error propagates through the entrypoint's `finally` (which disconnects the shared redis clients)
-   into the top-level handler in the repo-root `index.ts`, which logs it again at ERROR (`"There was an execution
+   into the top-level handler in the repo-root `index.ts`, which does the same (`"There was an execution
    error!"`, also `across-error`) and exits nonzero.
 
-When both land this produces two ERROR records per failure. That duplication is deliberate: in production
-(observed during the 2026-07-24/25 same-asset rebalancer crash-loop) the top-level handler's ERROR entry emitted
-after the rebalancer's redis teardown never reached any log sink — neither the Cloud Logging API transport nor
-stdout JSON — across dozens of runs, while output emitted at catch time (before the teardown) landed every run.
-Errors thrown before the entrypoint's try block (e.g. during client initialization) skip layer 1 and are reported
-by the top-level handler, which works on that path. Do not remove the local catch-time logging as "redundant"
-until the top-level vanishing behavior is understood and fixed.
+The duplication is deliberate: winston entries logged near process exit can vanish. When the Cloud Logging API
+transport degrades (hanging writes and 60s gax timeouts were observed in production during the 2026-07-24/25
+same-asset rebalancer crash-loop), its full write buffer backpressures the shared winston stream and pauses
+delivery to every transport — including stdout JSON — and `waitForLogger` cannot flush it, so entries buffered at
+that point are discarded when the process exits shortly after. Raw console output bypasses winston entirely and
+always reaches container logs, which is why each layer keeps the `console.error` alongside the winston call.
+Errors thrown before the entrypoint's try block (e.g. during client initialization) skip layer 1 and are
+reported by the top-level handler.
 
 ## Interactions with Other Bots and Clients
 

--- a/src/rebalancer/index.ts
+++ b/src/rebalancer/index.ts
@@ -211,6 +211,9 @@ export async function runCumulativeBalanceRebalancer(_logger: winston.Logger, ba
     // Do not remove as redundant with the top-level handler in index.ts: ERROR logs emitted after this
     // function's finally block have been observed to silently vanish in production, while catch-time output
     // (before the redis teardown) lands reliably. See "Failure reporting" in README.md.
+    // Raw console backstop: winston output is lost if the process exits while transports are backed up.
+    // eslint-disable-next-line no-console
+    console.error("Error running rebalancer", error);
     logger.error({
       at: `index.ts:${logLabel}`,
       message: "Error running rebalancer",
@@ -248,6 +251,9 @@ export async function runSameAssetRebalancer(_logger: winston.Logger, baseSigner
     // Do not remove as redundant with the top-level handler in index.ts: ERROR logs emitted after this
     // function's finally block have been observed to silently vanish in production, while catch-time output
     // (before the redis teardown) lands reliably. See "Failure reporting" in README.md.
+    // Raw console backstop: winston output is lost if the process exits while transports are backed up.
+    // eslint-disable-next-line no-console
+    console.error("Error running rebalancer", error);
     logger.error({
       at: `index.ts:${logLabel}`,
       message: "Error running rebalancer",

--- a/src/rebalancer/index.ts
+++ b/src/rebalancer/index.ts
@@ -9,7 +9,6 @@ import {
   disconnectRedisClients,
   getTokenInfoFromSymbol,
   Signer,
-  stringifyThrownValue,
   toBNWei,
   winston,
 } from "../utils";
@@ -207,20 +206,6 @@ export async function runCumulativeBalanceRebalancer(_logger: winston.Logger, ba
     // Maybe now enter a loop where we update rebalances continuously every X seconds until the next run where
     // we call rebalance inventory? The thinking is we should rebalance inventory once per "run" and then continually
     // update rebalance statuses/finalize pending rebalances.
-  } catch (error) {
-    // Do not remove as redundant with the top-level handler in index.ts: ERROR logs emitted after this
-    // function's finally block have been observed to silently vanish in production, while catch-time output
-    // (before the redis teardown) lands reliably. See "Failure reporting" in README.md.
-    // Raw console backstop: winston output is lost if the process exits while transports are backed up.
-    // eslint-disable-next-line no-console
-    console.error("Error running rebalancer", error);
-    logger.error({
-      at: `index.ts:${logLabel}`,
-      message: "Error running rebalancer",
-      error: stringifyThrownValue(error),
-      notificationPath: "across-error",
-    });
-    throw error;
   } finally {
     await disconnectRedisClients(logger);
   }
@@ -247,20 +232,6 @@ export async function runSameAssetRebalancer(_logger: winston.Logger, baseSigner
         duration: performance.now() - timerStart,
       });
     }
-  } catch (error) {
-    // Do not remove as redundant with the top-level handler in index.ts: ERROR logs emitted after this
-    // function's finally block have been observed to silently vanish in production, while catch-time output
-    // (before the redis teardown) lands reliably. See "Failure reporting" in README.md.
-    // Raw console backstop: winston output is lost if the process exits while transports are backed up.
-    // eslint-disable-next-line no-console
-    console.error("Error running rebalancer", error);
-    logger.error({
-      at: `index.ts:${logLabel}`,
-      message: "Error running rebalancer",
-      error: stringifyThrownValue(error),
-      notificationPath: "across-error",
-    });
-    throw error;
   } finally {
     await disconnectRedisClients(logger);
   }

--- a/src/rebalancer/index.ts
+++ b/src/rebalancer/index.ts
@@ -9,6 +9,7 @@ import {
   disconnectRedisClients,
   getTokenInfoFromSymbol,
   Signer,
+  stringifyThrownValue,
   toBNWei,
   winston,
 } from "../utils";
@@ -207,8 +208,11 @@ export async function runCumulativeBalanceRebalancer(_logger: winston.Logger, ba
     // we call rebalance inventory? The thinking is we should rebalance inventory once per "run" and then continually
     // update rebalance statuses/finalize pending rebalances.
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error("Error running rebalancer", error);
+    logger.error({
+      at: `index.ts:${logLabel}`,
+      message: "Error running rebalancer",
+      error: stringifyThrownValue(error),
+    });
     throw error;
   } finally {
     await disconnectRedisClients(logger);
@@ -237,8 +241,11 @@ export async function runSameAssetRebalancer(_logger: winston.Logger, baseSigner
       });
     }
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error("Error running rebalancer", error);
+    logger.error({
+      at: `index.ts:${logLabel}`,
+      message: "Error running rebalancer",
+      error: stringifyThrownValue(error),
+    });
     throw error;
   } finally {
     await disconnectRedisClients(logger);

--- a/src/rebalancer/index.ts
+++ b/src/rebalancer/index.ts
@@ -9,6 +9,7 @@ import {
   disconnectRedisClients,
   getTokenInfoFromSymbol,
   Signer,
+  stringifyThrownValue,
   toBNWei,
   winston,
 } from "../utils";
@@ -206,7 +207,17 @@ export async function runCumulativeBalanceRebalancer(_logger: winston.Logger, ba
     // Maybe now enter a loop where we update rebalances continuously every X seconds until the next run where
     // we call rebalance inventory? The thinking is we should rebalance inventory once per "run" and then continually
     // update rebalance statuses/finalize pending rebalances.
-    // Errors are deliberately not caught here: the top-level handler in index.ts logs them once at ERROR.
+  } catch (error) {
+    // Do not remove as redundant with the top-level handler in index.ts: ERROR logs emitted after this
+    // function's finally block have been observed to silently vanish in production, while catch-time output
+    // (before the redis teardown) lands reliably. See "Failure reporting" in README.md.
+    logger.error({
+      at: `index.ts:${logLabel}`,
+      message: "Error running rebalancer",
+      error: stringifyThrownValue(error),
+      notificationPath: "across-error",
+    });
+    throw error;
   } finally {
     await disconnectRedisClients(logger);
   }
@@ -233,7 +244,17 @@ export async function runSameAssetRebalancer(_logger: winston.Logger, baseSigner
         duration: performance.now() - timerStart,
       });
     }
-    // Errors are deliberately not caught here: the top-level handler in index.ts logs them once at ERROR.
+  } catch (error) {
+    // Do not remove as redundant with the top-level handler in index.ts: ERROR logs emitted after this
+    // function's finally block have been observed to silently vanish in production, while catch-time output
+    // (before the redis teardown) lands reliably. See "Failure reporting" in README.md.
+    logger.error({
+      at: `index.ts:${logLabel}`,
+      message: "Error running rebalancer",
+      error: stringifyThrownValue(error),
+      notificationPath: "across-error",
+    });
+    throw error;
   } finally {
     await disconnectRedisClients(logger);
   }

--- a/src/rebalancer/index.ts
+++ b/src/rebalancer/index.ts
@@ -9,7 +9,6 @@ import {
   disconnectRedisClients,
   getTokenInfoFromSymbol,
   Signer,
-  stringifyThrownValue,
   toBNWei,
   winston,
 } from "../utils";
@@ -207,13 +206,7 @@ export async function runCumulativeBalanceRebalancer(_logger: winston.Logger, ba
     // Maybe now enter a loop where we update rebalances continuously every X seconds until the next run where
     // we call rebalance inventory? The thinking is we should rebalance inventory once per "run" and then continually
     // update rebalance statuses/finalize pending rebalances.
-  } catch (error) {
-    logger.error({
-      at: `index.ts:${logLabel}`,
-      message: "Error running rebalancer",
-      error: stringifyThrownValue(error),
-    });
-    throw error;
+    // Errors are deliberately not caught here: the top-level handler in index.ts logs them once at ERROR.
   } finally {
     await disconnectRedisClients(logger);
   }
@@ -240,13 +233,7 @@ export async function runSameAssetRebalancer(_logger: winston.Logger, baseSigner
         duration: performance.now() - timerStart,
       });
     }
-  } catch (error) {
-    logger.error({
-      at: `index.ts:${logLabel}`,
-      message: "Error running rebalancer",
-      error: stringifyThrownValue(error),
-    });
-    throw error;
+    // Errors are deliberately not caught here: the top-level handler in index.ts logs them once at ERROR.
   } finally {
     await disconnectRedisClients(logger);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2117,10 +2117,10 @@
   resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-5.12.1.tgz#15b6deaaf3716bc2633311c0ed18201c9299392d"
   integrity sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==
 
-"@risk-labs/logger@^1.3.11":
-  version "1.3.11"
-  resolved "https://registry.yarnpkg.com/@risk-labs/logger/-/logger-1.3.11.tgz#ff37a8199dfcd170450e8374e69717288733992d"
-  integrity sha512-WqTteLQA+ZMmblsbveHpBzwvCRUO5ir5kB3janSsqAu3jFYi0W6uOSdmb63ibbc7W8wylr2FD3UXXZaNgTs2cA==
+"@risk-labs/logger@^1.3.11", "@risk-labs/logger@^1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@risk-labs/logger/-/logger-1.3.13.tgz#2e78fc77ded8fe17985f81e5dd849a480123f2cf"
+  integrity sha512-wSb7jyTwmzQr6jRu8eOKbGG/oNr7fe0UtkCudj0iK4yYLiGayeYEjnE44pKpassgB/ANi3VjPaUd2OdXPy8ceQ==
   dependencies:
     "@discordjs/rest" "^2.6.1"
     "@google-cloud/logging-winston" "^6.0.1"


### PR DESCRIPTION
## Motivation

`zion-across-same-asset-rebalancer` crash-looped in prod (2026-07-24/25) with the top-level `"There was an execution error!"` ERROR vanishing from every log sink. Root cause (details in Slack): under `ENVIRONMENT=serverless` the logger writes to the Cloud Logging API over gRPC; when those writes degrade (60s gax timeouts observed in the spoke), the transport's full write buffer backpressures the shared winston stream and pauses delivery to **all** transports, including stdout JSON. `waitForLogger` can't flush that state, so `process.exit` discards everything buffered — this bot's end-of-run logs were being eaten even on successful runs.

## Changes

Fix the transport instead of adding more log statements:

- Bump `@risk-labs/logger` to ^1.3.13 and dedupe the lockfile so `@risk-labs/serverless-orchestration`'s range also resolves to 1.3.13. This brings in `ENVIRONMENT=serverless-gcp` (risk-labs/logger#26: structured stdout logging ingested by the Cloud Run agent — no gRPC writes to hang) and the transport-error console fallback (risk-labs/logger#28 — transport failures are no longer silent).
- Remove the rebalancer catch-and-log blocks entirely: the top-level handler in `index.ts` is the single error-reporting path for all commands.
- Update the rebalancer README's Failure reporting section accordingly.

## Deploy ordering

The top-level report only becomes reliable once the spoke services run with `ENVIRONMENT=serverless-gcp` (zion change — children inherit it from the spoke container). That flip should land with or before this deploy; until then the removed catch-time logging was the only output that survived the stall. Note the env flip also moves entries from `logName=winston_log` to stdout ingestion — log queries/alerts keyed on `winston_log` need updating.

Companion fix already merged: #3627.

🤖 Generated with [Claude Code](https://claude.com/claude-code)