### PR TITLE
improve(TokenClient): assert token data exists in decrementLocalBalance

### DIFF
--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -82,6 +82,10 @@ export class TokenClient {
 
   decrementLocalBalance(chainId: number, token: Address, amount: BigNumber): void {
     const tokenAddr = token.toNative();
+    assert(
+      this._hasTokenPairData(chainId, token),
+      `TokenClient: cannot decrement balance for token ${tokenAddr} on chain ${chainId}; no token data`
+    );
     this.tokenData[chainId][tokenAddr].balance = this.tokenData[chainId][tokenAddr].balance.sub(amount);
   }
 


### PR DESCRIPTION
## Motivation

The prod crash-loop of `zion-across-same-asset-rebalancer` (2026-07-24/25) surfaced as an opaque `TypeError: Cannot read properties of undefined (reading 'balance')` thrown from `decrementLocalBalance`. Unlike `getBalance`, it has no guard for missing token data, so the failure names neither the chain nor the token.

## Changes

Assert `_hasTokenPairData` before decrementing, with a message naming the chain and token. Behavior is otherwise unchanged: a missing pair still throws (silently no-op'ing would corrupt inventory accounting), but the error is now diagnosable.

Companion observability fix: #3626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)