### PR TITLE
improve(TokenClient): console backstop for decrementLocalBalance assert

### DIFF
--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -82,10 +82,14 @@ export class TokenClient {
 
   decrementLocalBalance(chainId: number, token: Address, amount: BigNumber): void {
     const tokenAddr = token.toNative();
-    assert(
-      this._hasTokenPairData(chainId, token),
-      `TokenClient: cannot decrement balance for token ${tokenAddr} on chain ${chainId}; no token data`
-    );
+    const message = `TokenClient: cannot decrement balance by ${amount.toString()} for token ${tokenAddr} on chain ${chainId}; no token data`;
+    const hasData = this._hasTokenPairData(chainId, token);
+    if (!hasData) {
+      // Raw console output so the failure details reach container logs even if winston output is lost at exit.
+      // eslint-disable-next-line no-console
+      console.error(message);
+    }
+    assert(hasData, message);
     this.tokenData[chainId][tokenAddr].balance = this.tokenData[chainId][tokenAddr].balance.sub(amount);
   }
 


### PR DESCRIPTION
## Motivation

The `zion-across-same-asset-rebalancer` crash-loop throws from `decrementLocalBalance` (#3627's assert), but winston output near process exit is currently unreliable (see #3626), so the assert's details may never reach any log sink.

## Changes

When the assert is about to fail, first emit the message — token, chain, and amount — via raw `console.error`, which bypasses winston and always reaches container logs. No output on the happy path. The amount is included because the leading root-cause hypothesis is a rebalance amount that floors to exactly 0 slipping past the funding gate; this will confirm or refute it on the next failing run.

Interim measure until the transport fix (#3626 + logger `serverless-gcp` mode) lands next week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)