### PR TITLE
feat(deposit-address): env-gated per-lane bridgeOverride on v3 executes

### DIFF
--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -112,6 +112,12 @@ export interface DepositAddressExecuteRequest {
   amount: string;
   /** Origin-chain-native encoding, like `userAddress`. */
   executionFeeRecipient: string;
+  /**
+   * Ops escape hatch: force the bridge instead of the API's amount-aware
+   * router. Clamped server-side to the committed executable lane set — a
+   * non-executable value is a typed 400, never a mis-signed sweep.
+   */
+  bridgeOverride?: "cctp" | "spokepool" | "oft";
   /** Bot-priced payout, deducted from the bridged amount. Omitted => 0. */
   executionFee?: string;
   /**

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -1266,6 +1266,27 @@ export class DepositAddressHandler {
       // signer address per origin chain keeps the fee recipient the bot itself on every family.
       executionFeeRecipient: toAddressType(this.signerAddress.toNative(), originChainId).toNative(),
       integratorId,
+      // Per-lane ops override of the API's amount-aware router (gated; empty by default).
+      // The API clamps this to the committed executable lane set, so a stale entry is a
+      // typed 400 rather than a wrong-lane sweep.
+      ...(() => {
+        if (!this.config.enableExecuteBridgeOverride) {
+          return {};
+        }
+        const laneKey =
+          `${originChainId}:${erc20Transfer.contractAddress}:${Number(routeParams.destinationChainId)}`.toLowerCase();
+        const bridgeOverride = this.config.executeBridgeOverrides[laneKey];
+        if (!isDefined(bridgeOverride)) {
+          return {};
+        }
+        this.logger?.debug({
+          at: "DepositAddressHandler#_getExecuteTx",
+          message: "Applying configured bridgeOverride to execute request",
+          laneKey,
+          bridgeOverride,
+        });
+        return { bridgeOverride };
+      })(),
       // Provenance reference to the inbound funding transfer. When accepted, the API folds this into a
       // Multicall3 bundle that emits a version-2 provenance blob, giving the indexer an on-chain
       // sweep ↔ funding-transfer link in the execute receipt. Gated because an API without the schema

--- a/src/deposit-address/DepositAddressHandlerConfig.ts
+++ b/src/deposit-address/DepositAddressHandlerConfig.ts
@@ -22,6 +22,14 @@ export class DepositAddressHandlerConfig extends CommonConfig {
   enableExecuteInputToken: boolean;
   /** Gate for relaying the `erc20Transfer` provenance object on v3 executes. Requires an API that accepts the field. */
   enableExecuteErc20Transfer: boolean;
+  /** Gate for per-lane `bridgeOverride` on v3 executes. Off unless BOTH this flag and a matching entry in `executeBridgeOverrides` are set. */
+  enableExecuteBridgeOverride: boolean;
+  /**
+   * Per-lane forced bridge, keyed `originChainId:inputTokenLowercase:destinationChainId` →
+   * `cctp | spokepool | oft`. The API clamps overrides to the committed executable lane set,
+   * so a bad entry yields a typed 400, never a mis-signed sweep.
+   */
+  executeBridgeOverrides: Record<string, "cctp" | "spokepool" | "oft">;
 
   /** Gate for publishing `withdraw_executed` events to GCP Pub/Sub. */
   enableDepositAddressWithdrawPublisher: boolean;
@@ -49,6 +57,8 @@ export class DepositAddressHandlerConfig extends CommonConfig {
       ENABLE_V3_WITHDRAWALS,
       ENABLE_EXECUTE_INPUT_TOKEN,
       ENABLE_EXECUTE_ERC20_TRANSFER_METADATA,
+      ENABLE_EXECUTE_BRIDGE_OVERRIDE,
+      EXECUTE_BRIDGE_OVERRIDES,
       ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER,
       ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER,
       PUBSUB_GCP_PROJECT_ID,
@@ -74,6 +84,27 @@ export class DepositAddressHandlerConfig extends CommonConfig {
     this.enableV3Withdrawals = ENABLE_V3_WITHDRAWALS === "true";
     this.enableExecuteInputToken = ENABLE_EXECUTE_INPUT_TOKEN === "true";
     this.enableExecuteErc20Transfer = ENABLE_EXECUTE_ERC20_TRANSFER_METADATA === "true";
+    this.enableExecuteBridgeOverride = ENABLE_EXECUTE_BRIDGE_OVERRIDE === "true";
+    this.executeBridgeOverrides = {};
+    if (this.enableExecuteBridgeOverride) {
+      const allowedBridges = new Set(["cctp", "spokepool", "oft"]);
+      const laneKey = /^\d+:\S+:\d+$/;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(EXECUTE_BRIDGE_OVERRIDES ?? "{}");
+      } catch {
+        throw new Error("EXECUTE_BRIDGE_OVERRIDES must be valid JSON when ENABLE_EXECUTE_BRIDGE_OVERRIDE=true");
+      }
+      for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+        if (!laneKey.test(key) || typeof value !== "string" || !allowedBridges.has(value)) {
+          throw new Error(
+            `EXECUTE_BRIDGE_OVERRIDES entry "${key}": "${String(value)}" is invalid — expected ` +
+              '"originChainId:inputToken:destinationChainId" → "cctp" | "spokepool" | "oft"'
+          );
+        }
+        this.executeBridgeOverrides[key.toLowerCase()] = value as "cctp" | "spokepool" | "oft";
+      }
+    }
 
     this.enableDepositAddressWithdrawPublisher = ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER === "true";
     this.enableDepositAddressDepositPublisher = ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER === "true";

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -86,6 +86,13 @@ Two optional execute fields are gated behind env flags because an API that preda
 changes rejects an unknown param with `400 INVALID_PARAM`:
 
 - `ENABLE_EXECUTE_INPUT_TOKEN=true` → relays the funding token as `inputToken`.
+- `ENABLE_EXECUTE_BRIDGE_OVERRIDE=true` + `EXECUTE_BRIDGE_OVERRIDES` → per-lane forced bridge on
+  v3 executes. `EXECUTE_BRIDGE_OVERRIDES` is a JSON map keyed
+  `originChainId:inputToken:destinationChainId` (input token lowercased; origin-chain-native
+  encoding) → `cctp | spokepool | oft`, e.g.
+  `{"42161:0xfd08…cbb9:999":"oft"}`. Lanes without an entry keep the API's amount-aware routing.
+  The API clamps overrides to the committed executable lane set, so a stale/invalid entry is a
+  typed 400, never a wrong-lane sweep. Config-parse fails fast on malformed JSON or values.
 - `ENABLE_EXECUTE_ERC20_TRANSFER_METADATA=true` → relays an `erc20Transfer` provenance reference
   (`{ chainId, blockNumber, transactionHash, logIndex }` of the inbound funding transfer, taken
   verbatim from the indexer message; `chainId` coerced to an integer). When accepted, the API wraps

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -503,6 +503,43 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
     });
   });
 
