### PR TITLE
chore(deps): bump @across-protocol/sdk from 4.4.17 to 4.4.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants": "^3.1.123",
     "@across-protocol/contracts": "5.0.26",
-    "@across-protocol/sdk": "4.4.17",
+    "@across-protocol/sdk": "4.4.18",
     "@arbitrum/sdk": "^4.0.5",
     "@consensys/linea-sdk": "^0.3.0",
     "@coral-xyz/anchor": "^0.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,10 +34,10 @@
     bs58 "^6.0.0"
     ethers "5.7.2"
 
-"@across-protocol/sdk@4.4.17":
-  version "4.4.17"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.4.17.tgz#82c0ec2d1fb882885a5f3cca186e3227572b4269"
-  integrity sha512-WOxID7rm/hJ1tQcvuWTd7RumvOj2SNUKPARLRJR6ahhVH4YbUN9ikfSoCk+2tEer64+XlV87M8Je4772LoGp4Q==
+"@across-protocol/sdk@4.4.18":
+  version "4.4.18"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk/-/sdk-4.4.18.tgz#670c0f87492071493687be00f3c47545c80a3d25"
+  integrity sha512-HfbKT1N1nZHinW18jKPzLUzQh8XmcqADRvoZn9oCRyR0++Iz4ec2JI33foE6+Y2fYfb1XLILOlG1k403sxvgKA==
   dependencies:
     "@across-protocol/constants" "^3.1.123"
     "@across-protocol/contracts" "5.0.26"


### PR DESCRIPTION
## Motivation

Picks up SDK `4.4.18`, which carries [across-protocol/sdk#1505](https://github.com/across-protocol/sdk/pull/1505): `arch.tvm.submitTransaction` no longer throws when a populated transaction has no calldata. It dispatches that case as a TRON `TransferContract` (via TronWeb's `sendTransaction`) instead of `TriggerSmartContract`, which requires a deployed contract at the target address and so could never fund an EOA.

That unblocks native TRX refilling with no relayer code change: the refiller already emits a raw transaction with `args: []`, so `data` arrives `undefined` and now selects the transfer path. It supersedes #3665.

## Changes

- `package.json` / `yarn.lock`: `@across-protocol/sdk` `4.4.17` → `4.4.18`. No other lockfile entries move — the dependency set is identical between the two versions.

## Verification

- `yarn typecheck` clean.
- `yarn test test/TransactionClient.ts` — 16 passing.
- Confirmed the published `4.4.18` tarball contains the dispatch in both `src/` and `dist/cjs/`.

No README/AGENTS.md updates here: this is a dependency bump with no behavior, config or interface change in this repo. Documenting Tron refills in `src/refiller/README.md` belongs with the close-out of #3665 — note that the README text in that PR states GCKMS signers are unsupported on this path, which is wrong (`getGckmsSigner` returns an `ethers.Wallet`, exactly what `getTronWebFromEvmSigner` asserts on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)