### PR TITLE
fix(finalizer): finalize Lens asset-router withdrawals via finalizeDeposit

### DIFF
--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -1,6 +1,6 @@
 import { interfaces, utils as sdkUtils } from "@across-protocol/sdk";
 import { Contract, Signer } from "ethers";
-import { Provider as zksProvider, Wallet as zkWallet } from "zksync-ethers";
+import { Provider as zksProvider, Wallet as zkWallet, utils as zksUtils } from "zksync-ethers";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
 import { CONTRACT_ADDRESSES, getContractEntry } from "../../common";
 import {
@@ -215,6 +215,31 @@ async function getWithdrawalParams(
 }
 
 /**
+ * Which L1 entrypoint finalizes a given withdrawal.
+ *
+ * The legacy finalizeWithdrawal() does not carry l2Sender, so the L1 contract has to assume it. That
+ * assumption does not hold for withdrawals initiated by the L2 asset router -- every ERC-20, which on a
+ * chain whose base token isn't ETH includes WETH -- and the resulting message hash mismatch reverts
+ * InvalidProof(). finalizeDeposit() passes l2Sender explicitly, so prefer it wherever it exists. The
+ * standalone ZkStack USDC bridge only implements the legacy entrypoint, hence that exception.
+ *
+ * @dev Verified on mainnet state against Lens WETH 0xa964075c…12cec8 (l2Sender = L2 asset router), where
+ * finalizeWithdrawal() reverts InvalidProof() and finalizeDeposit() succeeds.
+ * @param l2ChainId Chain ID for the L2.
+ * @param l2Sender The L2 contract that initiated the withdrawal.
+ * @param requiresCustomUsdcBridge Whether this withdrawal routes via the standalone ZkStack USDC bridge.
+ * @returns true if the withdrawal must be finalized via the legacy finalizeWithdrawal() entrypoint.
+ */
+export function useLegacyFinalizeWithdrawal(
+  l2ChainId: number,
+  l2Sender: string,
+  requiresCustomUsdcBridge: boolean
+): boolean {
+  const isAssetRouterWithdrawal = l2Sender.toLowerCase() === zksUtils.L2_ASSET_ROUTER_ADDRESS.toLowerCase();
+  return requiresCustomUsdcBridge || ([CHAIN_IDs.LENS].includes(l2ChainId) && !isAssetRouterWithdrawal);
+}
+
+/**
  * @param withdrawal Withdrawal proof data for a single withdrawal.
  * @param ethAddr Ethereum address on the L2.
  * @param l1Mailbox zkSync mailbox contract on the L1.
@@ -224,19 +249,20 @@ async function getWithdrawalParams(
 async function prepareFinalization(
   withdrawal: zkSyncWithdrawalData,
   l2ChainId: number,
-  l1SharedBridge: Contract
+  l1SharedBridge: Contract,
+  requiresCustomUsdcBridge: boolean
 ): Promise<Multicall2Call> {
-  const isLegacyBridge = [CHAIN_IDs.LENS].includes(l2ChainId);
+  const useLegacyEntrypoint = useLegacyFinalizeWithdrawal(l2ChainId, withdrawal.sender, requiresCustomUsdcBridge);
   const args = [
     l2ChainId,
     withdrawal.l1BatchNumber,
     withdrawal.l2MessageIndex,
-    isLegacyBridge ? undefined : withdrawal.sender,
+    useLegacyEntrypoint ? undefined : withdrawal.sender,
     withdrawal.l2TxNumberInBlock,
     withdrawal.message,
     withdrawal.proof,
   ];
-  const calldata = isLegacyBridge
+  const calldata = useLegacyEntrypoint
     ? await l1SharedBridge.populateTransaction.finalizeWithdrawal(...args.filter(isDefined))
     : await l1SharedBridge.populateTransaction.finalizeDeposit(args);
 
@@ -264,12 +290,10 @@ async function prepareFinalizations(
   );
 
   return await sdkUtils.mapAsync(withdrawalParams, async (withdrawal, idx) => {
-    const finalizationContract = getFinalizationContract(
-      l1ChainId,
-      tokensBridged[idx].chainId,
-      tokensBridged[idx].l2TokenAddress
-    );
-    return prepareFinalization(withdrawal, l2ChainId, finalizationContract);
+    const { chainId, l2TokenAddress } = tokensBridged[idx];
+    const requiresCustomUsdcBridge = withdrawalRequiresCustomUsdcBridge(l1ChainId, chainId, l2TokenAddress);
+    const finalizationContract = getFinalizationContract(l1ChainId, chainId, l2TokenAddress);
+    return prepareFinalization(withdrawal, l2ChainId, finalizationContract, requiresCustomUsdcBridge);
   });
 }
 

--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -215,28 +215,22 @@ async function getWithdrawalParams(
 }
 
 /**
- * Which L1 entrypoint finalizes a given withdrawal.
+ * Which L1 entrypoint finalizes a given withdrawal on the L1Nullifier.
  *
  * The legacy finalizeWithdrawal() does not carry l2Sender, so the L1 contract has to assume it. That
  * assumption does not hold for withdrawals initiated by the L2 asset router -- every ERC-20, which on a
  * chain whose base token isn't ETH includes WETH -- and the resulting message hash mismatch reverts
- * InvalidProof(). finalizeDeposit() passes l2Sender explicitly, so prefer it wherever it exists. The
- * standalone ZkStack USDC bridge only implements the legacy entrypoint, hence that exception.
+ * InvalidProof(). finalizeDeposit() passes l2Sender explicitly, so prefer it wherever it exists.
  *
  * @dev Verified on mainnet state against Lens WETH 0xa964075c…12cec8 (l2Sender = L2 asset router), where
  * finalizeWithdrawal() reverts InvalidProof() and finalizeDeposit() succeeds.
  * @param l2ChainId Chain ID for the L2.
  * @param l2Sender The L2 contract that initiated the withdrawal.
- * @param requiresCustomUsdcBridge Whether this withdrawal routes via the standalone ZkStack USDC bridge.
  * @returns true if the withdrawal must be finalized via the legacy finalizeWithdrawal() entrypoint.
  */
-export function useLegacyFinalizeWithdrawal(
-  l2ChainId: number,
-  l2Sender: string,
-  requiresCustomUsdcBridge: boolean
-): boolean {
+export function useLegacyFinalizeWithdrawal(l2ChainId: number, l2Sender: string): boolean {
   const isAssetRouterWithdrawal = l2Sender.toLowerCase() === zksUtils.L2_ASSET_ROUTER_ADDRESS.toLowerCase();
-  return requiresCustomUsdcBridge || ([CHAIN_IDs.LENS].includes(l2ChainId) && !isAssetRouterWithdrawal);
+  return [CHAIN_IDs.LENS].includes(l2ChainId) && !isAssetRouterWithdrawal;
 }
 
 /**
@@ -244,15 +238,15 @@ export function useLegacyFinalizeWithdrawal(
  * @param ethAddr Ethereum address on the L2.
  * @param l1Mailbox zkSync mailbox contract on the L1.
  * @param l1ERC20Bridge zkSync ERC20 bridge contract on the L1.
+ * @param useLegacyEntrypoint Whether to finalize via the legacy finalizeWithdrawal() rather than finalizeDeposit().
  * @returns Calldata for a withdrawal finalization.
  */
 async function prepareFinalization(
   withdrawal: zkSyncWithdrawalData,
   l2ChainId: number,
   l1SharedBridge: Contract,
-  requiresCustomUsdcBridge: boolean
+  useLegacyEntrypoint: boolean
 ): Promise<Multicall2Call> {
-  const useLegacyEntrypoint = useLegacyFinalizeWithdrawal(l2ChainId, withdrawal.sender, requiresCustomUsdcBridge);
   const args = [
     l2ChainId,
     withdrawal.l1BatchNumber,
@@ -291,9 +285,14 @@ async function prepareFinalizations(
 
   return await sdkUtils.mapAsync(withdrawalParams, async (withdrawal, idx) => {
     const { chainId, l2TokenAddress } = tokensBridged[idx];
-    const requiresCustomUsdcBridge = withdrawalRequiresCustomUsdcBridge(l1ChainId, chainId, l2TokenAddress);
     const finalizationContract = getFinalizationContract(l1ChainId, chainId, l2TokenAddress);
-    return prepareFinalization(withdrawal, l2ChainId, finalizationContract, requiresCustomUsdcBridge);
+
+    // The standalone ZkStack USDC bridge only implements finalizeWithdrawal(), so it's the sole entrypoint
+    // available there. Everything else finalizes on the L1Nullifier, where the sender decides.
+    const useLegacyEntrypoint =
+      withdrawalRequiresCustomUsdcBridge(l1ChainId, chainId, l2TokenAddress) ||
+      useLegacyFinalizeWithdrawal(l2ChainId, withdrawal.sender);
+    return prepareFinalization(withdrawal, l2ChainId, finalizationContract, useLegacyEntrypoint);
   });
 }
 

--- a/test/ZkSyncFinalizer.ts
+++ b/test/ZkSyncFinalizer.ts
@@ -10,19 +10,17 @@ const LENS_L2_USDC_BRIDGE = "0x7188b6975eec82ae914b6ec7ac32b3c9a18b2c81";
 describe("ZkSyncFinalizer", function () {
   describe("useLegacyFinalizeWithdrawal", function () {
     // Each row was verified by simulating both entrypoints against mainnet state on 2026-08-05.
-    const cases: { name: string; l2ChainId: number; l2Sender: string; customUsdcBridge: boolean; legacy: boolean }[] = [
+    const cases: { name: string; l2ChainId: number; l2Sender: string; legacy: boolean }[] = [
       {
         name: "zkSync ETH withdrawal (base token)",
         l2ChainId: CHAIN_IDs.ZK_SYNC,
         l2Sender: zksUtils.L2_BASE_TOKEN_ADDRESS,
-        customUsdcBridge: false,
         legacy: false,
       },
       {
         name: "zkSync USDT withdrawal (asset router)",
         l2ChainId: CHAIN_IDs.ZK_SYNC,
         l2Sender: zksUtils.L2_ASSET_ROUTER_ADDRESS,
-        customUsdcBridge: false,
         legacy: false,
       },
       {
@@ -31,37 +29,34 @@ describe("ZkSyncFinalizer", function () {
         name: "Lens WETH withdrawal (asset router)",
         l2ChainId: CHAIN_IDs.LENS,
         l2Sender: zksUtils.L2_ASSET_ROUTER_ADDRESS,
-        customUsdcBridge: false,
         legacy: false,
       },
       {
         name: "Lens GHO withdrawal (base token)",
         l2ChainId: CHAIN_IDs.LENS,
         l2Sender: zksUtils.L2_BASE_TOKEN_ADDRESS,
-        customUsdcBridge: false,
         legacy: true,
       },
       {
-        // The standalone USDC bridge has no finalizeDeposit(), so this must stay on the legacy entrypoint
-        // regardless of the sender.
+        // Withdrawals routed via the standalone USDC bridge are forced onto the legacy entrypoint by
+        // prepareFinalizations(), since that bridge has no finalizeDeposit(). Pinned here too because this
+        // sender must not be mistaken for an asset-router withdrawal.
         name: "Lens USDC withdrawal (standalone USDC bridge)",
         l2ChainId: CHAIN_IDs.LENS,
         l2Sender: LENS_L2_USDC_BRIDGE,
-        customUsdcBridge: true,
         legacy: true,
       },
     ];
 
-    cases.forEach(({ name, l2ChainId, l2Sender, customUsdcBridge, legacy }) => {
+    cases.forEach(({ name, l2ChainId, l2Sender, legacy }) => {
       it(`${name} -> ${legacy ? "finalizeWithdrawal" : "finalizeDeposit"}`, function () {
-        expect(useLegacyFinalizeWithdrawal(l2ChainId, l2Sender, customUsdcBridge)).to.equal(legacy);
+        expect(useLegacyFinalizeWithdrawal(l2ChainId, l2Sender)).to.equal(legacy);
       });
     });
 
     it("Is not case-sensitive on the l2Sender", function () {
       const { L2_ASSET_ROUTER_ADDRESS: assetRouter } = zksUtils;
-      expect(useLegacyFinalizeWithdrawal(CHAIN_IDs.LENS, assetRouter.toUpperCase().replace("0X", "0x"), false)).to.be
-        .false;
+      expect(useLegacyFinalizeWithdrawal(CHAIN_IDs.LENS, assetRouter.toUpperCase().replace("0X", "0x"))).to.be.false;
     });
   });
 });

--- a/test/ZkSyncFinalizer.ts
+++ b/test/ZkSyncFinalizer.ts
@@ -1,0 +1,67 @@
+import { utils as zksUtils } from "zksync-ethers";
+import { useLegacyFinalizeWithdrawal } from "../src/finalizer/utils/zkSync";
+import { CHAIN_IDs } from "../src/utils";
+import { expect } from "./utils";
+
+// zkSync Era's and Lens' L2 USDC bridges are ordinary contracts rather than system contracts, so a USDC
+// withdrawal's l2Sender is neither the asset router nor the base token.
+const LENS_L2_USDC_BRIDGE = "0x7188b6975eec82ae914b6ec7ac32b3c9a18b2c81";
+
+describe("ZkSyncFinalizer", function () {
+  describe("useLegacyFinalizeWithdrawal", function () {
+    // Each row was verified by simulating both entrypoints against mainnet state on 2026-08-05.
+    const cases: { name: string; l2ChainId: number; l2Sender: string; customUsdcBridge: boolean; legacy: boolean }[] = [
+      {
+        name: "zkSync ETH withdrawal (base token)",
+        l2ChainId: CHAIN_IDs.ZK_SYNC,
+        l2Sender: zksUtils.L2_BASE_TOKEN_ADDRESS,
+        customUsdcBridge: false,
+        legacy: false,
+      },
+      {
+        name: "zkSync USDT withdrawal (asset router)",
+        l2ChainId: CHAIN_IDs.ZK_SYNC,
+        l2Sender: zksUtils.L2_ASSET_ROUTER_ADDRESS,
+        customUsdcBridge: false,
+        legacy: false,
+      },
+      {
+        // The regression: Lens' base token is GHO, so WETH is an ordinary ERC-20 routed via the asset
+        // router. Sending this through the legacy entrypoint reverts InvalidProof().
+        name: "Lens WETH withdrawal (asset router)",
+        l2ChainId: CHAIN_IDs.LENS,
+        l2Sender: zksUtils.L2_ASSET_ROUTER_ADDRESS,
+        customUsdcBridge: false,
+        legacy: false,
+      },
+      {
+        name: "Lens GHO withdrawal (base token)",
+        l2ChainId: CHAIN_IDs.LENS,
+        l2Sender: zksUtils.L2_BASE_TOKEN_ADDRESS,
+        customUsdcBridge: false,
+        legacy: true,
+      },
+      {
+        // The standalone USDC bridge has no finalizeDeposit(), so this must stay on the legacy entrypoint
+        // regardless of the sender.
+        name: "Lens USDC withdrawal (standalone USDC bridge)",
+        l2ChainId: CHAIN_IDs.LENS,
+        l2Sender: LENS_L2_USDC_BRIDGE,
+        customUsdcBridge: true,
+        legacy: true,
+      },
+    ];
+
+    cases.forEach(({ name, l2ChainId, l2Sender, customUsdcBridge, legacy }) => {
+      it(`${name} -> ${legacy ? "finalizeWithdrawal" : "finalizeDeposit"}`, function () {
+        expect(useLegacyFinalizeWithdrawal(l2ChainId, l2Sender, customUsdcBridge)).to.equal(legacy);
+      });
+    });
+
+    it("Is not case-sensitive on the l2Sender", function () {
+      const { L2_ASSET_ROUTER_ADDRESS: assetRouter } = zksUtils;
+      expect(useLegacyFinalizeWithdrawal(CHAIN_IDs.LENS, assetRouter.toUpperCase().replace("0X", "0x"), false)).to.be
+        .false;
+    });
+  });
+});


### PR DESCRIPTION
## Problem

A Lens WETH withdrawal — **19.2128 ETH**, `0xa964075c…12cec8`, initiated 2026-07-31 15:17 UTC — cannot be finalized. The call reverts `InvalidProof()` (`0x09bde339`).

It is also the **poison pill that has blocked every hub-chain finalization since 2026-07-31 21:31 UTC**, because the finalizer bundles them all into one all-or-nothing `Multicall3.aggregate()`. That bundling problem is fixed separately in #3660; this PR fixes the call itself.

## Cause

`prepareFinalization()` picks the L1 entrypoint **by chain**:

```ts
const isLegacyBridge = [CHAIN_IDs.LENS].includes(l2ChainId);
```

Lens therefore goes through `finalizeWithdrawal()`, which does not carry `l2Sender` and leaves the L1 contract to assume it. That assumption doesn't hold for withdrawals initiated by the **L2 asset router** — every ERC-20, and on Lens, whose base token is GHO rather than ETH, that includes WETH. The reconstructed message hash mismatches and the proof check fails.

## Fix

Select the entrypoint by the withdrawal's actual `l2Sender`:

| `l2Sender` | entrypoint | why |
|---|---|---|
| asset router `0x…010003` | `finalizeDeposit(struct)` | passes `l2Sender` explicitly |
| standalone ZkStack USDC bridge | `finalizeWithdrawal()` | the only entrypoint it implements |
| Lens base token (GHO) | `finalizeWithdrawal()` | unchanged |

## Verification

Simulated both entrypoints against mainnet state on 2026-08-05, using params derived from `zksync-ethers` 5.11.2 (the version this repo pins), i.e. the same library and calls the bot itself makes:

```
Lens WETH   (asset router)  finalizeWithdrawal -> InvalidProof()   finalizeDeposit -> OK (211,646 gas)
Lens USDC   (usdcBridge)    finalizeWithdrawal -> OK               finalizeDeposit -> no such function
zkSync ETH  (base token)    finalizeDeposit    -> OK   (5 withdrawals)
zkSync USDT (asset router)  finalizeDeposit    -> OK
```

- Extracted the rule into an exported `useLegacyFinalizeWithdrawal()` and pinned all five verified combinations in a new `test/ZkSyncFinalizer.ts` (6 passing).
- **Confirmed the test fails against the previous chain-based behaviour** (2 failing: `expected true to equal false`) and passes with the fix.
- `tsc --noEmit`, prettier, eslint clean.

## Reviewer notes

- **Deliberately conservative on Lens base-token (GHO) withdrawals.** Every historical one is already finalized, so there is no pending case to simulate, and I did not want to change a path I cannot verify. Given that base-token withdrawals from zkSync finalize fine via `finalizeDeposit`, I suspect the Lens legacy special-case is obsolete entirely and could be deleted — but that wants one pending GHO withdrawal to confirm first. Happy to follow up.
- No `README.md`/`AGENTS.md` update proposed: no doc describes the entrypoint choice, and the rule is now documented on the exported function it lives in. Say the word if you'd like it surfaced in `src/clients/README.md` alongside the finalizer batching notes.
- Related: `IGNORED_WITHDRAWALS` at the top of `zkSync.ts` hardcodes a Lens USDC withdrawal with `@todo remove`, which looks like an earlier instance of a poison pill being papered over. Left alone here — with #3660 merged a reverting withdrawal is excluded and reported loudly rather than blocking the batch, so that entry can probably go. Worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)