### PR TITLE
feat(deposit-address-service): validate and route the message payload

### DIFF
--- a/src/deposit-address-service/README.md
+++ b/src/deposit-address-service/README.md
@@ -5,7 +5,7 @@ and executes them, replacing the polling bot in [`../deposit-address`](../deposi
 left untouched until cutover. Why a service rather than a poller:
 [#3663](https://github.com/across-protocol/relayer/issues/3663).
 
-> **Shell only.** Validation, routing, the Redis lock, durable state and execution land in later PRs.
+> **Shell only.** The Redis lock, durable state and execution land in later PRs.
 > With no handler configured, or `EXECUTION_ENABLED` unset, the service **NACKs every delivery** and
 > `/ready` stays `503`, so nothing is discarded if a subscription is attached early.
 
@@ -13,7 +13,11 @@ left untouched until cutover. Why a service rather than a poller:
 
 `decodePushDelivery` validates the Pub/Sub transport contract once and yields a `PushDelivery` — decoded
 `payload`, required `messageId`, always-present `attributes` — so nothing downstream optional-chains
-transport fields. Payload validation is PR 2's job.
+transport fields.
+
+`parseTransfer` in [`message.ts`](./message.ts) then validates the **payload** and returns its
+`transferId` and route. Pure, no I/O. Not yet wired into a handler — there is nothing to do with the
+result until the execution paths land, and a handler that ACKed without executing would discard work.
 
 Handlers take one `RequestContext` (`delivery`, `startedAtMs`, `deadlineAtMs`, `signal`) and are
 **constructed once** with logger, config and shared clients closed over. Deliberate: the nonce cache

--- a/src/deposit-address-service/message.ts
+++ b/src/deposit-address-service/message.ts
@@ -1,0 +1,139 @@
+import {
+  StructError,
+  array,
+  boolean,
+  create,
+  enums,
+  integer,
+  literal,
+  min,
+  nullable,
+  optional,
+  string,
+  type,
+} from "superstruct";
+import { DepositAddressMessageV3, Erc20Transfer } from "../interfaces/DepositAddress";
+import { MessageValidationError, UnsupportedMessageError } from "./errors";
+
+/**
+ * `type()` rather than `object()` throughout: unknown keys are allowed, so the indexer adding a field
+ * cannot break this service. Matches the indexer's own webhook envelope, which uses `s.type` for the
+ * same reason. v3 messages get **no** structural validation in the polling bot — it checks `version`
+ * and casts the rest — so this is new coverage, not a port.
+ */
+const Erc20TransferStruct = type({
+  chainId: string(),
+  blockNumber: min(integer(), 0),
+  logIndex: min(integer(), 0),
+  from: string(),
+  to: string(),
+  amount: string(),
+  contractAddress: string(),
+  transactionHash: string(),
+  transferClassification: enums(["correct_transfer", "mis_route", "intent_refund"]),
+});
+
+const NamespacedAccountStruct = type({ namespace: string(), address: string() });
+
+const V3MessageStruct = type({
+  depositAddress: string(),
+  version: literal(3),
+  salt: string(),
+  initialRoot: string(),
+  counterfactualBeaconContractAddress: string(),
+  counterfactualFactoryContractAddress: string(),
+  adminWithdrawManagerContractAddress: string(),
+  shouldSponsorAccountCreation: boolean(),
+  counterfactualMaterials: array(
+    type({
+      kind: string(),
+      implementationAddress: string(),
+      encodedParams: string(),
+      leafHash: string(),
+      merkleProof: array(string()),
+    })
+  ),
+  routeParams: type({
+    outputToken: string(),
+    destinationChainId: string(),
+    recipient: NamespacedAccountStruct,
+  }),
+  refundAddress: NamespacedAccountStruct,
+  depositAddressNamespace: string(),
+  erc20Transfer: Erc20TransferStruct,
+  integrator: optional(nullable(type({ name: string(), integratorId: nullable(string()) }))),
+});
+
+/** Which path a message takes. `drop` is not represented: those throw {@link UnsupportedMessageError}. */
+export type TransferRoute = "deposit" | "withdraw";
+
+export interface ParsedTransfer {
+  readonly transferId: string;
+  readonly route: TransferRoute;
+  readonly message: DepositAddressMessageV3;
+}
+
+/**
+ * The indexer row's durable identity, and the tuple `DepositAddressExecutionConsumer` already keys
+ * lookups on. Deliberately finer than the polling bot's `getDepositKey`, which is
+ * `depositAddress:transactionHash` and so collides when one transaction makes two transfers to the same
+ * address.
+ *
+ * Normalised, because the same transfer must always produce the same id: `chainId` arrives as a string,
+ * and hash casing varies. No prefix normalisation — format is consistent per chain (EVM `0x`, Tron
+ * bare), and `chainId` is part of the id, so the two can never collide.
+ */
+export function transferId(transfer: Erc20Transfer): string {
+  return `${Number(transfer.chainId)}:${transfer.transactionHash.toLowerCase()}:${transfer.logIndex}`;
+}
+
+/**
+ * Validates a decoded payload and decides its route. Pure: no I/O, no clients, no config.
+ *
+ * Throws `MessageValidationError` (ACK — the same bytes fail identically on every redelivery) for bad
+ * JSON or a shape that breaks the contract, and `UnsupportedMessageError` (ACK) for anything this
+ * service does not act on: a non-v3 version, or a classification with no route.
+ *
+ * v1 is intentionally unsupported here; the polling bot still serves it until a later PR ports it.
+ */
+export function parseTransfer(payload: string): ParsedTransfer {
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(payload);
+  } catch (err) {
+    throw new MessageValidationError(`payload is not JSON: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  const version = (decoded as { version?: unknown })?.version;
+  if (version !== 3) {
+    throw new UnsupportedMessageError(`unsupported message version ${JSON.stringify(version)}`);
+  }
+
+  let message: DepositAddressMessageV3;
+  try {
+    message = create(decoded, V3MessageStruct);
+  } catch (err) {
+    // StructError names the offending path, which is the only useful thing in the log line.
+    const detail = err instanceof StructError ? `${err.path.join(".")}: ${err.message}` : String(err);
+    throw new MessageValidationError(`v3 message failed validation at ${detail}`);
+  }
+
+  return { transferId: transferId(message.erc20Transfer), route: route(message), message };
+}
+
+/**
+ * Mirrors `processExecution` in the polling bot, minus the refund-only marker: that state is gone, so a
+ * below-minimum transfer re-asks the execute endpoint on redelivery and falls back to withdraw again.
+ */
+function route(message: DepositAddressMessageV3): TransferRoute {
+  const { transferClassification } = message.erc20Transfer;
+  switch (transferClassification) {
+    case "correct_transfer":
+      return "deposit";
+    case "mis_route":
+      return "withdraw";
+    default:
+      // `intent_refund` is not supported on v3, matching the polling bot.
+      throw new UnsupportedMessageError(`no v3 route for classification ${transferClassification}`);
+  }
+}

--- a/test/DepositAddressService.message.ts
+++ b/test/DepositAddressService.message.ts
@@ -1,0 +1,119 @@
+import { expect } from "./utils";
+import { parseTransfer, transferId } from "../src/deposit-address-service/message";
+import { DepositAddressMessageV3 } from "../src/interfaces/DepositAddress";
+
+/** Minimal valid v3 item. Deep-merged overrides keep each test to the field under examination. */
+function v3(overrides: Record<string, unknown> = {}, transferOverrides: Record<string, unknown> = {}): string {
+  const message = {
+    depositAddress: "0x9f4Ae3C1b28D5e07A6f1B4c93D2e8a05F7c61B3d",
+    version: 3,
+    salt: "0x01",
+    initialRoot: "0x02",
+    counterfactualBeaconContractAddress: "0x03",
+    counterfactualFactoryContractAddress: "0x04",
+    adminWithdrawManagerContractAddress: "0x05",
+    shouldSponsorAccountCreation: false,
+    counterfactualMaterials: [
+      { kind: "withdraw", implementationAddress: "0x06", encodedParams: "0x", leafHash: "0x07", merkleProof: ["0x08"] },
+    ],
+    routeParams: {
+      outputToken: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      destinationChainId: "8453",
+      recipient: { namespace: "evm", address: "0x0a" },
+    },
+    refundAddress: { namespace: "evm", address: "0x0b" },
+    depositAddressNamespace: "evm",
+    erc20Transfer: {
+      chainId: "42161",
+      blockNumber: 312884201,
+      logIndex: 7,
+      from: "0x0c",
+      to: "0x9f4Ae3C1b28D5e07A6f1B4c93D2e8a05F7c61B3d",
+      amount: "25000000",
+      contractAddress: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      transactionHash: "0xA3F1C7D40E9B6852F1AD0C3B7E94F628A1D5C09E",
+      transferClassification: "correct_transfer",
+      ...transferOverrides,
+    },
+    integrator: { name: "acme", integratorId: "0x0a1b" },
+    ...overrides,
+  };
+  return JSON.stringify(message);
+}
+
+describe("transferId", function () {
+  const transfer = (over: Record<string, unknown> = {}) =>
+    ({
+      chainId: "42161",
+      blockNumber: 1,
+      logIndex: 7,
+      transactionHash: "0xABC",
+      ...over,
+    }) as unknown as DepositAddressMessageV3["erc20Transfer"];
+
+  it("is chainId:txHash:logIndex, normalised", function () {
+    expect(transferId(transfer())).to.equal("42161:0xabc:7");
+  });
+
+  it("is stable across the representations the indexer can send", function () {
+    // chainId arrives as a string and hash casing varies; the same transfer must not yield two ids.
+    expect(transferId(transfer({ chainId: "42161" }))).to.equal(transferId(transfer({ chainId: 42161 })));
+    expect(transferId(transfer({ transactionHash: "0xABC" }))).to.equal(
+      transferId(transfer({ transactionHash: "0xabc" }))
+    );
+  });
+
+  it("distinguishes two transfers in one transaction", function () {
+    // The polling bot's getDepositKey omits logIndex and collides here.
+    expect(transferId(transfer({ logIndex: 7 }))).to.not.equal(transferId(transfer({ logIndex: 8 })));
+  });
+});
+
+describe("parseTransfer", function () {
+  it("routes correct_transfer to deposit and returns the transferId", function () {
+    const parsed = parseTransfer(v3());
+    expect(parsed.route).to.equal("deposit");
+    expect(parsed.transferId).to.equal("42161:0xa3f1c7d40e9b6852f1ad0c3b7e94f628a1d5c09e:7");
+    expect(parsed.message.erc20Transfer.amount).to.equal("25000000");
+  });
+
+  it("routes mis_route to withdraw", function () {
+    expect(parseTransfer(v3({}, { transferClassification: "mis_route" })).route).to.equal("withdraw");
+  });
+
+  it("drops classifications v3 does not support", function () {
+    // intent_refund is unsupported on v3, matching the polling bot.
+    expect(() => parseTransfer(v3({}, { transferClassification: "intent_refund" }))).to.throw(/no v3 route/);
+  });
+
+  it("drops unsupported versions before validating the rest", function () {
+    for (const version of [1, 2, undefined, "3"]) {
+      expect(() => parseTransfer(v3({ version })), String(version)).to.throw(/unsupported message version/);
+    }
+  });
+
+  it("rejects payloads that are not JSON", function () {
+    expect(() => parseTransfer("{not json")).to.throw(/not JSON/);
+  });
+
+  it("names the offending field when the shape breaks", function () {
+    const missingRefund = JSON.parse(v3()) as Record<string, unknown>;
+    delete missingRefund.refundAddress;
+    expect(() => parseTransfer(JSON.stringify(missingRefund))).to.throw(/refundAddress/);
+
+    const badAmount = JSON.parse(v3()) as { erc20Transfer: Record<string, unknown> };
+    badAmount.erc20Transfer.amount = 25000000;
+    expect(() => parseTransfer(JSON.stringify(badAmount))).to.throw(/erc20Transfer.amount/);
+  });
+
+  it("accepts a message with no integrator", function () {
+    // Pre-integrator deposit addresses omit it; the execute path validates the id separately.
+    expect(parseTransfer(v3({ integrator: undefined })).route).to.equal("deposit");
+    expect(parseTransfer(v3({ integrator: null })).route).to.equal("deposit");
+  });
+
+  it("tolerates unknown fields so an indexer addition cannot break the service", function () {
+    const parsed = parseTransfer(v3({ someFutureField: { nested: true } }));
+    expect(parsed.route).to.equal("deposit");
+  });
+});


### PR DESCRIPTION
Part of #3663 — PR 2 of nine. **Stacked on #3668**, so the diff shows only this change; GitHub retargets the base to `master` when #3668 merges.

## What

Two exported functions in `src/deposit-address-service/message.ts`. Pure — no I/O, no clients, no config.

- `parseTransfer(payload)` → `{ transferId, route, message }`, throwing `MessageValidationError` (bad JSON or broken shape) or `UnsupportedMessageError` (non-v3 version, or a classification with no route). Both are terminal, so both ACK.
- `transferId(erc20Transfer)` → `chainId:txHash:logIndex`.

The polling bot gives v3 messages **no structural validation at all** — it checks `version` and casts the rest — so this is new coverage, not a port.

## Notable

**`type()` not `object()`** throughout the schema, so unknown keys are tolerated and an indexer field addition cannot break this service. The indexer's own webhook envelope uses `s.type` for the same reason.

**`transferId` is normalised** so one transfer always yields one id: `chainId` arrives as a string and hash casing varies. It is deliberately finer than the bot's `getDepositKey`, which is `depositAddress:transactionHash` and collides when a single transaction makes two transfers to the same address. No prefix normalisation — format is consistent per chain (EVM `0x`, Tron bare) and `chainId` is part of the id, so the two cannot collide.

**Routing mirrors `processExecution`, minus the refund-only marker.** That state no longer exists, so a below-minimum transfer re-asks the execute endpoint on redelivery and falls back to withdraw again — one wasted call, no persisted marker.

## Two deliberate deviations from the plan

**Not wired into a handler.** #3663 had this PR log a routing decision and return 204, which contradicts PR 1's rule that nothing is acknowledged without being executed. Wiring belongs with the execute path in PR 4.

**No `ExecutionCommand` discriminated union.** Two variants differing only by a tag is a route string plus a validated message. Worth introducing when a third case needs its own payload shape.

## Testing

`RELAYER_TEST=true yarn hardhat test "test/DepositAddressService*.ts"` → **59 passing** (11 new).

Covers both routes, every drop path, non-JSON, a named field on shape failure, absent/null integrator, id stability across `chainId` string-vs-number and hash casing, id distinctness for two transfers in one transaction, and tolerance of unknown fields.

`yarn build` reports only the three pre-existing `poolRebalanceLeafCount` errors. `yarn lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)