### PR TITLE
chore: bump @risk-labs/logger from 1.3.11 to 1.3.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@maticnetwork/maticjs": "^3.6.0",
     "@maticnetwork/maticjs-ethers": "^1.0.3",
     "@nktkas/hyperliquid": "^0.25.9",
-    "@risk-labs/logger": "^1.3.11",
+    "@risk-labs/logger": "^1.3.14",
     "@risk-labs/serverless-orchestration": "^1.3.0",
     "@solana-program/address-lookup-table": "^0.7.0",
     "@solana-program/compute-budget": "^0.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2117,10 +2117,10 @@
   resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-5.12.1.tgz#15b6deaaf3716bc2633311c0ed18201c9299392d"
   integrity sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==
 
-"@risk-labs/logger@^1.3.11":
-  version "1.3.11"
-  resolved "https://registry.yarnpkg.com/@risk-labs/logger/-/logger-1.3.11.tgz#ff37a8199dfcd170450e8374e69717288733992d"
-  integrity sha512-WqTteLQA+ZMmblsbveHpBzwvCRUO5ir5kB3janSsqAu3jFYi0W6uOSdmb63ibbc7W8wylr2FD3UXXZaNgTs2cA==
+"@risk-labs/logger@^1.3.14":
+  version "1.3.14"
+  resolved "https://registry.yarnpkg.com/@risk-labs/logger/-/logger-1.3.14.tgz"
+  integrity sha512-lZUWt/5WaUNoGhQmwjEOpCbfNOcl+kVg1151Hezi6DxGAxtL/i2P1u7/fnvDzb2CH6FJPBbRAeBqWLmaOtIa8Q==
   dependencies:
     "@discordjs/rest" "^2.6.1"
     "@google-cloud/logging-winston" "^6.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2117,7 +2117,7 @@
   resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-5.12.1.tgz#15b6deaaf3716bc2633311c0ed18201c9299392d"
   integrity sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==
 
-"@risk-labs/logger@^1.3.14":
+"@risk-labs/logger@^1.3.11", "@risk-labs/logger@^1.3.14":
   version "1.3.14"
   resolved "https://registry.yarnpkg.com/@risk-labs/logger/-/logger-1.3.14.tgz"
   integrity sha512-lZUWt/5WaUNoGhQmwjEOpCbfNOcl+kVg1151Hezi6DxGAxtL/i2P1u7/fnvDzb2CH6FJPBbRAeBqWLmaOtIa8Q==


### PR DESCRIPTION
Picks up risk-labs/logger#31, which silences the dotenv@17 startup banner the logger emits at import time on every bot startup:

```
◇ injected env (N) from .env // tip: ◈ secrets for agents [www.dotenvx.com]
```

Logger 1.3.11 → 1.3.14 has no dependency changes (identical ranges), so this is a pure version bump. This replaces the consumer-side workaround previously proposed in #3641.

No doc updates needed (dependency bump only; no behavior/config/interface change beyond log noise).

Requested by Paul in Slack: https://risklabs.slack.com/archives/C0BHMM63D9Q/p1785316898296319

🤖 Generated with [Claude Code](https://claude.com/claude-code)