### PR TITLE
chore(deps): bump @across-protocol/sdk from 4.4.14 to 4.4.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.123",
     "@across-protocol/contracts": "5.0.24",
-    "@across-protocol/sdk": "4.4.14",
+    "@across-protocol/sdk": "4.4.16",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,10 +34,10 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.4.14":
-  version "4.4.14"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.4.14.tgz#404fb77e7c604fe64228ab72a492f401f0744f41"
-  integrity sha512-ooC4yMEO9iPImgYhz2VVytbRRwTi+O+BHqN2ZGxQ6UP/b+b2t51+aiK7E0MYNJMnBPcb94NE8d9NjZu09NgcUw==
+"@across-protocol/sdk@4.4.16":
+  version "4.4.16"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.4.16.tgz#df3dd92bee96875e99203e284fcbdd50dd4a26a1"
+  integrity sha512-PU/OnksJw08vZYijv8VgJlkH/CMA/kVYX5UnLGVoXlsYUBwi5/m9bYdo91o1zwky/neyNmxeK3KNmJxN9hRBUQ==
   dependencies:
     "@across-protocol/constants" "^3.1.123"
     "@across-protocol/contracts" "5.0.24"


### PR DESCRIPTION
## Motivation

Prepares the relayer for SDK `4.4.16`, which includes [across-protocol/sdk#1499](https://github.com/across-protocol/sdk/pull/1499): `HubPoolClient` no longer throws (`SVM USDC address mismatch`) when processing a `SetPoolRebalanceRoute` event that disables an SVM route via a zero-address destination token. This must be deployed to all bots **before** executing the queued HubPool admin batch that prunes pool rebalance routes (including USDC on Solana), otherwise every `HubPoolClient.update()` throws once that event is mined.

## Changes

- `package.json`: `@across-protocol/sdk` `4.4.14` → `4.4.16`.
- `yarn.lock` intentionally **not** synced yet — `4.4.16` is not on npm until the SDK release completes. The lock refresh lands as a follow-up commit on this branch once the package is published; the PR stays draft until then (install/CI will fail against the stale lock).

No README/AGENTS.md updates needed: dependency bump only, no behavior/config/interface changes in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)