### PR TITLE
feat(DepositAddressHandler): send depositAddress and inputToken on execute

### DIFF
--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -98,8 +98,16 @@ export interface DepositAddressExecuteRequest {
     recipient: string;
   };
   originChainId: number;
-  // The origin token that funded the deposit address.
-  inputToken?: {
+  /**
+   * The funded address being swept, relayed so the API can resolve which contract generation it
+   * belongs to instead of assuming the latest. Origin-chain-native encoding, like `userAddress`.
+   */
+  depositAddress: string;
+  /**
+   * The origin token that funded the deposit address. Relayed explicitly rather than left to the
+   * API's origin-native-USDC default, so non-USDC funding sweeps route off the real token.
+   */
+  inputToken: {
     chainId: number;
     address: string;
   };

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -1228,7 +1228,7 @@ export class DepositAddressHandler {
     depositMessage: DepositAddressMessageV3,
     retriesRemaining = 3
   ): Promise<DepositAddressExecuteResponse | undefined> {
-    const { routeParams, refundAddress, erc20Transfer } = depositMessage;
+    const { routeParams, refundAddress, erc20Transfer, depositAddress } = depositMessage;
     // The API re-derives the deposit address and merkle materials from this identity; the bot
     // relays funding context plus the integratorId the address was derived with (≠ building
     // calldata). executionFee is omitted for now: the API defaults it to 0 and bot-side fee pricing
@@ -1249,16 +1249,16 @@ export class DepositAddressHandler {
         recipient: routeParams.recipient.address,
       },
       originChainId,
-      // The funding token is relayed verbatim from the indexer, which serves origin-chain-native
-      // encodings (base58 on Tron) — exactly what the execute endpoint expects for origin fields.
-      ...(this.config.enableExecuteInputToken
-        ? {
-            inputToken: {
-              chainId: originChainId,
-              address: erc20Transfer.contractAddress,
-            },
-          }
-        : {}),
+      // Both origin fields below are relayed verbatim from the indexer, which serves
+      // origin-chain-native encodings (base58 on Tron) — exactly what the execute endpoint expects
+      // for origin fields. The API resolves the swept address's contract generation from
+      // `depositAddress` rather than assuming the latest, and routes off `inputToken` instead of
+      // defaulting to origin-native USDC.
+      depositAddress,
+      inputToken: {
+        chainId: originChainId,
+        address: erc20Transfer.contractAddress,
+      },
       userAddress: refundAddress.address,
       amount: erc20Transfer.amount,
       // The API expects origin-chain-native encoding (base58 on Tron). The bot's Tron account is

--- a/src/deposit-address/DepositAddressHandlerConfig.ts
+++ b/src/deposit-address/DepositAddressHandlerConfig.ts
@@ -18,8 +18,6 @@ export class DepositAddressHandlerConfig extends CommonConfig {
   withdrawEnabled: boolean;
   /** Gate for the v3 (upgradeable-counterfactual) refund-withdraw path. Independent of withdrawEnabled. */
   enableV3Withdrawals: boolean;
-  /** Gate for relaying the funding token as `inputToken` on v3 executes. Requires an API that accepts the field. */
-  enableExecuteInputToken: boolean;
   /** Gate for relaying the `erc20Transfer` provenance object on v3 executes. Requires an API that accepts the field. */
   enableExecuteErc20Transfer: boolean;
 
@@ -47,7 +45,6 @@ export class DepositAddressHandlerConfig extends CommonConfig {
       INITIALIZATION_RETRY_ATTEMPTS,
       WITHDRAW_ENABLED,
       ENABLE_V3_WITHDRAWALS,
-      ENABLE_EXECUTE_INPUT_TOKEN,
       ENABLE_EXECUTE_ERC20_TRANSFER_METADATA,
       ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER,
       ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER,
@@ -72,7 +69,6 @@ export class DepositAddressHandlerConfig extends CommonConfig {
     this.initializationRetryAttempts = Number(INITIALIZATION_RETRY_ATTEMPTS ?? 3);
     this.withdrawEnabled = WITHDRAW_ENABLED === "true";
     this.enableV3Withdrawals = ENABLE_V3_WITHDRAWALS === "true";
-    this.enableExecuteInputToken = ENABLE_EXECUTE_INPUT_TOKEN === "true";
     this.enableExecuteErc20Transfer = ENABLE_EXECUTE_ERC20_TRANSFER_METADATA === "true";
 
     this.enableDepositAddressWithdrawPublisher = ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER === "true";

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -73,19 +73,30 @@ For `version: 3` messages the bot is a **thin submitter** of API-built calldata.
 execute endpoint (`POST /deposit-addresses/execute`, bearer-authed with the same `SWAP_API_KEY`)
 re-derives the deposit address and all counterfactual merkle materials server-side from the
 identity (`destination.token`, `destination.recipient`, `userAddress`); the bot relays funding
-context only — origin chain, amount, destination route, refund identity — plus its own
-`executionFeeRecipient` and the `integratorId` the address was derived with. `executionFee` is
-currently omitted (the API defaults it to 0); bot-side fee pricing is a follow-up task.
+context only — origin chain, swept `depositAddress`, funding `inputToken`, amount, destination
+route, refund identity — plus its own `executionFeeRecipient` and the `integratorId` the address
+was derived with. `executionFee` is currently omitted (the API defaults it to 0); bot-side fee
+pricing is a follow-up task.
 
 The `integratorId` (2-byte hex) is sourced from the indexer message's `integrator` projection (a
 property of the deposit address, not the bot's auth key) and is **required** by the execute
 endpoint — it folds into the CREATE2 salt + on-chain integrator tag, so the address is derived
 per-integrator. The bot relays it verbatim.
 
-Two optional execute fields are gated behind env flags because an API that predates their schema
-changes rejects an unknown param with `400 INVALID_PARAM`:
+Two origin-side fields are always sent, both relayed verbatim from the indexer message:
 
-- `ENABLE_EXECUTE_INPUT_TOKEN=true` → relays the funding token as `inputToken`.
+- `depositAddress` — the funded address being swept (`depositAddress` on the v3 item). The API
+  resolves which contract generation the address belongs to from this, instead of assuming the
+  latest.
+- `inputToken` — the funding token as `{ chainId, address }` (`erc20Transfer.contractAddress`).
+  Without it the API falls back to origin-native USDC, which mis-routes non-USDC sweeps.
+
+Neither is gated: every API deployment accepts them (older contract generations parse and ignore
+them), so one bot build is safe against every environment.
+
+One optional field remains behind an env flag, because an API that predates its schema change
+rejects an unknown param with `400 INVALID_PARAM`:
+
 - `ENABLE_EXECUTE_ERC20_TRANSFER_METADATA=true` → relays an `erc20Transfer` provenance reference
   (`{ chainId, blockNumber, transactionHash, logIndex }` of the inbound funding transfer, taken
   verbatim from the indexer message; `chainId` coerced to an integer). When accepted, the API wraps
@@ -93,7 +104,7 @@ changes rejects an unknown param with `400 INVALID_PARAM`:
   `AcrossEventEmitter`, giving the indexer an on-chain sweep ↔ funding-transfer link in the execute
   receipt.
 
-Both default off; enable them only against an API that accepts the field (e.g. the test bot ahead of
+Defaults off; enable it only against an API that accepts the field (e.g. the test bot ahead of
 the production rollout).
 
 The flow (`initiateDepositV3`):
@@ -126,8 +137,9 @@ read by the execute path — the API re-derives them, so they are carried for di
 (`depositAddressNamespace: "tron"`). No dedicated gate: Tron activates by adding its chainId
 (728126428) to `RELAYER_ORIGIN_CHAINS`, which also provisions the provider and dedup sets. v3
 messages stay un-normalized, so Tron fields flow **base58 end-to-end to the quote-api**
-(`userAddress`, `inputToken.address`; the bot re-encodes its own `executionFeeRecipient` to base58
-via `toAddressType`). The API responds with `executeTx.ecosystem: "tvm"`, a **0x-hex `to`** (the
+(`userAddress`, `depositAddress`, `inputToken.address`; the bot re-encodes its own
+`executionFeeRecipient` to base58 via `toAddressType`). The API responds with
+`executeTx.ecosystem: "tvm"`, a **0x-hex `to`** (the
 RPC-facing format), and the `depositAddress` echoed in base58; the bot validates the ecosystem
 against the chain family and compares deposit addresses canonically (base58 → hex) since base58 is
 case-sensitive. On-chain reads (`getDepositAddressBalance`) and receipt-log matching

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -19,7 +19,9 @@ import { DepositAddressHandlerConfig } from "../src/deposit-address/DepositAddre
 import { ERC20_TRANSFER_TOPIC } from "../src/deposit-address/withdrawPayload";
 import { NATIVE_TOKEN_SENTINEL_ADDRESS } from "../src/utils/DepositAddressUtils";
 
-const SIGNER = "0x000000000000000000000000000000000000BEEF";
+// EIP-55 checksummed: the handler round-trips the signer through `toAddressType().toNative()`,
+// which returns the checksummed form, so an un-checksummed literal fails the request-shape compares.
+const SIGNER = "0x000000000000000000000000000000000000bEEF";
 const DEPOSIT_ADDRESS = "0x000000000000000000000000000000000000C0DE";
 const REFUND_ADDRESS = "0x0000000000000000000000000000000000002222";
 const TOKEN = "0x000000000000000000000000000000000000DEAD";
@@ -441,18 +443,20 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
 
   afterEach(() => sinon.restore());
 
-  it("relays funding context and integratorId, with executionFee omitted", async function () {
+  it("relays funding context, depositAddress, inputToken and integratorId, with executionFee omitted", async function () {
     await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());
     expect(executeStub.calledOnce).to.equal(true);
-    // Exact request body with all execute feature flags off (the default / production shape): the
-    // execute endpoint re-derives the address/materials from this identity, and its superstruct
-    // schema rejects unknown or missing keys. Neither `inputToken` nor `erc20Transfer` is sent.
+    // Exact request body in the default / production shape: the execute endpoint re-derives the
+    // materials from this identity, and its superstruct schema rejects unknown or missing keys.
+    // `depositAddress` and `inputToken` are always sent; only `erc20Transfer` remains gated.
     expect(executeStub.firstCall.args[0]).to.deep.equal({
       destination: {
         token: { chainId: 1337, address: OUTPUT_TOKEN },
         recipient: RECIPIENT,
       },
       originChainId: 42161,
+      depositAddress: DEPOSIT_ADDRESS,
+      inputToken: { chainId: 42161, address: TOKEN },
       userAddress: REFUND_ADDRESS,
       amount: "5000",
       executionFeeRecipient: SIGNER,
@@ -471,6 +475,8 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
         recipient: RECIPIENT,
       },
       originChainId: 42161,
+      depositAddress: DEPOSIT_ADDRESS,
+      inputToken: { chainId: 42161, address: TOKEN },
       userAddress: REFUND_ADDRESS,
       amount: "5000",
       executionFeeRecipient: SIGNER,
@@ -485,24 +491,6 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
     });
   });
 
-  it("relays the funding token as inputToken when ENABLE_EXECUTE_INPUT_TOKEN is on", async function () {
-    (handler as unknown as { config: { enableExecuteInputToken: boolean } }).config.enableExecuteInputToken = true;
-    await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());
-    expect(executeStub.calledOnce).to.equal(true);
-    expect(executeStub.firstCall.args[0]).to.deep.equal({
-      destination: {
-        token: { chainId: 1337, address: OUTPUT_TOKEN },
-        recipient: RECIPIENT,
-      },
-      originChainId: 42161,
-      inputToken: { chainId: 42161, address: TOKEN },
-      userAddress: REFUND_ADDRESS,
-      amount: "5000",
-      executionFeeRecipient: SIGNER,
-      integratorId: "0xdead",
-    });
-  });
-
   it("retries on undefined responses and gives up after exhausting retries", async function () {
     executeStub.resolves(undefined);
     const result = await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());
@@ -510,7 +498,7 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
     expect(executeStub.callCount).to.equal(4); // initial attempt + 3 retries
   });
 
-  it("sends origin-native Tron encodings: base58 userAddress verbatim, base58 executionFeeRecipient", async function () {
+  it("sends origin-native Tron encodings: base58 identity fields verbatim, base58 executionFeeRecipient", async function () {
     await (handler as unknown as Internals)._getExecuteTx(tronDepositMessageV3());
     expect(executeStub.calledOnce).to.equal(true);
     const expectedFeeRecipient = toAddressType(SIGNER, CHAIN_IDs.TRON).toNative();
@@ -522,6 +510,8 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
         recipient: RECIPIENT,
       },
       originChainId: CHAIN_IDs.TRON,
+      depositAddress: TRON_DEPOSIT_ADDRESS,
+      inputToken: { chainId: CHAIN_IDs.TRON, address: TRON_TOKEN },
       userAddress: TRON_REFUND_ADDRESS,
       amount: "25000000",
       executionFeeRecipient: expectedFeeRecipient,
@@ -529,17 +519,12 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
     });
   });
 
-  it("relays base58 inputToken and the un-prefixed provenance hash verbatim when both gates are on", async function () {
-    const config = handler.config as unknown as {
-      enableExecuteInputToken: boolean;
-      enableExecuteErc20Transfer: boolean;
-    };
-    config.enableExecuteInputToken = true;
-    config.enableExecuteErc20Transfer = true;
+  it("relays the un-prefixed Tron provenance hash verbatim when the erc20Transfer gate is on", async function () {
+    (handler as unknown as { config: { enableExecuteErc20Transfer: boolean } }).config.enableExecuteErc20Transfer =
+      true;
     await (handler as unknown as Internals)._getExecuteTx(tronDepositMessageV3());
     expect(executeStub.calledOnce).to.equal(true);
     const request = executeStub.firstCall.args[0] as Record<string, unknown>;
-    expect(request.inputToken).to.deep.equal({ chainId: CHAIN_IDs.TRON, address: TRON_TOKEN });
     expect(request.erc20Transfer).to.deep.equal({
       chainId: CHAIN_IDs.TRON,
       blockNumber: 84_665_484,


### PR DESCRIPTION
## What

The `POST /deposit-addresses/execute` endpoint gained new payload params. Relay two of them on every v3 execute:

- **`depositAddress`** — the funded address being swept. The API resolves which contract generation the address belongs to from this, instead of assuming the latest.
- **`inputToken`** — the funding token as `{ chainId, address }`. Without it the API falls back to origin-native USDC, which mis-routes any non-USDC sweep.

## Indexer data availability (checked before implementing)

Both values are already on the polled `/deposit-address-transfers` item, so nothing new is needed indexer-side:

| Field | Source on the v3 item | Required? |
|---|---|---|
| `depositAddress` | top-level `depositAddress` (`= transfer.to`) | yes |
| `inputToken.address` | `erc20Transfer.contractAddress` | yes |

Both are non-optional on `DepositAddressTransferItemV3`, and the indexer's v3 builder skips-and-warns any row missing a required durable field — so every *served* v3 item carries them. Both are forwarded **verbatim**, keeping Tron base58 end-to-end (the execute endpoint expects origin-chain-native encodings for origin fields).

## Why neither field is gated

`inputToken` was previously behind `ENABLE_EXECUTE_INPUT_TOKEN`, because an API predating the schema change rejects an unknown param with `400 INVALID_PARAM` (superstruct `object()` is exact). That reason is gone: both fields are now `optional()` in `ExecuteRequestSchema` on quote-api `master`, accepted-and-ignored on older contract generations. One bot build is therefore safe against every environment, so the flag is removed rather than extended to cover the second field.

`ENABLE_EXECUTE_ERC20_TRANSFER_METADATA` is untouched and stays gated.

`bridgeOverride` — the third field the endpoint now accepts — is deliberately **not** wired up here. It is an ops escape hatch to force a bridge instead of letting the API route, and needs its own config surface.

## Config note

`ENABLE_EXECUTE_INPUT_TOKEN: true` in `bot-configs/serverless-bots/across-config-5m.json` becomes an unused key after this merges. Harmless (unknown env vars are ignored), but worth tidying in a bot-configs pass.

## Drive-by test fix

The `SIGNER` literal in `test/DepositAddressHandler.ts` was not EIP-55 checksummed, so it never matched the handler's `toAddressType().toNative()` output. Three request-shape assertions were **already red on master** before this change; checksumming the constant fixes them.

## Verification

- `test/DepositAddressHandler.ts`: **50 passing, 0 failing** (master baseline: 48 passing, 3 failing — the checksum issue above).
- `yarn lint`: clean.
- `yarn typecheck`: the 3 pre-existing `Dataworker.ts` / `validateRootBundle.ts` `poolRebalanceLeafCount` errors are present identically on master and unrelated to these files; no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzGPkq61Nh5zrpiXx3NY4R