### PR TITLE
Revert "feat(DepositAddressHandler): send depositAddress and inputToken on execute"

### DIFF
--- a/src/clients/AcrossSwapApiClient.ts
+++ b/src/clients/AcrossSwapApiClient.ts
@@ -98,16 +98,8 @@ export interface DepositAddressExecuteRequest {
     recipient: string;
   };
   originChainId: number;
-  /**
-   * The funded address being swept, relayed so the API can resolve which contract generation it
-   * belongs to instead of assuming the latest. Origin-chain-native encoding, like `userAddress`.
-   */
-  depositAddress: string;
-  /**
-   * The origin token that funded the deposit address. Relayed explicitly rather than left to the
-   * API's origin-native-USDC default, so non-USDC funding sweeps route off the real token.
-   */
-  inputToken: {
+  // The origin token that funded the deposit address.
+  inputToken?: {
     chainId: number;
     address: string;
   };

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -1228,7 +1228,7 @@ export class DepositAddressHandler {
     depositMessage: DepositAddressMessageV3,
     retriesRemaining = 3
   ): Promise<DepositAddressExecuteResponse | undefined> {
-    const { routeParams, refundAddress, erc20Transfer, depositAddress } = depositMessage;
+    const { routeParams, refundAddress, erc20Transfer } = depositMessage;
     // The API re-derives the deposit address and merkle materials from this identity; the bot
     // relays funding context plus the integratorId the address was derived with (≠ building
     // calldata). executionFee is omitted for now: the API defaults it to 0 and bot-side fee pricing
@@ -1249,16 +1249,16 @@ export class DepositAddressHandler {
         recipient: routeParams.recipient.address,
       },
       originChainId,
-      // Both origin fields below are relayed verbatim from the indexer, which serves
-      // origin-chain-native encodings (base58 on Tron) — exactly what the execute endpoint expects
-      // for origin fields. The API resolves the swept address's contract generation from
-      // `depositAddress` rather than assuming the latest, and routes off `inputToken` instead of
-      // defaulting to origin-native USDC.
-      depositAddress,
-      inputToken: {
-        chainId: originChainId,
-        address: erc20Transfer.contractAddress,
-      },
+      // The funding token is relayed verbatim from the indexer, which serves origin-chain-native
+      // encodings (base58 on Tron) — exactly what the execute endpoint expects for origin fields.
+      ...(this.config.enableExecuteInputToken
+        ? {
+            inputToken: {
+              chainId: originChainId,
+              address: erc20Transfer.contractAddress,
+            },
+          }
+        : {}),
       userAddress: refundAddress.address,
       amount: erc20Transfer.amount,
       // The API expects origin-chain-native encoding (base58 on Tron). The bot's Tron account is

--- a/src/deposit-address/DepositAddressHandlerConfig.ts
+++ b/src/deposit-address/DepositAddressHandlerConfig.ts
@@ -18,6 +18,8 @@ export class DepositAddressHandlerConfig extends CommonConfig {
   withdrawEnabled: boolean;
   /** Gate for the v3 (upgradeable-counterfactual) refund-withdraw path. Independent of withdrawEnabled. */
   enableV3Withdrawals: boolean;
+  /** Gate for relaying the funding token as `inputToken` on v3 executes. Requires an API that accepts the field. */
+  enableExecuteInputToken: boolean;
   /** Gate for relaying the `erc20Transfer` provenance object on v3 executes. Requires an API that accepts the field. */
   enableExecuteErc20Transfer: boolean;
 
@@ -45,6 +47,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
       INITIALIZATION_RETRY_ATTEMPTS,
       WITHDRAW_ENABLED,
       ENABLE_V3_WITHDRAWALS,
+      ENABLE_EXECUTE_INPUT_TOKEN,
       ENABLE_EXECUTE_ERC20_TRANSFER_METADATA,
       ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER,
       ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER,
@@ -69,6 +72,7 @@ export class DepositAddressHandlerConfig extends CommonConfig {
     this.initializationRetryAttempts = Number(INITIALIZATION_RETRY_ATTEMPTS ?? 3);
     this.withdrawEnabled = WITHDRAW_ENABLED === "true";
     this.enableV3Withdrawals = ENABLE_V3_WITHDRAWALS === "true";
+    this.enableExecuteInputToken = ENABLE_EXECUTE_INPUT_TOKEN === "true";
     this.enableExecuteErc20Transfer = ENABLE_EXECUTE_ERC20_TRANSFER_METADATA === "true";
 
     this.enableDepositAddressWithdrawPublisher = ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER === "true";

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -73,30 +73,19 @@ For `version: 3` messages the bot is a **thin submitter** of API-built calldata.
 execute endpoint (`POST /deposit-addresses/execute`, bearer-authed with the same `SWAP_API_KEY`)
 re-derives the deposit address and all counterfactual merkle materials server-side from the
 identity (`destination.token`, `destination.recipient`, `userAddress`); the bot relays funding
-context only — origin chain, swept `depositAddress`, funding `inputToken`, amount, destination
-route, refund identity — plus its own `executionFeeRecipient` and the `integratorId` the address
-was derived with. `executionFee` is currently omitted (the API defaults it to 0); bot-side fee
-pricing is a follow-up task.
+context only — origin chain, amount, destination route, refund identity — plus its own
+`executionFeeRecipient` and the `integratorId` the address was derived with. `executionFee` is
+currently omitted (the API defaults it to 0); bot-side fee pricing is a follow-up task.
 
 The `integratorId` (2-byte hex) is sourced from the indexer message's `integrator` projection (a
 property of the deposit address, not the bot's auth key) and is **required** by the execute
 endpoint — it folds into the CREATE2 salt + on-chain integrator tag, so the address is derived
 per-integrator. The bot relays it verbatim.
 
-Two origin-side fields are always sent, both relayed verbatim from the indexer message:
+Two optional execute fields are gated behind env flags because an API that predates their schema
+changes rejects an unknown param with `400 INVALID_PARAM`:
 
-- `depositAddress` — the funded address being swept (`depositAddress` on the v3 item). The API
-  resolves which contract generation the address belongs to from this, instead of assuming the
-  latest.
-- `inputToken` — the funding token as `{ chainId, address }` (`erc20Transfer.contractAddress`).
-  Without it the API falls back to origin-native USDC, which mis-routes non-USDC sweeps.
-
-Neither is gated: every API deployment accepts them (older contract generations parse and ignore
-them), so one bot build is safe against every environment.
-
-One optional field remains behind an env flag, because an API that predates its schema change
-rejects an unknown param with `400 INVALID_PARAM`:
-
+- `ENABLE_EXECUTE_INPUT_TOKEN=true` → relays the funding token as `inputToken`.
 - `ENABLE_EXECUTE_ERC20_TRANSFER_METADATA=true` → relays an `erc20Transfer` provenance reference
   (`{ chainId, blockNumber, transactionHash, logIndex }` of the inbound funding transfer, taken
   verbatim from the indexer message; `chainId` coerced to an integer). When accepted, the API wraps
@@ -104,7 +93,7 @@ rejects an unknown param with `400 INVALID_PARAM`:
   `AcrossEventEmitter`, giving the indexer an on-chain sweep ↔ funding-transfer link in the execute
   receipt.
 
-Defaults off; enable it only against an API that accepts the field (e.g. the test bot ahead of
+Both default off; enable them only against an API that accepts the field (e.g. the test bot ahead of
 the production rollout).
 
 The flow (`initiateDepositV3`):
@@ -137,9 +126,8 @@ read by the execute path — the API re-derives them, so they are carried for di
 (`depositAddressNamespace: "tron"`). No dedicated gate: Tron activates by adding its chainId
 (728126428) to `RELAYER_ORIGIN_CHAINS`, which also provisions the provider and dedup sets. v3
 messages stay un-normalized, so Tron fields flow **base58 end-to-end to the quote-api**
-(`userAddress`, `depositAddress`, `inputToken.address`; the bot re-encodes its own
-`executionFeeRecipient` to base58 via `toAddressType`). The API responds with
-`executeTx.ecosystem: "tvm"`, a **0x-hex `to`** (the
+(`userAddress`, `inputToken.address`; the bot re-encodes its own `executionFeeRecipient` to base58
+via `toAddressType`). The API responds with `executeTx.ecosystem: "tvm"`, a **0x-hex `to`** (the
 RPC-facing format), and the `depositAddress` echoed in base58; the bot validates the ecosystem
 against the chain family and compares deposit addresses canonically (base58 → hex) since base58 is
 case-sensitive. On-chain reads (`getDepositAddressBalance`) and receipt-log matching

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -443,20 +443,18 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
 
   afterEach(() => sinon.restore());
 
-  it("relays funding context, depositAddress, inputToken and integratorId, with executionFee omitted", async function () {
+  it("relays funding context and integratorId, with executionFee omitted", async function () {
     await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());
     expect(executeStub.calledOnce).to.equal(true);
-    // Exact request body in the default / production shape: the execute endpoint re-derives the
-    // materials from this identity, and its superstruct schema rejects unknown or missing keys.
-    // `depositAddress` and `inputToken` are always sent; only `erc20Transfer` remains gated.
+    // Exact request body with all execute feature flags off (the default / production shape): the
+    // execute endpoint re-derives the address/materials from this identity, and its superstruct
+    // schema rejects unknown or missing keys. Neither `inputToken` nor `erc20Transfer` is sent.
     expect(executeStub.firstCall.args[0]).to.deep.equal({
       destination: {
         token: { chainId: 1337, address: OUTPUT_TOKEN },
         recipient: RECIPIENT,
       },
       originChainId: 42161,
-      depositAddress: DEPOSIT_ADDRESS,
-      inputToken: { chainId: 42161, address: TOKEN },
       userAddress: REFUND_ADDRESS,
       amount: "5000",
       executionFeeRecipient: SIGNER,
@@ -475,8 +473,6 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
         recipient: RECIPIENT,
       },
       originChainId: 42161,
-      depositAddress: DEPOSIT_ADDRESS,
-      inputToken: { chainId: 42161, address: TOKEN },
       userAddress: REFUND_ADDRESS,
       amount: "5000",
       executionFeeRecipient: SIGNER,
@@ -491,6 +487,24 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
     });
   });
 
+  it("relays the funding token as inputToken when ENABLE_EXECUTE_INPUT_TOKEN is on", async function () {
+    (handler as unknown as { config: { enableExecuteInputToken: boolean } }).config.enableExecuteInputToken = true;
+    await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());
+    expect(executeStub.calledOnce).to.equal(true);
+    expect(executeStub.firstCall.args[0]).to.deep.equal({
+      destination: {
+        token: { chainId: 1337, address: OUTPUT_TOKEN },
+        recipient: RECIPIENT,
+      },
+      originChainId: 42161,
+      inputToken: { chainId: 42161, address: TOKEN },
+      userAddress: REFUND_ADDRESS,
+      amount: "5000",
+      executionFeeRecipient: SIGNER,
+      integratorId: "0xdead",
+    });
+  });
+
   it("retries on undefined responses and gives up after exhausting retries", async function () {
     executeStub.resolves(undefined);
     const result = await (handler as unknown as Internals)._getExecuteTx(depositMessageV3());
@@ -498,7 +512,7 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
     expect(executeStub.callCount).to.equal(4); // initial attempt + 3 retries
   });
 
-  it("sends origin-native Tron encodings: base58 identity fields verbatim, base58 executionFeeRecipient", async function () {
+  it("sends origin-native Tron encodings: base58 userAddress verbatim, base58 executionFeeRecipient", async function () {
     await (handler as unknown as Internals)._getExecuteTx(tronDepositMessageV3());
     expect(executeStub.calledOnce).to.equal(true);
     const expectedFeeRecipient = toAddressType(SIGNER, CHAIN_IDs.TRON).toNative();
@@ -510,8 +524,6 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
         recipient: RECIPIENT,
       },
       originChainId: CHAIN_IDs.TRON,
-      depositAddress: TRON_DEPOSIT_ADDRESS,
-      inputToken: { chainId: CHAIN_IDs.TRON, address: TRON_TOKEN },
       userAddress: TRON_REFUND_ADDRESS,
       amount: "25000000",
       executionFeeRecipient: expectedFeeRecipient,
@@ -519,12 +531,17 @@ describe("DepositAddressHandler._getExecuteTx request mapping", function () {
     });
   });
 
-  it("relays the un-prefixed Tron provenance hash verbatim when the erc20Transfer gate is on", async function () {
-    (handler as unknown as { config: { enableExecuteErc20Transfer: boolean } }).config.enableExecuteErc20Transfer =
-      true;
+  it("relays base58 inputToken and the un-prefixed provenance hash verbatim when both gates are on", async function () {
+    const config = handler.config as unknown as {
+      enableExecuteInputToken: boolean;
+      enableExecuteErc20Transfer: boolean;
+    };
+    config.enableExecuteInputToken = true;
+    config.enableExecuteErc20Transfer = true;
     await (handler as unknown as Internals)._getExecuteTx(tronDepositMessageV3());
     expect(executeStub.calledOnce).to.equal(true);
     const request = executeStub.firstCall.args[0] as Record<string, unknown>;
+    expect(request.inputToken).to.deep.equal({ chainId: CHAIN_IDs.TRON, address: TRON_TOKEN });
     expect(request.erc20Transfer).to.deep.equal({
       chainId: CHAIN_IDs.TRON,
       blockNumber: 84_665_484,


### PR DESCRIPTION
## ⚠️ Break-glass rollback — do not merge unless prod misbehaves

Pre-emptive revert of `ba2942b4` (#3636), opened as a **draft** so it is ready to go but cannot be merged by accident. Mark ready + merge only if the new execute payload params cause trouble.

## What reverting actually changes in prod

Worth knowing before pulling this lever, because the two fields roll back differently:

| Field | After revert | Why |
|---|---|---|
| `depositAddress` | **stops being sent** | Ungated on master — a code revert is the only lever. |
| `inputToken` | **keeps being sent** | Revert restores the `ENABLE_EXECUTE_INPUT_TOKEN` gate, and `bot-configs/serverless-bots/across-config-5m.json` sets it `true`. |

So if `inputToken` is the culprit, this PR alone is **not** enough — also flip `ENABLE_EXECUTE_INPUT_TOKEN` to `false` in bot-configs (which is the faster mitigation, no redeploy of the bot image needed). If `depositAddress` is the culprit, this PR is the fix.

Both fields are `optional()` in quote-api's `ExecuteRequestSchema`, so removing them cannot 400 — the failure mode this guards against is the API *acting* on them (resolving a different contract generation, or routing off a non-USDC input token) rather than rejecting them.

## Deviation from a pure `git revert`

One line kept, deliberately: the `SIGNER` test literal stays EIP-55 checksummed.

#3636 also fixed that constant, which had been red on master before it. A pure `git revert` re-breaks three request-shape assertions — **48 passing / 3 failing** — leaving CI red on the exact branch you'd want to merge in a hurry. The fix is orthogonal to the payload behavior (it only makes the literal match the handler's `toAddressType().toNative()` output), so it stays.

## Verification

- `test/DepositAddressHandler.ts`: **51 passing, 0 failing** (a pure revert without the kept line: 48 passing, 3 failing).
- `yarn lint`: clean.
- Revert applied cleanly to `origin/master` with no conflicts; the only non-mechanical diff is the `SIGNER` line above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzGPkq61Nh5zrpiXx3NY4R