### PR TITLE
improve: suppress dotenv startup log message

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
+// Must precede all imports: @risk-labs/logger runs dotenv@17 config() at import time, which logs unless quiet.
+process.env.DOTENV_CONFIG_QUIET ??= "true";
 import minimist from "minimist";
 import {
   config,


### PR DESCRIPTION
## Motivation

Every bot startup prints a dotenv advert:

```
◇ injected env (N) from .env // tip: ◈ secrets for agents [www.dotenvx.com]
```

## What

Sets `DOTENV_CONFIG_QUIET=true` (unless already set by the operator) as the first statement of the runtime entry point, before any imports run.

## Why this shape instead of `config({ quiet: true })`

The noisy dotenv is not the repo's own — this repo resolves `dotenv@16.3.1`, which predates the log message entirely (it arrived in 16.6.0). The message comes from `@risk-labs/logger`, whose `Transports.ts` calls `dotenv.config()` with its own nested `dotenv@17.4.2` **at import time** — i.e. before `index.ts`'s own `config()` call ever executes. So adding `{ quiet: true }` to the repo's `config()` call would be a no-op on both counts.

The env var is dotenv's documented suppression switch and reaches every dotenv instance in the process, including the logger's. Verified against dotenv@17.4.2: silent with `DOTENV_CONFIG_QUIET=true`, noisy without. `??=` keeps it operator-overridable. Same pattern already used in `scripts/buildJussiGraph.ts` (#3161); `tsconfig` targets CommonJS, so the assignment is emitted ahead of the first `require`.

No doc updates needed (no behavior/config/interface change beyond log noise).

Requested by Paul in Slack: https://risklabs.slack.com/archives/C0BHMM63D9Q/p1785316898296319

🤖 Generated with [Claude Code](https://claude.com/claude-code)