### PR TITLE
fix(rebalancer): skip Binance routes with suspended withdrawal networks

### DIFF
--- a/src/rebalancer/README.md
+++ b/src/rebalancer/README.md
@@ -339,6 +339,20 @@ EVM withdrawal recipients and the running signer account before applying this sh
 rebalance loading errors surface normally so operators can investigate instead of silently sweeping without the
 deduction.
 
+Binance suspends withdrawals per coin/network pair during chain upgrades and wallet maintenance, reporting `031026` on
+the withdrawal call. A suspended pair stays listed in `accountCoins().networkList` for the whole window, so the
+`withdrawEnable` flag on the network entry — not the pair's presence in the list — is what determines whether the
+withdrawal leg will be accepted. The Binance adapter handles this on both sides of an order. `initializeRebalance`
+checks `withdrawEnable` on the resolved destination network and skips the route before committing funds, because the
+deposit leg into Binance cannot be reversed from this adapter and an order that cannot be withdrawn would otherwise
+strand its tranche on the exchange until `REBALANCER_PENDING_ORDER_TTL` elapses. Account coins are read with the cache
+bypassed on that path, since the flag flips whenever a withdrawal window opens or closes and the cache entry uses a long
+TTL. For orders already holding an exchange balance, `_withdraw` treats `031026` the same way it treats `RW00441` — a
+retryable wait state that leaves the order pending, warns, and lets the existing prune/finalizer handover reclaim the
+deposit if the suspension outlasts the order TTL. Withdrawal availability is deliberately *not* asserted in
+`initialize()`: those assertions run at boot and throw, so gating them on a transient venue suspension would stop the
+bot from starting at all.
+
 ## Venue-specific operational note
 
 Hyperliquid spot metadata is currently configured with `pxDecimals=4` for USDT/USDC and prices are truncated to `pxDecimals` when submitting orders. This is a pragmatic setting to avoid tick-size divisibility rejections observed with more granular precision.

--- a/src/rebalancer/adapters/binance.ts
+++ b/src/rebalancer/adapters/binance.ts
@@ -757,7 +757,10 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
     const { sourceChain, sourceToken, destinationToken, destinationChain } = rebalanceRoute;
     const routeRequiresSwap = this._routeRequiresSwap(sourceToken, destinationToken);
 
-    const destinationCoin = await this._getAccountCoins(destinationToken);
+    // Read account coins fresh here: `withdrawEnable` flips whenever Binance opens or closes a withdrawal window, and
+    // a stale cache entry would either keep committing funds to a suspended route or keep skipping one that has
+    // already reopened.
+    const destinationCoin = await this._getAccountCoins(destinationToken, true);
     const destinationEntrypointNetwork = await this._getEntrypointNetwork(destinationChain, destinationToken);
     const destinationBinanceNetwork = destinationCoin.networkList.find(
       (network) => network.name === BINANCE_NETWORKS[destinationEntrypointNetwork]
@@ -766,6 +769,21 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       isDefined(destinationBinanceNetwork),
       `No Binance network entry for ${destinationToken} on chain ${destinationEntrypointNetwork}`
     );
+    // Binance keeps a suspended coin/network pair listed in `networkList`, so this flag is the only pre-trade signal
+    // that the withdrawal leg will be rejected. Bail out before any funds are committed: the deposit into Binance is
+    // not reversible from this adapter, so initiating an order we cannot withdraw would strand the tranche on the
+    // exchange until its TTL elapses and the finalizer reclaims it.
+    if (!isBinanceNetworkWithdrawEnabled(destinationBinanceNetwork)) {
+      this.logger.warn({
+        at: "BinanceStablecoinSwapAdapter.initializeRebalance",
+        message: `🚧 Skipping rebalance: Binance has suspended ${resolveBinanceCoinSymbol(
+          destinationToken
+        )} withdrawals on network ${BINANCE_NETWORKS[destinationEntrypointNetwork]}`,
+        rebalanceRoute,
+        destinationNetwork: BINANCE_NETWORKS[destinationEntrypointNetwork],
+      });
+      return bnZero;
+    }
     const { withdrawMin, withdrawMax } = destinationBinanceNetwork;
 
     // Make sure that the amount to transfer will be larger than the minimum withdrawal size after expected fees.
