### PR TITLE
fix(deposit-address): treat empty-data balanceOf CALL_EXCEPTION as terminal in v3 withdraws

### DIFF
--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -92,10 +92,25 @@ function expectedNamespaceForChain(chainId: number): "evm" | "tron" | undefined 
 }
 
 /**
+ * Gate for classifying an empty-data `balanceOf` CALL_EXCEPTION as terminal on the v3 withdraw
+ * path. A single such revert is strong evidence the token lacks `balanceOf`, but a misbehaving
+ * RPC backend (empty eth_call result) or unusual proxy state can produce the same shape
+ * transiently — and a false positive permanently strands the refund, since the terminal skip is
+ * persisted and never re-attempted. Terminal classification therefore requires the failure to
+ * persist: at least MIN_FAILURES observations spanning at least WINDOW_SECONDS, with any
+ * successful read resetting the streak. A genuine scam token fails deterministically on every
+ * poll, so the only cost is a short delay before its per-poll log spam is silenced.
+ */
+const EMPTY_BALANCE_TERMINAL_MIN_FAILURES = 3;
+const EMPTY_BALANCE_TERMINAL_WINDOW_SECONDS = 10 * 60;
+
+/**
  * True when `err` is an ethers CALL_EXCEPTION carrying no revert data (`data: "0x"`). For a
- * `balanceOf` read this is deterministic, not transient: the token contract does not implement
- * `balanceOf` — seen in the wild on scam/address-poisoning tokens that emit spoofed Transfer
- * events without any ERC-20 state — so retrying the call on later polls can never succeed.
+ * `balanceOf` read this is the signature of a token contract with no `balanceOf` — seen in the
+ * wild on scam/address-poisoning tokens that emit spoofed Transfer events without any ERC-20
+ * state. It is strong evidence, not proof: a misbehaving RPC backend or unusual proxy state can
+ * transiently produce the same shape, so callers gate terminal classification on the failure
+ * persisting across polls (see EMPTY_BALANCE_TERMINAL_*) rather than on a single observation.
  */
 function isEmptyDataCallException(err: unknown): boolean {
   return (
@@ -145,6 +160,15 @@ export class DepositAddressHandler {
    * sets once the indexer stops returning the source message.
    */
   private terminallySkippedWithdrawKeys: Set<string> = new Set();
+
+  /**
+   * Per depositKey: streak of empty-data `balanceOf` failures on the v3 withdraw path, feeding
+   * the terminal-skip gate (see EMPTY_BALANCE_TERMINAL_*). `firstSeenSec` anchors the observation
+   * window; any successful balance read clears the entry. In-memory only — a handover restarts
+   * the window, which merely delays terminal classification. Pruned alongside the other sets once
+   * the indexer stops returning the source message.
+   */
+  private emptyBalanceFailuresByKey: Map<string, { firstSeenSec: number; failures: number }> = new Map();
 
   /**
    * Per chainId (refund chain = erc20Transfer.chainId): set of depositKeys for withdraws currently
@@ -428,6 +452,11 @@ export class DepositAddressHandler {
     for (const key of [...this.terminallySkippedWithdrawKeys]) {
       if (!depositKeysFromIndexer.has(key)) {
         this.terminallySkippedWithdrawKeys.delete(key);
+      }
+    }
+    for (const key of [...this.emptyBalanceFailuresByKey.keys()]) {
+      if (!depositKeysFromIndexer.has(key)) {
+        this.emptyBalanceFailuresByKey.delete(key);
       }
     }
 
@@ -1410,21 +1439,53 @@ export class DepositAddressHandler {
       try {
         onchainBalance = await this.getDepositAddressBalance(chainId, token, depositAddress);
       } catch (err) {
-        // An empty-data revert means the token has no balanceOf — terminal, like a quote-api 422.
-        // Persist the skip so the message is not re-attempted (and re-warned) on every poll for
-        // the rest of its indexer TTL. Transient provider failures fall through to the plain skip
-        // below and are retried on the next poll.
+        // An empty-data revert usually means the token has no balanceOf — terminal, like a
+        // quote-api 422 — but a misbehaving RPC backend or unusual proxy state can produce the
+        // same shape transiently, and a false positive would strand the refund. Only once the
+        // failure has persisted across polls (EMPTY_BALANCE_TERMINAL_*) is the key persisted to
+        // the terminal-skip set so it stops being re-attempted (and re-warned) for the rest of
+        // its indexer TTL. Other failures fall through to the plain skip below and are retried
+        // on the next poll.
         if (isEmptyDataCallException(err)) {
-          this.terminallySkippedWithdrawKeys.add(depositKey);
-          await this._persistSkippedWithdrawKeysRedis();
-          this.logger.warn({
+          const nowSec = getCurrentTime();
+          const streak = this.emptyBalanceFailuresByKey.get(depositKey) ?? { firstSeenSec: nowSec, failures: 0 };
+          streak.failures += 1;
+          this.emptyBalanceFailuresByKey.set(depositKey, streak);
+          const observedForSeconds = nowSec - streak.firstSeenSec;
+          if (
+            streak.failures >= EMPTY_BALANCE_TERMINAL_MIN_FAILURES &&
+            observedForSeconds >= EMPTY_BALANCE_TERMINAL_WINDOW_SECONDS
+          ) {
+            this.emptyBalanceFailuresByKey.delete(depositKey);
+            this.terminallySkippedWithdrawKeys.add(depositKey);
+            await this._persistSkippedWithdrawKeysRedis();
+            this.logger.warn({
+              at: "DepositAddressHandler#initiateWithdrawV3",
+              message:
+                "Skipping withdraw permanently: balanceOf reverted with empty data throughout the observation window (token lacks balanceOf)",
+              depositAddress,
+              token,
+              depositKey,
+              refTxHash,
+              chainId,
+              failures: streak.failures,
+              observedForSeconds,
+              err: err instanceof Error ? err.message : String(err),
+            });
+            return;
+          }
+          // Warn once when the streak opens; later polls inside the window log at debug so a scam
+          // token does not re-warn on every 1s poll while the window matures.
+          this.logger[streak.failures === 1 ? "warn" : "debug"]({
             at: "DepositAddressHandler#initiateWithdrawV3",
-            message: "Skipping withdraw permanently: balanceOf reverted with empty data (token lacks balanceOf)",
+            message: "Skipping withdraw: balanceOf reverted with empty data (terminal-skip window open)",
             depositAddress,
             token,
             depositKey,
             refTxHash,
             chainId,
+            failures: streak.failures,
+            observedForSeconds,
             err: err instanceof Error ? err.message : String(err),
           });
           return;
@@ -1441,6 +1502,8 @@ export class DepositAddressHandler {
         });
         return;
       }
+      // A successful read disproves "token lacks balanceOf" — reset any open streak.
+      this.emptyBalanceFailuresByKey.delete(depositKey);
 
       if (onchainBalance.lt(toBN(amount))) {
         this.logger.debug({

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -1,6 +1,8 @@
 import winston from "winston";
+import { typeguards } from "@across-protocol/sdk";
 import { DepositAddressHandlerConfig } from "./DepositAddressHandlerConfig";
 import {
+  ethers,
   isDefined,
   parseJson,
   Signer,
@@ -90,6 +92,20 @@ function expectedNamespaceForChain(chainId: number): "evm" | "tron" | undefined 
 }
 
 /**
+ * True when `err` is an ethers CALL_EXCEPTION carrying no revert data (`data: "0x"`). For a
+ * `balanceOf` read this is deterministic, not transient: the token contract does not implement
+ * `balanceOf` — seen in the wild on scam/address-poisoning tokens that emit spoofed Transfer
+ * events without any ERC-20 state — so retrying the call on later polls can never succeed.
+ */
+function isEmptyDataCallException(err: unknown): boolean {
+  return (
+    typeguards.isEthersError(err) &&
+    err.code === ethers.errors.CALL_EXCEPTION &&
+    (err as { data?: unknown }).data === "0x"
+  );
+}
+
+/**
  * Independent relayer bot which processes EIP-3009 signatures into deposits and corresponding fills.
  */
 export class DepositAddressHandler {
@@ -122,10 +138,11 @@ export class DepositAddressHandler {
   private executedWithdrawKeys: Set<string> = new Set();
 
   /**
-   * Set of depositKeys for v3 refund withdraws the quote-api rejected with a terminal 422
-   * (`GAS_EXCEEDS_REFUND` / `UNPRICEABLE_REFUND_TOKEN`). Persisted in Redis so the skip survives
-   * handover and is not re-attempted on later polls. Pruned alongside the other sets once the
-   * indexer stops returning the source message.
+   * Set of depositKeys for v3 refund withdraws that failed terminally: the quote-api rejected
+   * with a 422 (`GAS_EXCEEDS_REFUND` / `UNPRICEABLE_REFUND_TOKEN`), or the token's `balanceOf`
+   * reverted with empty data (contract lacks balanceOf — scam-token spam). Persisted in Redis so
+   * the skip survives handover and is not re-attempted on later polls. Pruned alongside the other
+   * sets once the indexer stops returning the source message.
    */
   private terminallySkippedWithdrawKeys: Set<string> = new Set();
 
@@ -296,7 +313,7 @@ export class DepositAddressHandler {
     });
   }
 
-  /** Loads terminally-skipped (422) refund-withdraw depositKeys from Redis (e.g. after handover). */
+  /** Loads terminally-skipped refund-withdraw depositKeys from Redis (e.g. after handover). */
   private async _loadSkippedWithdrawKeysFromRedis(): Promise<void> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
     const { redisCache } = this;
@@ -703,7 +720,7 @@ export class DepositAddressHandler {
     await redisCache.set(redisKey, JSON.stringify([...this.executedWithdrawKeys]));
   }
 
-  /** Same pattern as `_persistWithdrawnKeysRedis` but for terminally-skipped (422) withdraw keys. */
+  /** Same pattern as `_persistWithdrawnKeysRedis` but for terminally-skipped withdraw keys. */
   private async _persistSkippedWithdrawKeysRedis(): Promise<void> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
     const { redisCache } = this;
@@ -1336,7 +1353,8 @@ export class DepositAddressHandler {
       return;
     }
 
-    // Skip if a previous attempt hit a terminal 422 (persisted in Redis); never re-attempt.
+    // Skip if a previous attempt failed terminally — quote-api 422 or balanceOf empty-data
+    // revert (persisted in Redis); never re-attempt.
     if (this.terminallySkippedWithdrawKeys.has(depositKey)) {
       this.logger.debug({
         at: "DepositAddressHandler#initiateWithdrawV3",
@@ -1392,6 +1410,25 @@ export class DepositAddressHandler {
       try {
         onchainBalance = await this.getDepositAddressBalance(chainId, token, depositAddress);
       } catch (err) {
+        // An empty-data revert means the token has no balanceOf — terminal, like a quote-api 422.
+        // Persist the skip so the message is not re-attempted (and re-warned) on every poll for
+        // the rest of its indexer TTL. Transient provider failures fall through to the plain skip
+        // below and are retried on the next poll.
+        if (isEmptyDataCallException(err)) {
+          this.terminallySkippedWithdrawKeys.add(depositKey);
+          await this._persistSkippedWithdrawKeysRedis();
+          this.logger.warn({
+            at: "DepositAddressHandler#initiateWithdrawV3",
+            message: "Skipping withdraw permanently: balanceOf reverted with empty data (token lacks balanceOf)",
+            depositAddress,
+            token,
+            depositKey,
+            refTxHash,
+            chainId,
+            err: err instanceof Error ? err.message : String(err),
+          });
+          return;
+        }
         this.logger.warn({
           at: "DepositAddressHandler#initiateWithdrawV3",
           message: "Skipping withdraw: failed to fetch deposit address balance",

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -162,11 +162,14 @@ stranded funds back to the committed refund address. `intent_refund` is **not** 
 3. Locate the withdraw leaf in `counterfactualMaterials` (`kind === "withdraw"`); skip if its
    `merkleProof` / `implementationAddress` are missing.
 4. Defensive on-chain balance check, as on the other paths. A `balanceOf` that reverts with
-   **empty data** (`CALL_EXCEPTION`, `data: "0x"`) is terminal: the token contract does not
-   implement `balanceOf` — scam/address-poisoning tokens that emit spoofed Transfer events without
-   any ERC-20 state — so the depositKey is persisted to the terminal-skip set (same set as the 422s
-   below) and never re-attempted. Any other balance-fetch failure is treated as transient and
-   re-attempted on the next poll.
+   **empty data** (`CALL_EXCEPTION`, `data: "0x"`) signals a token contract with no `balanceOf` —
+   scam/address-poisoning tokens that emit spoofed Transfer events without any ERC-20 state. A
+   misbehaving RPC or unusual proxy state can transiently produce the same shape, so the skip only
+   becomes terminal once the failure persists (≥ 3 observations spanning ≥ 10 minutes, tracked
+   in-memory per depositKey; a successful read resets the streak); the depositKey is then persisted
+   to the terminal-skip set (same set as the 422s below) and never re-attempted. While the window
+   matures, and for any other balance-fetch failure, the withdraw is skipped for that poll and
+   re-attempted on the next one.
 5. Fetch `{ signedWithdrawTx: { to, data, value, chainId }, deadline, requestedAmount, appliedGasFee, netAmount, bundledDeploy }`
    from `POST /deposit-addresses/sign-withdraw`. Unlike v1, **gas is deducted from the refund**
    (`deductGasFromRefund: true`) so refunds are not operated at a loss. The endpoint **verifies** the
@@ -217,7 +220,7 @@ Three sets persist across runs so handover does not double-spend, double-refund,
 
 - `deposit-address:executed:<botIdentifier>` — set of `erc20Transfer.transactionHash` for successfully executed deposits.
 - `deposit-address:withdrawn-deposit-keys:<botIdentifier>` — set of `depositKey` (`depositAddress:transactionHash`) for successfully executed refund withdraws.
-- `deposit-address:skipped-withdraw-keys:<botIdentifier>` — set of `depositKey` for v3 refund withdraws that failed terminally: quote-api 422 (`GAS_EXCEEDS_REFUND` / `UNPRICEABLE_REFUND_TOKEN`) or `balanceOf` empty-data revert (token lacks `balanceOf`); never re-attempted.
+- `deposit-address:skipped-withdraw-keys:<botIdentifier>` — set of `depositKey` for v3 refund withdraws that failed terminally: quote-api 422 (`GAS_EXCEEDS_REFUND` / `UNPRICEABLE_REFUND_TOKEN`) or `balanceOf` empty-data revert persisting past the observation window (token lacks `balanceOf`); never re-attempted.
 
 On each poll, entries whose source messages are no longer returned by the indexer are pruned — the indexer has its own TTL and stops returning expired messages.
 

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -161,7 +161,12 @@ stranded funds back to the committed refund address. `intent_refund` is **not** 
 2. Skip non-`evm` `depositAddressNamespace` / `refundAddress.namespace` (the withdraw user must be EVM).
 3. Locate the withdraw leaf in `counterfactualMaterials` (`kind === "withdraw"`); skip if its
    `merkleProof` / `implementationAddress` are missing.
-4. Defensive on-chain balance check, as on the other paths.
+4. Defensive on-chain balance check, as on the other paths. A `balanceOf` that reverts with
+   **empty data** (`CALL_EXCEPTION`, `data: "0x"`) is terminal: the token contract does not
+   implement `balanceOf` — scam/address-poisoning tokens that emit spoofed Transfer events without
+   any ERC-20 state — so the depositKey is persisted to the terminal-skip set (same set as the 422s
+   below) and never re-attempted. Any other balance-fetch failure is treated as transient and
+   re-attempted on the next poll.
 5. Fetch `{ signedWithdrawTx: { to, data, value, chainId }, deadline, requestedAmount, appliedGasFee, netAmount, bundledDeploy }`
    from `POST /deposit-addresses/sign-withdraw`. Unlike v1, **gas is deducted from the refund**
    (`deductGasFromRefund: true`) so refunds are not operated at a loss. The endpoint **verifies** the
@@ -212,7 +217,7 @@ Three sets persist across runs so handover does not double-spend, double-refund,
 
 - `deposit-address:executed:<botIdentifier>` — set of `erc20Transfer.transactionHash` for successfully executed deposits.
 - `deposit-address:withdrawn-deposit-keys:<botIdentifier>` — set of `depositKey` (`depositAddress:transactionHash`) for successfully executed refund withdraws.
-- `deposit-address:skipped-withdraw-keys:<botIdentifier>` — set of `depositKey` for v3 refund withdraws the quote-api rejected with a terminal 422 (`GAS_EXCEEDS_REFUND` / `UNPRICEABLE_REFUND_TOKEN`); never re-attempted.
+- `deposit-address:skipped-withdraw-keys:<botIdentifier>` — set of `depositKey` for v3 refund withdraws that failed terminally: quote-api 422 (`GAS_EXCEEDS_REFUND` / `UNPRICEABLE_REFUND_TOKEN`) or `balanceOf` empty-data revert (token lacks `balanceOf`); never re-attempted.
 
 On each poll, entries whose source messages are no longer returned by the indexer are pruned — the indexer has its own TTL and stops returning expired messages.
 

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -862,6 +862,7 @@ describe("DepositAddressHandler.initiateWithdrawV3 guards", function () {
   type Internals = {
     initiateWithdrawV3: (m: DepositAddressMessageV3) => Promise<void>;
     terminallySkippedWithdrawKeys: Set<string>;
+    emptyBalanceFailuresByKey: Map<string, { firstSeenSec: number; failures: number }>;
     getDepositAddressBalance: (chainId: number, token: string, depositAddress: string) => Promise<unknown>;
   };
 
@@ -916,22 +917,68 @@ describe("DepositAddressHandler.initiateWithdrawV3 guards", function () {
     expect(warnStub.calledOnce).to.equal(true);
   });
 
-  it("terminally skips when balanceOf reverts with empty data: persists the key, never re-reads", async function () {
+  it("does not terminally skip empty-data balanceOf reverts before the observation window matures", async function () {
+    makeHandler(true);
+    sinon.stub(handler as unknown as Internals, "getDepositAddressBalance").rejects(emptyDataCallException());
+    const message = withdrawMessageV3();
+    const depositKey = `${DEPOSIT_ADDRESS}:${message.erc20Transfer.transactionHash}`;
+    await (handler as unknown as Internals).initiateWithdrawV3(message);
+    expect((handler as unknown as Internals).terminallySkippedWithdrawKeys.size).to.equal(0);
+    expect(redisSetStub.notCalled).to.equal(true);
+    expect(signWithdrawStub.notCalled).to.equal(true);
+    expect(warnStub.calledOnce).to.equal(true);
+    expect((handler as unknown as Internals).emptyBalanceFailuresByKey.get(depositKey)?.failures).to.equal(1);
+
+    // Later polls inside the window: still not terminal, and no re-warn (debug only).
+    await (handler as unknown as Internals).initiateWithdrawV3(message);
+    await (handler as unknown as Internals).initiateWithdrawV3(message);
+    expect((handler as unknown as Internals).terminallySkippedWithdrawKeys.size).to.equal(0);
+    expect(redisSetStub.notCalled).to.equal(true);
+    expect(warnStub.calledOnce).to.equal(true);
+    expect((handler as unknown as Internals).emptyBalanceFailuresByKey.get(depositKey)?.failures).to.equal(3);
+  });
+
+  it("terminally skips once empty-data balanceOf reverts persist past the window: persists the key, never re-reads", async function () {
     makeHandler(true);
     const balanceStub = sinon
       .stub(handler as unknown as Internals, "getDepositAddressBalance")
       .rejects(emptyDataCallException());
     const message = withdrawMessageV3();
-    await (handler as unknown as Internals).initiateWithdrawV3(message);
     const depositKey = `${DEPOSIT_ADDRESS}:${message.erc20Transfer.transactionHash}`;
+    await (handler as unknown as Internals).initiateWithdrawV3(message);
+    await (handler as unknown as Internals).initiateWithdrawV3(message);
+    // Backdate the streak so the next failure crosses the observation window.
+    expect((handler as unknown as Internals).emptyBalanceFailuresByKey.get(depositKey)?.failures).to.equal(2);
+    (handler as unknown as Internals).emptyBalanceFailuresByKey.set(depositKey, { firstSeenSec: 0, failures: 2 });
+    await (handler as unknown as Internals).initiateWithdrawV3(message);
     expect((handler as unknown as Internals).terminallySkippedWithdrawKeys.has(depositKey)).to.equal(true);
+    expect((handler as unknown as Internals).emptyBalanceFailuresByKey.has(depositKey)).to.equal(false);
     expect(redisSetStub.calledOnce).to.equal(true);
     expect(signWithdrawStub.notCalled).to.equal(true);
-    expect(warnStub.calledOnce).to.equal(true);
+    expect(warnStub.calledTwice).to.equal(true); // streak-open warn + terminal warn
 
     // A later poll skips via the terminal set without re-reading the balance.
     await (handler as unknown as Internals).initiateWithdrawV3(message);
-    expect(balanceStub.calledOnce).to.equal(true);
+    expect(balanceStub.callCount).to.equal(3);
+  });
+
+  it("resets the empty-data streak on a successful balance read", async function () {
+    makeHandler(true);
+    const balanceStub = sinon
+      .stub(handler as unknown as Internals, "getDepositAddressBalance")
+      .rejects(emptyDataCallException());
+    const message = withdrawMessageV3();
+    const depositKey = `${DEPOSIT_ADDRESS}:${message.erc20Transfer.transactionHash}`;
+    await (handler as unknown as Internals).initiateWithdrawV3(message);
+    expect((handler as unknown as Internals).emptyBalanceFailuresByKey.has(depositKey)).to.equal(true);
+
+    // The read recovers (e.g. RPC backend healed); balance 0 < amount, so the poll still skips,
+    // but the streak must be gone so a later revert restarts the window from scratch.
+    balanceStub.resolves(toBN(0));
+    await (handler as unknown as Internals).initiateWithdrawV3(message);
+    expect((handler as unknown as Internals).emptyBalanceFailuresByKey.has(depositKey)).to.equal(false);
+    expect((handler as unknown as Internals).terminallySkippedWithdrawKeys.size).to.equal(0);
+    expect(signWithdrawStub.notCalled).to.equal(true);
   });
 
   it("does not terminally skip a transient balance-fetch failure", async function () {

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -856,11 +856,13 @@ describe("DepositAddressHandler.initiateWithdrawV3 guards", function () {
   let signWithdrawStub: sinon.SinonStub;
   let warnStub: sinon.SinonStub;
   let debugStub: sinon.SinonStub;
+  let redisSetStub: sinon.SinonStub;
   const chainId = 42161;
 
   type Internals = {
     initiateWithdrawV3: (m: DepositAddressMessageV3) => Promise<void>;
     terminallySkippedWithdrawKeys: Set<string>;
+    getDepositAddressBalance: (chainId: number, token: string, depositAddress: string) => Promise<unknown>;
   };
 
   function makeHandler(enableV3Withdrawals: boolean): void {
@@ -876,7 +878,17 @@ describe("DepositAddressHandler.initiateWithdrawV3 guards", function () {
     (handler as unknown as { observedExecutedWithdraws: Record<number, Set<string>> }).observedExecutedWithdraws = {
       [chainId]: new Set<string>(),
     };
-    (handler as unknown as { redisCache: { set: sinon.SinonStub } }).redisCache = { set: sinon.stub().resolves() };
+    redisSetStub = sinon.stub().resolves();
+    (handler as unknown as { redisCache: { set: sinon.SinonStub } }).redisCache = { set: redisSetStub };
+  }
+
+  /** Ethers v5 CALL_EXCEPTION as thrown for a balanceOf revert carrying no return data. */
+  function emptyDataCallException(): Error {
+    return Object.assign(new Error("missing revert data in call exception"), {
+      code: "CALL_EXCEPTION",
+      reason: "missing revert data in call exception",
+      data: "0x",
+    });
   }
 
   afterEach(() => sinon.restore());
@@ -900,6 +912,49 @@ describe("DepositAddressHandler.initiateWithdrawV3 guards", function () {
     await (handler as unknown as Internals).initiateWithdrawV3(
       withdrawMessageV3({ counterfactualMaterials: [{ ...v3WithdrawLeaf, kind: "vanilla-cctp" }] })
     );
+    expect(signWithdrawStub.notCalled).to.equal(true);
+    expect(warnStub.calledOnce).to.equal(true);
+  });
+
+  it("terminally skips when balanceOf reverts with empty data: persists the key, never re-reads", async function () {
+    makeHandler(true);
+    const balanceStub = sinon
+      .stub(handler as unknown as Internals, "getDepositAddressBalance")
+      .rejects(emptyDataCallException());
+    const message = withdrawMessageV3();
+    await (handler as unknown as Internals).initiateWithdrawV3(message);
+    const depositKey = `${DEPOSIT_ADDRESS}:${message.erc20Transfer.transactionHash}`;
+    expect((handler as unknown as Internals).terminallySkippedWithdrawKeys.has(depositKey)).to.equal(true);
+    expect(redisSetStub.calledOnce).to.equal(true);
+    expect(signWithdrawStub.notCalled).to.equal(true);
+    expect(warnStub.calledOnce).to.equal(true);
+
+    // A later poll skips via the terminal set without re-reading the balance.
+    await (handler as unknown as Internals).initiateWithdrawV3(message);
+    expect(balanceStub.calledOnce).to.equal(true);
+  });
+
+  it("does not terminally skip a transient balance-fetch failure", async function () {
+    makeHandler(true);
+    sinon.stub(handler as unknown as Internals, "getDepositAddressBalance").rejects(new Error("connection timeout"));
+    await (handler as unknown as Internals).initiateWithdrawV3(withdrawMessageV3());
+    expect((handler as unknown as Internals).terminallySkippedWithdrawKeys.size).to.equal(0);
+    expect(redisSetStub.notCalled).to.equal(true);
+    expect(signWithdrawStub.notCalled).to.equal(true);
+    expect(warnStub.calledOnce).to.equal(true);
+  });
+
+  it("does not terminally skip a CALL_EXCEPTION that carries revert data", async function () {
+    makeHandler(true);
+    const err = Object.assign(new Error("execution reverted"), {
+      code: "CALL_EXCEPTION",
+      reason: "execution reverted",
+      data: "0x08c379a0", // Error(string) selector — a real revert, potentially state-dependent.
+    });
+    sinon.stub(handler as unknown as Internals, "getDepositAddressBalance").rejects(err);
+    await (handler as unknown as Internals).initiateWithdrawV3(withdrawMessageV3());
+    expect((handler as unknown as Internals).terminallySkippedWithdrawKeys.size).to.equal(0);
+    expect(redisSetStub.notCalled).to.equal(true);
     expect(signWithdrawStub.notCalled).to.equal(true);
     expect(warnStub.calledOnce).to.equal(true);
   });


### PR DESCRIPTION
## Context

A v3 `mis_route` withdraw on Unichain (chain 130) was stuck warning `Skipping withdraw: failed to fetch deposit address balance` on every poll. Root cause: the "token" (`0x15a86530FD92Bb2Bd2C067D2FCecd00D3247053e`) is a scam contract — symbol `USḌC` (Unicode homoglyph of USDC) — that only implements `name`/`symbol`/`decimals` plus a bulk fake-`Transfer` emitter for address poisoning. It has no `balanceOf`, so the defensive balance read reverts with empty data (`CALL_EXCEPTION`, `data: "0x"`) — deterministically, forever.

Because the balance-fetch skip path is non-terminal, the handler released the in-flight lock and re-attempted (and re-warned) on every poll for the message's whole indexer TTL. Ironically, a scam token that *did* implement `balanceOf` would have reached the quote-api, gotten a 422 `UNPRICEABLE_REFUND_TOKEN`, and been terminally skipped.

Slack thread: T90K0AL22 / C0AHLJQLPQS / 1785366610.068239 (requested by Alex M).

## Change

- `initiateWithdrawV3`: an empty-data `CALL_EXCEPTION` from the `balanceOf` read now persists the depositKey to the existing `terminallySkippedWithdrawKeys` set (shared with quote-api 422s) and never re-attempts. One `warn` is emitted at classification time; later polls skip via the terminal set (`debug`).
- Every other balance-fetch failure keeps the previous behavior: warn, skip this poll, retry next poll.
- Classifier (`isEmptyDataCallException`) requires **both** `code === CALL_EXCEPTION` **and** `data === "0x"` — a revert carrying real data (potentially state-dependent) stays transient. This shape also covers the no-code-at-address flavor of the ethers v5 error.
- README + field/comment docs updated; the Redis skip-set semantics are unchanged (same key, still pruned when the indexer stops returning the message).

## Scope notes

- v3 path only. The v1 `initiateWithdraw` path has no terminal-skip mechanism at all today; introducing one there is a bigger semantic change and v1 traffic is winding down, so left unchanged.
- Residual risk: a provider that deterministically mis-reverts an `eth_call` with empty data could terminally skip a legitimate withdraw until the indexer message expires. Given the retrying/quorum provider stack this seemed acceptable versus poll-loop warn spam, but flagging for reviewer judgment.

## Testing

- 3 new unit tests in the `initiateWithdrawV3 guards` suite: terminal classification persists the key and short-circuits later polls; transient errors and data-carrying `CALL_EXCEPTION`s do not terminally skip.
- `yarn hardhat test test/DepositAddressHandler.ts`: 53 passing. `tsc --noEmit`, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)