+  it("applies a configured bridgeOverride when the gate is on and the lane matches", async function () {
+    const config = handler.config as unknown as {
+      enableExecuteBridgeOverride: boolean;
+      executeBridgeOverrides: Record<string, string>;
+    };
+    config.enableExecuteBridgeOverride = true;
+    config.executeBridgeOverrides = { [`42161:${TOKEN.toLowerCase()}:1337`]: "oft" };
+    await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());
+    expect(executeStub.calledOnce).to.equal(true);
+    const request = executeStub.firstCall.args[0] as Record<string, unknown>;
+    expect(request.bridgeOverride).to.equal("oft");
+  });
+
+  it("omits bridgeOverride when the gate is on but no lane matches", async function () {
+    const config = handler.config as unknown as {
+      enableExecuteBridgeOverride: boolean;
+      executeBridgeOverrides: Record<string, string>;
+    };
+    config.enableExecuteBridgeOverride = true;
+    config.executeBridgeOverrides = { "1:0xdeadbeef:8453": "spokepool" };
+    await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());
+    const request = executeStub.firstCall.args[0] as Record<string, unknown>;
+    expect(request).to.not.have.property("bridgeOverride");
+  });
+
+  it("omits bridgeOverride when the gate is off even if a lane matches", async function () {
+    const config = handler.config as unknown as {
+      enableExecuteBridgeOverride: boolean;
+      executeBridgeOverrides: Record<string, string>;
+    };
+    config.enableExecuteBridgeOverride = false;
+    config.executeBridgeOverrides = { [`42161:${TOKEN.toLowerCase()}:1337`]: "oft" };
+    await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());
+    const request = executeStub.firstCall.args[0] as Record<string, unknown>;
+    expect(request).to.not.have.property("bridgeOverride");
+  });
+
   it("retries on undefined responses and gives up after exhausting retries", async function () {
     executeStub.resolves(undefined);
     const result = await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());


### PR DESCRIPTION
## Motivation

The quote-api's `POST /deposit-addresses/execute` accepts an ops escape hatch, `bridgeOverride: "cctp" | "spokepool" | "oft"`, but the sweeper never sends it — lane selection is always the API's amount-aware router. That leaves no operational lever to (a) force a healthy rail during a lane incident (e.g. an Iris outage failing CCTP quotes) or (b) exercise lanes the router never picks (the dedup rule prefers spokepool over oft for the same input, so OFT sweeps can only be tested by hand-broadcasting).

## Change

Per-lane forced bridge on v3 executes, dark by default and double-gated (the `ENABLE_*` pattern used by `ENABLE_EXECUTE_INPUT_TOKEN` / `ENABLE_EXECUTE_ERC20_TRANSFER_METADATA`):

- `ENABLE_EXECUTE_BRIDGE_OVERRIDE=true` — master gate; off ⇒ requests are byte-identical to today.
- `EXECUTE_BRIDGE_OVERRIDES` — JSON map `"originChainId:inputToken:destinationChainId" → "cctp" | "spokepool" | "oft"` (input token lowercased, origin-chain-native encoding). Config parsing fails fast on malformed JSON, malformed lane keys, or unknown bridge values.
- `_getExecuteTx` looks up the funded lane and, on a hit, includes `bridgeOverride` in the execute request (debug-logged). No entry ⇒ field omitted ⇒ the API's router decides, exactly as today.

Safe by construction: the API clamps `bridgeOverride` to the committed executable lane set for `(origin, inputToken, destination)` — a stale or wrong entry produces a typed 400, never a mis-signed or wrong-lane sweep. The bot adds no routing logic of its own.

## Tests

Three new cases in `test/DepositAddressHandler.ts`: override applied on a lane match, omitted on a miss, omitted when the gate is off despite a match. 51 passing locally; the 3 pre-existing `executionFeeRecipient` checksum-casing failures reproduce identically on clean master and are untouched.

## Rollout

Intended for the test bot first (flag on + a single OFT lane entry to validate the Arbitrum USDT → HyperEVM lane through the production path), default-off everywhere else. Requires no API change — the endpoint already accepts the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)