### PR TITLE
fix(TransactionClient): detect reverted TVM transactions in wait()

### DIFF
--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -414,6 +414,43 @@ async function _runTransaction(
   }
 }
 
+/**
+ * Build the `wait` implementation for a TVM transaction response.
+ *
+ * TronWeb submits the transaction, but we still hold an ethers `Provider`, so `wait` mirrors
+ * `JsonRpcProvider`: resolve a real receipt (including `logs`) via `provider.waitForTransaction`.
+ *
+ * It must mirror the *rejection* half of that contract too. `provider.waitForTransaction` resolves
+ * with whatever receipt it finds, reverted or not; the `status === 0` check that turns a reverted tx
+ * into a thrown CALL_EXCEPTION lives in `BaseProvider._wrapTransaction`'s `wait` closure, which only
+ * a provider-submitted (EVM) transaction gets. Re-adding it here keeps TVM and EVM callers on one
+ * contract: a resolved `wait()` means the transaction succeeded. Without it a reverted Tron tx reads
+ * as a confirmed one, and callers that gate on receipt presence alone (`sendAndConfirmTransaction` →
+ * the deposit-address handler, which marks the transfer swept and never retries it) commit to a
+ * sweep that never happened.
+ */
+export function tvmTransactionWait(
+  provider: Provider,
+  txid: string,
+  at: string
+): (confirmations?: number) => Promise<TransactionReceipt> {
+  return async (confirmations?: number) => {
+    const txHexHash = txid.startsWith("0x") ? txid : `0x${txid}`;
+    const receipt = await provider.waitForTransaction(txHexHash, confirmations ?? 1);
+    // `waitForTransaction` resolves null when asked for 0 confirmations and the tx is still pending;
+    // pass that through rather than reading `status` off null.
+    if (receipt?.status === 0) {
+      // Thrown through ethers' own logger so the error carries `code`/`reason` exactly like the EVM
+      // path — `_submit` switches on `ethers.errors.CALL_EXCEPTION` and callers read `reason`.
+      new ethers.utils.Logger(at).throwError("transaction failed", ethers.errors.CALL_EXCEPTION, {
+        transactionHash: txHexHash,
+        receipt,
+      });
+    }
+    return receipt;
+  };
+}
+
 async function _runTransactionTvm(
   logger: winston.Logger,
   contract: Contract,
@@ -487,8 +524,7 @@ async function _runTransactionTvm(
   // nonces in the EVM sense, so we set nonce to 0 to satisfy downstream nonce tracking without
   // side effects (TVM nonce tracking in submit() is harmless — it just overwrites to 0 each time).
   //
-  // `wait` must resolve to a real receipt (including `logs`). TronWeb submits the tx; we still
-  // have an ethers `Provider`, so mirror JsonRpcProvider: `wait` → `provider.waitForTransaction`.
+  // See `tvmTransactionWait` for the `wait` contract (including revert detection).
   return {
     hash: result.txid,
     nonce: 0,
@@ -498,10 +534,7 @@ async function _runTransactionTvm(
     gasLimit: BigNumber.from(feeLimit),
     value,
     data: populatedTransaction.data ?? "0x",
-    wait: (confirmations?: number) => {
-      const txHexHash = result.txid.startsWith("0x") ? result.txid : `0x${result.txid}`;
-      return provider.waitForTransaction(txHexHash, confirmations ?? 1);
-    },
+    wait: tvmTransactionWait(provider, result.txid, at),
   } as unknown as TransactionResponse;
 }
 

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -146,8 +146,12 @@ case-sensitive. On-chain reads (`getDepositAddressBalance`) and receipt-log matc
 (`buildDepositExecutedPayload`) convert base58 → 0x-hex via `getEthersCompatibleAddress` because
 Tron providers speak eth-JSON-RPC. Submission reuses the existing TVM path in `TransactionClient`
 (`_runTransactionTvm`, raw calldata, TRX `feeLimit`); the bot signer's key doubles as its Tron
-account, which must hold TRX for fees. Tron refund-withdraws remain unsupported (the v3 withdraw
-path is still EVM-only).
+account, which must hold TRX for fees. A **reverted** Tron execute (out of energy, `feeLimit` too
+low, the deploy+execute itself reverting) surfaces as a submission failure, not a confirmed sweep:
+the TVM response's `wait` checks `receipt.status` and throws `CALL_EXCEPTION` like the EVM path
+(`tvmTransactionWait`), so `sendAndConfirmTransaction` returns `undefined`, the transfer is *not*
+added to the executed set, and the next poll retries it. Tron refund-withdraws remain unsupported
+(the v3 withdraw path is still EVM-only).
 
 ## v3 refund-withdraw flow
 

--- a/test/TransactionClient.ts
+++ b/test/TransactionClient.ts
@@ -1,8 +1,10 @@
 import { AugmentedTransaction } from "../src/clients";
+import { tvmTransactionWait } from "../src/clients/TransactionClient";
 import {
   BigNumber,
   ethers,
   isDefined,
+  Provider,
   TransactionReceipt,
   TransactionResponse,
   TransactionSimulationResult,
@@ -236,6 +238,63 @@ describe("TransactionClient", function () {
       expect(txnResponses.length).to.equal(1);
       // wait() was called maxTries times (default is 10).
       expect(waitCalls).to.equal(10);
+    });
+  });
+
+  describe("tvmTransactionWait", function () {
+    const TXID = "3b699036b64d765dea6a9103c33793d343381bab361b3e96051e56de2d174247";
+    const at = "TransactionClient#_runTransactionTvm";
+
+    /** Stub provider recording the hash/confirmations it was asked for. */
+    function stubProvider(receipt: Partial<TransactionReceipt> | null): {
+      provider: Provider;
+      calls: { hash: string; confirmations?: number }[];
+    } {
+      const calls: { hash: string; confirmations?: number }[] = [];
+      const provider = {
+        waitForTransaction: (hash: string, confirmations?: number) => {
+          calls.push({ hash, confirmations });
+          return Promise.resolve(receipt as TransactionReceipt);
+        },
+      } as unknown as Provider;
+      return { provider, calls };
+    }
+
+    it("resolves the receipt on a successful transaction", async function () {
+      const { provider, calls } = stubProvider({ status: 1, transactionHash: `0x${TXID}` });
+      const receipt = await tvmTransactionWait(provider, TXID, at)();
+      expect(receipt.status).to.equal(1);
+      // 0x-prefixes the Tron txid and defaults to 1 confirmation.
+      expect(calls).to.deep.equal([{ hash: `0x${TXID}`, confirmations: 1 }]);
+    });
+
+    it("throws CALL_EXCEPTION on a reverted transaction rather than resolving it", async function () {
+      // The regression this guards: `provider.waitForTransaction` resolves a status-0 receipt, so
+      // without the explicit check a reverted Tron tx reads as confirmed and callers gating on
+      // receipt presence (sendAndConfirmTransaction) mark the work done.
+      const { provider } = stubProvider({ status: 0, transactionHash: `0x${TXID}` });
+      const thrown = await tvmTransactionWait(provider, TXID, at)().then(
+        (receipt) => ({ resolved: receipt }),
+        (error: Error & { code?: string; reason?: string }) => ({ error })
+      );
+      expect("error" in thrown).to.equal(true);
+      // Must be shaped like an ethers error: _submit switches on `code`, callers read `reason`.
+      const { error } = thrown as { error: Error & { code?: string; reason?: string } };
+      expect(error.code).to.equal(ethers.errors.CALL_EXCEPTION);
+      expect(error.reason).to.equal("transaction failed");
+    });
+
+    it("passes an already-prefixed txid through unchanged", async function () {
+      const { provider, calls } = stubProvider({ status: 1 });
+      await tvmTransactionWait(provider, `0x${TXID}`, at)(3);
+      expect(calls).to.deep.equal([{ hash: `0x${TXID}`, confirmations: 3 }]);
+    });
+
+    it("passes through a null receipt when asked for 0 confirmations", async function () {
+      // waitForTransaction resolves null for a still-pending tx at 0 confirmations; reading
+      // `status` off it must not throw.
+      const { provider } = stubProvider(null);
+      expect(await tvmTransactionWait(provider, TXID, at)(0)).to.equal(null);
     });
   });
 });