@@ -1690,18 +1708,36 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
       });
     } catch (error) {
       const unlockErrorMessage = getBinanceDepositUnlockErrorMessage(error);
-      if (!unlockErrorMessage) {
-        throw error;
+      if (unlockErrorMessage) {
+        this.logger.debug({
+          at: "BinanceStablecoinSwapAdapter._withdraw",
+          message: `Binance rejected withdrawal for order ${cloid} because recent deposits have not reached withdrawal-unlock confirmations. Waiting before retrying.`,
+          cloid,
+          destinationToken,
+          amountToWithdraw,
+          error: unlockErrorMessage,
+        });
+        return false;
       }
-      this.logger.debug({
-        at: "BinanceStablecoinSwapAdapter._withdraw",
-        message: `Binance rejected withdrawal for order ${cloid} because recent deposits have not reached withdrawal-unlock confirmations. Waiting before retrying.`,
-        cloid,
-        destinationToken,
-        amountToWithdraw,
-        error: unlockErrorMessage,
-      });
-      return false;
+      // A suspended withdrawal window is a venue-side outage, not a bug in this order. Leave the order pending so it
+      // retries once Binance reopens withdrawals; if the suspension outlasts REBALANCER_PENDING_ORDER_TTL the prune
+      // path hands the deposit back to the Binance finalizer, which reclaims it.
+      const withdrawDisabledErrorMessage = getBinanceWithdrawDisabledErrorMessage(error);
+      if (withdrawDisabledErrorMessage) {
+        this.logger.warn({
+          at: "BinanceStablecoinSwapAdapter._withdraw",
+          message: `🚧 Binance has suspended ${binanceDestinationCoin} withdrawals on network ${
+            BINANCE_NETWORKS[destinationEntrypointNetwork]
+          }; leaving order ${cloid} pending until withdrawals reopen.`,
+          cloid,
+          destinationToken,
+          destinationNetwork: BINANCE_NETWORKS[destinationEntrypointNetwork],
+          amountToWithdraw,
+          error: withdrawDisabledErrorMessage,
+        });
+        return false;
+      }
+      throw error;
     }
     const initiatedWithdrawalKey = this._redisGetInitiatedWithdrawalKey(cloid);
     await this.redisCache.set(initiatedWithdrawalKey, withdrawalId.id);
@@ -1758,4 +1794,19 @@ export class BinanceStablecoinSwapAdapter extends BaseAdapter {
 function getBinanceDepositUnlockErrorMessage(error: unknown): string | undefined {
   const message = error instanceof Error ? error.message : String(error);
   return message.includes("[RW00441]") ? message : undefined;
+}
+
+// Binance reports [031026] when withdrawals for a coin/network pair are administratively suspended, for example during
+// a chain upgrade or a wallet maintenance window. The pair stays listed in `networkList` for the whole suspension, so
+// presence in the network list is not sufficient to conclude that a withdrawal will be accepted.
+function getBinanceWithdrawDisabledErrorMessage(error: unknown): string | undefined {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("[031026]") ? message : undefined;
+}
+
+// Binance omits `withdrawEnable` on some `accountCoins` responses, so treat an absent flag as enabled — a missing
+// field should never strand an otherwise healthy route. Mirrors `isNetworkEnabledForDirection` in
+// scripts/swapOnBinance.ts.
+function isBinanceNetworkWithdrawEnabled(network: { withdrawEnable?: boolean }): boolean {
+  return network.withdrawEnable ?? true;
 }

--- a/test/BinanceAdapter.helpers.ts
+++ b/test/BinanceAdapter.helpers.ts
@@ -10,6 +10,7 @@ import {
   BINANCE_WITHDRAW_RECV_WINDOW_MS,
   BINANCE_WITHDRAWAL_STATUS,
   BigNumber,
+  bnZero,
   CHAIN_IDs,
   EvmAddress,
   getEthersCompatibleAddress,
@@ -269,6 +270,161 @@ describe("Binance adapter helpers", function () {
     expect(debug.calledOnce).to.equal(true);
     expect(debug.getCall(0).args[0].error).to.include("[RW00441]");
     expect(debug.getCall(0).args[0].error).to.include("required unlock confirmations for withdrawal");
+  });
+
+  it("treats Binance 031026 withdrawal suspensions as a retryable wait state", async function () {
+    const [signer] = await ethers.getSigners();
+    const warn = sinon.stub();
+    const adapter = new BinanceStablecoinSwapAdapter(
+      { ...TEST_LOGGER, warn } as unknown as winston.Logger,
+      {} as RebalancerConfig,
+      signer,
+      {} as CctpAdapter,
+      {} as OftAdapter
+    );
+    const internals = adapter as unknown as {
+      baseSignerAddress: EvmAddress;
+      binanceApiClient: { withdraw: sinon.SinonStub };
+      _withdraw(cloid: string, quantity: number, destinationToken: string, destinationChain: number): Promise<boolean>;
+      _getEntrypointNetwork(chainId: number, token: string): Promise<number>;
+      _getTokenInfo(token: string, chainId: number): { decimals: number };
+    };
+    internals.baseSignerAddress = EvmAddress.from(await signer.getAddress());
+    internals.binanceApiClient = {
+      withdraw: sinon.stub().rejects(new Error("[031026] Withdrawal is not available for this currency.")),
+    };
+    sinon.stub(internals, "_getEntrypointNetwork").resolves(CHAIN_IDs.AVALANCHE);
+    sinon.stub(internals, "_getTokenInfo").returns({ decimals: 6 });
+
+    // A suspended withdrawal window must not escape as an exception: an unhandled rejection here crashes the whole
+    // rebalancer run, which is what turned a routine Binance maintenance window into a paging loop.
+    const result = await internals._withdraw("cloid", 100, "USDT", CHAIN_IDs.AVALANCHE);
+
+    expect(result).to.equal(false);
+    expect(internals.binanceApiClient.withdraw.calledOnce).to.equal(true);
+    expect(warn.calledOnce).to.equal(true);
+    expect(warn.getCall(0).args[0].error).to.include("[031026]");
+    expect(warn.getCall(0).args[0].destinationNetwork).to.equal(BINANCE_NETWORKS[CHAIN_IDs.AVALANCHE]);
+  });
+
+  it("skips initializing a rebalance whose destination withdrawal network is suspended", async function () {
+    const [signer] = await ethers.getSigners();
+    const warn = sinon.stub();
+    const adapter = new BinanceStablecoinSwapAdapter(
+      { ...TEST_LOGGER, warn } as unknown as winston.Logger,
+      {} as RebalancerConfig,
+      signer,
+      {} as CctpAdapter,
+      {} as OftAdapter
+    );
+    const internals = adapter as unknown as {
+      initializeRebalance(route: unknown, amountToTransfer: BigNumber): Promise<BigNumber>;
+      _assertInitialized(): void;
+      _assertRouteIsSupported(route: unknown): void;
+      _routeRequiresSwap(sourceToken: string, destinationToken: string): boolean;
+      _getAccountCoins(symbol: string, skipCache?: boolean): Promise<unknown>;
+      _getEntrypointNetwork(chainId: number, token: string): Promise<number>;
+      _getBridgingFees(route: unknown, amountToTransfer: BigNumber): Promise<BigNumber>;
+    };
+    sinon.stub(internals, "_assertInitialized");
+    sinon.stub(internals, "_assertRouteIsSupported");
+    sinon.stub(internals, "_routeRequiresSwap").returns(false);
+    sinon.stub(internals, "_getEntrypointNetwork").resolves(CHAIN_IDs.AVALANCHE);
+    const accountCoins = sinon.stub(internals, "_getAccountCoins").resolves({
+      symbol: "USDT",
+      balance: "0",
+      networkList: [
+        {
+          name: BINANCE_NETWORKS[CHAIN_IDs.AVALANCHE],
+          coin: "USDT",
+          withdrawMin: "1",
+          withdrawMax: "1000000",
+          withdrawFee: "0",
+          contractAddress: TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.AVALANCHE],
+          withdrawEnable: false,
+        },
+      ],
+    });
+    const bridgingFees = sinon.stub(internals, "_getBridgingFees").resolves(bnZero);
+
+    const result = await internals.initializeRebalance(
+      {
+        sourceChain: CHAIN_IDs.MAINNET,
+        sourceToken: "USDT",
+        destinationChain: CHAIN_IDs.AVALANCHE,
+        destinationToken: "USDT",
+        adapter: "binance",
+      },
+      toBNWei("6000", 6)
+    );
+
+    expect(result.eq(bnZero)).to.equal(true);
+    // The deposit leg into Binance is not reversible from this adapter, so the gate has to run before any pricing or
+    // bridging work commits funds to a route we cannot withdraw from.
+    expect(bridgingFees.called).to.equal(false);
+    expect(warn.calledOnce).to.equal(true);
+    expect(warn.getCall(0).args[0].destinationNetwork).to.equal(BINANCE_NETWORKS[CHAIN_IDs.AVALANCHE]);
+    // Withdrawal availability has to be read fresh — the account-coins cache uses a long TTL, so a cached entry would
+    // keep the route dead after Binance reopens withdrawals.
+    expect(accountCoins.getCall(0).args[1]).to.equal(true);
+  });
+
+  it("treats an absent withdrawEnable flag as withdrawable", async function () {
+    const [signer] = await ethers.getSigners();
+    const warn = sinon.stub();
+    const adapter = new BinanceStablecoinSwapAdapter(
+      { ...TEST_LOGGER, warn } as unknown as winston.Logger,
+      {} as RebalancerConfig,
+      signer,
+      {} as CctpAdapter,
+      {} as OftAdapter
+    );
+    const internals = adapter as unknown as {
+      initializeRebalance(route: unknown, amountToTransfer: BigNumber): Promise<BigNumber>;
+      _assertInitialized(): void;
+      _assertRouteIsSupported(route: unknown): void;
+      _routeRequiresSwap(sourceToken: string, destinationToken: string): boolean;
+      _getAccountCoins(symbol: string, skipCache?: boolean): Promise<unknown>;
+      _getEntrypointNetwork(chainId: number, token: string): Promise<number>;
+      _getBridgingFees(route: unknown, amountToTransfer: BigNumber): Promise<BigNumber>;
+    };
+    sinon.stub(internals, "_assertInitialized");
+    sinon.stub(internals, "_assertRouteIsSupported");
+    sinon.stub(internals, "_routeRequiresSwap").returns(false);
+    sinon.stub(internals, "_getEntrypointNetwork").resolves(CHAIN_IDs.AVALANCHE);
+    sinon.stub(internals, "_getAccountCoins").resolves({
+      symbol: "USDT",
+      balance: "0",
+      // No withdrawEnable key at all, which is how Binance renders some accountCoins entries.
+      networkList: [
+        {
+          name: BINANCE_NETWORKS[CHAIN_IDs.AVALANCHE],
+          coin: "USDT",
+          withdrawMin: "1",
+          withdrawMax: "1000000",
+          withdrawFee: "0",
+          contractAddress: TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.AVALANCHE],
+        },
+      ],
+    });
+    // Proves the gate let the route through: execution reached the next external call rather than returning early.
+    const bridgingFees = sinon.stub(internals, "_getBridgingFees").rejects(new Error("reached bridging fees"));
+
+    await expect(
+      internals.initializeRebalance(
+        {
+          sourceChain: CHAIN_IDs.MAINNET,
+          sourceToken: "USDT",
+          destinationChain: CHAIN_IDs.AVALANCHE,
+          destinationToken: "USDT",
+          adapter: "binance",
+        },
+        toBNWei("6000", 6)
+      )
+    ).to.be.rejectedWith("reached bridging fees");
+
+    expect(bridgingFees.calledOnce).to.equal(true);
+    expect(warn.called).to.equal(false);
   });
 
   it("builds Tron direct deposit transfers with ethers-compatible addresses", async function () {


### PR DESCRIPTION
## Context

Binance suspended USDT withdrawals on the **AVAXC** network on 2026-08-04. `zion-across-same-asset-rebalancer`'s `USDT Ethereum(1) -> USDT Avalanche(43114)` route kept depositing into the exchange and then failed the withdrawal leg with:

```
Error: [031026] Withdrawal is not available for this currency.
    at BinanceStablecoinSwapAdapter._withdraw (src/rebalancer/adapters/binance.ts)
    at BinanceStablecoinSwapAdapter.updateRebalanceStatuses
    at updateAdapters (src/rebalancer/index.ts)
```

The error escaped `_withdraw`, crashed the spoke with `Process exited with code 1`, and paged **21 times between 2026-08-04T18:19Z and 2026-08-05T00:29Z** (one crash every ~2.5 min). It was still firing when this was written.

Worse than the pages: the loop **re-armed itself hourly**. Each time a pending order hit `REBALANCER_PENDING_ORDER_TTL` the prune path released its tranche, and the next run deposited a fresh one into Binance that also could not be withdrawn — about **13.3k USDT** stranded on the exchange across the incident (`0x059d664e…` 6,717.76 USDT pruned, `0x3b943969…` 6,626.91 USDT live). Nothing user-facing was affected; every other spoke reported healthy throughout.

## Root cause

Two independent gaps turned a routine venue maintenance window into a crash loop.

**1. `_withdraw` only classified `[RW00441]` as a retryable venue wait state** and rethrew everything else. A suspended withdrawal window is equally a venue-side condition with an equally correct "leave the order pending" response, but it took down the whole run instead.

**2. Nothing consulted `withdrawEnable`.** Binance keeps a suspended coin/network pair listed in `accountCoins().networkList` for the entire suspension, so every existing gate — the `initialize()` asserts, `_getEntrypointNetwork`, and `initializeRebalance`'s network lookup — still resolved the route as valid. `src/utils/BinanceUtils.ts` has parsed `withdrawEnable` since the adapter was written and `scripts/swapOnBinance.ts` gates on it correctly; the adapter just never read it.

## Changes

All in `src/rebalancer/adapters/binance.ts`:

- **`initializeRebalance` checks `withdrawEnable`** on the resolved destination network and returns `bnZero` before any funds are committed. Placed ahead of the pricing/bridging work because the deposit leg into Binance is not reversible from this adapter — initiating an order we cannot withdraw is what strands the tranche.
- **That path reads account coins with the cache bypassed** (`_getAccountCoins(token, true)`). The flag flips whenever a withdrawal window opens or closes and the cache entry uses a long TTL, so a cached value would either keep committing funds to a suspended route or keep the route dead after Binance reopens it. Consistent with `_getBinanceBalance`, which already skips the cache.
- **`_withdraw` treats `[031026]` the way it already treats `[RW00441]`** — warn and leave the order pending. Orders already holding an exchange balance retry until withdrawals reopen; if the suspension outlasts the order TTL the existing prune path hands the deposit to the Binance finalizer to reclaim. `warn` rather than `error` so a venue outage is visible without paging.

## Deliberate non-changes

- **`initialize()` still asserts network presence only.** Those asserts run at boot and throw — gating them on `withdrawEnable` would stop the bot from starting during a transient suspension. Called out in the README.
- **`_getEntrypointNetwork` does not reroute.** Falling back to the default Arbitrum entrypoint when the destination network is suspended would deliver funds to the wrong chain. Skipping the route is correct; an intermediate-bridge alternative is a larger design change with fee implications.
- **`getEstimatedCost` is not gated.** A suspended route may still win cost competition and then no-op in `initializeRebalance` — one wasted evaluation, no funds at risk. Signalling "unavailable" through a `BigNumber` return isn't expressible cleanly; worth a follow-up if it proves noisy.
- **Absent `withdrawEnable` is treated as enabled**, matching `isNetworkEnabledForDirection` in `scripts/swapOnBinance.ts`. Binance omits the field on some responses and a missing field should never strand a healthy route.

## Relationship to #3595

[#3595](https://github.com/across-protocol/relayer/pull/3595) (open since 2026-07-19) adds the per-adapter isolation in `updateAdapters` that would have contained this crash to the Binance adapter instead of aborting the whole run. **The two are complementary and don't overlap** — #3595 touches `src/rebalancer/index.ts` and the client classes, this PR touches only the Binance adapter. #3595 stops one venue from taking down every adapter; this PR stops the Binance adapter from failing in the first place and from stranding funds. Both are worth landing.

## Testing

Three new unit tests in `test/BinanceAdapter.helpers.ts`:
- `[031026]` is a retryable wait state — `_withdraw` returns `false` rather than throwing, and warns with the destination network.
- `initializeRebalance` skips a suspended destination network, returns zero, short-circuits before `_getBridgingFees`, and reads account coins with `skipCache=true`.
- An absent `withdrawEnable` flag still lets the route through.

```
test/BinanceAdapter.helpers.ts                    19 passing
Binance suites (conversions/quotes/withdrawals/
  client/finalizer/utils/swapOnBinance/sweep)     68 passing
Rebalancer suites (routeSupport/cumulative/
  buildRoutes/cloid/utils/config/loadBalances)    59 passing
tsc --noEmit                                      clean
eslint + prettier                                 clean
```

## Docs

Extended `src/rebalancer/README.md` alongside the existing `RW00441` paragraph, covering the `withdrawEnable`-vs-presence distinction, the cache-bypass rationale, and why `initialize()` is intentionally left alone.

## Operator note

This stops the bleeding in code, but the route stays dead until Binance re-enables USDT/AVAXC. If Avalanche USDT inventory needs replenishing before then, it has to go via a different venue or an on-chain bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
