### PR TITLE
fix(test): de-flake "Correctly defers destination chain fills"

### DIFF
--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -90,6 +90,9 @@ describe("Relayer: Check for Unfilled Deposits and Fill", function () {
 
   let chainIds: number[];
 
+  // Set by any test that pins an SDK helper for its own duration; unwound after that test.
+  let archStub: sinon.SinonStub | undefined;
+
   const updateAllClients = async (): Promise<void> => {
     await configStoreClient.update();
     await hubPoolClient.update();
@@ -246,6 +249,11 @@ describe("Relayer: Check for Unfilled Deposits and Fill", function () {
     // Set the spokePool's time to the provider time. This is done to enable the block utility time finder identify a
     // "reasonable" block number based off the block time when looking at quote timestamps.
     await spokePool_1.setCurrentTime(await getLastBlockTime(spokePool_1.provider));
+  });
+
+  afterEach(function () {
+    archStub?.restore();
+    archStub = undefined;
   });
 
   describe("Relayer: Check for Unfilled v3 Deposits and Fill", function () {
@@ -607,7 +615,23 @@ describe("Relayer: Check for Unfilled Deposits and Fill", function () {
     });
 
     it("Correctly defers destination chain fills", async function () {
-      const { average: avgBlockTime } = await arch.evm.averageBlockTime(spokePool_2.provider);
+      // Pin the average block time both this test and the relayer read, rather than sampling the hardhat
+      // chain, which cannot produce a usable figure. The SDK averages over a fixed 120-block window
+      // (`latest - 10` back to `latest - 130`) and memoises the result per chainId for 15 minutes, and
+      // every spoke pool here shares hardhat's chainId — so the value is whatever the first test in this
+      // mocha process measured. Below 130 blocks that window's lower bound is negative, ethers resolves
+      // it relative to the head and clamps at genesis, and the sample collapses while the divisor stays
+      // 120: the average comes back as low as 1/120 s/block, and zero or negative at heights 120-129.
+      // minFillTime is a duration derived from the average whereas the relayer ages deposits in blocks,
+      // so too small an average desynchronises the two and the fill asserted below never happens. How
+      // long the chain is at first measurement depends on which files precede this one, which the CI
+      // test split varies — hence the sporadic failure.
+      const avgBlockTime = 1;
+      archStub = sinon.stub(arch, "evm").value({
+        ...arch.evm,
+        averageBlockTime: async () => ({ average: avgBlockTime, blockRange: 120 }),
+      });
+
       const minDepositAgeBlocks = 4; // Fill after deposit has aged this # of blocks.
       const minFillTime = Math.ceil(minDepositAgeBlocks * avgBlockTime);
 
@@ -644,8 +668,11 @@ describe("Relayer: Check for Unfilled Deposits and Fill", function () {
       }
       expect(lastSpyLogIncludes(spy, "due to insufficient fill time for")).to.be.true;
 
-      // Mine enough blocks such that the deposit has aged sufficiently.
-      for (let i = 0; i < minFillTime * minDepositAgeBlocks * 10; i++) {
+      // Mine enough blocks such that the deposit has aged sufficiently. The relayer ages the deposit as
+      // floor(avgBlockTime * blocksElapsed), so invert that to size the loop; scaling minFillTime by a
+      // fixed factor instead undershoots whenever avgBlockTime is below 1.
+      const blocksToMine = Math.ceil((minFillTime + 1) / avgBlockTime);
+      for (let i = 0; i < blocksToMine; i++) {
         await hre.network.provider.send("evm_mine");
       }
       await updateAllClients();


### PR DESCRIPTION
Fixes the sporadic failure reported in Slack against #3668:

```
1) Relayer: Check for Unfilled Deposits and Fill
     Relayer: Check for Unfilled v3 Deposits and Fill
       Correctly defers destination chain fills:

    AssertionError: expected +0 to equal 1
    at Context.<anonymous> (test/Relayer.BasicFill.ts:654:34)
```

It is sporadic, it is a test bug rather than a relayer bug, and it is reproducible on demand.

## Why it fails

The test sizes both its `minFillTime` config and its mining loop from the SDK's `arch.evm.averageBlockTime`, which cannot produce a usable figure on hardhat.

`averageBlockTime` averages over a fixed 120-block window — `latest - 10` back to `latest - 130` — and memoises the result per chainId for 15 minutes. Every spoke pool in the suite is deployed to the same hardhat network, so they all share one chainId, and the value this test reads is whichever one the *first* `averageBlockTime` call in the mocha process measured. In this file that call comes from the first `checkForUnfilledDepositsAndFill()`, which fetches the value for `hubPoolBlockBuffer`.

Below 130 blocks the window's lower bound is negative. ethers resolves a negative block tag relative to the head and clamps at genesis, so the sample collapses to a handful of blocks while the divisor stays at a hardcoded 120. Since hardhat advances timestamps by one second per block, the measured average tracks chain height rather than block time:

| Height at first measurement | Average reported |
| --- | --- |
| ≤ 10 | `0` |
| 11 / 12 | `1/120` / `2/120` |
| 118 / 119 | `2/120` / `1/120` |
| 120 | `0` |
| 121–129 | negative |
| ≥ 130 | `1` |

`minFillTime` is a *duration* derived from that average, whereas the relayer ages deposits in *blocks*, as `floor(avgBlockTime * blocksElapsed)`. The two conversions have to agree, and with an undersized average they do not. At an average of `1/120`, `minFillTime` is 1s, the loop mines `minFillTime * minDepositAgeBlocks * 10` = 40 blocks, and the relayer still reads the deposit as `floor(40/120)` = 0s old — so the deferral never lifts and no fill is submitted. That is the reported assertion.

A non-positive average instead makes `minFillTime` zero, which skips the deferral branch entirely and trips the *earlier* assertion in the same test with `expected 1 to equal +0` at line 643. Same root cause, adjacent symptom.

How long the chain is at first measurement depends on which files precede this one in the process. CircleCI splits 120 test files across 20 containers, so this file sits within the first few in its container and the preceding block count varies from run to run — hence sporadic.

## The fix

Two changes, both local to the one test:

1. **Pin the average** for the duration of the test, so the test and the relayer are guaranteed to agree and neither depends on chain height, cache state, or file ordering. `arch.evm.averageBlockTime` is a non-configurable getter and cannot be stubbed directly, so the stub replaces `arch.evm` with a copy carrying the override; it is unwound in `afterEach` so it cannot leak into the tests that follow.
2. **Size the mining loop by inverting the relayer's own conversion**, `ceil((minFillTime + 1) / avgBlockTime)`, rather than scaling `minFillTime` by a fixed factor — which undershoots whenever the average is below 1. Correct for any positive average, and as a side effect the loop now mines 5 blocks rather than 160.

## Verification

Reproduced by seeding the SDK's cache at a chosen chain height in a throwaway spec ordered ahead of this file, mimicking what a preceding test file does in CI. Heights 11, 118 and 119 reproduce the reported failure verbatim, and 120 and 125 the adjacent `expected 1 to equal +0`:

```
### WITHOUT FIX ###
L=11    1 failing  AssertionError: expected +0 to equal 1   (test/Relayer.BasicFill.ts:654:34)
L=118   1 failing  AssertionError: expected +0 to equal 1   (test/Relayer.BasicFill.ts:654:34)
L=119   1 failing  AssertionError: expected +0 to equal 1   (test/Relayer.BasicFill.ts:654:34)
L=120   1 failing  AssertionError: expected 1 to equal +0   (test/Relayer.BasicFill.ts:643:44)
L=125   1 failing  AssertionError: expected 1 to equal +0   (test/Relayer.BasicFill.ts:643:44)

### WITH FIX ###
L=11    ✔ Correctly defers destination chain fills
L=118   ✔ Correctly defers destination chain fills
L=119   ✔ Correctly defers destination chain fills
L=120   ✔ Correctly defers destination chain fills
L=125   ✔ Correctly defers destination chain fills
```

Also passing at heights 5, 63, 117 and 200, and `RELAYER_TEST=true yarn hardhat test test/Relayer.BasicFill.ts` reports **24 passing**. `yarn typecheck` clean; `eslint` and `prettier` clean on the changed file.

## Note for the SDK, not this PR

No production impact: a real chain is never shorter than 130 blocks, so the sample window is never clamped and the average is always sane. The SDK could still be made robust here by dividing by the span actually sampled, `lastBlock.number - firstBlock.number`, rather than by the requested `blockRange`. That would remove the whole failure band at source and make `averageBlockTime` correct on any chain with at least two blocks. Happy to open that PR against `across-protocol/sdk` if it looks worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