### PR DESCRIPTION
## The bug

A **reverted Tron transaction was reported as a confirmed one**, so the bot committed work that never happened.

Real example — [`40d5c99a…0919a08`](https://tronscan.org/transaction/40d5c99a52067cdd4ceb888f11bf51f9bb07604c59e27ce3d53a8610d0919a08/overview), a deposit-address execute the bot submitted on 2026-07-23 and believed had succeeded:

- Tronscan: **`FAILED - Out of Energy`**, but **`Status: CONFIRMED`** (200+ blocks).
- The bot's own Tron RPC returns `status: "0x0"`, `logs: 0` for it.

## Why the bot missed it

`_runTransactionTvm` hand-rolls an ethers `TransactionResponse` (TronWeb does the submitting), and its `wait` delegated straight to `provider.waitForTransaction`:

```ts
wait: (confirmations?: number) => {
  const txHexHash = result.txid.startsWith("0x") ? result.txid : `0x${result.txid}`;
  return provider.waitForTransaction(txHexHash, confirmations ?? 1);
},
```

`waitForTransaction` resolves with whatever receipt it finds, reverted or not. The `status === 0` → `CALL_EXCEPTION` check lives somewhere else entirely: in the `wait` closure built by `BaseProvider._wrapTransaction`, which **only a provider-submitted (EVM) transaction gets**. So the TVM path silently lost revert detection, and nothing downstream re-checked `receipt.status`.

On the deposit-address v3 execute path that meant: `isDefined(depositReceipt)` passed → the transfer was added to the executed set and persisted to Redis (`DepositAddressHandler.ts:1146-1148`) → funds stayed on the deposit address and **the bot never retried**. The only trace was `"Skipping publish: no ERC20 Transfer of the input token leaving the deposit address found in receipt"` — which reads like a payload-matching quirk, not a failed transaction (a reverted tx has no logs, hence `logs: 0` above).

EVM was never affected: there `wait()` throws, `_submit` rethrows, `sendAndConfirmTransaction` returns `undefined`, and the caller correctly declines to commit.

## The fix

Restore the missing half of the contract where it was dropped, so **a resolved `wait()` means the transaction succeeded** on TVM and EVM alike:

- Extracted the closure as `tvmTransactionWait(provider, txid, at)`, now unit-testable.
- It throws on `receipt?.status === 0`, via ethers' own logger so the error carries the same `code`/`reason` that `_submit`'s `CALL_EXCEPTION` branch and `willSucceed` already read.
- A `null` receipt (still pending at 0 confirmations) passes through untouched.

Fixed here rather than in `sendAndConfirmTransaction` so every TVM caller benefits, not just deposit-address.

## Note: this fixes detection, not the underlying failure

The example above ran out of energy at a **100 TRX** fee limit — the `DEFAULT_TVM_FEE_LIMIT` fallback, since the v3 execute passes no `gasLimit` and `TVM_GAS_LIMIT` is unset. After this PR such an execute is correctly seen as failed and retried, but it will keep failing for the same reason (burning ~46 TRX per attempt) until the energy budget is raised separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzGPkq61Nh5zrpiXx3NY4R
