### PR TITLE
feat(gasless): submit smart-wallet ERC-3009 deposits via *Bytes periphery methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.123",
     "@across-protocol/contracts": "5.0.26",
-    "@across-protocol/sdk": "4.4.16",
+    "@across-protocol/sdk": "4.4.17",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@across-protocol/constants": "^3.1.123",
-    "@across-protocol/contracts": "5.0.24",
+    "@across-protocol/contracts": "5.0.26",
     "@across-protocol/sdk": "4.4.16",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
@@ -133,7 +133,8 @@
   "resolutions": {
     "protobufjs": "^7.5.4",
     "fast-xml-parser": "^5.7.1",
-    "better-sqlite3": "^11.10.0"
+    "better-sqlite3": "^11.10.0",
+    "@across-protocol/contracts": "5.0.26"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.com/",

--- a/src/common/abi/SpokePoolPeriphery.json
+++ b/src/common/abi/SpokePoolPeriphery.json
@@ -1,755 +1,765 @@
 [
   {
-    "inputs": [{ "internalType": "contract IPermit2", "name": "_permit2", "type": "address" }],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  { "inputs": [], "name": "InvalidMinExpectedInputAmount", "type": "error" },
-  { "inputs": [], "name": "InvalidMsgValue", "type": "error" },
-  { "inputs": [], "name": "InvalidNonce", "type": "error" },
-  { "inputs": [], "name": "InvalidShortString", "type": "error" },
-  { "inputs": [], "name": "InvalidSignature", "type": "error" },
-  { "inputs": [], "name": "MinimumExpectedInputAmount", "type": "error" },
-  {
-    "inputs": [{ "internalType": "string", "name": "str", "type": "string" }],
-    "name": "StringTooLong",
-    "type": "error"
-  },
-  { "anonymous": false, "inputs": [], "name": "EIP712DomainChanged", "type": "event" },
-  {
-    "anonymous": false,
+    "type": "constructor",
     "inputs": [
-      { "indexed": false, "internalType": "address", "name": "exchange", "type": "address" },
-      { "indexed": false, "internalType": "bytes", "name": "exchangeCalldata", "type": "bytes" },
-      { "indexed": true, "internalType": "address", "name": "swapToken", "type": "address" },
-      { "indexed": true, "internalType": "address", "name": "acrossInputToken", "type": "address" },
-      { "indexed": false, "internalType": "uint256", "name": "swapTokenAmount", "type": "uint256" },
-      { "indexed": false, "internalType": "uint256", "name": "acrossInputAmount", "type": "uint256" },
-      { "indexed": true, "internalType": "bytes32", "name": "acrossOutputToken", "type": "bytes32" },
-      { "indexed": false, "internalType": "uint256", "name": "acrossOutputAmount", "type": "uint256" }
+      { "name": "_permit2", "type": "address", "internalType": "contract IPermit2" },
+      { "name": "_multicall3", "type": "address", "internalType": "address" }
     ],
-    "name": "SwapBeforeBridge",
-    "type": "event"
+    "stateMutability": "nonpayable"
   },
   {
-    "inputs": [],
+    "type": "function",
     "name": "AUTHORIZATION_NONCE_IDENTIFIER",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "stateMutability": "view",
-    "type": "function"
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
+    "stateMutability": "view"
   },
   {
-    "inputs": [],
+    "type": "function",
     "name": "BRIDGE_AND_SWAP_WITNESS_IDENTIFIER",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "stateMutability": "view",
-    "type": "function"
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
+    "stateMutability": "view"
   },
   {
-    "inputs": [],
+    "type": "function",
     "name": "BRIDGE_WITNESS_IDENTIFIER",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "stateMutability": "view",
-    "type": "function"
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
+    "stateMutability": "view"
   },
   {
-    "inputs": [],
+    "type": "function",
     "name": "DEPOSIT_NONCE_IDENTIFIER",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "stateMutability": "view",
-    "type": "function"
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
+    "stateMutability": "view"
   },
   {
-    "inputs": [],
+    "type": "function",
     "name": "PERMIT2_NONCE_IDENTIFIER",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "stateMutability": "view",
-    "type": "function"
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
+    "stateMutability": "view"
   },
   {
-    "inputs": [],
+    "type": "function",
     "name": "PERMIT_NONCE_IDENTIFIER",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "stateMutability": "view",
-    "type": "function"
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
+    "stateMutability": "view"
   },
   {
-    "inputs": [
-      { "internalType": "address", "name": "spokePool", "type": "address" },
-      { "internalType": "address", "name": "depositor", "type": "address" },
-      { "internalType": "bytes32", "name": "recipient", "type": "bytes32" },
-      { "internalType": "address", "name": "inputToken", "type": "address" },
-      { "internalType": "uint256", "name": "inputAmount", "type": "uint256" },
-      { "internalType": "bytes32", "name": "outputToken", "type": "bytes32" },
-      { "internalType": "uint256", "name": "outputAmount", "type": "uint256" },
-      { "internalType": "uint256", "name": "destinationChainId", "type": "uint256" },
-      { "internalType": "bytes32", "name": "exclusiveRelayer", "type": "bytes32" },
-      { "internalType": "uint32", "name": "quoteTimestamp", "type": "uint32" },
-      { "internalType": "uint32", "name": "fillDeadline", "type": "uint32" },
-      { "internalType": "uint32", "name": "exclusivityParameter", "type": "uint32" },
-      { "internalType": "bytes", "name": "message", "type": "bytes" }
-    ],
+    "type": "function",
     "name": "depositNative",
+    "inputs": [
+      { "name": "spokePool", "type": "address", "internalType": "address" },
+      { "name": "depositor", "type": "address", "internalType": "address" },
+      { "name": "recipient", "type": "bytes32", "internalType": "bytes32" },
+      { "name": "inputToken", "type": "address", "internalType": "address" },
+      { "name": "inputAmount", "type": "uint256", "internalType": "uint256" },
+      { "name": "outputToken", "type": "bytes32", "internalType": "bytes32" },
+      { "name": "outputAmount", "type": "uint256", "internalType": "uint256" },
+      { "name": "destinationChainId", "type": "uint256", "internalType": "uint256" },
+      { "name": "exclusiveRelayer", "type": "bytes32", "internalType": "bytes32" },
+      { "name": "quoteTimestamp", "type": "uint32", "internalType": "uint32" },
+      { "name": "fillDeadline", "type": "uint32", "internalType": "uint32" },
+      { "name": "exclusivityParameter", "type": "uint32", "internalType": "uint32" },
+      { "name": "message", "type": "bytes", "internalType": "bytes" }
+    ],
     "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
+    "stateMutability": "payable"
   },
   {
-    "inputs": [
-      { "internalType": "address", "name": "signatureOwner", "type": "address" },
-      {
-        "components": [
-          {
-            "components": [
-              { "internalType": "uint256", "name": "amount", "type": "uint256" },
-              { "internalType": "address", "name": "recipient", "type": "address" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.Fees",
-            "name": "submissionFees",
-            "type": "tuple"
-          },
-          {
-            "components": [
-              { "internalType": "address", "name": "inputToken", "type": "address" },
-              { "internalType": "bytes32", "name": "outputToken", "type": "bytes32" },
-              { "internalType": "uint256", "name": "outputAmount", "type": "uint256" },
-              { "internalType": "address", "name": "depositor", "type": "address" },
-              { "internalType": "bytes32", "name": "recipient", "type": "bytes32" },
-              { "internalType": "uint256", "name": "destinationChainId", "type": "uint256" },
-              { "internalType": "bytes32", "name": "exclusiveRelayer", "type": "bytes32" },
-              { "internalType": "uint32", "name": "quoteTimestamp", "type": "uint32" },
-              { "internalType": "uint32", "name": "fillDeadline", "type": "uint32" },
-              { "internalType": "uint32", "name": "exclusivityParameter", "type": "uint32" },
-              { "internalType": "bytes", "name": "message", "type": "bytes" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
-            "name": "baseDepositData",
-            "type": "tuple"
-          },
-          { "internalType": "uint256", "name": "inputAmount", "type": "uint256" },
-          { "internalType": "address", "name": "spokePool", "type": "address" },
-          { "internalType": "uint256", "name": "nonce", "type": "uint256" }
-        ],
-        "internalType": "struct SpokePoolPeripheryInterface.DepositData",
-        "name": "depositData",
-        "type": "tuple"
-      },
-      { "internalType": "uint256", "name": "validAfter", "type": "uint256" },
-      { "internalType": "uint256", "name": "validBefore", "type": "uint256" },
-      { "internalType": "bytes", "name": "receiveWithAuthSignature", "type": "bytes" }
-    ],
+    "type": "function",
     "name": "depositWithAuthorization",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "inputs": [
-      { "internalType": "address", "name": "signatureOwner", "type": "address" },
+      { "name": "signatureOwner", "type": "address", "internalType": "address" },
       {
+        "name": "depositData",
+        "type": "tuple",
+        "internalType": "struct SpokePoolPeripheryInterface.DepositData",
         "components": [
           {
-            "components": [
-              { "internalType": "uint256", "name": "amount", "type": "uint256" },
-              { "internalType": "address", "name": "recipient", "type": "address" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.Fees",
             "name": "submissionFees",
-            "type": "tuple"
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.Fees",
+            "components": [
+              { "name": "amount", "type": "uint256", "internalType": "uint256" },
+              { "name": "recipient", "type": "address", "internalType": "address" }
+            ]
           },
           {
-            "components": [
-              { "internalType": "address", "name": "inputToken", "type": "address" },
-              { "internalType": "bytes32", "name": "outputToken", "type": "bytes32" },
-              { "internalType": "uint256", "name": "outputAmount", "type": "uint256" },
-              { "internalType": "address", "name": "depositor", "type": "address" },
-              { "internalType": "bytes32", "name": "recipient", "type": "bytes32" },
-              { "internalType": "uint256", "name": "destinationChainId", "type": "uint256" },
-              { "internalType": "bytes32", "name": "exclusiveRelayer", "type": "bytes32" },
-              { "internalType": "uint32", "name": "quoteTimestamp", "type": "uint32" },
-              { "internalType": "uint32", "name": "fillDeadline", "type": "uint32" },
-              { "internalType": "uint32", "name": "exclusivityParameter", "type": "uint32" },
-              { "internalType": "bytes", "name": "message", "type": "bytes" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
             "name": "baseDepositData",
-            "type": "tuple"
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
+            "components": [
+              { "name": "inputToken", "type": "address", "internalType": "address" },
+              { "name": "outputToken", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "outputAmount", "type": "uint256", "internalType": "uint256" },
+              { "name": "depositor", "type": "address", "internalType": "address" },
+              { "name": "recipient", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "destinationChainId", "type": "uint256", "internalType": "uint256" },
+              { "name": "exclusiveRelayer", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "quoteTimestamp", "type": "uint32", "internalType": "uint32" },
+              { "name": "fillDeadline", "type": "uint32", "internalType": "uint32" },
+              { "name": "exclusivityParameter", "type": "uint32", "internalType": "uint32" },
+              { "name": "message", "type": "bytes", "internalType": "bytes" }
+            ]
           },
-          { "internalType": "uint256", "name": "inputAmount", "type": "uint256" },
-          { "internalType": "address", "name": "spokePool", "type": "address" },
-          { "internalType": "uint256", "name": "nonce", "type": "uint256" }
-        ],
-        "internalType": "struct SpokePoolPeripheryInterface.DepositData",
-        "name": "depositData",
-        "type": "tuple"
+          { "name": "inputAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "spokePool", "type": "address", "internalType": "address" },
+          { "name": "nonce", "type": "uint256", "internalType": "uint256" }
+        ]
       },
-      { "internalType": "uint256", "name": "validAfter", "type": "uint256" },
-      { "internalType": "uint256", "name": "validBefore", "type": "uint256" },
-      { "internalType": "bytes", "name": "receiveWithAuthSignature", "type": "bytes" }
+      { "name": "validAfter", "type": "uint256", "internalType": "uint256" },
+      { "name": "validBefore", "type": "uint256", "internalType": "uint256" },
+      { "name": "receiveWithAuthSignature", "type": "bytes", "internalType": "bytes" }
     ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "depositWithAuthorizationBytes",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "inputs": [
-      { "internalType": "address", "name": "signatureOwner", "type": "address" },
+      { "name": "signatureOwner", "type": "address", "internalType": "address" },
       {
+        "name": "depositData",
+        "type": "tuple",
+        "internalType": "struct SpokePoolPeripheryInterface.DepositData",
         "components": [
           {
-            "components": [
-              { "internalType": "uint256", "name": "amount", "type": "uint256" },
-              { "internalType": "address", "name": "recipient", "type": "address" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.Fees",
             "name": "submissionFees",
-            "type": "tuple"
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.Fees",
+            "components": [
+              { "name": "amount", "type": "uint256", "internalType": "uint256" },
+              { "name": "recipient", "type": "address", "internalType": "address" }
+            ]
           },
           {
-            "components": [
-              { "internalType": "address", "name": "inputToken", "type": "address" },
-              { "internalType": "bytes32", "name": "outputToken", "type": "bytes32" },
-              { "internalType": "uint256", "name": "outputAmount", "type": "uint256" },
-              { "internalType": "address", "name": "depositor", "type": "address" },
-              { "internalType": "bytes32", "name": "recipient", "type": "bytes32" },
-              { "internalType": "uint256", "name": "destinationChainId", "type": "uint256" },
-              { "internalType": "bytes32", "name": "exclusiveRelayer", "type": "bytes32" },
-              { "internalType": "uint32", "name": "quoteTimestamp", "type": "uint32" },
-              { "internalType": "uint32", "name": "fillDeadline", "type": "uint32" },
-              { "internalType": "uint32", "name": "exclusivityParameter", "type": "uint32" },
-              { "internalType": "bytes", "name": "message", "type": "bytes" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
             "name": "baseDepositData",
-            "type": "tuple"
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
+            "components": [
+              { "name": "inputToken", "type": "address", "internalType": "address" },
+              { "name": "outputToken", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "outputAmount", "type": "uint256", "internalType": "uint256" },
+              { "name": "depositor", "type": "address", "internalType": "address" },
+              { "name": "recipient", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "destinationChainId", "type": "uint256", "internalType": "uint256" },
+              { "name": "exclusiveRelayer", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "quoteTimestamp", "type": "uint32", "internalType": "uint32" },
+              { "name": "fillDeadline", "type": "uint32", "internalType": "uint32" },
+              { "name": "exclusivityParameter", "type": "uint32", "internalType": "uint32" },
+              { "name": "message", "type": "bytes", "internalType": "bytes" }
+            ]
           },
-          { "internalType": "uint256", "name": "inputAmount", "type": "uint256" },
-          { "internalType": "address", "name": "spokePool", "type": "address" },
-          { "internalType": "uint256", "name": "nonce", "type": "uint256" }
-        ],
-        "internalType": "struct SpokePoolPeripheryInterface.DepositData",
-        "name": "depositData",
-        "type": "tuple"
+          { "name": "inputAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "spokePool", "type": "address", "internalType": "address" },
+          { "name": "nonce", "type": "uint256", "internalType": "uint256" }
+        ]
       },
-      { "internalType": "uint256", "name": "deadline", "type": "uint256" },
-      { "internalType": "bytes", "name": "permitSignature", "type": "bytes" },
-      { "internalType": "bytes", "name": "depositDataSignature", "type": "bytes" }
+      { "name": "validAfter", "type": "uint256", "internalType": "uint256" },
+      { "name": "validBefore", "type": "uint256", "internalType": "uint256" },
+      { "name": "receiveWithAuthSignature", "type": "bytes", "internalType": "bytes" }
     ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "depositWithPermit",
+    "inputs": [
+      { "name": "signatureOwner", "type": "address", "internalType": "address" },
+      {
+        "name": "depositData",
+        "type": "tuple",
+        "internalType": "struct SpokePoolPeripheryInterface.DepositData",
+        "components": [
+          {
+            "name": "submissionFees",
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.Fees",
+            "components": [
+              { "name": "amount", "type": "uint256", "internalType": "uint256" },
+              { "name": "recipient", "type": "address", "internalType": "address" }
+            ]
+          },
+          {
+            "name": "baseDepositData",
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
+            "components": [
+              { "name": "inputToken", "type": "address", "internalType": "address" },
+              { "name": "outputToken", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "outputAmount", "type": "uint256", "internalType": "uint256" },
+              { "name": "depositor", "type": "address", "internalType": "address" },
+              { "name": "recipient", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "destinationChainId", "type": "uint256", "internalType": "uint256" },
+              { "name": "exclusiveRelayer", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "quoteTimestamp", "type": "uint32", "internalType": "uint32" },
+              { "name": "fillDeadline", "type": "uint32", "internalType": "uint32" },
+              { "name": "exclusivityParameter", "type": "uint32", "internalType": "uint32" },
+              { "name": "message", "type": "bytes", "internalType": "bytes" }
+            ]
+          },
+          { "name": "inputAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "spokePool", "type": "address", "internalType": "address" },
+          { "name": "nonce", "type": "uint256", "internalType": "uint256" }
+        ]
+      },
+      { "name": "deadline", "type": "uint256", "internalType": "uint256" },
+      { "name": "permitSignature", "type": "bytes", "internalType": "bytes" },
+      { "name": "depositDataSignature", "type": "bytes", "internalType": "bytes" }
+    ],
     "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    "stateMutability": "nonpayable"
   },
   {
-    "inputs": [
-      { "internalType": "address", "name": "signatureOwner", "type": "address" },
-      {
-        "components": [
-          {
-            "components": [
-              { "internalType": "uint256", "name": "amount", "type": "uint256" },
-              { "internalType": "address", "name": "recipient", "type": "address" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.Fees",
-            "name": "submissionFees",
-            "type": "tuple"
-          },
-          {
-            "components": [
-              { "internalType": "address", "name": "inputToken", "type": "address" },
-              { "internalType": "bytes32", "name": "outputToken", "type": "bytes32" },
-              { "internalType": "uint256", "name": "outputAmount", "type": "uint256" },
-              { "internalType": "address", "name": "depositor", "type": "address" },
-              { "internalType": "bytes32", "name": "recipient", "type": "bytes32" },
-              { "internalType": "uint256", "name": "destinationChainId", "type": "uint256" },
-              { "internalType": "bytes32", "name": "exclusiveRelayer", "type": "bytes32" },
-              { "internalType": "uint32", "name": "quoteTimestamp", "type": "uint32" },
-              { "internalType": "uint32", "name": "fillDeadline", "type": "uint32" },
-              { "internalType": "uint32", "name": "exclusivityParameter", "type": "uint32" },
-              { "internalType": "bytes", "name": "message", "type": "bytes" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
-            "name": "baseDepositData",
-            "type": "tuple"
-          },
-          { "internalType": "uint256", "name": "inputAmount", "type": "uint256" },
-          { "internalType": "address", "name": "spokePool", "type": "address" },
-          { "internalType": "uint256", "name": "nonce", "type": "uint256" }
-        ],
-        "internalType": "struct SpokePoolPeripheryInterface.DepositData",
-        "name": "depositData",
-        "type": "tuple"
-      },
-      {
-        "components": [
-          {
-            "components": [
-              { "internalType": "address", "name": "token", "type": "address" },
-              { "internalType": "uint256", "name": "amount", "type": "uint256" }
-            ],
-            "internalType": "struct IPermit2.TokenPermissions",
-            "name": "permitted",
-            "type": "tuple"
-          },
-          { "internalType": "uint256", "name": "nonce", "type": "uint256" },
-          { "internalType": "uint256", "name": "deadline", "type": "uint256" }
-        ],
-        "internalType": "struct IPermit2.PermitTransferFrom",
-        "name": "permit",
-        "type": "tuple"
-      },
-      { "internalType": "bytes", "name": "signature", "type": "bytes" }
-    ],
+    "type": "function",
     "name": "depositWithPermit2",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "domainSeparator",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "eip712Domain",
-    "outputs": [
-      { "internalType": "bytes1", "name": "fields", "type": "bytes1" },
-      { "internalType": "string", "name": "name", "type": "string" },
-      { "internalType": "string", "name": "version", "type": "string" },
-      { "internalType": "uint256", "name": "chainId", "type": "uint256" },
-      { "internalType": "address", "name": "verifyingContract", "type": "address" },
-      { "internalType": "bytes32", "name": "salt", "type": "bytes32" },
-      { "internalType": "uint256[]", "name": "extensions", "type": "uint256[]" }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [
-      { "internalType": "address", "name": "depositor", "type": "address" },
-      { "internalType": "address", "name": "authorizer", "type": "address" },
-      { "internalType": "bytes32", "name": "nonceIdentifier", "type": "bytes32" },
-      { "internalType": "uint256", "name": "nonce", "type": "uint256" },
-      { "internalType": "contract V3SpokePoolInterface", "name": "spokePool", "type": "address" }
-    ],
-    "name": "getDepositId",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
+      { "name": "signatureOwner", "type": "address", "internalType": "address" },
       {
-        "components": [
-          {
-            "components": [
-              { "internalType": "uint256", "name": "amount", "type": "uint256" },
-              { "internalType": "address", "name": "recipient", "type": "address" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.Fees",
-            "name": "submissionFees",
-            "type": "tuple"
-          },
-          {
-            "components": [
-              { "internalType": "address", "name": "inputToken", "type": "address" },
-              { "internalType": "bytes32", "name": "outputToken", "type": "bytes32" },
-              { "internalType": "uint256", "name": "outputAmount", "type": "uint256" },
-              { "internalType": "address", "name": "depositor", "type": "address" },
-              { "internalType": "bytes32", "name": "recipient", "type": "bytes32" },
-              { "internalType": "uint256", "name": "destinationChainId", "type": "uint256" },
-              { "internalType": "bytes32", "name": "exclusiveRelayer", "type": "bytes32" },
-              { "internalType": "uint32", "name": "quoteTimestamp", "type": "uint32" },
-              { "internalType": "uint32", "name": "fillDeadline", "type": "uint32" },
-              { "internalType": "uint32", "name": "exclusivityParameter", "type": "uint32" },
-              { "internalType": "bytes", "name": "message", "type": "bytes" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
-            "name": "baseDepositData",
-            "type": "tuple"
-          },
-          { "internalType": "uint256", "name": "inputAmount", "type": "uint256" },
-          { "internalType": "address", "name": "spokePool", "type": "address" },
-          { "internalType": "uint256", "name": "nonce", "type": "uint256" }
-        ],
-        "internalType": "struct SpokePoolPeripheryInterface.DepositData",
         "name": "depositData",
-        "type": "tuple"
-      }
-    ],
-    "name": "getERC3009DepositWitness",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
+        "type": "tuple",
+        "internalType": "struct SpokePoolPeripheryInterface.DepositData",
         "components": [
           {
-            "components": [
-              { "internalType": "uint256", "name": "amount", "type": "uint256" },
-              { "internalType": "address", "name": "recipient", "type": "address" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.Fees",
             "name": "submissionFees",
-            "type": "tuple"
-          },
-          {
-            "components": [
-              { "internalType": "address", "name": "inputToken", "type": "address" },
-              { "internalType": "bytes32", "name": "outputToken", "type": "bytes32" },
-              { "internalType": "uint256", "name": "outputAmount", "type": "uint256" },
-              { "internalType": "address", "name": "depositor", "type": "address" },
-              { "internalType": "bytes32", "name": "recipient", "type": "bytes32" },
-              { "internalType": "uint256", "name": "destinationChainId", "type": "uint256" },
-              { "internalType": "bytes32", "name": "exclusiveRelayer", "type": "bytes32" },
-              { "internalType": "uint32", "name": "quoteTimestamp", "type": "uint32" },
-              { "internalType": "uint32", "name": "fillDeadline", "type": "uint32" },
-              { "internalType": "uint32", "name": "exclusivityParameter", "type": "uint32" },
-              { "internalType": "bytes", "name": "message", "type": "bytes" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
-            "name": "depositData",
-            "type": "tuple"
-          },
-          { "internalType": "address", "name": "swapToken", "type": "address" },
-          { "internalType": "address", "name": "exchange", "type": "address" },
-          { "internalType": "enum SpokePoolPeripheryInterface.TransferType", "name": "transferType", "type": "uint8" },
-          { "internalType": "uint256", "name": "swapTokenAmount", "type": "uint256" },
-          { "internalType": "uint256", "name": "minExpectedInputTokenAmount", "type": "uint256" },
-          { "internalType": "bytes", "name": "routerCalldata", "type": "bytes" },
-          { "internalType": "bool", "name": "enableProportionalAdjustment", "type": "bool" },
-          { "internalType": "address", "name": "spokePool", "type": "address" },
-          { "internalType": "uint256", "name": "nonce", "type": "uint256" }
-        ],
-        "internalType": "struct SpokePoolPeripheryInterface.SwapAndDepositData",
-        "name": "swapAndDepositData",
-        "type": "tuple"
-      }
-    ],
-    "name": "getERC3009SwapAndBridgeWitness",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "bytes[]", "name": "data", "type": "bytes[]" }],
-    "name": "multicall",
-    "outputs": [{ "internalType": "bytes[]", "name": "results", "type": "bytes[]" }],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "permit2",
-    "outputs": [{ "internalType": "contract IPermit2", "name": "", "type": "address" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "address", "name": "user", "type": "address" }],
-    "name": "permitNonces",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "components": [
-          {
-            "components": [
-              { "internalType": "uint256", "name": "amount", "type": "uint256" },
-              { "internalType": "address", "name": "recipient", "type": "address" }
-            ],
+            "type": "tuple",
             "internalType": "struct SpokePoolPeripheryInterface.Fees",
-            "name": "submissionFees",
-            "type": "tuple"
+            "components": [
+              { "name": "amount", "type": "uint256", "internalType": "uint256" },
+              { "name": "recipient", "type": "address", "internalType": "address" }
+            ]
           },
           {
-            "components": [
-              { "internalType": "address", "name": "inputToken", "type": "address" },
-              { "internalType": "bytes32", "name": "outputToken", "type": "bytes32" },
-              { "internalType": "uint256", "name": "outputAmount", "type": "uint256" },
-              { "internalType": "address", "name": "depositor", "type": "address" },
-              { "internalType": "bytes32", "name": "recipient", "type": "bytes32" },
-              { "internalType": "uint256", "name": "destinationChainId", "type": "uint256" },
-              { "internalType": "bytes32", "name": "exclusiveRelayer", "type": "bytes32" },
-              { "internalType": "uint32", "name": "quoteTimestamp", "type": "uint32" },
-              { "internalType": "uint32", "name": "fillDeadline", "type": "uint32" },
-              { "internalType": "uint32", "name": "exclusivityParameter", "type": "uint32" },
-              { "internalType": "bytes", "name": "message", "type": "bytes" }
-            ],
+            "name": "baseDepositData",
+            "type": "tuple",
             "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
-            "name": "depositData",
-            "type": "tuple"
-          },
-          { "internalType": "address", "name": "swapToken", "type": "address" },
-          { "internalType": "address", "name": "exchange", "type": "address" },
-          { "internalType": "enum SpokePoolPeripheryInterface.TransferType", "name": "transferType", "type": "uint8" },
-          { "internalType": "uint256", "name": "swapTokenAmount", "type": "uint256" },
-          { "internalType": "uint256", "name": "minExpectedInputTokenAmount", "type": "uint256" },
-          { "internalType": "bytes", "name": "routerCalldata", "type": "bytes" },
-          { "internalType": "bool", "name": "enableProportionalAdjustment", "type": "bool" },
-          { "internalType": "address", "name": "spokePool", "type": "address" },
-          { "internalType": "uint256", "name": "nonce", "type": "uint256" }
-        ],
-        "internalType": "struct SpokePoolPeripheryInterface.SwapAndDepositData",
-        "name": "swapAndDepositData",
-        "type": "tuple"
-      }
-    ],
-    "name": "swapAndBridge",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "signatureOwner", "type": "address" },
-      {
-        "components": [
-          {
             "components": [
-              { "internalType": "uint256", "name": "amount", "type": "uint256" },
-              { "internalType": "address", "name": "recipient", "type": "address" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.Fees",
-            "name": "submissionFees",
-            "type": "tuple"
+              { "name": "inputToken", "type": "address", "internalType": "address" },
+              { "name": "outputToken", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "outputAmount", "type": "uint256", "internalType": "uint256" },
+              { "name": "depositor", "type": "address", "internalType": "address" },
+              { "name": "recipient", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "destinationChainId", "type": "uint256", "internalType": "uint256" },
+              { "name": "exclusiveRelayer", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "quoteTimestamp", "type": "uint32", "internalType": "uint32" },
+              { "name": "fillDeadline", "type": "uint32", "internalType": "uint32" },
+              { "name": "exclusivityParameter", "type": "uint32", "internalType": "uint32" },
+              { "name": "message", "type": "bytes", "internalType": "bytes" }
+            ]
           },
-          {
-            "components": [
-              { "internalType": "address", "name": "inputToken", "type": "address" },
-              { "internalType": "bytes32", "name": "outputToken", "type": "bytes32" },
-              { "internalType": "uint256", "name": "outputAmount", "type": "uint256" },
-              { "internalType": "address", "name": "depositor", "type": "address" },
-              { "internalType": "bytes32", "name": "recipient", "type": "bytes32" },
-              { "internalType": "uint256", "name": "destinationChainId", "type": "uint256" },
-              { "internalType": "bytes32", "name": "exclusiveRelayer", "type": "bytes32" },
-              { "internalType": "uint32", "name": "quoteTimestamp", "type": "uint32" },
-              { "internalType": "uint32", "name": "fillDeadline", "type": "uint32" },
-              { "internalType": "uint32", "name": "exclusivityParameter", "type": "uint32" },
-              { "internalType": "bytes", "name": "message", "type": "bytes" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
-            "name": "depositData",
-            "type": "tuple"
-          },
-          { "internalType": "address", "name": "swapToken", "type": "address" },
-          { "internalType": "address", "name": "exchange", "type": "address" },
-          { "internalType": "enum SpokePoolPeripheryInterface.TransferType", "name": "transferType", "type": "uint8" },
-          { "internalType": "uint256", "name": "swapTokenAmount", "type": "uint256" },
-          { "internalType": "uint256", "name": "minExpectedInputTokenAmount", "type": "uint256" },
-          { "internalType": "bytes", "name": "routerCalldata", "type": "bytes" },
-          { "internalType": "bool", "name": "enableProportionalAdjustment", "type": "bool" },
-          { "internalType": "address", "name": "spokePool", "type": "address" },
-          { "internalType": "uint256", "name": "nonce", "type": "uint256" }
-        ],
-        "internalType": "struct SpokePoolPeripheryInterface.SwapAndDepositData",
-        "name": "swapAndDepositData",
-        "type": "tuple"
-      },
-      { "internalType": "uint256", "name": "validAfter", "type": "uint256" },
-      { "internalType": "uint256", "name": "validBefore", "type": "uint256" },
-      { "internalType": "bytes", "name": "receiveWithAuthSignature", "type": "bytes" }
-    ],
-    "name": "swapAndBridgeWithAuthorization",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "signatureOwner", "type": "address" },
-      {
-        "components": [
-          {
-            "components": [
-              { "internalType": "uint256", "name": "amount", "type": "uint256" },
-              { "internalType": "address", "name": "recipient", "type": "address" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.Fees",
-            "name": "submissionFees",
-            "type": "tuple"
-          },
-          {
-            "components": [
-              { "internalType": "address", "name": "inputToken", "type": "address" },
-              { "internalType": "bytes32", "name": "outputToken", "type": "bytes32" },
-              { "internalType": "uint256", "name": "outputAmount", "type": "uint256" },
-              { "internalType": "address", "name": "depositor", "type": "address" },
-              { "internalType": "bytes32", "name": "recipient", "type": "bytes32" },
-              { "internalType": "uint256", "name": "destinationChainId", "type": "uint256" },
-              { "internalType": "bytes32", "name": "exclusiveRelayer", "type": "bytes32" },
-              { "internalType": "uint32", "name": "quoteTimestamp", "type": "uint32" },
-              { "internalType": "uint32", "name": "fillDeadline", "type": "uint32" },
-              { "internalType": "uint32", "name": "exclusivityParameter", "type": "uint32" },
-              { "internalType": "bytes", "name": "message", "type": "bytes" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
-            "name": "depositData",
-            "type": "tuple"
-          },
-          { "internalType": "address", "name": "swapToken", "type": "address" },
-          { "internalType": "address", "name": "exchange", "type": "address" },
-          { "internalType": "enum SpokePoolPeripheryInterface.TransferType", "name": "transferType", "type": "uint8" },
-          { "internalType": "uint256", "name": "swapTokenAmount", "type": "uint256" },
-          { "internalType": "uint256", "name": "minExpectedInputTokenAmount", "type": "uint256" },
-          { "internalType": "bytes", "name": "routerCalldata", "type": "bytes" },
-          { "internalType": "bool", "name": "enableProportionalAdjustment", "type": "bool" },
-          { "internalType": "address", "name": "spokePool", "type": "address" },
-          { "internalType": "uint256", "name": "nonce", "type": "uint256" }
-        ],
-        "internalType": "struct SpokePoolPeripheryInterface.SwapAndDepositData",
-        "name": "swapAndDepositData",
-        "type": "tuple"
-      },
-      { "internalType": "uint256", "name": "validAfter", "type": "uint256" },
-      { "internalType": "uint256", "name": "validBefore", "type": "uint256" },
-      { "internalType": "bytes", "name": "receiveWithAuthSignature", "type": "bytes" }
-    ],
-    "name": "swapAndBridgeWithAuthorizationBytes",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "signatureOwner", "type": "address" },
-      {
-        "components": [
-          {
-            "components": [
-              { "internalType": "uint256", "name": "amount", "type": "uint256" },
-              { "internalType": "address", "name": "recipient", "type": "address" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.Fees",
-            "name": "submissionFees",
-            "type": "tuple"
-          },
-          {
-            "components": [
-              { "internalType": "address", "name": "inputToken", "type": "address" },
-              { "internalType": "bytes32", "name": "outputToken", "type": "bytes32" },
-              { "internalType": "uint256", "name": "outputAmount", "type": "uint256" },
-              { "internalType": "address", "name": "depositor", "type": "address" },
-              { "internalType": "bytes32", "name": "recipient", "type": "bytes32" },
-              { "internalType": "uint256", "name": "destinationChainId", "type": "uint256" },
-              { "internalType": "bytes32", "name": "exclusiveRelayer", "type": "bytes32" },
-              { "internalType": "uint32", "name": "quoteTimestamp", "type": "uint32" },
-              { "internalType": "uint32", "name": "fillDeadline", "type": "uint32" },
-              { "internalType": "uint32", "name": "exclusivityParameter", "type": "uint32" },
-              { "internalType": "bytes", "name": "message", "type": "bytes" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
-            "name": "depositData",
-            "type": "tuple"
-          },
-          { "internalType": "address", "name": "swapToken", "type": "address" },
-          { "internalType": "address", "name": "exchange", "type": "address" },
-          { "internalType": "enum SpokePoolPeripheryInterface.TransferType", "name": "transferType", "type": "uint8" },
-          { "internalType": "uint256", "name": "swapTokenAmount", "type": "uint256" },
-          { "internalType": "uint256", "name": "minExpectedInputTokenAmount", "type": "uint256" },
-          { "internalType": "bytes", "name": "routerCalldata", "type": "bytes" },
-          { "internalType": "bool", "name": "enableProportionalAdjustment", "type": "bool" },
-          { "internalType": "address", "name": "spokePool", "type": "address" },
-          { "internalType": "uint256", "name": "nonce", "type": "uint256" }
-        ],
-        "internalType": "struct SpokePoolPeripheryInterface.SwapAndDepositData",
-        "name": "swapAndDepositData",
-        "type": "tuple"
-      },
-      { "internalType": "uint256", "name": "deadline", "type": "uint256" },
-      { "internalType": "bytes", "name": "permitSignature", "type": "bytes" },
-      { "internalType": "bytes", "name": "swapAndDepositDataSignature", "type": "bytes" }
-    ],
-    "name": "swapAndBridgeWithPermit",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "signatureOwner", "type": "address" },
-      {
-        "components": [
-          {
-            "components": [
-              { "internalType": "uint256", "name": "amount", "type": "uint256" },
-              { "internalType": "address", "name": "recipient", "type": "address" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.Fees",
-            "name": "submissionFees",
-            "type": "tuple"
-          },
-          {
-            "components": [
-              { "internalType": "address", "name": "inputToken", "type": "address" },
-              { "internalType": "bytes32", "name": "outputToken", "type": "bytes32" },
-              { "internalType": "uint256", "name": "outputAmount", "type": "uint256" },
-              { "internalType": "address", "name": "depositor", "type": "address" },
-              { "internalType": "bytes32", "name": "recipient", "type": "bytes32" },
-              { "internalType": "uint256", "name": "destinationChainId", "type": "uint256" },
-              { "internalType": "bytes32", "name": "exclusiveRelayer", "type": "bytes32" },
-              { "internalType": "uint32", "name": "quoteTimestamp", "type": "uint32" },
-              { "internalType": "uint32", "name": "fillDeadline", "type": "uint32" },
-              { "internalType": "uint32", "name": "exclusivityParameter", "type": "uint32" },
-              { "internalType": "bytes", "name": "message", "type": "bytes" }
-            ],
-            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
-            "name": "depositData",
-            "type": "tuple"
-          },
-          { "internalType": "address", "name": "swapToken", "type": "address" },
-          { "internalType": "address", "name": "exchange", "type": "address" },
-          { "internalType": "enum SpokePoolPeripheryInterface.TransferType", "name": "transferType", "type": "uint8" },
-          { "internalType": "uint256", "name": "swapTokenAmount", "type": "uint256" },
-          { "internalType": "uint256", "name": "minExpectedInputTokenAmount", "type": "uint256" },
-          { "internalType": "bytes", "name": "routerCalldata", "type": "bytes" },
-          { "internalType": "bool", "name": "enableProportionalAdjustment", "type": "bool" },
-          { "internalType": "address", "name": "spokePool", "type": "address" },
-          { "internalType": "uint256", "name": "nonce", "type": "uint256" }
-        ],
-        "internalType": "struct SpokePoolPeripheryInterface.SwapAndDepositData",
-        "name": "swapAndDepositData",
-        "type": "tuple"
+          { "name": "inputAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "spokePool", "type": "address", "internalType": "address" },
+          { "name": "nonce", "type": "uint256", "internalType": "uint256" }
+        ]
       },
       {
-        "components": [
-          {
-            "components": [
-              { "internalType": "address", "name": "token", "type": "address" },
-              { "internalType": "uint256", "name": "amount", "type": "uint256" }
-            ],
-            "internalType": "struct IPermit2.TokenPermissions",
-            "name": "permitted",
-            "type": "tuple"
-          },
-          { "internalType": "uint256", "name": "nonce", "type": "uint256" },
-          { "internalType": "uint256", "name": "deadline", "type": "uint256" }
-        ],
-        "internalType": "struct IPermit2.PermitTransferFrom",
         "name": "permit",
-        "type": "tuple"
+        "type": "tuple",
+        "internalType": "struct IPermit2.PermitTransferFrom",
+        "components": [
+          {
+            "name": "permitted",
+            "type": "tuple",
+            "internalType": "struct IPermit2.TokenPermissions",
+            "components": [
+              { "name": "token", "type": "address", "internalType": "address" },
+              { "name": "amount", "type": "uint256", "internalType": "uint256" }
+            ]
+          },
+          { "name": "nonce", "type": "uint256", "internalType": "uint256" },
+          { "name": "deadline", "type": "uint256", "internalType": "uint256" }
+        ]
       },
-      { "internalType": "bytes", "name": "signature", "type": "bytes" }
+      { "name": "signature", "type": "bytes", "internalType": "bytes" }
     ],
-    "name": "swapAndBridgeWithPermit2",
     "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    "stateMutability": "nonpayable"
   },
   {
+    "type": "function",
+    "name": "domainSeparator",
     "inputs": [],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "eip712Domain",
+    "inputs": [],
+    "outputs": [
+      { "name": "fields", "type": "bytes1", "internalType": "bytes1" },
+      { "name": "name", "type": "string", "internalType": "string" },
+      { "name": "version", "type": "string", "internalType": "string" },
+      { "name": "chainId", "type": "uint256", "internalType": "uint256" },
+      { "name": "verifyingContract", "type": "address", "internalType": "address" },
+      { "name": "salt", "type": "bytes32", "internalType": "bytes32" },
+      { "name": "extensions", "type": "uint256[]", "internalType": "uint256[]" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDepositId",
+    "inputs": [
+      { "name": "depositor", "type": "address", "internalType": "address" },
+      { "name": "authorizer", "type": "address", "internalType": "address" },
+      { "name": "nonceIdentifier", "type": "bytes32", "internalType": "bytes32" },
+      { "name": "nonce", "type": "uint256", "internalType": "uint256" },
+      { "name": "spokePool", "type": "address", "internalType": "contract V3SpokePoolInterface" }
+    ],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getERC3009DepositWitness",
+    "inputs": [
+      {
+        "name": "depositData",
+        "type": "tuple",
+        "internalType": "struct SpokePoolPeripheryInterface.DepositData",
+        "components": [
+          {
+            "name": "submissionFees",
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.Fees",
+            "components": [
+              { "name": "amount", "type": "uint256", "internalType": "uint256" },
+              { "name": "recipient", "type": "address", "internalType": "address" }
+            ]
+          },
+          {
+            "name": "baseDepositData",
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
+            "components": [
+              { "name": "inputToken", "type": "address", "internalType": "address" },
+              { "name": "outputToken", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "outputAmount", "type": "uint256", "internalType": "uint256" },
+              { "name": "depositor", "type": "address", "internalType": "address" },
+              { "name": "recipient", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "destinationChainId", "type": "uint256", "internalType": "uint256" },
+              { "name": "exclusiveRelayer", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "quoteTimestamp", "type": "uint32", "internalType": "uint32" },
+              { "name": "fillDeadline", "type": "uint32", "internalType": "uint32" },
+              { "name": "exclusivityParameter", "type": "uint32", "internalType": "uint32" },
+              { "name": "message", "type": "bytes", "internalType": "bytes" }
+            ]
+          },
+          { "name": "inputAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "spokePool", "type": "address", "internalType": "address" },
+          { "name": "nonce", "type": "uint256", "internalType": "uint256" }
+        ]
+      }
+    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getERC3009SwapAndBridgeWitness",
+    "inputs": [
+      {
+        "name": "swapAndDepositData",
+        "type": "tuple",
+        "internalType": "struct SpokePoolPeripheryInterface.SwapAndDepositData",
+        "components": [
+          {
+            "name": "submissionFees",
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.Fees",
+            "components": [
+              { "name": "amount", "type": "uint256", "internalType": "uint256" },
+              { "name": "recipient", "type": "address", "internalType": "address" }
+            ]
+          },
+          {
+            "name": "depositData",
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
+            "components": [
+              { "name": "inputToken", "type": "address", "internalType": "address" },
+              { "name": "outputToken", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "outputAmount", "type": "uint256", "internalType": "uint256" },
+              { "name": "depositor", "type": "address", "internalType": "address" },
+              { "name": "recipient", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "destinationChainId", "type": "uint256", "internalType": "uint256" },
+              { "name": "exclusiveRelayer", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "quoteTimestamp", "type": "uint32", "internalType": "uint32" },
+              { "name": "fillDeadline", "type": "uint32", "internalType": "uint32" },
+              { "name": "exclusivityParameter", "type": "uint32", "internalType": "uint32" },
+              { "name": "message", "type": "bytes", "internalType": "bytes" }
+            ]
+          },
+          { "name": "swapToken", "type": "address", "internalType": "address" },
+          { "name": "exchange", "type": "address", "internalType": "address" },
+          { "name": "transferType", "type": "uint8", "internalType": "enum SpokePoolPeripheryInterface.TransferType" },
+          { "name": "swapTokenAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "minExpectedInputTokenAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "routerCalldata", "type": "bytes", "internalType": "bytes" },
+          { "name": "enableProportionalAdjustment", "type": "bool", "internalType": "bool" },
+          { "name": "spokePool", "type": "address", "internalType": "address" },
+          { "name": "nonce", "type": "uint256", "internalType": "uint256" }
+        ]
+      }
+    ],
+    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "multicall",
+    "inputs": [{ "name": "data", "type": "bytes[]", "internalType": "bytes[]" }],
+    "outputs": [{ "name": "results", "type": "bytes[]", "internalType": "bytes[]" }],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "multicall3",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address", "internalType": "contract IMulticall3" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "permit2",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address", "internalType": "contract IPermit2" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "permitNonces",
+    "inputs": [{ "name": "user", "type": "address", "internalType": "address" }],
+    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "swapAndBridge",
+    "inputs": [
+      {
+        "name": "swapAndDepositData",
+        "type": "tuple",
+        "internalType": "struct SpokePoolPeripheryInterface.SwapAndDepositData",
+        "components": [
+          {
+            "name": "submissionFees",
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.Fees",
+            "components": [
+              { "name": "amount", "type": "uint256", "internalType": "uint256" },
+              { "name": "recipient", "type": "address", "internalType": "address" }
+            ]
+          },
+          {
+            "name": "depositData",
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
+            "components": [
+              { "name": "inputToken", "type": "address", "internalType": "address" },
+              { "name": "outputToken", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "outputAmount", "type": "uint256", "internalType": "uint256" },
+              { "name": "depositor", "type": "address", "internalType": "address" },
+              { "name": "recipient", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "destinationChainId", "type": "uint256", "internalType": "uint256" },
+              { "name": "exclusiveRelayer", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "quoteTimestamp", "type": "uint32", "internalType": "uint32" },
+              { "name": "fillDeadline", "type": "uint32", "internalType": "uint32" },
+              { "name": "exclusivityParameter", "type": "uint32", "internalType": "uint32" },
+              { "name": "message", "type": "bytes", "internalType": "bytes" }
+            ]
+          },
+          { "name": "swapToken", "type": "address", "internalType": "address" },
+          { "name": "exchange", "type": "address", "internalType": "address" },
+          { "name": "transferType", "type": "uint8", "internalType": "enum SpokePoolPeripheryInterface.TransferType" },
+          { "name": "swapTokenAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "minExpectedInputTokenAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "routerCalldata", "type": "bytes", "internalType": "bytes" },
+          { "name": "enableProportionalAdjustment", "type": "bool", "internalType": "bool" },
+          { "name": "spokePool", "type": "address", "internalType": "address" },
+          { "name": "nonce", "type": "uint256", "internalType": "uint256" }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "swapAndBridgeWithAuthorization",
+    "inputs": [
+      { "name": "signatureOwner", "type": "address", "internalType": "address" },
+      {
+        "name": "swapAndDepositData",
+        "type": "tuple",
+        "internalType": "struct SpokePoolPeripheryInterface.SwapAndDepositData",
+        "components": [
+          {
+            "name": "submissionFees",
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.Fees",
+            "components": [
+              { "name": "amount", "type": "uint256", "internalType": "uint256" },
+              { "name": "recipient", "type": "address", "internalType": "address" }
+            ]
+          },
+          {
+            "name": "depositData",
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
+            "components": [
+              { "name": "inputToken", "type": "address", "internalType": "address" },
+              { "name": "outputToken", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "outputAmount", "type": "uint256", "internalType": "uint256" },
+              { "name": "depositor", "type": "address", "internalType": "address" },
+              { "name": "recipient", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "destinationChainId", "type": "uint256", "internalType": "uint256" },
+              { "name": "exclusiveRelayer", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "quoteTimestamp", "type": "uint32", "internalType": "uint32" },
+              { "name": "fillDeadline", "type": "uint32", "internalType": "uint32" },
+              { "name": "exclusivityParameter", "type": "uint32", "internalType": "uint32" },
+              { "name": "message", "type": "bytes", "internalType": "bytes" }
+            ]
+          },
+          { "name": "swapToken", "type": "address", "internalType": "address" },
+          { "name": "exchange", "type": "address", "internalType": "address" },
+          { "name": "transferType", "type": "uint8", "internalType": "enum SpokePoolPeripheryInterface.TransferType" },
+          { "name": "swapTokenAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "minExpectedInputTokenAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "routerCalldata", "type": "bytes", "internalType": "bytes" },
+          { "name": "enableProportionalAdjustment", "type": "bool", "internalType": "bool" },
+          { "name": "spokePool", "type": "address", "internalType": "address" },
+          { "name": "nonce", "type": "uint256", "internalType": "uint256" }
+        ]
+      },
+      { "name": "validAfter", "type": "uint256", "internalType": "uint256" },
+      { "name": "validBefore", "type": "uint256", "internalType": "uint256" },
+      { "name": "receiveWithAuthSignature", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "swapAndBridgeWithAuthorizationBytes",
+    "inputs": [
+      { "name": "signatureOwner", "type": "address", "internalType": "address" },
+      {
+        "name": "swapAndDepositData",
+        "type": "tuple",
+        "internalType": "struct SpokePoolPeripheryInterface.SwapAndDepositData",
+        "components": [
+          {
+            "name": "submissionFees",
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.Fees",
+            "components": [
+              { "name": "amount", "type": "uint256", "internalType": "uint256" },
+              { "name": "recipient", "type": "address", "internalType": "address" }
+            ]
+          },
+          {
+            "name": "depositData",
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
+            "components": [
+              { "name": "inputToken", "type": "address", "internalType": "address" },
+              { "name": "outputToken", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "outputAmount", "type": "uint256", "internalType": "uint256" },
+              { "name": "depositor", "type": "address", "internalType": "address" },
+              { "name": "recipient", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "destinationChainId", "type": "uint256", "internalType": "uint256" },
+              { "name": "exclusiveRelayer", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "quoteTimestamp", "type": "uint32", "internalType": "uint32" },
+              { "name": "fillDeadline", "type": "uint32", "internalType": "uint32" },
+              { "name": "exclusivityParameter", "type": "uint32", "internalType": "uint32" },
+              { "name": "message", "type": "bytes", "internalType": "bytes" }
+            ]
+          },
+          { "name": "swapToken", "type": "address", "internalType": "address" },
+          { "name": "exchange", "type": "address", "internalType": "address" },
+          { "name": "transferType", "type": "uint8", "internalType": "enum SpokePoolPeripheryInterface.TransferType" },
+          { "name": "swapTokenAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "minExpectedInputTokenAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "routerCalldata", "type": "bytes", "internalType": "bytes" },
+          { "name": "enableProportionalAdjustment", "type": "bool", "internalType": "bool" },
+          { "name": "spokePool", "type": "address", "internalType": "address" },
+          { "name": "nonce", "type": "uint256", "internalType": "uint256" }
+        ]
+      },
+      { "name": "validAfter", "type": "uint256", "internalType": "uint256" },
+      { "name": "validBefore", "type": "uint256", "internalType": "uint256" },
+      { "name": "receiveWithAuthSignature", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "swapAndBridgeWithPermit",
+    "inputs": [
+      { "name": "signatureOwner", "type": "address", "internalType": "address" },
+      {
+        "name": "swapAndDepositData",
+        "type": "tuple",
+        "internalType": "struct SpokePoolPeripheryInterface.SwapAndDepositData",
+        "components": [
+          {
+            "name": "submissionFees",
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.Fees",
+            "components": [
+              { "name": "amount", "type": "uint256", "internalType": "uint256" },
+              { "name": "recipient", "type": "address", "internalType": "address" }
+            ]
+          },
+          {
+            "name": "depositData",
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
+            "components": [
+              { "name": "inputToken", "type": "address", "internalType": "address" },
+              { "name": "outputToken", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "outputAmount", "type": "uint256", "internalType": "uint256" },
+              { "name": "depositor", "type": "address", "internalType": "address" },
+              { "name": "recipient", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "destinationChainId", "type": "uint256", "internalType": "uint256" },
+              { "name": "exclusiveRelayer", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "quoteTimestamp", "type": "uint32", "internalType": "uint32" },
+              { "name": "fillDeadline", "type": "uint32", "internalType": "uint32" },
+              { "name": "exclusivityParameter", "type": "uint32", "internalType": "uint32" },
+              { "name": "message", "type": "bytes", "internalType": "bytes" }
+            ]
+          },
+          { "name": "swapToken", "type": "address", "internalType": "address" },
+          { "name": "exchange", "type": "address", "internalType": "address" },
+          { "name": "transferType", "type": "uint8", "internalType": "enum SpokePoolPeripheryInterface.TransferType" },
+          { "name": "swapTokenAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "minExpectedInputTokenAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "routerCalldata", "type": "bytes", "internalType": "bytes" },
+          { "name": "enableProportionalAdjustment", "type": "bool", "internalType": "bool" },
+          { "name": "spokePool", "type": "address", "internalType": "address" },
+          { "name": "nonce", "type": "uint256", "internalType": "uint256" }
+        ]
+      },
+      { "name": "deadline", "type": "uint256", "internalType": "uint256" },
+      { "name": "permitSignature", "type": "bytes", "internalType": "bytes" },
+      { "name": "swapAndDepositDataSignature", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "swapAndBridgeWithPermit2",
+    "inputs": [
+      { "name": "signatureOwner", "type": "address", "internalType": "address" },
+      {
+        "name": "swapAndDepositData",
+        "type": "tuple",
+        "internalType": "struct SpokePoolPeripheryInterface.SwapAndDepositData",
+        "components": [
+          {
+            "name": "submissionFees",
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.Fees",
+            "components": [
+              { "name": "amount", "type": "uint256", "internalType": "uint256" },
+              { "name": "recipient", "type": "address", "internalType": "address" }
+            ]
+          },
+          {
+            "name": "depositData",
+            "type": "tuple",
+            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
+            "components": [
+              { "name": "inputToken", "type": "address", "internalType": "address" },
+              { "name": "outputToken", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "outputAmount", "type": "uint256", "internalType": "uint256" },
+              { "name": "depositor", "type": "address", "internalType": "address" },
+              { "name": "recipient", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "destinationChainId", "type": "uint256", "internalType": "uint256" },
+              { "name": "exclusiveRelayer", "type": "bytes32", "internalType": "bytes32" },
+              { "name": "quoteTimestamp", "type": "uint32", "internalType": "uint32" },
+              { "name": "fillDeadline", "type": "uint32", "internalType": "uint32" },
+              { "name": "exclusivityParameter", "type": "uint32", "internalType": "uint32" },
+              { "name": "message", "type": "bytes", "internalType": "bytes" }
+            ]
+          },
+          { "name": "swapToken", "type": "address", "internalType": "address" },
+          { "name": "exchange", "type": "address", "internalType": "address" },
+          { "name": "transferType", "type": "uint8", "internalType": "enum SpokePoolPeripheryInterface.TransferType" },
+          { "name": "swapTokenAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "minExpectedInputTokenAmount", "type": "uint256", "internalType": "uint256" },
+          { "name": "routerCalldata", "type": "bytes", "internalType": "bytes" },
+          { "name": "enableProportionalAdjustment", "type": "bool", "internalType": "bool" },
+          { "name": "spokePool", "type": "address", "internalType": "address" },
+          { "name": "nonce", "type": "uint256", "internalType": "uint256" }
+        ]
+      },
+      {
+        "name": "permit",
+        "type": "tuple",
+        "internalType": "struct IPermit2.PermitTransferFrom",
+        "components": [
+          {
+            "name": "permitted",
+            "type": "tuple",
+            "internalType": "struct IPermit2.TokenPermissions",
+            "components": [
+              { "name": "token", "type": "address", "internalType": "address" },
+              { "name": "amount", "type": "uint256", "internalType": "uint256" }
+            ]
+          },
+          { "name": "nonce", "type": "uint256", "internalType": "uint256" },
+          { "name": "deadline", "type": "uint256", "internalType": "uint256" }
+        ]
+      },
+      { "name": "signature", "type": "bytes", "internalType": "bytes" }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "swapProxy",
-    "outputs": [{ "internalType": "contract SwapProxy", "name": "", "type": "address" }],
-    "stateMutability": "view",
-    "type": "function"
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address", "internalType": "contract SwapProxy" }],
+    "stateMutability": "view"
+  },
+  { "type": "event", "name": "EIP712DomainChanged", "inputs": [], "anonymous": false },
+  {
+    "type": "event",
+    "name": "SwapBeforeBridge",
+    "inputs": [
+      { "name": "exchange", "type": "address", "indexed": false, "internalType": "address" },
+      { "name": "exchangeCalldata", "type": "bytes", "indexed": false, "internalType": "bytes" },
+      { "name": "swapToken", "type": "address", "indexed": true, "internalType": "address" },
+      { "name": "acrossInputToken", "type": "address", "indexed": true, "internalType": "address" },
+      { "name": "swapTokenAmount", "type": "uint256", "indexed": false, "internalType": "uint256" },
+      { "name": "acrossInputAmount", "type": "uint256", "indexed": false, "internalType": "uint256" },
+      { "name": "acrossOutputToken", "type": "bytes32", "indexed": true, "internalType": "bytes32" },
+      { "name": "acrossOutputAmount", "type": "uint256", "indexed": false, "internalType": "uint256" }
+    ],
+    "anonymous": false
+  },
+  { "type": "error", "name": "InvalidMinExpectedInputAmount", "inputs": [] },
+  { "type": "error", "name": "InvalidMsgValue", "inputs": [] },
+  { "type": "error", "name": "InvalidNonce", "inputs": [] },
+  { "type": "error", "name": "InvalidShortString", "inputs": [] },
+  { "type": "error", "name": "InvalidSignature", "inputs": [] },
+  { "type": "error", "name": "MinimumExpectedInputAmount", "inputs": [] },
+  {
+    "type": "error",
+    "name": "StringTooLong",
+    "inputs": [{ "name": "str", "type": "string", "internalType": "string" }]
   }
 ]

--- a/src/common/abi/SpokePoolPeriphery.json
+++ b/src/common/abi/SpokePoolPeriphery.json
@@ -183,6 +183,55 @@
         "name": "depositData",
         "type": "tuple"
       },
+      { "internalType": "uint256", "name": "validAfter", "type": "uint256" },
+      { "internalType": "uint256", "name": "validBefore", "type": "uint256" },
+      { "internalType": "bytes", "name": "receiveWithAuthSignature", "type": "bytes" }
+    ],
+    "name": "depositWithAuthorizationBytes",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "signatureOwner", "type": "address" },
+      {
+        "components": [
+          {
+            "components": [
+              { "internalType": "uint256", "name": "amount", "type": "uint256" },
+              { "internalType": "address", "name": "recipient", "type": "address" }
+            ],
+            "internalType": "struct SpokePoolPeripheryInterface.Fees",
+            "name": "submissionFees",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              { "internalType": "address", "name": "inputToken", "type": "address" },
+              { "internalType": "bytes32", "name": "outputToken", "type": "bytes32" },
+              { "internalType": "uint256", "name": "outputAmount", "type": "uint256" },
+              { "internalType": "address", "name": "depositor", "type": "address" },
+              { "internalType": "bytes32", "name": "recipient", "type": "bytes32" },
+              { "internalType": "uint256", "name": "destinationChainId", "type": "uint256" },
+              { "internalType": "bytes32", "name": "exclusiveRelayer", "type": "bytes32" },
+              { "internalType": "uint32", "name": "quoteTimestamp", "type": "uint32" },
+              { "internalType": "uint32", "name": "fillDeadline", "type": "uint32" },
+              { "internalType": "uint32", "name": "exclusivityParameter", "type": "uint32" },
+              { "internalType": "bytes", "name": "message", "type": "bytes" }
+            ],
+            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
+            "name": "baseDepositData",
+            "type": "tuple"
+          },
+          { "internalType": "uint256", "name": "inputAmount", "type": "uint256" },
+          { "internalType": "address", "name": "spokePool", "type": "address" },
+          { "internalType": "uint256", "name": "nonce", "type": "uint256" }
+        ],
+        "internalType": "struct SpokePoolPeripheryInterface.DepositData",
+        "name": "depositData",
+        "type": "tuple"
+      },
       { "internalType": "uint256", "name": "deadline", "type": "uint256" },
       { "internalType": "bytes", "name": "permitSignature", "type": "bytes" },
       { "internalType": "bytes", "name": "depositDataSignature", "type": "bytes" }
@@ -511,6 +560,61 @@
       { "internalType": "bytes", "name": "receiveWithAuthSignature", "type": "bytes" }
     ],
     "name": "swapAndBridgeWithAuthorization",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "signatureOwner", "type": "address" },
+      {
+        "components": [
+          {
+            "components": [
+              { "internalType": "uint256", "name": "amount", "type": "uint256" },
+              { "internalType": "address", "name": "recipient", "type": "address" }
+            ],
+            "internalType": "struct SpokePoolPeripheryInterface.Fees",
+            "name": "submissionFees",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              { "internalType": "address", "name": "inputToken", "type": "address" },
+              { "internalType": "bytes32", "name": "outputToken", "type": "bytes32" },
+              { "internalType": "uint256", "name": "outputAmount", "type": "uint256" },
+              { "internalType": "address", "name": "depositor", "type": "address" },
+              { "internalType": "bytes32", "name": "recipient", "type": "bytes32" },
+              { "internalType": "uint256", "name": "destinationChainId", "type": "uint256" },
+              { "internalType": "bytes32", "name": "exclusiveRelayer", "type": "bytes32" },
+              { "internalType": "uint32", "name": "quoteTimestamp", "type": "uint32" },
+              { "internalType": "uint32", "name": "fillDeadline", "type": "uint32" },
+              { "internalType": "uint32", "name": "exclusivityParameter", "type": "uint32" },
+              { "internalType": "bytes", "name": "message", "type": "bytes" }
+            ],
+            "internalType": "struct SpokePoolPeripheryInterface.BaseDepositData",
+            "name": "depositData",
+            "type": "tuple"
+          },
+          { "internalType": "address", "name": "swapToken", "type": "address" },
+          { "internalType": "address", "name": "exchange", "type": "address" },
+          { "internalType": "enum SpokePoolPeripheryInterface.TransferType", "name": "transferType", "type": "uint8" },
+          { "internalType": "uint256", "name": "swapTokenAmount", "type": "uint256" },
+          { "internalType": "uint256", "name": "minExpectedInputTokenAmount", "type": "uint256" },
+          { "internalType": "bytes", "name": "routerCalldata", "type": "bytes" },
+          { "internalType": "bool", "name": "enableProportionalAdjustment", "type": "bool" },
+          { "internalType": "address", "name": "spokePool", "type": "address" },
+          { "internalType": "uint256", "name": "nonce", "type": "uint256" }
+        ],
+        "internalType": "struct SpokePoolPeripheryInterface.SwapAndDepositData",
+        "name": "swapAndDepositData",
+        "type": "tuple"
+      },
+      { "internalType": "uint256", "name": "validAfter", "type": "uint256" },
+      { "internalType": "uint256", "name": "validBefore", "type": "uint256" },
+      { "internalType": "bytes", "name": "receiveWithAuthSignature", "type": "bytes" }
+    ],
+    "name": "swapAndBridgeWithAuthorizationBytes",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/src/gasless/README.md
+++ b/src/gasless/README.md
@@ -49,7 +49,7 @@ The deposit transaction itself is built from the API message and is unaffected b
 | `INITIALIZATION_RETRY_ATTEMPTS` | `3` | Retries for the first API query on startup. |
 | `GASLESS_ALLOWED_PEGGED_PAIRS` | `{}` | Allowed input→output token symbol pairs (same shape as `PEGGED_TOKEN_PRICES`). |
 | `NO_PERMIT2_CONTRACT_CHAINS` | `[]` | Origin chains without canonical Permit2 (skip nonce-bitmap reads). |
-| `SPOKE_POOL_PERIPHERY_OVERRIDES` | `{}` | Per-chain SpokePool periphery address overrides. |
+| `SPOKE_POOL_PERIPHERY_OVERRIDES` | `{}` | Per-chain SpokePool periphery address overrides. An override must support the `*WithAuthorizationBytes` methods (contracts ≥5.0.26 deployments) — older peripheries revert smart-wallet (>65-byte) authorizations. |
 | `RELAYER_GASLESS_DEPOSIT_USD_PAGE_THRESHOLD` | `1000` | Page-worthy deposit size threshold (stablecoin input); `0` disables. |
 | `RELAYER_GASLESS_REFUND_FLOW_TEST_ENABLED` | `false` | Test mode: allow refund-shaped deposits; submit deposit but skip fill. |
 | `RELAYER_GASLESS_FILLS_ENABLED` | `true` | When `false`, submit origin deposits only (no destination fills). |

--- a/src/utils/GaslessUtils.ts
+++ b/src/utils/GaslessUtils.ts
@@ -396,12 +396,15 @@ function toContractDepositData(data: BridgeWitnessData) {
   };
 }
 
-function normalizeSignature(signature: string): string {
+// EOA signatures are exactly 65 bytes; smart-wallet (EIP-1271 / ERC-6492) signatures are longer
+// and must be submitted via the periphery's *Bytes methods, which forward them to the token's
+// bytes-signature EIP-3009 overload. The quote API applies the same dispatch at simulation time.
+function normalizeAuthSignature(signature: string): { signature: string; isSmartWallet: boolean } {
   const hex = signature.startsWith("0x") ? signature : `0x${signature}`;
-  if (hex.length !== 132) {
-    throw new Error("receiveWithAuthSignature must be 65 bytes (132 hex chars)");
+  if (hex.length < 132) {
+    throw new Error("receiveWithAuthSignature must be at least 65 bytes (132 hex chars)");
   }
-  return hex;
+  return { signature: hex, isSmartWallet: hex.length > 132 };
 }
 
 function normalizeSignatureBytes(signature: string): string {
@@ -509,7 +512,8 @@ export async function isErc2612PermitNonceConsumed(params: {
 }
 
 /**
- * Builds calldata for SpokePoolPeriphery.depositWithAuthorization(signatureOwner, depositData, validAfter, validBefore, signature).
+ * Builds calldata for SpokePoolPeriphery.depositWithAuthorization[Bytes](signatureOwner, depositData, validAfter, validBefore, signature).
+ * The *Bytes variant is used for smart-wallet (>65-byte) signatures.
  */
 export function buildReceiveWithAuthorizationGaslessDepositTx(
   depositMessage: GaslessDepositMessage,
@@ -520,16 +524,12 @@ export function buildReceiveWithAuthorizationGaslessDepositTx(
   const { from: signatureOwner, validBefore, validAfter } = (permit as ReceiveWithAuthorization).message;
   const witnessData: BridgeWitnessData = { inputAmount, baseDepositData, submissionFees, spokePool, nonce };
   const depositData = toContractDepositData(witnessData);
-  const args = [
-    signatureOwner,
-    depositData,
-    BigNumber.from(validAfter),
-    BigNumber.from(validBefore),
-    normalizeSignature(signature),
-  ];
+  const { signature: authSignature, isSmartWallet } = normalizeAuthSignature(signature);
+  const method = isSmartWallet ? "depositWithAuthorizationBytes" : "depositWithAuthorization";
+  const args = [signatureOwner, depositData, BigNumber.from(validAfter), BigNumber.from(validBefore), authSignature];
 
   if (integratorId) {
-    const calldata = spokePoolPeripheryContract.interface.encodeFunctionData("depositWithAuthorization", args);
+    const calldata = spokePoolPeripheryContract.interface.encodeFunctionData(method, args);
     const taggedCalldata = tagIntegratorId(calldata, integratorId);
     return {
       contract: spokePoolPeripheryContract,
@@ -543,7 +543,7 @@ export function buildReceiveWithAuthorizationGaslessDepositTx(
   return {
     contract: spokePoolPeripheryContract,
     chainId: depositMessage.originChainId,
-    method: "depositWithAuthorization",
+    method,
     args,
     ensureConfirmation: true,
     spray: depositMessage.originChainId === CHAIN_IDs.MAINNET, // If mainnet, send to all available private RPCs.
@@ -551,8 +551,8 @@ export function buildReceiveWithAuthorizationGaslessDepositTx(
 }
 
 /**
- * Builds the origin-chain deposit tx for any gasless API message: bridge (depositWithAuthorization /
- * depositWithPermit2) or swap-and-bridge (swapAndBridgeWithAuthorization / swapAndBridgeWithPermit2).
+ * Builds the origin-chain deposit tx for any gasless API message: bridge (depositWithAuthorization[Bytes] /
+ * depositWithPermit2) or swap-and-bridge (swapAndBridgeWithAuthorization[Bytes] / swapAndBridgeWithPermit2).
  */
 export function buildGaslessDepositTx(
   depositMessage: AnyGaslessDepositMessage,
@@ -603,8 +603,8 @@ function toContractSwapAndDepositData(msg: SwapAndBridgeGaslessDepositMessage) {
 }
 
 /**
- * Builds calldata for SpokePoolPeriphery.swapAndBridgeWithAuthorization or .swapAndBridgeWithPermit2
- * depending on {@link SwapAndBridgeGaslessDepositMessage.permitType}.
+ * Builds calldata for SpokePoolPeriphery.swapAndBridgeWithAuthorization[Bytes] or .swapAndBridgeWithPermit2
+ * depending on {@link SwapAndBridgeGaslessDepositMessage.permitType} (and signature length for erc3009).
  */
 export function buildSwapAndBridgeDepositTx(
   depositMessage: SwapAndBridgeGaslessDepositMessage,
@@ -612,7 +612,11 @@ export function buildSwapAndBridgeDepositTx(
 ): AugmentedTransaction {
   const swapAndDepositData = toContractSwapAndDepositData(depositMessage);
 
-  let method: "swapAndBridgeWithAuthorization" | "swapAndBridgeWithPermit2" | "swapAndBridgeWithPermit";
+  let method:
+    | "swapAndBridgeWithAuthorization"
+    | "swapAndBridgeWithAuthorizationBytes"
+    | "swapAndBridgeWithPermit2"
+    | "swapAndBridgeWithPermit";
   let args: unknown[];
 
   if (depositMessage.permitType === "permit2") {
@@ -645,19 +649,14 @@ export function buildSwapAndBridgeDepositTx(
       normalizeSignatureBytes(depositMessage.signature),
     ];
   } else {
-    method = "swapAndBridgeWithAuthorization";
     const {
       from: signatureOwner,
       validAfter,
       validBefore,
     } = (depositMessage.permit as ReceiveWithAuthorization).message;
-    args = [
-      signatureOwner,
-      swapAndDepositData,
-      BigNumber.from(validAfter),
-      BigNumber.from(validBefore),
-      normalizeSignature(depositMessage.signature),
-    ];
+    const { signature: authSignature, isSmartWallet } = normalizeAuthSignature(depositMessage.signature);
+    method = isSmartWallet ? "swapAndBridgeWithAuthorizationBytes" : "swapAndBridgeWithAuthorization";
+    args = [signatureOwner, swapAndDepositData, BigNumber.from(validAfter), BigNumber.from(validBefore), authSignature];
   }
 
   if (depositMessage.integratorId) {

--- a/test/GaslessUtils.ts
+++ b/test/GaslessUtils.ts
@@ -14,6 +14,8 @@ import SPOKE_POOL_PERIPHERY_ABI from "../src/common/abi/SpokePoolPeriphery.json"
 
 // Minimal valid 65-byte signature (hex)
 const DUMMY_SIGNATURE = "0x" + "ab".repeat(65);
+// >65 bytes — smart-wallet (EIP-1271 / ERC-6492) shape, routed to the *Bytes periphery methods.
+const SMART_WALLET_SIGNATURE = "0x" + "ab".repeat(65) + "cd".repeat(32);
 
 const DUMMY_ADDRESS = "0x" + "11".repeat(20);
 const DUMMY_BYTES32 = "0x" + "22".repeat(32);
@@ -98,6 +100,22 @@ function makeApiResponse(overrides: { integratorId?: string; type?: string } = {
 
 function makeSpokePoolPeripheryContract(): Contract {
   return new Contract(DUMMY_ADDRESS, SPOKE_POOL_PERIPHERY_ABI);
+}
+
+function makeSwapAndBridgeErc3009Message(signature: string) {
+  const bridge = makeDepositMessage({ signature });
+  return {
+    ...bridge,
+    depositFlowType: "swapAndBridge",
+    depositData: bridge.baseDepositData,
+    swapToken: DUMMY_ADDRESS,
+    exchange: DUMMY_ADDRESS,
+    transferType: 0,
+    swapTokenAmount: "123",
+    minExpectedInputTokenAmount: "120",
+    routerCalldata: "0x",
+    enableProportionalAdjustment: true,
+  };
 }
 
 describe("GaslessUtils", function () {
@@ -297,6 +315,50 @@ describe("GaslessUtils", function () {
       const iface = new ethers.utils.Interface(SPOKE_POOL_PERIPHERY_ABI);
       const selector = iface.getSighash("depositWithAuthorization");
       expect(calldata.startsWith(selector)).to.be.true;
+    });
+
+    it("routes a smart-wallet (>65-byte) signature to depositWithAuthorizationBytes", function () {
+      const msg = makeDepositMessage({ signature: SMART_WALLET_SIGNATURE });
+      const contract = makeSpokePoolPeripheryContract();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const tx = buildGaslessDepositTx(msg as any, contract);
+      expect(tx.method).to.equal("depositWithAuthorizationBytes");
+      expect(tx.args.length).to.equal(5);
+      expect(tx.args[4]).to.equal(SMART_WALLET_SIGNATURE);
+    });
+
+    it("tagged calldata uses the depositWithAuthorizationBytes selector for smart-wallet signatures", function () {
+      const msg = makeDepositMessage({ signature: SMART_WALLET_SIGNATURE, integratorId: "0x0001" });
+      const contract = makeSpokePoolPeripheryContract();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const tx = buildGaslessDepositTx(msg as any, contract);
+      const calldata = tx.args[0] as string;
+      const iface = new ethers.utils.Interface(SPOKE_POOL_PERIPHERY_ABI);
+      expect(calldata.startsWith(iface.getSighash("depositWithAuthorizationBytes"))).to.be.true;
+    });
+
+    it("routes swapAndBridge erc3009 with a smart-wallet signature to swapAndBridgeWithAuthorizationBytes", function () {
+      const msg = makeSwapAndBridgeErc3009Message(SMART_WALLET_SIGNATURE);
+      const contract = makeSpokePoolPeripheryContract();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const tx = buildGaslessDepositTx(msg as any, contract);
+      expect(tx.method).to.equal("swapAndBridgeWithAuthorizationBytes");
+      expect(tx.args.length).to.equal(5);
+    });
+
+    it("keeps swapAndBridge erc3009 with a 65-byte signature on swapAndBridgeWithAuthorization", function () {
+      const msg = makeSwapAndBridgeErc3009Message(DUMMY_SIGNATURE);
+      const contract = makeSpokePoolPeripheryContract();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const tx = buildGaslessDepositTx(msg as any, contract);
+      expect(tx.method).to.equal("swapAndBridgeWithAuthorization");
+    });
+
+    it("throws for a signature shorter than 65 bytes", function () {
+      const msg = makeDepositMessage({ signature: "0x" + "ab".repeat(64) });
+      const contract = makeSpokePoolPeripheryContract();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(() => buildGaslessDepositTx(msg as any, contract)).to.throw(/at least 65 bytes/);
     });
 
     it("builds swapAndBridgeWithPermit tx for permit flow", function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,7 +12,7 @@
   resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.123.tgz#72c9f8aecdbced2a21d7d2313398db87f5193af8"
   integrity sha512-68SA6sNd/DsVJU/RbhmyC+u40iScoX+QDQNdPBAUJjG1khHc3+ltFz4oy3ahnxCOA+nHNwXJ6on8piI31m4/rA==
 
-"@across-protocol/contracts@5.0.24", "@across-protocol/contracts@5.0.26":
+"@across-protocol/contracts@5.0.26":
   version "5.0.26"
   resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-5.0.26.tgz#8d1811fc5799945f2ca898f4aec5e4d227c978ee"
   integrity sha512-YVdEtv4esbAjlqlsd1CP11h7qon1Xlv6B8BQ4aqPOjPXBQqJfZxpUPuVKC2D8emWlDi19hFFfnlbekIZjerRrA==
@@ -34,13 +34,13 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.4.16":
-  version "4.4.16"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.4.16.tgz#df3dd92bee96875e99203e284fcbdd50dd4a26a1"
-  integrity sha512-PU/OnksJw08vZYijv8VgJlkH/CMA/kVYX5UnLGVoXlsYUBwi5/m9bYdo91o1zwky/neyNmxeK3KNmJxN9hRBUQ==
+"@across-protocol/sdk@4.4.17":
+  version "4.4.17"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.4.17.tgz#82c0ec2d1fb882885a5f3cca186e3227572b4269"
+  integrity sha512-WOxID7rm/hJ1tQcvuWTd7RumvOj2SNUKPARLRJR6ahhVH4YbUN9ikfSoCk+2tEer64+XlV87M8Je4772LoGp4Q==
   dependencies:
     "@across-protocol/constants" "^3.1.123"
-    "@across-protocol/contracts" "5.0.24"
+    "@across-protocol/contracts" "5.0.26"
     "@coral-xyz/anchor" "^0.30.1"
     "@eth-optimism/sdk" "^3.3.1"
     "@ethersproject/bignumber" "^5.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.123.tgz#72c9f8aecdbced2a21d7d2313398db87f5193af8"
   integrity sha512-68SA6sNd/DsVJU/RbhmyC+u40iScoX+QDQNdPBAUJjG1khHc3+ltFz4oy3ahnxCOA+nHNwXJ6on8piI31m4/rA==
 
-"@across-protocol/contracts@5.0.24":
-  version "5.0.24"
-  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-5.0.24.tgz#3d15aa4ff779303d48f7345afd97e3913de4ecee"
-  integrity sha512-qx8dZ/XpwLsNjzVIIwd/E33ZIX1KgmhpX2G/rD16qb6sLprpJyyDjI/LXKrhRbihvbeASiog8HGE9f3ymSrZKw==
+"@across-protocol/contracts@5.0.24", "@across-protocol/contracts@5.0.26":
+  version "5.0.26"
+  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-5.0.26.tgz#8d1811fc5799945f2ca898f4aec5e4d227c978ee"
+  integrity sha512-YVdEtv4esbAjlqlsd1CP11h7qon1Xlv6B8BQ4aqPOjPXBQqJfZxpUPuVKC2D8emWlDi19hFFfnlbekIZjerRrA==
   dependencies:
     "@across-protocol/constants" "^3.1.118"
     "@coral-xyz/anchor" "^0.31.1"


### PR DESCRIPTION
## What

Submits smart-wallet (EIP-1271 / ERC-6492, e.g. Coinbase Smart Wallet) gasless ERC-3009 deposits via the new SpokePoolPeriphery `depositWithAuthorizationBytes` / `swapAndBridgeWithAuthorizationBytes` methods (across-protocol/contracts#1504, released in `@across-protocol/contracts@5.0.26`).

- Bumps `@across-protocol/contracts` to `5.0.26`, so the new periphery addresses resolve by default via `getDeployedAddress` — no `SPOKE_POOL_PERIPHERY_OVERRIDES` needed for the rollout. Also pinned via `resolutions` because the SDK still pins `5.0.24` (a split tree makes contracts types mutually incompatible in tsc).
- Replaces the vendored `SpokePoolPeriphery.json` with the released artifact ABI.
- Dispatches on signature length when building the deposit tx: >65 bytes → `*Bytes` method; exactly 65 bytes (EOA) stays on the legacy method, which exists on every periphery generation. <65 bytes still throws.
- No message-shape change; deposit tracking (`AuthorizationUsed`) is method-agnostic.

Pairs with across-protocol/quote-api#2974, which applies the same dispatch at submit-time simulation and moves its address maps to the new periphery deploys. Deploy the two together.

## Test plan

- `hardhat test test/GaslessUtils.ts test/GaslessRelayer.ts`: 67 passing; new dispatch cases (bridge + swapAndBridge, named-method and integrator-tagged calldata paths). `tsc --build` clean with the unified contracts version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hJczDvqxYdfT1yiigRRZ7
