### PR TITLE
fix(DepositAddressHandler): persist in-flight v3 executes across handover

### DIFF
--- a/src/cache/Redis.ts
+++ b/src/cache/Redis.ts
@@ -11,6 +11,9 @@ export interface RedisCacheInterface extends interfaces.CachingMechanismInterfac
   decr(key: string): Promise<number>;
   decrBy(key: string, amount: number): Promise<number>;
   del(key: string): Promise<number>;
+  hDel(key: string, field: string): Promise<number>;
+  hGetAll(key: string): Promise<Record<string, string>>;
+  hSet(key: string, field: string, value: string): Promise<number>;
   releaseLock(key: string, token: string): Promise<boolean>;
   renewLock(key: string, token: string, ttlMs: number): Promise<boolean>;
   incr(key: string): Promise<number>;
@@ -104,6 +107,20 @@ export class RedisCache implements RedisCacheInterface {
       }
     );
     return reply === 1;
+  }
+
+  // Hash fields are written and deleted independently, so concurrent writers touching different
+  // fields cannot clobber each other the way a read-modify-write of one serialized blob can.
+  hSet(key: string, field: string, value: string): Promise<number> {
+    return this.client.hSet(this.getNamespacedKey(key), field, value);
+  }
+
+  hGetAll(key: string): Promise<Record<string, string>> {
+    return this.client.hGetAll(this.getNamespacedKey(key));
+  }
+
+  hDel(key: string, field: string): Promise<number> {
+    return this.client.hDel(this.getNamespacedKey(key), field);
   }
 
   sAdd(key: string, value: string): Promise<number> {

--- a/src/cache/Redis.ts
+++ b/src/cache/Redis.ts
@@ -13,6 +13,7 @@ export interface RedisCacheInterface extends interfaces.CachingMechanismInterfac
   del(key: string): Promise<number>;
   hDel(key: string, field: string): Promise<number>;
   hDelIfEquals(key: string, field: string, expected: string): Promise<boolean>;
+  hGet(key: string, field: string): Promise<string | undefined>;
   hGetAll(key: string): Promise<Record<string, string>>;
   hSet(key: string, field: string, value: string): Promise<number>;
   releaseLock(key: string, token: string): Promise<boolean>;
@@ -114,6 +115,12 @@ export class RedisCache implements RedisCacheInterface {
   // fields cannot clobber each other the way a read-modify-write of one serialized blob can.
   hSet(key: string, field: string, value: string): Promise<number> {
     return this.client.hSet(this.getNamespacedKey(key), field, value);
+  }
+
+  // Prefer this over hGetAll wherever one field answers the question: the caller's cost then does not
+  // scale with unrelated fields the hash happens to be retaining.
+  async hGet(key: string, field: string): Promise<string | undefined> {
+    return (await this.client.hGet(this.getNamespacedKey(key), field)) ?? undefined;
   }
 
   hGetAll(key: string): Promise<Record<string, string>> {

--- a/src/cache/Redis.ts
+++ b/src/cache/Redis.ts
@@ -12,6 +12,7 @@ export interface RedisCacheInterface extends interfaces.CachingMechanismInterfac
   decrBy(key: string, amount: number): Promise<number>;
   del(key: string): Promise<number>;
   hDel(key: string, field: string): Promise<number>;
+  hDelIfEquals(key: string, field: string, expected: string): Promise<boolean>;
   hGetAll(key: string): Promise<Record<string, string>>;
   hSet(key: string, field: string, value: string): Promise<number>;
   releaseLock(key: string, token: string): Promise<boolean>;
@@ -121,6 +122,22 @@ export class RedisCache implements RedisCacheInterface {
 
   hDel(key: string, field: string): Promise<number> {
     return this.client.hDel(this.getNamespacedKey(key), field);
+  }
+
+  /**
+   * Deletes `field` only if it still holds exactly `expected`. Same token-checked pattern as
+   * `releaseLock`: a read followed by a delete is a TOCTOU, so callers that must not clobber a value
+   * another writer replaced in between use this instead.
+   */
+  async hDelIfEquals(key: string, field: string, expected: string): Promise<boolean> {
+    const reply = await this.client.eval(
+      "if redis.call('hget', KEYS[1], ARGV[1]) == ARGV[2] then return redis.call('hdel', KEYS[1], ARGV[1]) else return 0 end",
+      {
+        keys: [this.getNamespacedKey(key)],
+        arguments: [field, expected],
+      }
+    );
+    return reply === 1;
   }
 
   sAdd(key: string, value: string): Promise<number> {

--- a/src/clients/README.md
+++ b/src/clients/README.md
@@ -101,3 +101,16 @@ RELAYER_POLICY_EXAMPLE_GAS_MULTIPLIER=0
 This client is responsible for submitting transactions on-chain and therefore for setting the transaction's gas price values, nonce, and implements important retry and error decoding logic. It is designed to be shared across all code modules that submit on-chain transactions.
 
 For transactions submitted with `ensureConfirmation: true`, confirmation is awaited with a bounded wait (6 s, or 24 s on mainnet) that retains ethers' replacement detection. The wait bound is only a sampling cadence — replacement decisions are block-driven: a transaction is resubmitted at the same nonce with freshly-priced gas once the chain has produced at least 2 blocks without including it. An externally-replaced transaction (`TRANSACTION_REPLACED`) is resubmitted immediately, except when the mined replacement carries identical calldata ("repriced" — i.e. the original won the race against its own replacement), which is adopted as-is. Reverted transactions propagate as submission failures; exhausted resubmissions emit an error-level log (paging the on-call) and return the unconfirmed response.
+
+### `onBroadcast` — durably recording submission intent
+
+`AugmentedTransaction.onBroadcast?: (response: TransactionResponse) => Promise<void>` is invoked once a transaction is broadcast and its hash is known, **before** the confirmation wait. It exists for callers that must survive being killed mid-confirmation: a caller that only records success after the receipt has no record of a transaction already on the wire. `src/deposit-address` uses it to persist an in-flight execute claim.
+
+Contract:
+
+- **Best-effort.** The transaction is already on the wire when the hook runs, so a rejection is logged and swallowed — losing the record must never lose the transaction. Callers cannot use it to veto a submission.
+- **Invoked again whenever the hash to track changes.** A repriced replacement is notified with the replacement hash, because only the replacement will ever have a receipt. This includes a replacement that **reverted**: a caller left holding the original hash could never resolve it.
+- **Fires on both submission paths**, dispatcher and non-dispatcher, since `dispatch()` and `submit()` both route through `_submit`. The bot's own resubmits (timeout and non-repriced replacement) recurse into `_submit` and so notify their new hash too.
+- **Not called if the broadcast itself fails**, so no hook means no transaction to account for.
+
+Callers are expected to treat the recorded hash as "outcome unknown" and resolve it against the chain later; the hook says a transaction exists, not that it succeeded.

--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -85,6 +85,10 @@ export interface AugmentedTransaction {
   nonMulticall?: boolean;
   // Flag indicating whether the client should await the transaction response for onchain confirmation.
   ensureConfirmation?: boolean;
+  // Invoked once the transaction is broadcast and its hash is known, before the confirmation wait —
+  // callers use this to durably record submission intent. The tx is already on the wire by then, so
+  // a rejection here is logged and swallowed rather than aborting the submission.
+  onBroadcast?: (response: TransactionResponse) => Promise<void>;
   // If true, the contract's provider will be replaced with the TransactionClient's SpeedProvider for
   // this chain (if configured), enabling parallel multi-RPC dispatch for faster submission.
   spray?: boolean;
@@ -147,6 +151,29 @@ export class TransactionClient {
     return transactionHandler(this.logger, contract, method, args, value, gasLimit, nonce);
   }
 
+  /**
+   * Runs the caller's `onBroadcast` hook for `response`. The transaction is already on the wire, so a
+   * rejection is logged and swallowed rather than aborting the submission. Called again whenever the
+   * hash a caller should be tracking changes, so a durably-recorded hash stays resolvable on-chain.
+   */
+  protected async _notifyBroadcast(txn: AugmentedTransaction, response: TransactionResponse): Promise<void> {
+    if (!isDefined(txn.onBroadcast)) {
+      return;
+    }
+    try {
+      await txn.onBroadcast(response);
+    } catch (error) {
+      this.logger.warn({
+        at: "TransactionClient#_submit",
+        message: "onBroadcast hook failed; continuing to await confirmation",
+        chainId: txn.chainId,
+        method: txn.method,
+        txnRef: blockExplorerLink(response.hash, txn.chainId),
+        error: stringifyThrownValue(error),
+      });
+    }
+  }
+
   protected async _submit(
     txn: AugmentedTransaction,
     opts: { nonce: number | null; maxTries?: number }
@@ -154,6 +181,12 @@ export class TransactionClient {
     const { chainId } = txn;
     const { nonce = null, maxTries = 10 } = opts;
     const txnPromise = this._getTransactionPromise(txn, nonce);
+
+    if (isDefined(txn.onBroadcast)) {
+      // Awaited outside _notifyBroadcast's try/catch so a failed broadcast still propagates to the
+      // caller as before; only the hook itself is best-effort.
+      await this._notifyBroadcast(txn, await txnPromise);
+    }
 
     if (txn.ensureConfirmation) {
       const at = "TransactionClient#_submit";
@@ -202,6 +235,9 @@ export class TransactionClient {
                   this.logger.warn({ ...common, message: `Transaction on ${chain} failed during execution...` });
                   throw error;
                 }
+                // Only the replacement will ever have a receipt, so re-notify: a caller that durably
+                // recorded the original hash must be able to resolve its claim against the chain.
+                await this._notifyBroadcast(txn, error.replacement);
                 return error.replacement;
               }
               this.logger.warn({

--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -231,13 +231,15 @@ export class TransactionClient {
             case ethers.errors.TRANSACTION_REPLACED:
               // "repriced" ⇒ a transaction identical to ours (data/to/value) was mined at this nonce; adopt it.
               if (error.reason === "repriced" && isReplacedError(error)) {
+                // Only the replacement will ever have a receipt — including when it reverted — so
+                // re-notify before deciding the outcome. A caller that durably recorded the original
+                // hash must be able to resolve its claim against the chain either way; notifying only
+                // on success would strand it on a hash that can never resolve.
+                await this._notifyBroadcast(txn, error.replacement);
                 if (error.receipt.status === 0) {
                   this.logger.warn({ ...common, message: `Transaction on ${chain} failed during execution...` });
                   throw error;
                 }
-                // Only the replacement will ever have a receipt, so re-notify: a caller that durably
-                // recorded the original hash must be able to resolve its claim against the chain.
-                await this._notifyBroadcast(txn, error.replacement);
                 return error.replacement;
               }
               this.logger.warn({

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -49,6 +49,7 @@ import {
 import { AcrossIndexerApiClient } from "../clients/AcrossIndexerApiClient";
 import { GcpPubSubPublisher, getGcpPubSubPublisher } from "../messaging/gcp";
 import { buildDepositExecutedPayload, buildWithdrawExecutedPayload } from "./withdrawPayload";
+import { PendingExecute, parsePendingExecute } from "./pendingExecutes";
 import ERC20_ABI from "../common/abi/MinimalERC20.json";
 
 /**
@@ -80,6 +81,9 @@ const HEARTBEAT_TIMEOUT_MS = 5_000;
 // outage, rather than once per tick or once ever).
 const HEARTBEAT_FAILURE_WARN_THRESHOLD = 10;
 
+/** Minimum seconds between re-checking the same unresolved claim on-chain during a run. */
+const PENDING_EXECUTE_RESETTLE_INTERVAL = 60;
+
 /**
  * Account namespace expected for addresses living on `chainId`; undefined = chain family the v3
  * execute path does not support. Note zkSync-family chains are EVM here, so a `zksync`-namespaced
@@ -87,6 +91,14 @@ const HEARTBEAT_FAILURE_WARN_THRESHOLD = 10;
  */
 function expectedNamespaceForChain(chainId: number): "evm" | "tron" | undefined {
   return chainIsTvm(chainId) ? "tron" : chainIsEvm(chainId) ? "evm" : undefined;
+}
+
+/**
+ * TVM records TronWeb's un-prefixed `txid` as the response hash, but providers speak eth-JSON-RPC
+ * and need it 0x-prefixed. Mirrors the normalization `_runTransactionTvm` applies.
+ */
+function receiptLookupHash(chainId: number, txHash: string): string {
+  return chainIsTvm(chainId) && !txHash.startsWith("0x") ? `0x${txHash}` : txHash;
 }
 
 /**
@@ -136,6 +148,15 @@ export class DepositAddressHandler {
    * `observedExecutedDeposits` on the deposit path.
    */
   private observedExecutedWithdraws: { [chainId: number]: Set<string> } = {};
+
+  /**
+   * Executes broadcast on the v3 path whose on-chain outcome is not yet known, keyed by depositKey.
+   * An in-memory mirror of the Redis claim hash, which is the source of truth.
+   */
+  private pendingExecutes: Record<string, PendingExecute> = {};
+
+  /** Unix seconds of the last on-chain settle attempt per depositKey; throttles re-checks. */
+  private lastSettleAttempt: Record<string, number> = {};
 
   private api: AcrossSwapApiClient;
   private indexerApi: AcrossIndexerApiClient;
@@ -222,6 +243,8 @@ export class DepositAddressHandler {
     await this._loadExecutedDepositsFromRedis();
     await this._loadWithdrawnKeysFromRedis();
     await this._loadSkippedWithdrawKeysFromRedis();
+    // Must follow the executed-deposits load: adopting an inherited execute writes to that set.
+    await this._resolvePendingExecutes();
 
     this.initialized = true;
   }
@@ -236,6 +259,12 @@ export class DepositAddressHandler {
 
   private getSkippedWithdrawKeysRedisKey(): string {
     return `deposit-address:skipped-withdraw-keys:${this.config.botIdentifier}`;
+  }
+
+  // A Redis hash (one field per depositKey), carrying no TTL: a claim must outlive the indexer
+  // message that produced it, and is only removed once its outcome is known.
+  private getPendingExecutesRedisKey(): string {
+    return `deposit-address:pending-execute-claims:${this.config.botIdentifier}`;
   }
 
   /** Loads executed deposit tx hashes from Redis (e.g. after handover). */
@@ -323,6 +352,151 @@ export class DepositAddressHandler {
       message: "Loaded terminally-skipped withdraw deposit keys from Redis",
       count: this.terminallySkippedWithdrawKeys.size,
     });
+  }
+
+  /** Reads every persisted claim. Throws on a malformed payload, which callers treat as claimed. */
+  private async _readPendingExecutes(): Promise<Record<string, PendingExecute>> {
+    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    const redisKey = this.getPendingExecutesRedisKey();
+    const raw = await this.redisCache.hGetAll(redisKey);
+    try {
+      return Object.fromEntries(
+        Object.entries(raw).map(([depositKey, claim]) => [depositKey, parsePendingExecute(claim)])
+      );
+    } catch (err) {
+      this.logger.error({
+        at: "DepositAddressHandler#_readPendingExecutes",
+        message: "Failed to parse pending executes from Redis",
+        redisKey,
+        err: err instanceof Error ? err.message : String(err),
+        notificationPath: "across-bot-error",
+      });
+
+      throw err;
+    }
+  }
+
+  /**
+   * Durably records a broadcast execute before its confirmation is awaited. Invoked from the
+   * TransactionClient's `onBroadcast` hook, so the window in which an eviction loses track of a
+   * transfer already on the wire shrinks from the confirmation wait to a single Redis write.
+   */
+  private async _recordPendingExecute(depositKey: string, pending: PendingExecute): Promise<void> {
+    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    // Only this transfer's field, so a concurrent run recording a different one cannot drop it.
+    await this.redisCache.hSet(this.getPendingExecutesRedisKey(), depositKey, JSON.stringify(pending));
+    this.pendingExecutes[depositKey] = pending;
+    this.logger.debug({
+      at: "DepositAddressHandler#_recordPendingExecute",
+      message: "Recorded in-flight execute before awaiting confirmation",
+      depositKey,
+      txHash: pending.txHash,
+      chainId: pending.chainId,
+    });
+  }
+
+  private async _clearPendingExecute(depositKey: string): Promise<void> {
+    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    await this.redisCache.hDel(this.getPendingExecutesRedisKey(), depositKey);
+    delete this.pendingExecutes[depositKey];
+    delete this.lastSettleAttempt[depositKey];
+  }
+
+  /**
+   * Resolves one claim against the chain. A claim with no receipt is deliberately never discarded:
+   * stranding a transfer for manual recovery is reversible, a second sweep is not. See the module
+   * README for how to release one by hand.
+   */
+  private async _settlePendingExecute(
+    depositKey: string,
+    pending: PendingExecute
+  ): Promise<"executed" | "reverted" | "unresolved"> {
+    const logContext = {
+      at: "DepositAddressHandler#_settlePendingExecute",
+      depositKey,
+      txHash: pending.txHash,
+      refTxHash: pending.refTxHash,
+      chainId: pending.chainId,
+    };
+    this.lastSettleAttempt[depositKey] = getCurrentTime();
+
+    const provider = this.providersByChain[pending.chainId];
+    if (!isDefined(provider)) {
+      this.logger.warn({ ...logContext, message: "Cannot resolve pending execute: no provider for chain" });
+      return "unresolved";
+    }
+
+    let receipt: TransactionReceipt | null;
+    try {
+      receipt = await provider.getTransactionReceipt(receiptLookupHash(pending.chainId, pending.txHash));
+    } catch (err) {
+      this.logger.warn({
+        ...logContext,
+        message: "Failed to fetch receipt for pending execute; leaving the record in place",
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return "unresolved";
+    }
+
+    if (!isDefined(receipt) || !isDefined(receipt.blockNumber)) {
+      this.logger.debug({
+        ...logContext,
+        message: "Pending execute not mined yet; keeping the claim",
+        ageSeconds: getCurrentTime() - pending.submittedAt,
+      });
+      return "unresolved";
+    }
+
+    // Only an explicit status of 0 is a revert; ethers leaves it undefined on some chains, and
+    // treating that as success can strand a deposit but can never cause a second sweep.
+    if (receipt.status === 0) {
+      await this._clearPendingExecute(depositKey);
+      this.logger.warn({ ...logContext, message: "Pending execute reverted on-chain; deposit will be re-attempted" });
+      return "reverted";
+    }
+
+    this.executedDepositTxHashes.add(pending.refTxHash);
+    await this._persistExecutedDepositsRedis();
+    await this._clearPendingExecute(depositKey);
+    this.logger.info({
+      ...logContext,
+      message: "Adopted an execute broadcast by a previous run and confirmed on-chain",
+      blockNumber: receipt.blockNumber,
+    });
+    return "executed";
+  }
+
+  /**
+   * Settles executes a previous run broadcast but never saw confirmed. Runs once at startup, right
+   * after handover, so a successor inherits the incumbent's in-flight work.
+   */
+  private async _resolvePendingExecutes(): Promise<void> {
+    this.pendingExecutes = await this._readPendingExecutes();
+    const entries = Object.entries(this.pendingExecutes);
+    if (entries.length === 0) {
+      return;
+    }
+
+    this.logger.debug({
+      at: "DepositAddressHandler#_resolvePendingExecutes",
+      message: "Resolving in-flight executes inherited from a previous run",
+      count: entries.length,
+    });
+
+    for (const [depositKey, pending] of entries) {
+      // One unresolvable record must not prevent startup; it stays in Redis for the next run.
+      try {
+        await this._settlePendingExecute(depositKey, pending);
+      } catch (err) {
+        this.logger.warn({
+          at: "DepositAddressHandler#_resolvePendingExecutes",
+          message: "Failed to settle inherited pending execute",
+          depositKey,
+          txHash: pending.txHash,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
   }
 
   /*
@@ -1034,6 +1208,21 @@ export class DepositAddressHandler {
       return;
     }
 
+    // An execute for this transfer is already on the wire — either this run broadcast it, or a
+    // previous run did and was evicted before confirmation. Re-check it on-chain rather than
+    // skipping blindly, so a revert is retried on a later poll instead of waiting for the next run.
+    const pending = this.pendingExecutes[depositKey];
+    if (isDefined(pending)) {
+      const lastAttempt = this.lastSettleAttempt[depositKey] ?? 0;
+      if (getCurrentTime() - lastAttempt < PENDING_EXECUTE_RESETTLE_INTERVAL) {
+        return;
+      }
+      if ((await this._settlePendingExecute(depositKey, pending)) !== "reverted") {
+        // "executed" is now covered by executedDepositTxHashes; "unresolved" must not be re-submitted.
+        return;
+      }
+    }
+
     if (this.observedExecutedDeposits[originChainId]?.has(depositKey)) {
       return;
     }
@@ -1127,8 +1316,45 @@ export class DepositAddressHandler {
         )}, using deposit address ${blockExplorerLink(depositAddress, originChainId)}`,
       };
 
-      const depositReceipt = await sendAndConfirmTransaction(executeTx, this.transactionClient, useDispatcher);
+      // Last gate before the transaction goes out. The checks at the top of this method ran before
+      // the quote-api round trip, during which an overlapping run may have broadcast its own
+      // execute; re-read from Redis rather than the mirror, which only this run writes to. This
+      // narrows the overlap window to a single Redis read — it does not close it.
+      try {
+        const claimed = (await this._readPendingExecutes())[depositKey];
+        if (isDefined(claimed)) {
+          this.logger.warn({
+            at: "DepositAddressHandler#initiateDepositV3",
+            message: "Skipping execute: an execute for this transfer has already been broadcast",
+            depositKey,
+            pendingTxHash: claimed.txHash,
+          });
+          return;
+        }
+      } catch {
+        // Already logged. Treat unverifiable state as claimed rather than risk a duplicate sweep.
+        return;
+      }
+
+      const depositReceipt = await sendAndConfirmTransaction(
+        {
+          ...executeTx,
+          // Persist the hash the moment it exists, so an eviction during the confirmation wait
+          // cannot lose the fact that this transfer has already been swept.
+          onBroadcast: (response) =>
+            this._recordPendingExecute(depositKey, {
+              txHash: response.hash,
+              chainId: originChainId,
+              refTxHash,
+              submittedAt: getCurrentTime(),
+            }),
+        },
+        this.transactionClient,
+        useDispatcher
+      );
       if (!isDefined(depositReceipt)) {
+        // A revert also surfaces here as an undefined receipt. Any claim recorded above stays in
+        // place; a later poll resolves its real outcome against the chain.
         this.logger.warn({
           at: "DepositAddressHandler#initiateDepositV3",
           message: "Failed to submit execute tx",
@@ -1142,10 +1368,13 @@ export class DepositAddressHandler {
       }
 
       // The execute is on-chain; keep the in-flight lock and persist to Redis immediately so
-      // handover cannot miss this execute.
+      // handover cannot miss this execute. The executed set is written before the claim is cleared:
+      // a crash in between leaves a redundant claim that startup tidies, whereas the reverse order
+      // would reopen the duplicate-sweep window.
       this.executedDepositTxHashes.add(refTxHash);
       executeCommitted = true;
       await this._persistExecutedDepositsRedis();
+      await this._clearPendingExecute(depositKey);
       await this._publishDepositExecuted(depositReceipt, depositMessage);
     } finally {
       if (!executeCommitted) {

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -436,28 +436,54 @@ export class DepositAddressHandler {
    */
   private async _clearPendingExecute(depositKey: string, settledTxHash?: string): Promise<boolean> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    const { redisCache } = this;
+    const redisKey = this.getPendingExecutesRedisKey();
+    const forget = () => {
+      delete this.pendingExecutes[depositKey];
+      delete this.lastSettleAttempt[depositKey];
+    };
 
-    if (isDefined(settledTxHash)) {
-      const stored = (await this._readPendingExecutes()).claims[depositKey];
-      if (isDefined(stored) && stored.txHash !== settledTxHash) {
-        this.pendingExecutes[depositKey] = stored;
-        delete this.lastSettleAttempt[depositKey];
-        this.logger.warn({
-          at: "DepositAddressHandler#_clearPendingExecute",
-          message: "Keeping a newer in-flight claim rather than clearing the one just resolved",
-          depositKey,
-          settledTxHash,
-          storedTxHash: stored.txHash,
-          notificationPath: "across-bot-error",
-        });
-        return false;
-      }
+    if (!isDefined(settledTxHash)) {
+      await redisCache.hDel(redisKey, depositKey);
+      forget();
+      return true;
     }
 
-    await this.redisCache.hDel(this.getPendingExecutesRedisKey(), depositKey);
-    delete this.pendingExecutes[depositKey];
+    const raw = (await redisCache.hGetAll(redisKey))[depositKey];
+    if (!isDefined(raw)) {
+      forget();
+      return true;
+    }
+
+    let stored: PendingExecute;
+    try {
+      stored = parsePendingExecute(raw);
+    } catch {
+      // Quarantined elsewhere; never delete a claim whose contents we could not read.
+      return false;
+    }
+
+    // Compare-and-delete on the exact bytes read, so a claim another run writes between the read and
+    // the delete survives rather than being lost to the gap between two commands.
+    if (stored.txHash === settledTxHash && (await redisCache.hDelIfEquals(redisKey, depositKey, raw))) {
+      forget();
+      return true;
+    }
+
+    // Either a newer transaction already owned the claim, or one replaced it mid-delete. Track what is
+    // there: that transaction, not the one just resolved, decides this transfer's outcome. The
+    // throttle is dropped so the next poll re-settles against the live hash immediately.
+    this.pendingExecutes[depositKey] = stored;
     delete this.lastSettleAttempt[depositKey];
-    return true;
+    this.logger.warn({
+      at: "DepositAddressHandler#_clearPendingExecute",
+      message: "Keeping a newer in-flight claim rather than clearing the one just resolved",
+      depositKey,
+      settledTxHash,
+      storedTxHash: stored.txHash,
+      notificationPath: "across-bot-error",
+    });
+    return false;
   }
 
   /**

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -523,6 +523,23 @@ export class DepositAddressHandler {
     }
 
     if (!isDefined(receipt) || !isDefined(receipt.blockNumber)) {
+      // A hash with no receipt may simply be pending — or may have been replaced in Redis by another
+      // run (e.g. a timeout resubmit) after this one cached it. Reconcile against the field before
+      // settling for "keep waiting", or a replaced hash would never resolve and would block the
+      // transfer for this process's lifetime: every later poll would re-settle the same dead hash and
+      // return before the pre-broadcast read that would otherwise have noticed.
+      const live = (await this._readPendingExecutes()).claims[depositKey];
+      if (isDefined(live) && live.txHash !== pending.txHash) {
+        this.pendingExecutes[depositKey] = live;
+        delete this.lastSettleAttempt[depositKey];
+        this.logger.info({
+          ...logContext,
+          message: "Adopted a replacement claim recorded by another run; settling that instead",
+          liveTxHash: live.txHash,
+        });
+        return "unresolved";
+      }
+
       this.logger.debug({
         ...logContext,
         message: "Pending execute not mined yet; keeping the claim",

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -423,11 +423,41 @@ export class DepositAddressHandler {
     });
   }
 
-  private async _clearPendingExecute(depositKey: string): Promise<void> {
+  /**
+   * Removes a claim. Pass `settledTxHash` to delete only if the stored claim is still that
+   * transaction: overlapping runs write the same field, so an unconditional delete can drop a *newer*
+   * claim whose transaction is still in flight, unblocking a transfer that is mid-sweep. When the
+   * stored claim has moved on, adopt it locally instead so this run resolves the live transaction.
+   *
+   * Callers that have already recorded the transfer in the executed set may omit `settledTxHash` —
+   * that set guards the transfer by `refTxHash` from then on, whatever the claim says.
+   *
+   * @returns whether the claim was actually removed.
+   */
+  private async _clearPendingExecute(depositKey: string, settledTxHash?: string): Promise<boolean> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+
+    if (isDefined(settledTxHash)) {
+      const stored = (await this._readPendingExecutes()).claims[depositKey];
+      if (isDefined(stored) && stored.txHash !== settledTxHash) {
+        this.pendingExecutes[depositKey] = stored;
+        delete this.lastSettleAttempt[depositKey];
+        this.logger.warn({
+          at: "DepositAddressHandler#_clearPendingExecute",
+          message: "Keeping a newer in-flight claim rather than clearing the one just resolved",
+          depositKey,
+          settledTxHash,
+          storedTxHash: stored.txHash,
+          notificationPath: "across-bot-error",
+        });
+        return false;
+      }
+    }
+
     await this.redisCache.hDel(this.getPendingExecutesRedisKey(), depositKey);
     delete this.pendingExecutes[depositKey];
     delete this.lastSettleAttempt[depositKey];
+    return true;
   }
 
   /**
@@ -478,7 +508,12 @@ export class DepositAddressHandler {
     // Only an explicit status of 0 is a revert; ethers leaves it undefined on some chains, and
     // treating that as success can strand a deposit but can never cause a second sweep.
     if (receipt.status === 0) {
-      await this._clearPendingExecute(depositKey);
+      // Only report a revert if this really was the transfer's live claim. If a newer broadcast has
+      // replaced it, that transaction — not this revert — decides the outcome, and the transfer must
+      // stay blocked meanwhile.
+      if (!(await this._clearPendingExecute(depositKey, pending.txHash))) {
+        return "unresolved";
+      }
       this.logger.warn({ ...logContext, message: "Pending execute reverted on-chain; deposit will be re-attempted" });
       return "reverted";
     }

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -158,6 +158,9 @@ export class DepositAddressHandler {
   /** Unix seconds of the last on-chain settle attempt per depositKey; throttles re-checks. */
   private lastSettleAttempt: Record<string, number> = {};
 
+  /** depositKeys whose persisted claim could not be parsed. Treated as claimed; never re-attempted. */
+  private unparseableClaimKeys: Set<string> = new Set();
+
   private api: AcrossSwapApiClient;
   private indexerApi: AcrossIndexerApiClient;
   private _signerAddress?: EvmAddress;
@@ -244,7 +247,7 @@ export class DepositAddressHandler {
     // persists the executed hash and only then clears its claim, so reading in this order means a
     // claim already gone by now had its hash persisted earlier — and the load below therefore sees
     // it. Reading the claims after the load would leave a window where the successor sees neither.
-    const inheritedClaims = await this._readPendingExecutes();
+    const { claims: inheritedClaims } = await this._readPendingExecutes();
 
     await this._loadExecutedDepositsFromRedis();
     await this._loadWithdrawnKeysFromRedis();
@@ -361,26 +364,44 @@ export class DepositAddressHandler {
     });
   }
 
-  /** Reads every persisted claim. Throws on a malformed payload, which callers treat as claimed. */
-  private async _readPendingExecutes(): Promise<Record<string, PendingExecute>> {
+  /**
+   * Reads every persisted claim, parsing each hash field independently so one bad field cannot stop
+   * the rest from resolving — the same isolation the per-field hash gives writes. An unparseable
+   * field is quarantined, not dropped: its `depositKey` still blocks submission, since a claim we
+   * cannot read may well describe a transfer already swept. A failure of the read itself (rather than
+   * of a field) still throws, and callers treat that as claimed.
+   */
+  private async _readPendingExecutes(): Promise<{
+    claims: Record<string, PendingExecute>;
+    unparseable: Set<string>;
+  }> {
     assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
     const redisKey = this.getPendingExecutesRedisKey();
     const raw = await this.redisCache.hGetAll(redisKey);
-    try {
-      return Object.fromEntries(
-        Object.entries(raw).map(([depositKey, claim]) => [depositKey, parsePendingExecute(claim)])
-      );
-    } catch (err) {
-      this.logger.error({
-        at: "DepositAddressHandler#_readPendingExecutes",
-        message: "Failed to parse pending executes from Redis",
-        redisKey,
-        err: err instanceof Error ? err.message : String(err),
-        notificationPath: "across-bot-error",
-      });
 
-      throw err;
+    const claims: Record<string, PendingExecute> = {};
+    const unparseable = new Set<string>();
+    for (const [depositKey, claim] of Object.entries(raw)) {
+      try {
+        claims[depositKey] = parsePendingExecute(claim);
+      } catch (err) {
+        unparseable.add(depositKey);
+        // This read runs on every poll that reaches submission, so alert once per key per process.
+        if (!this.unparseableClaimKeys.has(depositKey)) {
+          this.logger.error({
+            at: "DepositAddressHandler#_readPendingExecutes",
+            message: "Quarantined an unparseable pending-execute claim; its transfer stays blocked",
+            redisKey,
+            depositKey,
+            err: err instanceof Error ? err.message : String(err),
+            notificationPath: "across-bot-error",
+          });
+        }
+      }
     }
+
+    this.unparseableClaimKeys = unparseable;
+    return { claims, unparseable };
   }
 
   /**
@@ -1220,6 +1241,18 @@ export class DepositAddressHandler {
     // An execute for this transfer is already on the wire — either this run broadcast it, or a
     // previous run did and was evicted before confirmation. Re-check it on-chain rather than
     // skipping blindly, so a revert is retried on a later poll instead of waiting for the next run.
+    // A quarantined claim can't be settled (its txHash is unreadable), but it may describe a transfer
+    // already swept, so it must keep blocking. Cleared by fixing or deleting the Redis field.
+    if (this.unparseableClaimKeys.has(depositKey)) {
+      this.logger.debug({
+        at: "DepositAddressHandler#initiateDepositV3",
+        message: "Skipping deposit: this transfer's persisted claim is unparseable",
+        refTxHash,
+        depositKey,
+      });
+      return;
+    }
+
     const pending = this.pendingExecutes[depositKey];
     if (isDefined(pending)) {
       const lastAttempt = this.lastSettleAttempt[depositKey] ?? 0;
@@ -1330,13 +1363,14 @@ export class DepositAddressHandler {
       // execute; re-read from Redis rather than the mirror, which only this run writes to. This
       // narrows the overlap window to a single Redis read — it does not close it.
       try {
-        const claimed = (await this._readPendingExecutes())[depositKey];
-        if (isDefined(claimed)) {
+        const { claims, unparseable } = await this._readPendingExecutes();
+        const claimed = claims[depositKey];
+        if (isDefined(claimed) || unparseable.has(depositKey)) {
           this.logger.warn({
             at: "DepositAddressHandler#initiateDepositV3",
             message: "Skipping execute: an execute for this transfer has already been broadcast",
             depositKey,
-            pendingTxHash: claimed.txHash,
+            pendingTxHash: claimed?.txHash ?? "unparseable claim",
           });
           return;
         }

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -449,7 +449,7 @@ export class DepositAddressHandler {
       return true;
     }
 
-    const raw = (await redisCache.hGetAll(redisKey))[depositKey];
+    const raw = await redisCache.hGet(redisKey, depositKey);
     if (!isDefined(raw)) {
       forget();
       return true;
@@ -495,13 +495,40 @@ export class DepositAddressHandler {
    * stale mirror entry can neither block a transfer indefinitely nor hide a live one.
    */
   private async _syncClaim(depositKey: string): Promise<PendingExecute | undefined> {
-    const live = (await this._readPendingExecutes()).claims[depositKey];
+    assert(isDefined(this.redisCache), "DepositAddressHandler: redisCache accessed before initialize()");
+    // One field, not the whole hash: claims are deliberately never pruned, so reading all of them here
+    // would make this per-transfer path cost scale with every unrelated claim being retained.
+    const raw = await this.redisCache.hGet(this.getPendingExecutesRedisKey(), depositKey);
 
-    if (!isDefined(live)) {
+    if (!isDefined(raw)) {
+      this.unparseableClaimKeys.delete(depositKey);
       delete this.pendingExecutes[depositKey];
       delete this.lastSettleAttempt[depositKey];
       return undefined;
     }
+
+    let live: PendingExecute;
+    try {
+      live = parsePendingExecute(raw);
+    } catch (err) {
+      // Quarantine this field alone. Callers must consult `unparseableClaimKeys`, since a claim that
+      // cannot be read has to keep blocking its transfer rather than read as absent.
+      if (!this.unparseableClaimKeys.has(depositKey)) {
+        this.logger.error({
+          at: "DepositAddressHandler#_syncClaim",
+          message: "Quarantined an unparseable pending-execute claim; its transfer stays blocked",
+          depositKey,
+          err: err instanceof Error ? err.message : String(err),
+          notificationPath: "across-bot-error",
+        });
+      }
+      this.unparseableClaimKeys.add(depositKey);
+      delete this.pendingExecutes[depositKey];
+      delete this.lastSettleAttempt[depositKey];
+      return undefined;
+    }
+
+    this.unparseableClaimKeys.delete(depositKey);
 
     // A different hash is a different transaction; re-settle it without waiting out the throttle.
     if (this.pendingExecutes[depositKey]?.txHash !== live.txHash) {
@@ -561,6 +588,11 @@ export class DepositAddressHandler {
       }
 
       if (!isDefined(live)) {
+        // Quarantined is not the same as gone: we could not read the claim, so keep blocking.
+        if (this.unparseableClaimKeys.has(depositKey)) {
+          this.logger.warn({ ...logContext, message: "Pending execute claim is unreadable; transfer stays blocked" });
+          return "unresolved";
+        }
         this.logger.warn({
           ...logContext,
           message: "Pending execute claim no longer present; deposit may be re-attempted",
@@ -1361,7 +1393,9 @@ export class DepositAddressHandler {
       // Re-read first: the quarantine set is otherwise only refreshed at startup, so the documented
       // ops recovery — repair or delete the malformed field — would not take effect until the process
       // was replaced.
-      const { claims } = await this._readPendingExecutes();
+      // _syncClaim updates the mirror and this key's quarantine state, so a repaired or removed field
+      // takes effect here without a restart.
+      await this._syncClaim(depositKey);
       if (this.unparseableClaimKeys.has(depositKey)) {
         this.logger.debug({
           at: "DepositAddressHandler#initiateDepositV3",
@@ -1370,13 +1404,6 @@ export class DepositAddressHandler {
           depositKey,
         });
         return;
-      }
-
-      // Repaired or removed. Track whatever the field holds now so the checks below act on it.
-      if (isDefined(claims[depositKey])) {
-        this.pendingExecutes[depositKey] = claims[depositKey];
-      } else {
-        delete this.pendingExecutes[depositKey];
       }
     }
 

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -487,6 +487,31 @@ export class DepositAddressHandler {
   }
 
   /**
+   * Refreshes the local mirror for one transfer from Redis and returns the live claim.
+   *
+   * Redis is the source of truth and this process only snapshots it at startup, while an overlapping
+   * run can record a new claim, replace one (a resubmit at the same nonce), or have one removed by an
+   * operator at any point. Every decision that depends on a claim therefore reads through here, so a
+   * stale mirror entry can neither block a transfer indefinitely nor hide a live one.
+   */
+  private async _syncClaim(depositKey: string): Promise<PendingExecute | undefined> {
+    const live = (await this._readPendingExecutes()).claims[depositKey];
+
+    if (!isDefined(live)) {
+      delete this.pendingExecutes[depositKey];
+      delete this.lastSettleAttempt[depositKey];
+      return undefined;
+    }
+
+    // A different hash is a different transaction; re-settle it without waiting out the throttle.
+    if (this.pendingExecutes[depositKey]?.txHash !== live.txHash) {
+      delete this.lastSettleAttempt[depositKey];
+    }
+    this.pendingExecutes[depositKey] = live;
+    return live;
+  }
+
+  /**
    * Resolves one claim against the chain. A claim with no receipt is deliberately never discarded:
    * stranding a transfer for manual recovery is reversible, a second sweep is not. See the module
    * README for how to release one by hand.
@@ -494,7 +519,7 @@ export class DepositAddressHandler {
   private async _settlePendingExecute(
     depositKey: string,
     pending: PendingExecute
-  ): Promise<"executed" | "reverted" | "unresolved"> {
+  ): Promise<"executed" | "unclaimed" | "unresolved"> {
     const logContext = {
       at: "DepositAddressHandler#_settlePendingExecute",
       depositKey,
@@ -523,15 +548,26 @@ export class DepositAddressHandler {
     }
 
     if (!isDefined(receipt) || !isDefined(receipt.blockNumber)) {
-      // A hash with no receipt may simply be pending — or may have been replaced in Redis by another
-      // run (e.g. a timeout resubmit) after this one cached it. Reconcile against the field before
-      // settling for "keep waiting", or a replaced hash would never resolve and would block the
-      // transfer for this process's lifetime: every later poll would re-settle the same dead hash and
-      // return before the pre-broadcast read that would otherwise have noticed.
-      const live = (await this._readPendingExecutes()).claims[depositKey];
-      if (isDefined(live) && live.txHash !== pending.txHash) {
-        this.pendingExecutes[depositKey] = live;
-        delete this.lastSettleAttempt[depositKey];
+      // A hash with no receipt may simply be pending — or may have been replaced by another run, or
+      // released by an operator, since this process cached it. Reconcile before settling for "keep
+      // waiting", or a hash that can never resolve would block the transfer for this process's
+      // lifetime: later polls would re-settle it and return before the pre-broadcast read.
+      let live: PendingExecute | undefined;
+      try {
+        live = await this._syncClaim(depositKey);
+      } catch {
+        // Already logged. Unverifiable state keeps the transfer blocked, never unblocks it.
+        return "unresolved";
+      }
+
+      if (!isDefined(live)) {
+        this.logger.warn({
+          ...logContext,
+          message: "Pending execute claim no longer present; deposit may be re-attempted",
+        });
+        return "unclaimed";
+      }
+      if (live.txHash !== pending.txHash) {
         this.logger.info({
           ...logContext,
           message: "Adopted a replacement claim recorded by another run; settling that instead",
@@ -558,7 +594,7 @@ export class DepositAddressHandler {
         return "unresolved";
       }
       this.logger.warn({ ...logContext, message: "Pending execute reverted on-chain; deposit will be re-attempted" });
-      return "reverted";
+      return "unclaimed";
     }
 
     this.executedDepositTxHashes.add(pending.refTxHash);
@@ -1350,8 +1386,9 @@ export class DepositAddressHandler {
       if (getCurrentTime() - lastAttempt < PENDING_EXECUTE_RESETTLE_INTERVAL) {
         return;
       }
-      if ((await this._settlePendingExecute(depositKey, pending)) !== "reverted") {
-        // "executed" is now covered by executedDepositTxHashes; "unresolved" must not be re-submitted.
+      // "unclaimed" = no live claim remains (reverted, or released by an operator), so fall through and
+      // re-attempt. "executed" is covered by executedDepositTxHashes; "unresolved" must not resubmit.
+      if ((await this._settlePendingExecute(depositKey, pending)) !== "unclaimed") {
         return;
       }
     }
@@ -1454,9 +1491,10 @@ export class DepositAddressHandler {
       // execute; re-read from Redis rather than the mirror, which only this run writes to. This
       // narrows the overlap window to a single Redis read — it does not close it.
       try {
-        const { claims, unparseable } = await this._readPendingExecutes();
-        const claimed = claims[depositKey];
-        if (isDefined(claimed) || unparseable.has(depositKey)) {
+        // _syncClaim caches whatever it finds, so a claim an overlapping run recorded after this
+        // process started is settled by the next poll rather than re-quoted on every one.
+        const claimed = await this._syncClaim(depositKey);
+        if (isDefined(claimed) || this.unparseableClaimKeys.has(depositKey)) {
           this.logger.warn({
             at: "DepositAddressHandler#initiateDepositV3",
             message: "Skipping execute: an execute for this transfer has already been broadcast",

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -240,11 +240,18 @@ export class DepositAddressHandler {
     );
     await this.instanceCoordinator.initiateHandover();
 
+    // Snapshot claims *before* the executed-set load. An incumbent that confirms concurrently
+    // persists the executed hash and only then clears its claim, so reading in this order means a
+    // claim already gone by now had its hash persisted earlier — and the load below therefore sees
+    // it. Reading the claims after the load would leave a window where the successor sees neither.
+    const inheritedClaims = await this._readPendingExecutes();
+
     await this._loadExecutedDepositsFromRedis();
     await this._loadWithdrawnKeysFromRedis();
     await this._loadSkippedWithdrawKeysFromRedis();
-    // Must follow the executed-deposits load: adopting an inherited execute writes to that set.
-    await this._resolvePendingExecutes();
+    // Settling must follow the loads: adopting a claim adds to the executed set, which the load
+    // replaces wholesale (and would then persist back to Redis minus every other hash).
+    await this._resolvePendingExecutes(inheritedClaims);
 
     this.initialized = true;
   }
@@ -468,10 +475,12 @@ export class DepositAddressHandler {
 
   /**
    * Settles executes a previous run broadcast but never saw confirmed. Runs once at startup, right
-   * after handover, so a successor inherits the incumbent's in-flight work.
+   * after handover, so a successor inherits the incumbent's in-flight work. Takes the claim snapshot
+   * as an argument because it must be read before the executed-set load, but applied after it — see
+   * `initialize()`.
    */
-  private async _resolvePendingExecutes(): Promise<void> {
-    this.pendingExecutes = await this._readPendingExecutes();
+  private async _resolvePendingExecutes(inherited: Record<string, PendingExecute>): Promise<void> {
+    this.pendingExecutes = inherited;
     const entries = Object.entries(this.pendingExecutes);
     if (entries.length === 0) {
       return;

--- a/src/deposit-address/DepositAddressHandler.ts
+++ b/src/deposit-address/DepositAddressHandler.ts
@@ -1305,13 +1305,26 @@ export class DepositAddressHandler {
     // A quarantined claim can't be settled (its txHash is unreadable), but it may describe a transfer
     // already swept, so it must keep blocking. Cleared by fixing or deleting the Redis field.
     if (this.unparseableClaimKeys.has(depositKey)) {
-      this.logger.debug({
-        at: "DepositAddressHandler#initiateDepositV3",
-        message: "Skipping deposit: this transfer's persisted claim is unparseable",
-        refTxHash,
-        depositKey,
-      });
-      return;
+      // Re-read first: the quarantine set is otherwise only refreshed at startup, so the documented
+      // ops recovery — repair or delete the malformed field — would not take effect until the process
+      // was replaced.
+      const { claims } = await this._readPendingExecutes();
+      if (this.unparseableClaimKeys.has(depositKey)) {
+        this.logger.debug({
+          at: "DepositAddressHandler#initiateDepositV3",
+          message: "Skipping deposit: this transfer's persisted claim is unparseable",
+          refTxHash,
+          depositKey,
+        });
+        return;
+      }
+
+      // Repaired or removed. Track whatever the field holds now so the checks below act on it.
+      if (isDefined(claims[depositKey])) {
+        this.pendingExecutes[depositKey] = claims[depositKey];
+      } else {
+        delete this.pendingExecutes[depositKey];
+      }
     }
 
     const pending = this.pendingExecutes[depositKey];
@@ -1478,8 +1491,20 @@ export class DepositAddressHandler {
       this.executedDepositTxHashes.add(refTxHash);
       executeCommitted = true;
       await this._persistExecutedDepositsRedis();
-      await this._clearPendingExecute(depositKey);
+      // Publish before clearing. The executed set already guards this transfer, so the claim is now
+      // redundant and a leftover is tidied at startup — whereas a skipped publish is lost for good,
+      // since later polls skip the transfer and adoption deliberately does not re-publish.
       await this._publishDepositExecuted(depositReceipt, depositMessage);
+      try {
+        await this._clearPendingExecute(depositKey);
+      } catch (err) {
+        this.logger.warn({
+          at: "DepositAddressHandler#initiateDepositV3",
+          message: "Failed to clear a now-redundant execute claim; startup will tidy it",
+          depositKey,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
     } finally {
       if (!executeCommitted) {
         this.observedExecutedDeposits[originChainId].delete(depositKey);

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -245,7 +245,7 @@ field so overlapping runs recording different transfers cannot clobber each othe
 branch re-notifies — including for a replacement that reverted — so the persisted hash is always one
 that can actually be resolved on-chain.
 
-Redis is the source of truth, not the in-memory mirror: this process only snapshots claims at startup, while an overlapping run can record, replace or (via the ops procedure below) remove one at any time. Every decision that depends on a claim therefore reads through `_syncClaim`, so a stale entry can neither block a transfer indefinitely nor hide a live one.
+Redis is the source of truth, not the in-memory mirror: this process only snapshots claims at startup, while an overlapping run can record, replace or (via the ops procedure below) remove one at any time. Every decision that depends on a claim therefore reads through `_syncClaim`, so a stale entry can neither block a transfer indefinitely nor hide a live one. `_syncClaim` reads the **single** field it needs (`HGET`), because claims are never pruned and a per-transfer path must not cost more as unrelated claims accumulate; `HGETALL` is reserved for the startup snapshot. A field that fails to parse is quarantined per key and keeps blocking only its own transfer.
 
 Startup read order matters. An incumbent that confirms concurrently persists the executed hash and
 only then clears its claim, so the successor snapshots the claim hash **before** loading the executed

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -75,8 +75,8 @@ re-derives the deposit address and all counterfactual merkle materials server-si
 identity (`destination.token`, `destination.recipient`, `userAddress`); the bot relays funding
 context only — origin chain, swept `depositAddress`, funding `inputToken`, amount, destination
 route, refund identity — plus its own `executionFeeRecipient` and the `integratorId` the address
-was derived with. `executionFee` is currently omitted (the API defaults it to 0); bot-side fee
-pricing is a follow-up task.
+was derived with. `executionFee` is
+currently omitted (the API defaults it to 0); bot-side fee pricing is a follow-up task.
 
 The `integratorId` (2-byte hex) is sourced from the indexer message's `integrator` projection (a
 property of the deposit address, not the bot's auth key) and is **required** by the execute
@@ -139,9 +139,8 @@ read by the execute path — the API re-derives them, so they are carried for di
 (`depositAddressNamespace: "tron"`). No dedicated gate: Tron activates by adding its chainId
 (728126428) to `RELAYER_ORIGIN_CHAINS`, which also provisions the provider and dedup sets. v3
 messages stay un-normalized, so Tron fields flow **base58 end-to-end to the quote-api**
-(`userAddress`, `depositAddress`, `inputToken.address`; the bot re-encodes its own
-`executionFeeRecipient` to base58 via `toAddressType`). The API responds with
-`executeTx.ecosystem: "tvm"`, a **0x-hex `to`** (the
+(`userAddress`, `depositAddress`, `inputToken.address`; the bot re-encodes its own `executionFeeRecipient` to base58
+via `toAddressType`). The API responds with `executeTx.ecosystem: "tvm"`, a **0x-hex `to`** (the
 RPC-facing format), and the `depositAddress` echoed in base58; the bot validates the ecosystem
 against the chain family and compares deposit addresses canonically (base58 → hex) since base58 is
 case-sensitive. On-chain reads (`getDepositAddressBalance`) and receipt-log matching
@@ -234,6 +233,12 @@ So on the v3 execute path the broadcast hash is persisted from `TransactionClien
 hook, before the confirmation wait, and cleared once the executed set is written. Claims are written
 per hash field so overlapping runs recording different transfers cannot clobber each other, and the
 repriced branch re-notifies so the persisted hash is always one that can actually mine.
+
+Startup read order matters. An incumbent that confirms concurrently persists the executed hash and
+only then clears its claim, so the successor snapshots the claim hash **before** loading the executed
+set: a claim already gone by then had its hash persisted earlier, so the load picks it up. Reading
+claims after the load would leave a window where the successor sees neither. The snapshot is applied
+**after** the loads, because adoption writes to the executed set and the load replaces it wholesale.
 
 A claim is resolved against the chain at startup, and again (throttled to once a minute per key) when
 a poll encounters an outstanding one:

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -263,7 +263,8 @@ not re-publish `deposit_executed`.
 - A claim whose transaction never mines is **never** discarded, so that transfer stays blocked
   indefinitely. Stranding a deposit is reversible; a second sweep is not. Find them with
   `HGETALL deposit-address:pending-execute-claims:<botIdentifier>` and release one by deleting its
-  field once its transaction is confirmed dead.
+  field once its transaction is confirmed dead. A field whose JSON doesn't parse is quarantined the
+  same way — alerted once, its own transfer blocked, everything else unaffected.
 - The v1 deposit path and both refund-withdraw paths still persist only after confirmation.
 
 ## Refund-withdraw flow (high level)

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -126,11 +126,20 @@ The flow (`initiateDepositV3`):
    must match the origin chain, `isPlaceholder` must be false, and `signatureDeadline` must have
    ≥60s of headroom. The calldata embeds a deadline-bounded signature — it is perishable, and on
    any failure the next poll **re-requests fresh calldata; stale payloads are never patched**.
-7. Re-read the claim hash from Redis (see "In-flight execute claims") and skip if another run has
-   already broadcast for this transfer during the quote round trip.
+7. Re-read the claim hash from Redis via `_syncClaim` (see "In-flight execute claims") and skip if
+   another run has already broadcast for this transfer during the quote round trip.
 8. Sign and submit via `TransactionClient` (gas, nonce, rebroadcast), recording a claim from the
-   `onBroadcast` hook, then persist the tx hash to Redis exactly like v1 and clear the claim.
-9. Publish a `deposit_executed` lifecycle event to GCP Pub/Sub (if `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER=true`).
+   `onBroadcast` hook before the confirmation wait.
+9. On confirmation, persist the tx hash to Redis exactly like v1, **then** publish a
+   `deposit_executed` lifecycle event to GCP Pub/Sub (if
+   `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER=true`), **then** clear the claim.
+
+   This order is load-bearing in both directions and must not be rearranged. The executed set is
+   written before the claim is cleared, because the reverse would reopen the duplicate-sweep window.
+   The publish precedes the clear, and the clear is best-effort, because once the executed set is
+   written the claim is redundant — the executed-set check runs first on later polls, and startup
+   tidies a leftover — whereas a skipped publish is lost for good: later polls skip the transfer and
+   claim adoption deliberately does not re-publish.
 
 The v3 message's `counterfactualMaterials`/`initialRoot`/`salt` are relayed by the indexer but not
 read by the execute path — the API re-derives them, so they are carried for diagnostics only.
@@ -230,9 +239,11 @@ sweep would leave no trace — and because the deposit address is a shared pot, 
 transfer makes the stale message look executable again.
 
 So on the v3 execute path the broadcast hash is persisted from `TransactionClient`'s `onBroadcast`
-hook, before the confirmation wait, and cleared once the executed set is written. Claims are written
-per hash field so overlapping runs recording different transfers cannot clobber each other, and the
-repriced branch re-notifies so the persisted hash is always one that can actually mine.
+hook, before the confirmation wait, and cleared once the executed set is written and the lifecycle
+event published (step 9 above gives the ordering and why it matters). Claims are written per hash
+field so overlapping runs recording different transfers cannot clobber each other, and the repriced
+branch re-notifies — including for a replacement that reverted — so the persisted hash is always one
+that can actually be resolved on-chain.
 
 Redis is the source of truth, not the in-memory mirror: this process only snapshots claims at startup, while an overlapping run can record, replace or (via the ops procedure below) remove one at any time. Every decision that depends on a claim therefore reads through `_syncClaim`, so a stale entry can neither block a transfer indefinitely nor hide a live one.
 

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -234,6 +234,8 @@ hook, before the confirmation wait, and cleared once the executed set is written
 per hash field so overlapping runs recording different transfers cannot clobber each other, and the
 repriced branch re-notifies so the persisted hash is always one that can actually mine.
 
+Redis is the source of truth, not the in-memory mirror: this process only snapshots claims at startup, while an overlapping run can record, replace or (via the ops procedure below) remove one at any time. Every decision that depends on a claim therefore reads through `_syncClaim`, so a stale entry can neither block a transfer indefinitely nor hide a live one.
+
 Startup read order matters. An incumbent that confirms concurrently persists the executed hash and
 only then clears its claim, so the successor snapshots the claim hash **before** loading the executed
 set: a claim already gone by then had its hash persisted earlier, so the load picks it up. Reading
@@ -247,7 +249,8 @@ a poll encounters an outstanding one:
 | --- | --- | --- |
 | no provider / RPC error | `unresolved` | warn, keep the claim |
 | absent | `unresolved` | keep the claim; the transfer stays blocked |
-| `status === 0` | `reverted` | clear; the deposit is re-attempted |
+| absent, and the field was released externally | `unclaimed` | the deposit is re-attempted |
+| `status === 0` | `unclaimed` | clear; the deposit is re-attempted |
 | mined, `status !== 0` | `executed` | adopt into the executed set, clear |
 
 Only an explicit `status === 0` counts as a revert: ethers leaves `status` undefined on some chains,

--- a/src/deposit-address/README.md
+++ b/src/deposit-address/README.md
@@ -126,9 +126,11 @@ The flow (`initiateDepositV3`):
    must match the origin chain, `isPlaceholder` must be false, and `signatureDeadline` must have
    ≥60s of headroom. The calldata embeds a deadline-bounded signature — it is perishable, and on
    any failure the next poll **re-requests fresh calldata; stale payloads are never patched**.
-7. Sign and submit via `TransactionClient` (gas, nonce, rebroadcast), then persist the tx hash to
-   Redis exactly like v1.
-8. Publish a `deposit_executed` lifecycle event to GCP Pub/Sub (if `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER=true`).
+7. Re-read the claim hash from Redis (see "In-flight execute claims") and skip if another run has
+   already broadcast for this transfer during the quote round trip.
+8. Sign and submit via `TransactionClient` (gas, nonce, rebroadcast), recording a claim from the
+   `onBroadcast` hook, then persist the tx hash to Redis exactly like v1 and clear the claim.
+9. Publish a `deposit_executed` lifecycle event to GCP Pub/Sub (if `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER=true`).
 
 The v3 message's `counterfactualMaterials`/`initialRoot`/`salt` are relayed by the indexer but not
 read by the execute path — the API re-derives them, so they are carried for diagnostics only.
@@ -215,6 +217,49 @@ Three sets persist across runs so handover does not double-spend, double-refund,
 - `deposit-address:skipped-withdraw-keys:<botIdentifier>` — set of `depositKey` for v3 refund withdraws the quote-api rejected with a terminal 422 (`GAS_EXCEEDS_REFUND` / `UNPRICEABLE_REFUND_TOKEN`); never re-attempted.
 
 On each poll, entries whose source messages are no longer returned by the indexer are pruned — the indexer has its own TTL and stops returning expired messages.
+
+A fourth key, `deposit-address:pending-execute-claims:<botIdentifier>`, is a **hash** (one field per
+`depositKey`) rather than a set, carries no TTL, and is **not** pruned against the indexer — a claim
+must outlive the message that produced it.
+
+## In-flight execute claims
+
+Runs overlap: a successor overwrites the instance key at startup while the incumbent only notices on
+its next 1s `InstanceCoordinator.subscribe()` poll. A run can therefore broadcast an execute and be
+evicted before the receipt lands. Since the executed set is only written *after* confirmation, that
+sweep would leave no trace — and because the deposit address is a shared pot, a later inbound
+transfer makes the stale message look executable again.
+
+So on the v3 execute path the broadcast hash is persisted from `TransactionClient`'s `onBroadcast`
+hook, before the confirmation wait, and cleared once the executed set is written. Claims are written
+per hash field so overlapping runs recording different transfers cannot clobber each other, and the
+repriced branch re-notifies so the persisted hash is always one that can actually mine.
+
+A claim is resolved against the chain at startup, and again (throttled to once a minute per key) when
+a poll encounters an outstanding one:
+
+| Receipt | Outcome | Action |
+| --- | --- | --- |
+| no provider / RPC error | `unresolved` | warn, keep the claim |
+| absent | `unresolved` | keep the claim; the transfer stays blocked |
+| `status === 0` | `reverted` | clear; the deposit is re-attempted |
+| mined, `status !== 0` | `executed` | adopt into the executed set, clear |
+
+Only an explicit `status === 0` counts as a revert: ethers leaves `status` undefined on some chains,
+and treating that as success can strand a deposit but can never cause a second sweep. Adoption does
+not re-publish `deposit_executed`.
+
+**Deliberately not covered.** This narrows the failure window rather than closing it:
+
+- Two overlapping runs can still both broadcast. The pre-broadcast re-read shrinks that window from
+  the whole quote-api round trip to one Redis read; it does not eliminate it. Note it is only a real
+  double-sweep where a resubmit lands in a different nonce space — always on nonce-less TVM, and on
+  EVM when dispatcher keys rotate the retry onto another signer.
+- A claim whose transaction never mines is **never** discarded, so that transfer stays blocked
+  indefinitely. Stranding a deposit is reversible; a second sweep is not. Find them with
+  `HGETALL deposit-address:pending-execute-claims:<botIdentifier>` and release one by deleting its
+  field once its transaction is confirmed dead.
+- The v1 deposit path and both refund-withdraw paths still persist only after confirmation.
 
 ## Refund-withdraw flow (high level)
 

--- a/src/deposit-address/pendingExecutes.ts
+++ b/src/deposit-address/pendingExecutes.ts
@@ -1,0 +1,29 @@
+import { create, number, object, string } from "superstruct";
+
+/**
+ * A deposit execute that has been broadcast but whose outcome this process never observed. Written
+ * before the confirmation wait, so a process evicted at handover doesn't lose track of a transfer
+ * already on the wire. See the module README's "In-flight execute claims" section.
+ */
+export type PendingExecute = {
+  /** Hash of the broadcast execute; the key used to resolve its outcome on-chain later. */
+  txHash: string;
+  /** Chain the execute was submitted to (also the funding transfer's chain). */
+  chainId: number;
+  /** `erc20Transfer.transactionHash` — the dedup key for the executed-deposits set. */
+  refTxHash: string;
+  /** Unix seconds at broadcast. Purely diagnostic: no logic expires a claim. */
+  submittedAt: number;
+};
+
+const PendingExecuteStruct = object({
+  txHash: string(),
+  chainId: number(),
+  refTxHash: string(),
+  submittedAt: number(),
+});
+
+/** Parse one persisted claim (a single Redis hash field). Throws on a malformed payload. */
+export function parsePendingExecute(json: string): PendingExecute {
+  return create(JSON.parse(json), PendingExecuteStruct);
+}

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -1271,6 +1271,33 @@ describe("DepositAddressHandler pending-execute claim", function () {
     expect(warnStub.firstCall.firstArg.message).to.contain("already been broadcast");
   });
 
+  // Overlapping runs write the same hash field. If an older transaction reverts while a newer one is
+  // still in flight, clearing unconditionally would drop the live claim and unblock a mid-sweep
+  // transfer — turning a two-sweep interleaving into a three-sweep one.
+  it("keeps a newer in-flight claim when the transaction it replaced reverted", async function () {
+    const newerTxHash = "0x" + "f".repeat(64);
+    seedClaim(pendingRecord({ txHash: newerTxHash }));
+    // This run's mirror still points at its own, older transaction.
+    const ours = pendingRecord({ txHash: executeTxHash });
+    (handler as unknown as Internals).pendingExecutes = { [depositKey]: ours };
+    // Ours reverted; the newer one is still unmined.
+    getReceiptStub.withArgs(executeTxHash).resolves(sweepReceipt(0));
+    getReceiptStub.withArgs(newerTxHash).resolves(null);
+
+    const outcome = await (handler as unknown as Internals)._settlePendingExecute(depositKey, ours);
+
+    // Not "reverted": that would let the caller re-submit immediately.
+    expect(outcome).to.equal("unresolved");
+    expect(hashes.get(redisKey)?.get(depositKey)).to.equal(JSON.stringify(pendingRecord({ txHash: newerTxHash })));
+    // And this run now tracks the live transaction instead of its own.
+    expect((handler as unknown as Internals).pendingExecutes[depositKey].txHash).to.equal(newerTxHash);
+    expect(warnStub.args.some((a) => a[0].message.includes("Keeping a newer in-flight claim"))).to.equal(true);
+
+    // The transfer stays blocked.
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
+    expect(executeStub.notCalled).to.equal(true);
+  });
+
   // The per-field hash isolates writes, so the read must isolate too: one corrupt field previously
   // threw for the whole map, which bricked startup and made the pre-broadcast check block every v3
   // deposit indefinitely. A bad field is quarantined — still blocking its own transfer, nothing else.

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -1113,7 +1113,7 @@ describe("DepositAddressHandler pending-execute claim", function () {
 
   type Internals = {
     initiateDepositV3: (m: DepositAddressMessageV3) => Promise<void>;
-    _settlePendingExecute: (k: string, p: PendingExecute) => Promise<"executed" | "reverted" | "unresolved">;
+    _settlePendingExecute: (k: string, p: PendingExecute) => Promise<"executed" | "unclaimed" | "unresolved">;
     _recordPendingExecute: (k: string, p: PendingExecute) => Promise<void>;
     _readPendingExecutes: () => Promise<{ claims: Record<string, PendingExecute>; unparseable: Set<string> }>;
     _resolvePendingExecutes: (inherited: Record<string, PendingExecute>) => Promise<void>;
@@ -1295,7 +1295,7 @@ describe("DepositAddressHandler pending-execute claim", function () {
 
     const outcome = await (handler as unknown as Internals)._settlePendingExecute(depositKey, ours);
 
-    // Not "reverted": that would let the caller re-submit immediately.
+    // Not "unclaimed": that would let the caller re-submit immediately.
     expect(outcome).to.equal("unresolved");
     expect(hashes.get(redisKey)?.get(depositKey)).to.equal(JSON.stringify(pendingRecord({ txHash: newerTxHash })));
     // And this run now tracks the live transaction instead of its own.
@@ -1325,6 +1325,50 @@ describe("DepositAddressHandler pending-execute claim", function () {
     // The next poll settles the live hash, sees the revert, and lets the deposit be re-attempted.
     await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
     expect(executeStub.called).to.equal(true);
+  });
+
+  // The README's recovery is to delete a confirmed-dead claim. Without honouring an absent field the
+  // mirror kept the dead hash, rechecked it every minute, and blocked the transfer until restart.
+  it("releases the transfer when an operator deletes a cached claim", async function () {
+    const ours = pendingRecord({ txHash: executeTxHash });
+    (handler as unknown as Internals).pendingExecutes = { [depositKey]: ours };
+    getReceiptStub.resolves(null); // never mined, so the claim can only be released by hand
+    // Operator deletes the field; nothing seeded in Redis.
+
+    const outcome = await (handler as unknown as Internals)._settlePendingExecute(depositKey, ours);
+
+    expect(outcome).to.equal("unclaimed");
+    expect((handler as unknown as Internals).pendingExecutes[depositKey]).to.equal(undefined);
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
+    expect(executeStub.called).to.equal(true);
+  });
+
+  // The pre-broadcast gate is the only place a claim written after startup is seen. Not caching it
+  // meant every later poll re-ran the balance check and quote request before blocking here again,
+  // and _settlePendingExecute was never reached to resolve it.
+  it("caches a claim discovered by the pre-broadcast check so later polls settle it", async function () {
+    (handler as unknown as { getExecuteContract: sinon.SinonStub }).getExecuteContract = sinon
+      .stub()
+      .returns({ address: TOKEN });
+    executeStub.resolves({
+      depositAddress: DEPOSIT_ADDRESS,
+      executeTx: { ecosystem: "evm", chainId, to: TOKEN, data: "0x", value: "0" },
+      signer: SIGNER,
+      signatureDeadline: getCurrentTime() + 600,
+      isPlaceholder: false,
+    });
+    // Recorded by an overlapping run after this process snapshotted, so absent from the mirror.
+    seedClaim(pendingRecord());
+    getReceiptStub.resolves(sweepReceipt(0));
+
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
+    expect(executeStub.calledOnce).to.equal(true);
+    expect((handler as unknown as Internals).pendingExecutes[depositKey].txHash).to.equal(executeTxHash);
+
+    // Next poll resolves it instead of re-quoting: reverted, so the deposit is re-attempted.
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
+    expect(getReceiptStub.called).to.equal(true);
+    expect(executeStub.callCount).to.equal(2);
   });
 
   // The README tells operators to repair or delete a malformed field to release a stuck transfer. The
@@ -1469,7 +1513,7 @@ describe("DepositAddressHandler pending-execute claim on Tron", function () {
   let getReceiptStub: sinon.SinonStub;
 
   type Internals = {
-    _settlePendingExecute: (k: string, p: PendingExecute) => Promise<"executed" | "reverted" | "unresolved">;
+    _settlePendingExecute: (k: string, p: PendingExecute) => Promise<"executed" | "unclaimed" | "unresolved">;
   };
 
   beforeEach(function () {

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -1075,6 +1075,7 @@ function redisHashFake(hashes: Map<string, Map<string, string>>) {
       hashes.set(key, hash);
       return 1;
     },
+    hGet: async (key: string, field: string) => hashes.get(key)?.get(field),
     hGetAll: async (key: string) => Object.fromEntries(hashes.get(key) ?? new Map<string, string>()),
     hDel: async (key: string, field: string) => (hashes.get(key)?.delete(field) ? 1 : 0),
     hDelIfEquals: async (key: string, field: string, expected: string) => {
@@ -1325,6 +1326,24 @@ describe("DepositAddressHandler pending-execute claim", function () {
     // The next poll settles the live hash, sees the revert, and lets the deposit be re-attempted.
     await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
     expect(executeStub.called).to.equal(true);
+  });
+
+  // Claims are deliberately never pruned, so the per-transfer path must not read the whole hash:
+  // otherwise its cost scales with every unrelated claim being retained. hGetAll is startup-only.
+  it("reads a single field when syncing one transfer's claim", async function () {
+    const cache = (handler as unknown as { redisCache: Record<string, sinon.SinonStub> }).redisCache;
+    const hGetAllSpy = sinon.spy(cache, "hGetAll" as never);
+    const hGetSpy = sinon.spy(cache, "hGet" as never);
+    // Unrelated retained claims, as a neglected deployment would accumulate.
+    for (let i = 0; i < 5; i++) {
+      seedClaim(pendingRecord({ txHash: `0x${i}`.padEnd(66, "0") }), `${DEPOSIT_ADDRESS}:other-${i}`);
+    }
+    seedClaim(pendingRecord());
+
+    await (handler as unknown as { _syncClaim: (k: string) => Promise<unknown> })._syncClaim(depositKey);
+
+    expect(hGetSpy.calledOnceWith(sinon.match.string, depositKey)).to.equal(true);
+    expect(hGetAllSpy.notCalled).to.equal(true);
   });
 
   // The README's recovery is to delete a confirmed-dead claim. Without honouring an absent field the

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -1076,6 +1076,14 @@ function redisHashFake(hashes: Map<string, Map<string, string>>) {
     },
     hGetAll: async (key: string) => Object.fromEntries(hashes.get(key) ?? new Map<string, string>()),
     hDel: async (key: string, field: string) => (hashes.get(key)?.delete(field) ? 1 : 0),
+    hDelIfEquals: async (key: string, field: string, expected: string) => {
+      const hash = hashes.get(key);
+      if (hash?.get(field) !== expected) {
+        return false;
+      }
+      hash.delete(field);
+      return true;
+    },
   };
 }
 
@@ -1294,6 +1302,27 @@ describe("DepositAddressHandler pending-execute claim", function () {
     expect(warnStub.args.some((a) => a[0].message.includes("Keeping a newer in-flight claim"))).to.equal(true);
 
     // The transfer stays blocked.
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
+    expect(executeStub.notCalled).to.equal(true);
+  });
+
+  // The compare and the delete are separate Redis commands, so a claim written in between would be
+  // lost to a plain hDel. The delete is a compare-and-swap on the exact bytes read: if they changed,
+  // it fails and the claim stays.
+  it("does not delete a claim rewritten between the compare and the delete", async function () {
+    const ours = pendingRecord({ txHash: executeTxHash });
+    seedClaim(ours);
+    (handler as unknown as Internals).pendingExecutes = { [depositKey]: ours };
+    getReceiptStub.resolves(sweepReceipt(0));
+    // Stands in for another run's hSet landing in the gap: the CAS no longer matches.
+    (handler as unknown as { redisCache: { hDelIfEquals: sinon.SinonStub } }).redisCache.hDelIfEquals = sinon
+      .stub()
+      .resolves(false);
+
+    const outcome = await (handler as unknown as Internals)._settlePendingExecute(depositKey, ours);
+
+    expect(outcome).to.equal("unresolved");
+    expect(hashes.get(redisKey)?.has(depositKey)).to.equal(true);
     await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
     expect(executeStub.notCalled).to.equal(true);
   });

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -1100,12 +1100,13 @@ describe("DepositAddressHandler pending-execute claim", function () {
   let executeStub: sinon.SinonStub;
   let balanceStub: sinon.SinonStub;
   let warnStub: sinon.SinonStub;
+  let errorStub: sinon.SinonStub;
 
   type Internals = {
     initiateDepositV3: (m: DepositAddressMessageV3) => Promise<void>;
     _settlePendingExecute: (k: string, p: PendingExecute) => Promise<"executed" | "reverted" | "unresolved">;
     _recordPendingExecute: (k: string, p: PendingExecute) => Promise<void>;
-    _readPendingExecutes: () => Promise<Record<string, PendingExecute>>;
+    _readPendingExecutes: () => Promise<{ claims: Record<string, PendingExecute>; unparseable: Set<string> }>;
     _resolvePendingExecutes: (inherited: Record<string, PendingExecute>) => Promise<void>;
     _loadExecutedDepositsFromRedis: () => Promise<void>;
     executedDepositTxHashes: Set<string>;
@@ -1132,11 +1133,12 @@ describe("DepositAddressHandler pending-execute claim", function () {
     store = new Map<string, string>();
     hashes = new Map<string, Map<string, string>>();
     warnStub = sinon.stub();
+    errorStub = sinon.stub();
     const logger = {
       warn: warnStub,
       debug: sinon.stub(),
       info: sinon.stub(),
-      error: sinon.stub(),
+      error: errorStub,
     } as unknown as winston.Logger;
     const config = {
       botIdentifier: "test-bot",
@@ -1175,8 +1177,8 @@ describe("DepositAddressHandler pending-execute claim", function () {
     await (handler as unknown as Internals)._recordPendingExecute(depositKey, pendingRecord());
     expect(hashes.get(redisKey)?.has(depositKey)).to.equal(true);
     const persisted = await (handler as unknown as Internals)._readPendingExecutes();
-    expect(persisted[depositKey].txHash).to.equal(executeTxHash);
-    expect(persisted[depositKey].refTxHash).to.equal(refTxHash);
+    expect(persisted.claims[depositKey].txHash).to.equal(executeTxHash);
+    expect(persisted.claims[depositKey].refTxHash).to.equal(refTxHash);
   });
 
   it("does not request execute calldata while a recently-checked claim is outstanding", async function () {
@@ -1193,7 +1195,7 @@ describe("DepositAddressHandler pending-execute claim", function () {
     getReceiptStub.resolves(sweepReceipt(1));
 
     const inherited = await (handler as unknown as Internals)._readPendingExecutes();
-    await (handler as unknown as Internals)._resolvePendingExecutes(inherited);
+    await (handler as unknown as Internals)._resolvePendingExecutes(inherited.claims);
 
     // Adopted into the executed set, so no later run re-submits for this transfer.
     expect((handler as unknown as Internals).executedDepositTxHashes.has(refTxHash)).to.equal(true);
@@ -1209,7 +1211,7 @@ describe("DepositAddressHandler pending-execute claim", function () {
     getReceiptStub.resolves(sweepReceipt(0));
 
     const inherited = await (handler as unknown as Internals)._readPendingExecutes();
-    await (handler as unknown as Internals)._resolvePendingExecutes(inherited);
+    await (handler as unknown as Internals)._resolvePendingExecutes(inherited.claims);
 
     expect((handler as unknown as Internals).executedDepositTxHashes.has(refTxHash)).to.equal(false);
     expect((handler as unknown as Internals).pendingExecutes).to.deep.equal({});
@@ -1224,7 +1226,7 @@ describe("DepositAddressHandler pending-execute claim", function () {
     getReceiptStub.resolves(null);
 
     const inherited = await (handler as unknown as Internals)._readPendingExecutes();
-    await (handler as unknown as Internals)._resolvePendingExecutes(inherited);
+    await (handler as unknown as Internals)._resolvePendingExecutes(inherited.claims);
 
     expect((handler as unknown as Internals).pendingExecutes[depositKey].txHash).to.equal(executeTxHash);
     expect((handler as unknown as Internals).executedDepositTxHashes.has(refTxHash)).to.equal(false);
@@ -1269,6 +1271,30 @@ describe("DepositAddressHandler pending-execute claim", function () {
     expect(warnStub.firstCall.firstArg.message).to.contain("already been broadcast");
   });
 
+  // The per-field hash isolates writes, so the read must isolate too: one corrupt field previously
+  // threw for the whole map, which bricked startup and made the pre-broadcast check block every v3
+  // deposit indefinitely. A bad field is quarantined — still blocking its own transfer, nothing else.
+  it("quarantines one unparseable claim without affecting other transfers", async function () {
+    const otherKey = `${DEPOSIT_ADDRESS}:0x${"7".repeat(64)}`;
+    const hash = new Map<string, string>();
+    hash.set(depositKey, "{not-valid-json");
+    hash.set(otherKey, JSON.stringify(pendingRecord({ refTxHash: "0x" + "7".repeat(64) })));
+    hashes.set(redisKey, hash);
+
+    const { claims, unparseable } = await (handler as unknown as Internals)._readPendingExecutes();
+
+    expect(Object.keys(claims)).to.deep.equal([otherKey]);
+    expect([...unparseable]).to.deep.equal([depositKey]);
+    // Alerted, and the corrupt field is retained rather than dropped.
+    expect(errorStub.calledOnce).to.equal(true);
+    expect(errorStub.firstCall.firstArg.notificationPath).to.equal("across-bot-error");
+    expect(hashes.get(redisKey)?.has(depositKey)).to.equal(true);
+
+    // The quarantined transfer stays blocked; no calldata is requested for it.
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
+    expect(executeStub.notCalled).to.equal(true);
+  });
+
   // Regression for the startup ordering invariant. An incumbent that confirms concurrently persists
   // the executed hash and only then clears its claim, so the successor must snapshot claims BEFORE
   // loading the executed set (or it can see neither) but apply them AFTER (or adoption's whole-array
@@ -1282,7 +1308,7 @@ describe("DepositAddressHandler pending-execute claim", function () {
 
     const inherited = await (handler as unknown as Internals)._readPendingExecutes();
     await (handler as unknown as Internals)._loadExecutedDepositsFromRedis();
-    await (handler as unknown as Internals)._resolvePendingExecutes(inherited);
+    await (handler as unknown as Internals)._resolvePendingExecutes(inherited.claims);
 
     expect(JSON.parse(store.get(executedKey) as string).sort()).to.deep.equal([priorHash, refTxHash].sort());
   });
@@ -1300,7 +1326,7 @@ describe("DepositAddressHandler pending-execute claim", function () {
     ]);
 
     const persisted = await (handler as unknown as Internals)._readPendingExecutes();
-    expect(Object.keys(persisted).sort()).to.deep.equal([depositKey, otherKey].sort());
+    expect(Object.keys(persisted.claims).sort()).to.deep.equal([depositKey, otherKey].sort());
   });
 });
 

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -9,11 +9,18 @@ import {
   toAddressType,
   toBN,
   TransactionReceipt,
+  TransactionResponse,
   utils,
   winston,
 } from "../src/utils";
 import { DepositAddressMessage, DepositAddressMessageV3 } from "../src/interfaces/DepositAddress";
-import { DepositAddressExecuteResponse, DepositAddressSignWithdrawResponse } from "../src/clients";
+import {
+  AugmentedTransaction,
+  DepositAddressExecuteResponse,
+  DepositAddressSignWithdrawResponse,
+  TransactionClient,
+} from "../src/clients";
+import { PendingExecute } from "../src/deposit-address/pendingExecutes";
 import { DepositAddressHandler } from "../src/deposit-address/DepositAddressHandler";
 import { DepositAddressHandlerConfig } from "../src/deposit-address/DepositAddressHandlerConfig";
 import { ERC20_TRANSFER_TOPIC } from "../src/deposit-address/withdrawPayload";
@@ -1055,5 +1062,384 @@ describe("DepositAddressHandler._publishDepositExecuted", function () {
       true;
     await (handler as unknown as Internals)._publishDepositExecuted(receipt, depositMessageV3());
     expect(publishStub.called).to.equal(false);
+  });
+});
+
+/** Fake of the Redis hash commands the claim store uses, backed by `hashKey -> field -> value`. */
+function redisHashFake(hashes: Map<string, Map<string, string>>) {
+  return {
+    hSet: async (key: string, field: string, val: string) => {
+      const hash = hashes.get(key) ?? new Map<string, string>();
+      hash.set(field, val);
+      hashes.set(key, hash);
+      return 1;
+    },
+    hGetAll: async (key: string) => Object.fromEntries(hashes.get(key) ?? new Map<string, string>()),
+    hDel: async (key: string, field: string) => (hashes.get(key)?.delete(field) ? 1 : 0),
+  };
+}
+
+/**
+ * Cover for the duplicate-sweep failure mode this change limits: a run broadcasts an execute, is
+ * evicted mid-confirmation (routine — runs overlap on every handover), and its successor has no
+ * record that the transfer was already swept. The balance check cannot save it, because the deposit
+ * address is a shared pot: an unrelated inbound transfer makes the stale message executable again.
+ */
+describe("DepositAddressHandler pending-execute claim", function () {
+  const chainId = 42161;
+  const refTxHash = "0x" + "3".repeat(64); // depositMessageV3().erc20Transfer.transactionHash
+  const depositKey = `${DEPOSIT_ADDRESS}:${refTxHash}`;
+  const executeTxHash = "0x" + "e".repeat(64);
+  const redisKey = "deposit-address:pending-execute-claims:test-bot";
+
+  let handler: DepositAddressHandler;
+  let store: Map<string, string>;
+  let hashes: Map<string, Map<string, string>>;
+  let getReceiptStub: sinon.SinonStub;
+  let publishStub: sinon.SinonStub;
+  let executeStub: sinon.SinonStub;
+  let balanceStub: sinon.SinonStub;
+  let warnStub: sinon.SinonStub;
+
+  type Internals = {
+    initiateDepositV3: (m: DepositAddressMessageV3) => Promise<void>;
+    _settlePendingExecute: (k: string, p: PendingExecute) => Promise<"executed" | "reverted" | "unresolved">;
+    _recordPendingExecute: (k: string, p: PendingExecute) => Promise<void>;
+    _readPendingExecutes: () => Promise<Record<string, PendingExecute>>;
+    _resolvePendingExecutes: () => Promise<void>;
+    executedDepositTxHashes: Set<string>;
+    pendingExecutes: Record<string, PendingExecute>;
+    lastSettleAttempt: Record<string, number>;
+  };
+
+  function pendingRecord(overrides: Partial<PendingExecute> = {}): PendingExecute {
+    return { txHash: executeTxHash, chainId, refTxHash, submittedAt: getCurrentTime(), ...overrides };
+  }
+
+  function sweepReceipt(status: number): TransactionReceipt {
+    return { blockNumber: 5_000_000, transactionHash: executeTxHash, status } as unknown as TransactionReceipt;
+  }
+
+  /** Seeds a claim directly into the persisted hash, as a previous run would have left it. */
+  function seedClaim(pending: PendingExecute, key = depositKey): void {
+    const hash = hashes.get(redisKey) ?? new Map<string, string>();
+    hash.set(key, JSON.stringify(pending));
+    hashes.set(redisKey, hash);
+  }
+
+  beforeEach(function () {
+    store = new Map<string, string>();
+    hashes = new Map<string, Map<string, string>>();
+    warnStub = sinon.stub();
+    const logger = {
+      warn: warnStub,
+      debug: sinon.stub(),
+      info: sinon.stub(),
+      error: sinon.stub(),
+    } as unknown as winston.Logger;
+    const config = {
+      botIdentifier: "test-bot",
+      relayerOriginChains: [chainId],
+      enableDepositAddressDepositPublisher: true,
+      enableExecuteErc20Transfer: false,
+    } as unknown as DepositAddressHandlerConfig;
+    handler = new DepositAddressHandler(logger, config, {} as unknown as Signer, []);
+    (handler as unknown as { redisCache: unknown }).redisCache = {
+      get: async (key: string) => store.get(key) ?? null,
+      set: async (key: string, val: unknown) => {
+        store.set(key, String(val));
+        return "OK";
+      },
+      ...redisHashFake(hashes),
+    };
+    getReceiptStub = sinon.stub();
+    (handler as unknown as { providersByChain: Record<number, unknown> }).providersByChain = {
+      [chainId]: { getTransactionReceipt: getReceiptStub },
+    };
+    publishStub = sinon.stub().resolves("msg-id");
+    (handler as unknown as { executionPublisher: unknown }).executionPublisher = { publishJson: publishStub };
+    executeStub = sinon.stub().resolves(undefined);
+    (handler as unknown as { api: unknown }).api = { executeDepositAddress: executeStub };
+    (handler as unknown as { observedExecutedDeposits: Record<number, Set<string>> }).observedExecutedDeposits = {
+      [chainId]: new Set<string>(),
+    };
+    balanceStub = sinon.stub().resolves(toBN("5000"));
+    (handler as unknown as { getDepositAddressBalance: sinon.SinonStub }).getDepositAddressBalance = balanceStub;
+    (handler as unknown as { _signerAddress: EvmAddress })._signerAddress = EvmAddress.from(SIGNER);
+  });
+
+  afterEach(() => sinon.restore());
+
+  it("persists the claim so a later run can read it back", async function () {
+    await (handler as unknown as Internals)._recordPendingExecute(depositKey, pendingRecord());
+    expect(hashes.get(redisKey)?.has(depositKey)).to.equal(true);
+    const persisted = await (handler as unknown as Internals)._readPendingExecutes();
+    expect(persisted[depositKey].txHash).to.equal(executeTxHash);
+    expect(persisted[depositKey].refTxHash).to.equal(refTxHash);
+  });
+
+  it("does not request execute calldata while a recently-checked claim is outstanding", async function () {
+    (handler as unknown as Internals).pendingExecutes = { [depositKey]: pendingRecord() };
+    (handler as unknown as Internals).lastSettleAttempt = { [depositKey]: getCurrentTime() };
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
+    expect(executeStub.notCalled).to.equal(true);
+    // The throttle also means no redundant receipt lookup on every 1s poll.
+    expect(getReceiptStub.notCalled).to.equal(true);
+  });
+
+  it("adopts an inherited execute that confirmed on-chain", async function () {
+    seedClaim(pendingRecord());
+    getReceiptStub.resolves(sweepReceipt(1));
+
+    await (handler as unknown as Internals)._resolvePendingExecutes();
+
+    // Adopted into the executed set, so no later run re-submits for this transfer.
+    expect((handler as unknown as Internals).executedDepositTxHashes.has(refTxHash)).to.equal(true);
+    expect((handler as unknown as Internals).pendingExecutes).to.deep.equal({});
+
+    // And the deposit is now skipped outright rather than swept a second time.
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
+    expect(executeStub.notCalled).to.equal(true);
+  });
+
+  it("clears the claim when the inherited execute reverted, so the deposit is re-attempted", async function () {
+    seedClaim(pendingRecord());
+    getReceiptStub.resolves(sweepReceipt(0));
+
+    await (handler as unknown as Internals)._resolvePendingExecutes();
+
+    expect((handler as unknown as Internals).executedDepositTxHashes.has(refTxHash)).to.equal(false);
+    expect((handler as unknown as Internals).pendingExecutes).to.deep.equal({});
+    expect(publishStub.called).to.equal(false);
+    expect(warnStub.firstCall.firstArg.message).to.contain("reverted on-chain");
+  });
+
+  it("keeps the claim while the transaction is still unmined, and never discards it", async function () {
+    // No staleness rule: an unresolved claim is retained indefinitely, since stranding a transfer is
+    // reversible but a second sweep is not. Ops release it by deleting the Redis hash field.
+    seedClaim(pendingRecord({ submittedAt: getCurrentTime() - 86_400 }));
+    getReceiptStub.resolves(null);
+
+    await (handler as unknown as Internals)._resolvePendingExecutes();
+
+    expect((handler as unknown as Internals).pendingExecutes[depositKey].txHash).to.equal(executeTxHash);
+    expect((handler as unknown as Internals).executedDepositTxHashes.has(refTxHash)).to.equal(false);
+    // The retained claim is what blocks a second submission.
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
+    expect(executeStub.notCalled).to.equal(true);
+  });
+
+  // Without this the bot would wait for the next run to retry a revert, where today it retries on the
+  // next 1s poll — the claim must not cost liveness on the common failure.
+  it("re-settles an outstanding claim past the throttle and re-attempts a reverted execute", async function () {
+    (handler as unknown as Internals).pendingExecutes = { [depositKey]: pendingRecord() };
+    (handler as unknown as Internals).lastSettleAttempt = { [depositKey]: getCurrentTime() - 3600 };
+    getReceiptStub.resolves(sweepReceipt(0));
+
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
+
+    expect(getReceiptStub.calledOnce).to.equal(true);
+    expect((handler as unknown as Internals).pendingExecutes).to.deep.equal({});
+    // Claim cleared, so the execute proceeded to request fresh calldata in this same poll.
+    expect(executeStub.called).to.equal(true);
+  });
+
+  it("does not submit when another run claimed the transfer during the quote round trip", async function () {
+    // Written to Redis only: the in-memory mirror predates it, exactly as it would for a run that
+    // snapshotted state before an overlapping instance broadcast.
+    executeStub.resolves({
+      depositAddress: DEPOSIT_ADDRESS,
+      executeTx: { ecosystem: "evm", chainId, to: TOKEN, data: "0x", value: "0" },
+      signer: SIGNER,
+      signatureDeadline: getCurrentTime() + 600,
+      isPlaceholder: false,
+    });
+    (handler as unknown as { getExecuteContract: sinon.SinonStub }).getExecuteContract = sinon
+      .stub()
+      .returns({ address: TOKEN });
+    seedClaim(pendingRecord());
+
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
+
+    expect(warnStub.calledOnce).to.equal(true);
+    expect(warnStub.firstCall.firstArg.message).to.contain("already been broadcast");
+  });
+
+  // Regression: rewriting a whole serialized map from a fresh read let concurrent broadcasts (polls
+  // run under Promise.all) drop each other's claims, losing a transaction already on the wire.
+  it("keeps both claims when two deposits broadcast concurrently", async function () {
+    const otherKey = `${DEPOSIT_ADDRESS}:0x${"7".repeat(64)}`;
+    await Promise.all([
+      (handler as unknown as Internals)._recordPendingExecute(depositKey, pendingRecord()),
+      (handler as unknown as Internals)._recordPendingExecute(
+        otherKey,
+        pendingRecord({ txHash: "0x" + "8".repeat(64), refTxHash: "0x" + "7".repeat(64) })
+      ),
+    ]);
+
+    const persisted = await (handler as unknown as Internals)._readPendingExecutes();
+    expect(Object.keys(persisted).sort()).to.deep.equal([depositKey, otherKey].sort());
+  });
+});
+
+describe("DepositAddressHandler pending-execute claim on Tron", function () {
+  const chainId = CHAIN_IDs.TRON;
+  const depositKey = `${TRON_DEPOSIT_ADDRESS}:${TRON_TX_HASH}`;
+  // TronWeb reports an un-prefixed txid, which is what `onBroadcast` records verbatim.
+  const executeTxid = "9f2c" + "0".repeat(60);
+
+  let handler: DepositAddressHandler;
+  let getReceiptStub: sinon.SinonStub;
+
+  type Internals = {
+    _settlePendingExecute: (k: string, p: PendingExecute) => Promise<"executed" | "reverted" | "unresolved">;
+  };
+
+  beforeEach(function () {
+    const logger = {
+      warn: sinon.stub(),
+      debug: sinon.stub(),
+      info: sinon.stub(),
+      error: sinon.stub(),
+    } as unknown as winston.Logger;
+    const config = {
+      botIdentifier: "test-bot",
+      relayerOriginChains: [chainId],
+    } as unknown as DepositAddressHandlerConfig;
+    handler = new DepositAddressHandler(logger, config, {} as unknown as Signer, []);
+    (handler as unknown as { redisCache: unknown }).redisCache = redisHashFake(new Map());
+    getReceiptStub = sinon.stub().resolves(null);
+    (handler as unknown as { providersByChain: Record<number, unknown> }).providersByChain = {
+      [chainId]: { getTransactionReceipt: getReceiptStub },
+    };
+  });
+
+  afterEach(() => sinon.restore());
+
+  it("0x-prefixes the Tron txid before looking the receipt up", async function () {
+    await (handler as unknown as Internals)._settlePendingExecute(depositKey, {
+      txHash: executeTxid,
+      chainId,
+      refTxHash: TRON_TX_HASH,
+      submittedAt: getCurrentTime(),
+    });
+    // Un-prefixed would be rejected by the eth-JSON-RPC provider, leaving every Tron claim unresolved.
+    expect(getReceiptStub.calledOnceWith(`0x${executeTxid}`)).to.equal(true);
+  });
+});
+
+describe("TransactionClient onBroadcast hook", function () {
+  const chainId = 1;
+  const broadcastHash = "0x" + "b".repeat(64);
+  let events: string[];
+
+  // Stubs out broadcasting so the hook's ordering relative to the confirmation wait is observable.
+  class TestTransactionClient extends TransactionClient {
+    protected _getTransactionPromise(): Promise<TransactionResponse> {
+      return Promise.resolve({
+        hash: broadcastHash,
+        nonce: 7,
+        wait: async () => {
+          events.push("wait");
+          return {
+            blockNumber: 1,
+            transactionHash: broadcastHash,
+            status: 1,
+            logs: [],
+          } as unknown as TransactionReceipt;
+        },
+      } as unknown as TransactionResponse);
+    }
+  }
+
+  type Internals = {
+    _submit: (txn: AugmentedTransaction, opts: { nonce: number | null }) => Promise<TransactionResponse>;
+  };
+
+  function transaction(onBroadcast?: (r: TransactionResponse) => Promise<void>): AugmentedTransaction {
+    return {
+      contract: { address: TOKEN } as unknown as AugmentedTransaction["contract"],
+      chainId,
+      method: "",
+      args: ["0x"],
+      ensureConfirmation: true,
+      onBroadcast,
+    };
+  }
+
+  beforeEach(function () {
+    events = [];
+  });
+
+  afterEach(() => sinon.restore());
+
+  it("invokes the hook with the broadcast response before awaiting confirmation", async function () {
+    const client = new TestTransactionClient({ warn: sinon.stub(), debug: sinon.stub() } as unknown as winston.Logger);
+    const seen: string[] = [];
+    await (client as unknown as Internals)._submit(
+      transaction(async (response) => {
+        events.push("hook");
+        seen.push(response.hash);
+      }),
+      { nonce: null }
+    );
+    // Intent must be recorded before the wait, since the wait is where an eviction lands.
+    expect(events).to.deep.equal(["hook", "wait"]);
+    expect(seen).to.deep.equal([broadcastHash]);
+  });
+
+  it("does not abort the submission when the hook rejects", async function () {
+    const warnStub = sinon.stub();
+    const client = new TestTransactionClient({ warn: warnStub, debug: sinon.stub() } as unknown as winston.Logger);
+    const response = await (client as unknown as Internals)._submit(
+      transaction(async () => {
+        throw new Error("redis unavailable");
+      }),
+      { nonce: null }
+    );
+    // The transaction is already on the wire; losing the claim must not lose the transaction.
+    expect(response.hash).to.equal(broadcastHash);
+    expect(events).to.deep.equal(["wait"]);
+    expect(warnStub.calledOnce).to.equal(true);
+    expect(warnStub.firstCall.firstArg.message).to.contain("onBroadcast hook failed");
+  });
+
+  // Regression: the "repriced" branch adopts a replacement whose hash differs from the one already
+  // broadcast, and only that replacement will ever have a receipt. Without re-notifying, a durably
+  // recorded claim points at a hash that never mines, stranding the transfer permanently.
+  it("re-invokes the hook with the replacement hash when a repriced transaction is adopted", async function () {
+    const replacementHash = "0x" + "c".repeat(64);
+    class RepricedTransactionClient extends TransactionClient {
+      protected _getTransactionPromise(): Promise<TransactionResponse> {
+        return Promise.resolve({
+          hash: broadcastHash,
+          nonce: 7,
+          wait: async () => {
+            const error = new Error("repriced") as Error & Record<string, unknown>;
+            error.code = "TRANSACTION_REPLACED";
+            error.reason = "repriced";
+            error.receipt = { blockNumber: 10, status: 1 };
+            error.replacement = { hash: replacementHash };
+            throw error;
+          },
+        } as unknown as TransactionResponse);
+      }
+    }
+
+    const client = new RepricedTransactionClient({
+      warn: sinon.stub(),
+      debug: sinon.stub(),
+    } as unknown as winston.Logger);
+    const seen: string[] = [];
+    const response = await (client as unknown as Internals)._submit(
+      transaction(async (r) => {
+        seen.push(r.hash);
+      }),
+      { nonce: null }
+    );
+
+    expect(response.hash).to.equal(replacementHash);
+    // The original at broadcast, then the replacement that actually mined.
+    expect(seen).to.deep.equal([broadcastHash, replacementHash]);
   });
 });

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -1546,4 +1546,48 @@ describe("TransactionClient onBroadcast hook", function () {
     // The original at broadcast, then the replacement that actually mined.
     expect(seen).to.deep.equal([broadcastHash, replacementHash]);
   });
+
+  // A reverted replacement must be notified too. Only the replacement has a receipt, so a caller left
+  // holding the original hash could never resolve it — the transfer would block forever instead of
+  // being retried after the revert.
+  it("re-invokes the hook when the repriced replacement reverted", async function () {
+    const replacementHash = "0x" + "d".repeat(64);
+    class RevertedRepriceClient extends TransactionClient {
+      protected _getTransactionPromise(): Promise<TransactionResponse> {
+        return Promise.resolve({
+          hash: broadcastHash,
+          nonce: 7,
+          wait: async () => {
+            const error = new Error("repriced") as Error & Record<string, unknown>;
+            error.code = "TRANSACTION_REPLACED";
+            error.reason = "repriced";
+            error.receipt = { blockNumber: 10, status: 0 };
+            error.replacement = { hash: replacementHash };
+            throw error;
+          },
+        } as unknown as TransactionResponse);
+      }
+    }
+
+    const client = new RevertedRepriceClient({
+      warn: sinon.stub(),
+      debug: sinon.stub(),
+    } as unknown as winston.Logger);
+    const seen: string[] = [];
+    let threw = false;
+    try {
+      await (client as unknown as Internals)._submit(
+        transaction(async (r) => {
+          seen.push(r.hash);
+        }),
+        { nonce: null }
+      );
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).to.equal(true);
+    // The claim now points at the reverted replacement, which resolves to status 0 and is retried.
+    expect(seen).to.deep.equal([broadcastHash, replacementHash]);
+  });
 });

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -1307,6 +1307,26 @@ describe("DepositAddressHandler pending-execute claim", function () {
     expect(executeStub.notCalled).to.equal(true);
   });
 
+  // A cached hash with no receipt may have been replaced in Redis by another run's timeout resubmit.
+  // Without reconciling, every later poll re-settles the same dead hash and returns before the
+  // pre-broadcast read, so the transfer would stay blocked for this process's lifetime.
+  it("adopts a replacement hash another run recorded when the cached one has no receipt", async function () {
+    const replacementTxHash = "0x" + "9".repeat(64);
+    const ours = pendingRecord({ txHash: executeTxHash });
+    (handler as unknown as Internals).pendingExecutes = { [depositKey]: ours };
+    // Redis has moved on to the replacement; ours was replaced at the same nonce and never mined.
+    seedClaim(pendingRecord({ txHash: replacementTxHash }));
+    getReceiptStub.withArgs(executeTxHash).resolves(null);
+    getReceiptStub.withArgs(replacementTxHash).resolves(sweepReceipt(0));
+
+    expect(await (handler as unknown as Internals)._settlePendingExecute(depositKey, ours)).to.equal("unresolved");
+    expect((handler as unknown as Internals).pendingExecutes[depositKey].txHash).to.equal(replacementTxHash);
+
+    // The next poll settles the live hash, sees the revert, and lets the deposit be re-attempted.
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
+    expect(executeStub.called).to.equal(true);
+  });
+
   // The README tells operators to repair or delete a malformed field to release a stuck transfer. The
   // quarantine set is only rebuilt on a Redis read, so without re-reading here that recovery would
   // need a restart to take effect.

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -1106,7 +1106,8 @@ describe("DepositAddressHandler pending-execute claim", function () {
     _settlePendingExecute: (k: string, p: PendingExecute) => Promise<"executed" | "reverted" | "unresolved">;
     _recordPendingExecute: (k: string, p: PendingExecute) => Promise<void>;
     _readPendingExecutes: () => Promise<Record<string, PendingExecute>>;
-    _resolvePendingExecutes: () => Promise<void>;
+    _resolvePendingExecutes: (inherited: Record<string, PendingExecute>) => Promise<void>;
+    _loadExecutedDepositsFromRedis: () => Promise<void>;
     executedDepositTxHashes: Set<string>;
     pendingExecutes: Record<string, PendingExecute>;
     lastSettleAttempt: Record<string, number>;
@@ -1191,7 +1192,8 @@ describe("DepositAddressHandler pending-execute claim", function () {
     seedClaim(pendingRecord());
     getReceiptStub.resolves(sweepReceipt(1));
 
-    await (handler as unknown as Internals)._resolvePendingExecutes();
+    const inherited = await (handler as unknown as Internals)._readPendingExecutes();
+    await (handler as unknown as Internals)._resolvePendingExecutes(inherited);
 
     // Adopted into the executed set, so no later run re-submits for this transfer.
     expect((handler as unknown as Internals).executedDepositTxHashes.has(refTxHash)).to.equal(true);
@@ -1206,7 +1208,8 @@ describe("DepositAddressHandler pending-execute claim", function () {
     seedClaim(pendingRecord());
     getReceiptStub.resolves(sweepReceipt(0));
 
-    await (handler as unknown as Internals)._resolvePendingExecutes();
+    const inherited = await (handler as unknown as Internals)._readPendingExecutes();
+    await (handler as unknown as Internals)._resolvePendingExecutes(inherited);
 
     expect((handler as unknown as Internals).executedDepositTxHashes.has(refTxHash)).to.equal(false);
     expect((handler as unknown as Internals).pendingExecutes).to.deep.equal({});
@@ -1220,7 +1223,8 @@ describe("DepositAddressHandler pending-execute claim", function () {
     seedClaim(pendingRecord({ submittedAt: getCurrentTime() - 86_400 }));
     getReceiptStub.resolves(null);
 
-    await (handler as unknown as Internals)._resolvePendingExecutes();
+    const inherited = await (handler as unknown as Internals)._readPendingExecutes();
+    await (handler as unknown as Internals)._resolvePendingExecutes(inherited);
 
     expect((handler as unknown as Internals).pendingExecutes[depositKey].txHash).to.equal(executeTxHash);
     expect((handler as unknown as Internals).executedDepositTxHashes.has(refTxHash)).to.equal(false);
@@ -1263,6 +1267,24 @@ describe("DepositAddressHandler pending-execute claim", function () {
 
     expect(warnStub.calledOnce).to.equal(true);
     expect(warnStub.firstCall.firstArg.message).to.contain("already been broadcast");
+  });
+
+  // Regression for the startup ordering invariant. An incumbent that confirms concurrently persists
+  // the executed hash and only then clears its claim, so the successor must snapshot claims BEFORE
+  // loading the executed set (or it can see neither) but apply them AFTER (or adoption's whole-array
+  // persist drops every other hash). This pins the second half: swapping the two clobbers Redis.
+  it("preserves previously-executed hashes when adopting an inherited claim", async function () {
+    const priorHash = "0x" + "a".repeat(64);
+    const executedKey = "deposit-address:executed:test-bot";
+    store.set(executedKey, JSON.stringify([priorHash]));
+    seedClaim(pendingRecord());
+    getReceiptStub.resolves(sweepReceipt(1));
+
+    const inherited = await (handler as unknown as Internals)._readPendingExecutes();
+    await (handler as unknown as Internals)._loadExecutedDepositsFromRedis();
+    await (handler as unknown as Internals)._resolvePendingExecutes(inherited);
+
+    expect(JSON.parse(store.get(executedKey) as string).sort()).to.deep.equal([priorHash, refTxHash].sort());
   });
 
   // Regression: rewriting a whole serialized map from a fresh read let concurrent broadcasts (polls

--- a/test/DepositAddressHandler.ts
+++ b/test/DepositAddressHandler.ts
@@ -21,6 +21,7 @@ import {
   TransactionClient,
 } from "../src/clients";
 import { PendingExecute } from "../src/deposit-address/pendingExecutes";
+import * as txUtils from "../src/utils/TransactionUtils";
 import { DepositAddressHandler } from "../src/deposit-address/DepositAddressHandler";
 import { DepositAddressHandlerConfig } from "../src/deposit-address/DepositAddressHandlerConfig";
 import { ERC20_TRANSFER_TOPIC } from "../src/deposit-address/withdrawPayload";
@@ -1304,6 +1305,58 @@ describe("DepositAddressHandler pending-execute claim", function () {
     // The transfer stays blocked.
     await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
     expect(executeStub.notCalled).to.equal(true);
+  });
+
+  // The README tells operators to repair or delete a malformed field to release a stuck transfer. The
+  // quarantine set is only rebuilt on a Redis read, so without re-reading here that recovery would
+  // need a restart to take effect.
+  it("picks up an operator's repair of a quarantined claim without a restart", async function () {
+    const hash = new Map<string, string>();
+    hash.set(depositKey, "{not-valid-json");
+    hashes.set(redisKey, hash);
+    // Startup quarantines it, and the transfer is blocked.
+    await (handler as unknown as Internals)._readPendingExecutes();
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
+    expect(executeStub.notCalled).to.equal(true);
+
+    // Operator deletes the field; no restart.
+    hashes.get(redisKey)?.delete(depositKey);
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
+
+    expect(executeStub.called).to.equal(true);
+  });
+
+  // A failed claim delete must not cost the lifecycle event: the executed set already guards the
+  // transfer, so later polls skip it and startup adoption deliberately does not re-publish.
+  it("publishes deposit_executed even if clearing the redundant claim fails", async function () {
+    (handler as unknown as { getExecuteContract: sinon.SinonStub }).getExecuteContract = sinon
+      .stub()
+      .returns({ address: TOKEN });
+    executeStub.resolves({
+      depositAddress: DEPOSIT_ADDRESS,
+      executeTx: { ecosystem: "evm", chainId, to: TOKEN, data: "0x", value: "0" },
+      signer: SIGNER,
+      signatureDeadline: getCurrentTime() + 600,
+      isPlaceholder: false,
+    });
+    sinon.stub(txUtils, "sendAndConfirmTransaction").resolves(sweepReceipt(1));
+
+    // Order is what matters: the publish is unrecoverable, the claim delete is not.
+    const calls: string[] = [];
+    const publishSpy = sinon.stub().callsFake(async () => void calls.push("publish"));
+    (handler as unknown as { _publishDepositExecuted: unknown })._publishDepositExecuted = publishSpy;
+    (handler as unknown as { redisCache: { hDel: sinon.SinonStub } }).redisCache.hDel = sinon
+      .stub()
+      .callsFake(async () => {
+        calls.push("hDel");
+        throw new Error("redis unavailable");
+      });
+
+    await (handler as unknown as Internals).initiateDepositV3(depositMessageV3());
+
+    expect(calls).to.deep.equal(["publish", "hDel"]);
+    expect((handler as unknown as Internals).executedDepositTxHashes.has(refTxHash)).to.equal(true);
+    expect(warnStub.args.some((a) => a[0].message.includes("startup will tidy it"))).to.equal(true);
   });
 
   // The compare and the delete are separate Redis commands, so a claim written in between would be


### PR DESCRIPTION
## Scope: reduce the frequency, not eliminate the bug

**Reviewers (human and AI): please read this section first.**

Duplicate deposit-address executes are not fully solvable at the bot layer. The goal of this PR is a
**considerable reduction in how often the bug fires — not full mitigation.** Every remaining limit
case is knowingly assumed, whether or not it is named below, and a periodic manual sweep is the
accepted backstop. That is a deliberate product decision taken with the team, not an oversight.

So please calibrate accordingly:

- A finding of the form "edge case X still exists" is **not** actionable here. It is the premise.
- A finding of the form "the mechanism as written fails to do the one thing it claims" **is** very
  actionable — e.g. the claim isn't durable before the confirmation wait, a recorded hash can't be
  resolved on-chain, or a confirmed sweep gets re-attempted anyway.
- Extra hardening that closes a residual window at the cost of another Redis key, lock, or lifecycle
  is explicitly out of scope. That path was already taken in #3630 and rejected as overengineered
  for the isolated case worth fixing; this PR replaces it.

The *Deliberately out of scope* section below lists the gaps we are most aware of. It is
illustrative, not exhaustive — an unlisted residual gap is still assumed, not a defect.

## The bug being narrowed

Runs overlap by design. A successor overwrites the Redis instance key during `initialize()`, while
the incumbent only discovers it on its next 1s `InstanceCoordinator.subscribe()` poll — and
`abort()` merely does `clearInterval`, so a tick already in flight runs to completion. Two bots are
routinely live for a second or more.

A run can therefore broadcast an execute and be evicted before the receipt lands. Today the bot
records "I swept this" **only after** confirmation (`executedDepositTxHashes` → Redis), so that sweep
leaves no trace anywhere. Because a deposit address is a shared pot, the untracked sweep resurfaces
later: when a new transfer funds the same address, the old message's balance check passes again and
the bot executes stale calldata against the new money.

## The fix

Persist submission intent before the confirmation wait; clear it on confirmation; reconcile on the
next run.

- **`TransactionClient`** gains an optional `onBroadcast` hook, invoked once the hash exists and
  before the confirmation wait. Hook rejections are logged and swallowed — the transaction is already
  on the wire, so losing the record must not lose the transaction. The `repriced` branch re-notifies
  with the replacement hash, since only the replacement will ever have a receipt.
- **Claims** live in a new Redis hash, `deposit-address:pending-execute-claims:<botIdentifier>`, one
  field per `depositKey`, so two runs recording different transfers cannot clobber each other. No
  TTL: a claim must outlive the indexer message that produced it. This needs `hSet`/`hGetAll`/`hDel`
  on `RedisCacheInterface`.
- **Resolution** against the chain happens at startup (adopting the incumbent's in-flight work) and
  again, throttled to once a minute per key, when a poll finds an outstanding claim:

  | Receipt | Outcome | Action |
  | --- | --- | --- |
  | no provider / RPC error | `unresolved` | warn, keep |
  | absent | `unresolved` | keep; transfer stays blocked |
  | `status === 0` | `reverted` | clear; deposit re-attempted |
  | mined, `status !== 0` | `executed` | adopt into the executed set, clear |

  Only an explicit `status === 0` is a revert — ethers leaves `status` undefined on some chains, and
  treating that as success can strand a deposit but can never cause a second sweep.

The in-run re-check is not extra scope: without it a revert would wait for the next run to retry,
where today it retries on the next 1s poll. It also replaces the need for a separate inline
post-failure settle path.

Tron note: TronWeb reports an un-prefixed `txid`, which is what the hook records verbatim, so
`receiptLookupHash` 0x-prefixes it for the eth-JSON-RPC provider. Without that every Tron claim would
fail to resolve forever.

## Deliberately out of scope (accepted, with reasons — illustrative, not exhaustive)

1. **Two overlapping runs can still both broadcast.** At the moment each bot checks, neither has
   broadcast yet, so there is nothing for either to find — persisting on broadcast cannot fix this.
   A re-read of the claim hash immediately before the send narrows the window from the whole
   quote-api round trip (~1-2s) to a single Redis read, but does not close it. A mutual-exclusion
   lock would; it was dropped as disproportionate. Note this is only a genuine double-sweep where
   the retry lands in a different nonce space: always on nonce-less TVM, and on EVM when dispatcher
   keys rotate the retry onto a different signer. With a single EVM signer, both submissions occupy
   the same nonce and only one can land.
2. **A claim whose transaction never mines is never discarded**, so that transfer stays blocked
   until someone deletes the Redis field. `submittedAt` is recorded but no logic expires it, and
   there is no EVM/TVM branch. Auto-discarding would be unsound on TVM (a resubmit is an independent
   transaction, so both could land) and unsound on EVM whenever dispatcher keys are in play. One
   stuck transfer plus one manual action beats a possible double sweep. Claims are per-`depositKey`,
   so nothing else is affected. Ops procedure is in the module README.
3. **v1 `initiateDeposit` and both refund-withdraw paths are unchanged** and still persist only
   after confirmation. Same structural hole, but the incident was on the v3 execute path.
4. **An externally repriced execute whose replacement hash this bot never observed** leaves a claim
   pointing at a hash that cannot resolve, so the transfer blocks until an ops release (same handling
   as item 2). The bot's own resubmit paths update the claim, and a repriced-and-reverted replacement
   is now notified too, so this needs a replacement broadcast by something other than this bot.
   Recovering it would mean mapping `(sender, nonce)` to the transaction that mined there — no
   standard JSON-RPC lookup exists — or inferring a sweep from a consumed nonce without a receipt,
   which is the one inversion this design refuses.
5. **The defensive balance check remains unsound by design** — a shared pot means a sufficient
   balance never proves *this* transfer is unswept. Unchanged here.

## Testing

`RELAYER_TEST=true yarn hardhat test test/DepositAddressHandler.ts` → 62 passing, 12 new:

- claim round-trip through the Redis hash; concurrent writes on two keys keep both
- an outstanding, recently-checked claim blocks resubmission without a redundant receipt lookup
- inherited claim confirmed ⇒ adopted, and a subsequent `initiateDepositV3` is a no-op
- inherited claim reverted ⇒ cleared, no publish; and past the throttle, re-attempted in the same poll
- unmined claim ⇒ retained (even a day old) and blocks resubmission
- a claim present in Redis but not the in-memory mirror blocks the send
- Tron txid is 0x-prefixed before receipt lookup
- `onBroadcast` fires before `wait`, survives a rejecting hook, and re-fires with the replacement hash

`test/DepositAddressHandler.publish.ts`, `test/TransactionClient.ts`, `test/DepositAddressUtils.ts`
→ 39 passing. `yarn lint` clean. `yarn build` reports only the three `poolRebalanceLeafCount` errors
already present on master.

## Note on `fix/tvm-wait-revert-detection`

That branch (#659cbaad, not yet on master) makes a reverted TVM transaction throw in `wait()`, which
surfaces here as an undefined receipt and lets a later poll observe `status === 0` and clear the
claim. Until it lands, TVM reverts resolve as success. The two changes compose; neither blocks the
other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




