### PR TITLE
chore(constants): drop LSK from Lisk supported tokens

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -364,7 +364,7 @@ export const SUPPORTED_TOKENS: { [chainId: number]: string[] } = {
   [CHAIN_IDs.INK]: ["ETH", "WETH", "USDT", "USDC"],
   [CHAIN_IDs.LENS]: ["WETH", "WGHO", "USDC"],
   [CHAIN_IDs.LINEA]: ["USDC", "USDT", "WETH", "WBTC", "DAI"],
-  [CHAIN_IDs.LISK]: ["WETH", "USDC", "USDT", "LSK", "WBTC"],
+  [CHAIN_IDs.LISK]: ["WETH", "USDC", "USDT", "WBTC"],
   [CHAIN_IDs.MEGAETH]: ["WETH", "USDT"],
   [CHAIN_IDs.MODE]: ["ETH", "WETH", "USDC", "USDT", "WBTC"],
   [CHAIN_IDs.MONAD]: ["USDC", "USDT"], // @TODO: Add WBTC after its added to the chain token list


### PR DESCRIPTION
## Summary

Removes `LSK` from `SUPPORTED_TOKENS[CHAIN_IDs.LISK]`. The LSK relaying strategy has been wound down — LSK is routed via swaps instead.

## Why now

- The relayer's LSK inventory was consolidated off Lisk via the canonical bridge over ~5 weeks (21.6k on 2026-06-30, 20.9k on 2026-07-04, 14.5k on 2026-08-05), and the residual ~106.9k LSK was swept to treasury multisigs on 2026-08-06.
- Balance is now **0 LSK on both Ethereum and Lisk**. Last LSK fill was 2026-07-27 (mainnet) / 2026-07-28 (Lisk).
- The matching bot config was already removed in configurama #142 (2026-07-29, _"LSK will be routed via swaps instead"_). This repo was the remaining reference.

## Scope / blast radius

`SUPPORTED_TOKENS[chainId]` is consumed by `AdapterManager` to (a) construct per-token canonical bridge adapters and (b) build the per-token monitored-address map. Leaving `LSK` in place keeps constructing an LSK bridge adapter for a token the relayer no longer holds or rebalances.

This is the **only** `LSK` reference in the repo — no other code paths change.

Lisk itself is unaffected: `WETH`, `USDC`, `USDT` and `WBTC` remain, and Lisk is still actively served (our primary relayer filled WETH there minutes before this PR was opened, alongside third-party relayers).

## Docs

Per `AGENTS.md`, no `README.md` / `AGENTS.md` updates are proposed — this removes one entry from a token constant and changes no documented behaviour, config surface, interface, or runtime flow.

## Test plan

- [x] `SUPPORTED_TOKENS` is the sole consumer; verified no other `LSK` references (`grep -rw LSK`).
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)