### PR TITLE
feat(deposit-address-service): per-transfer lock and durable state

### DIFF
--- a/src/deposit-address-service/README.md
+++ b/src/deposit-address-service/README.md
@@ -5,7 +5,7 @@ and executes them, replacing the polling bot in [`../deposit-address`](../deposi
 left untouched until cutover. Why a service rather than a poller:
 [#3663](https://github.com/across-protocol/relayer/issues/3663).
 
-> **Shell only.** The Redis lock, durable state and execution land in later PRs.
+> **Not wired yet.** The execution paths land in later PRs.
 > With no handler configured, or `EXECUTION_ENABLED` unset, the service **NACKs every delivery** and
 > `/ready` stays `503`, so nothing is discarded if a subscription is attached early.
 
@@ -16,8 +16,14 @@ left untouched until cutover. Why a service rather than a poller:
 transport fields.
 
 `parseTransfer` in [`message.ts`](./message.ts) then validates the **payload** and returns its
-`transferId` and route. Pure, no I/O. Not yet wired into a handler — there is nothing to do with the
-result until the execution paths land, and a handler that ACKed without executing would discard work.
+`transferId` and route. Pure, no I/O.
+
+[`transferState.ts`](./transferState.ts) holds the two Redis keys per transfer — an expiring `lock:` and a
+`state:` that must not expire while a transaction could still land — plus `classifyReceipt`, which reports
+what a receipt says and leaves the retry policy to the caller.
+
+None of it is wired into a handler yet: there is nothing to do with a route or a lock until the execution
+paths exist, and a handler that ACKed without executing would discard work.
 
 Handlers take one `RequestContext` (`delivery`, `startedAtMs`, `deadlineAtMs`, `signal`) and are
 **constructed once** with logger, config and shared clients closed over. Deliberate: the nonce cache

--- a/src/deposit-address-service/errors.ts
+++ b/src/deposit-address-service/errors.ts
@@ -72,6 +72,36 @@ export class ExecutionDisabledError extends DepositAddressServiceError {
 }
 
 /**
+ * A durable state record exists but cannot be decoded. Distinct from an ordinary dependency failure:
+ * deterministic, and it clears only when an operator repairs or deletes the key. Still retriable, so the
+ * message is preserved and the transfer stays blocked — a record we cannot read may describe a transfer
+ * already swept.
+ */
+export class CorruptTransferStateError extends DepositAddressServiceError {
+  readonly retriable = true;
+  readonly code = "CORRUPT_TRANSFER_STATE";
+}
+
+/**
+ * A critical write was not acknowledged by Redis. Retriable, and it must stop the caller: awaiting a
+ * confirmation while believing a broadcast hash is durable is the one unrecoverable direction.
+ */
+export class StatePersistenceError extends DepositAddressServiceError {
+  readonly retriable = true;
+  readonly code = "STATE_PERSISTENCE_FAILED";
+}
+
+/**
+ * A transition that would lose funds-safety information — writing `broadcast_pending` over a terminal
+ * outcome. Retriable so nothing is discarded, but it means a caller reached a write without the state
+ * read that every path is supposed to begin with.
+ */
+export class IllegalStateTransitionError extends DepositAddressServiceError {
+  readonly retriable = true;
+  readonly code = "ILLEGAL_STATE_TRANSITION";
+}
+
+/**
  * The application deadline passed before a fund-moving step could start. NACK: a redelivery gets a fresh
  * budget, and refusing late is what keeps the un-renewed lock safe.
  */

--- a/src/deposit-address-service/transferState.ts
+++ b/src/deposit-address-service/transferState.ts
@@ -3,7 +3,12 @@ import { Infer, create, enums, integer, literal, min, string, type, union } from
 import { RedisCacheInterface } from "../cache/Redis";
 import { TransactionReceipt } from "../utils";
 import { isDefined } from "../utils/TypeGuards";
-import { CorruptTransferStateError, IllegalStateTransitionError, StatePersistenceError } from "./errors";
+import {
+  CorruptTransferStateError,
+  IllegalStateTransitionError,
+  StatePersistenceError,
+  TransientDependencyError,
+} from "./errors";
 
 /** Long enough that a dead consumer's lock lapses, short enough that the transfer is not stuck for long. */
 const LOCK_TTL_MS = 600_000;
@@ -59,6 +64,25 @@ export function isTerminal(state: TransferState): state is TerminalState {
 }
 
 /**
+ * Whether `terminal` may replace what is already recorded.
+ *
+ * A pending record may only be replaced by the outcome of **its own** transaction. The hash comes from
+ * the terminal record rather than a parameter, so a mismatched one cannot be passed in. `withdraw_failed`
+ * carries no hash and therefore can never replace a pending broadcast — that transaction may still land.
+ * An identical outcome is idempotent; a different one is refused.
+ *
+ * This matters because a worker can outlive its lock: nothing threads the application deadline into
+ * `TransactionClient`, whose confirmation wait resubmits with a decrementing `maxTries`, so on mainnet it
+ * can occupy a worker for far longer than the 600s lock TTL.
+ */
+function canReplace(current: TransferState, terminal: TerminalState): boolean {
+  if (isTerminal(current)) {
+    return current.status === terminal.status;
+  }
+  return "txHash" in terminal && current.txHash === terminal.txHash;
+}
+
+/**
  * What a receipt says about a broadcast transaction. Facts only — whether each means ACK, NACK, clear or
  * persist is retry policy, and belongs with the orchestration that also holds the lock.
  *
@@ -108,13 +132,19 @@ export class TransferStore {
    */
   async acquireLock(transferId: string): Promise<TransferLock | undefined> {
     const token = randomUUID();
-    const acquired = await this.redis.acquireLock(this.lockKey(transferId), token, LOCK_TTL_MS);
+    const key = this.lockKey(transferId);
+    const acquired = await this.command("acquireLock", transferId, () =>
+      this.redis.acquireLock(key, token, LOCK_TTL_MS)
+    );
     if (!acquired) {
       return undefined;
     }
 
     // Token-checked, so a lapsed attempt cannot delete the lock a later one now holds.
-    return { transferId, release: () => this.redis.releaseLock(this.lockKey(transferId), token) };
+    return {
+      transferId,
+      release: () => this.command("releaseLock", transferId, () => this.redis.releaseLock(key, token)),
+    };
   }
 
   /**
@@ -122,7 +152,7 @@ export class TransferStore {
    * describe a transfer already swept, so the transfer stays blocked until someone looks.
    */
   async read(transferId: string): Promise<TransferState | undefined> {
-    const raw = await this.redis.get<string>(this.stateKey(transferId));
+    const raw = await this.command("get", transferId, () => this.redis.get<string>(this.stateKey(transferId)));
     if (!isDefined(raw)) {
       return undefined;
     }
@@ -153,8 +183,21 @@ export class TransferStore {
     await this.write(transferId, { status: "broadcast_pending", ...pending }, Number.POSITIVE_INFINITY);
   }
 
-  /** Written once the outcome is known. The polling bot's executed set, per transfer. */
+  /**
+   * Written once the outcome is known. The polling bot's executed set, per transfer.
+   *
+   * Refuses anything {@link canReplace} rejects: a worker whose lock lapsed must not write its own
+   * transaction's outcome over a newer pending one, and `withdraw_failed` must not erase a broadcast that
+   * may still land.
+   */
   async recordTerminal(transferId: string, terminal: TerminalState): Promise<void> {
+    const current = await this.read(transferId);
+    if (isDefined(current) && !canReplace(current, terminal)) {
+      throw new IllegalStateTransitionError(
+        `refusing to write ${terminal.status} over ${current.status} for ${transferId}`
+      );
+    }
+
     await this.write(transferId, terminal, TERMINAL_TTL_SECONDS);
   }
 
@@ -175,7 +218,7 @@ export class TransferStore {
       return false;
     }
 
-    await this.redis.del(this.stateKey(transferId));
+    await this.command("del", transferId, () => this.redis.del(this.stateKey(transferId)));
     return true;
   }
 
@@ -184,10 +227,28 @@ export class TransferStore {
    * and a caller that proceeded to await confirmation would believe a hash was durable when it was not.
    */
   private async write(transferId: string, state: TransferState, expirySeconds: number): Promise<void> {
-    const reply = await this.redis.set(this.stateKey(transferId), JSON.stringify(state), expirySeconds);
+    const reply = await this.command("set", transferId, () =>
+      this.redis.set(this.stateKey(transferId), JSON.stringify(state), expirySeconds)
+    );
     if (reply !== "OK") {
       throw new StatePersistenceError(
         `redis did not acknowledge ${state.status} for ${transferId} (replied ${JSON.stringify(reply)})`
+      );
+    }
+  }
+
+  /**
+   * Rejections from Redis become {@link TransientDependencyError}. Without this the raw client error
+   * escapes, and since an unrecognised throw is treated as alerting, an ordinary Redis outage would page
+   * on every delivery instead of taking the debug-level retry path it belongs on.
+   */
+  private async command<T>(name: string, transferId: string, op: () => Promise<T>): Promise<T> {
+    try {
+      return await op();
+    } catch (err) {
+      throw new TransientDependencyError(
+        `redis ${name} failed for ${transferId}: ${err instanceof Error ? err.message : String(err)}`,
+        err
       );
     }
   }

--- a/src/deposit-address-service/transferState.ts
+++ b/src/deposit-address-service/transferState.ts
@@ -1,0 +1,202 @@
+import { randomUUID } from "crypto";
+import { Infer, create, enums, integer, literal, min, string, type, union } from "superstruct";
+import { RedisCacheInterface } from "../cache/Redis";
+import { TransactionReceipt } from "../utils";
+import { isDefined } from "../utils/TypeGuards";
+import { CorruptTransferStateError, IllegalStateTransitionError, StatePersistenceError } from "./errors";
+
+/** Long enough that a dead consumer's lock lapses, short enough that the transfer is not stuck for long. */
+const LOCK_TTL_MS = 600_000;
+
+/** Beyond the 31-day Pub/Sub retention, so a replayed message cannot outlive the record saying it is done. */
+const TERMINAL_TTL_SECONDS = 90 * 24 * 60 * 60;
+
+/** Milliseconds, matching `RequestContext`. Seconds elsewhere in the repo is a trap worth not repeating. */
+const timestampMs = () => min(integer(), 0);
+
+const BroadcastPending = type({
+  status: literal("broadcast_pending"),
+  operation: enums(["deposit", "withdraw"]),
+  txHash: string(),
+  chainId: min(integer(), 1),
+  submittedAtMs: timestampMs(),
+});
+
+const DepositExecuted = type({
+  status: literal("deposit_executed"),
+  txHash: string(),
+  chainId: min(integer(), 1),
+  blockNumber: min(integer(), 0),
+  completedAtMs: timestampMs(),
+});
+
+/** Separate from `DepositExecuted` because only this one gains lifecycle-publication state (PR 6). */
+const WithdrawExecuted = type({
+  status: literal("withdraw_executed"),
+  txHash: string(),
+  chainId: min(integer(), 1),
+  blockNumber: min(integer(), 0),
+  completedAtMs: timestampMs(),
+});
+
+const WithdrawFailed = type({
+  status: literal("withdraw_failed"),
+  code: enums(["GAS_EXCEEDS_REFUND", "UNPRICEABLE_REFUND_TOKEN"]),
+  reason: string(),
+  recordedAtMs: timestampMs(),
+});
+
+const TerminalStateStruct = union([DepositExecuted, WithdrawExecuted, WithdrawFailed]);
+const TransferStateStruct = union([BroadcastPending, TerminalStateStruct]);
+
+export type BroadcastPendingState = Infer<typeof BroadcastPending>;
+export type TerminalState = Infer<typeof TerminalStateStruct>;
+export type TransferState = Infer<typeof TransferStateStruct>;
+
+/** Anything other than `broadcast_pending`: the funds have moved, or will never move. */
+export function isTerminal(state: TransferState): state is TerminalState {
+  return state.status !== "broadcast_pending";
+}
+
+/**
+ * What a receipt says about a broadcast transaction. Facts only — whether each means ACK, NACK, clear or
+ * persist is retry policy, and belongs with the orchestration that also holds the lock.
+ *
+ * A receipt with no explicit `status === 0` reads as confirmed: ethers leaves `status` undefined on some
+ * chains, and guessing "confirmed" can strand a deposit for manual recovery, whereas guessing "reverted"
+ * would re-broadcast one that already landed. Only the first is reversible.
+ */
+export function classifyReceipt(
+  receipt: TransactionReceipt | null | undefined
+): "confirmed" | "reverted" | "unresolved" {
+  if (!isDefined(receipt) || !isDefined(receipt.blockNumber)) {
+    return "unresolved";
+  }
+  return receipt.status === 0 ? "reverted" : "confirmed";
+}
+
+/** Held while a transfer is being worked. The token stays inside, so no caller can supply or reuse one. */
+export interface TransferLock {
+  readonly transferId: string;
+  release(): Promise<boolean>;
+}
+
+/** Only the commands this store issues, so a test fake can `satisfies` it rather than be cast. */
+export type TransferStoreRedis = Pick<RedisCacheInterface, "acquireLock" | "releaseLock" | "get" | "set" | "del">;
+
+/**
+ * The two Redis keys per transfer.
+ *
+ * They are separate because their lifetimes are opposites: the **lock** must expire, so a consumer that
+ * dies does not block a transfer forever; the **state** must not, because a `broadcast_pending` record
+ * has to outlive anything that could still land on-chain. Merging them would reintroduce exactly the
+ * problem the design exists to remove.
+ *
+ * Redis is injected — `getRedisCache` returns `undefined` under `RELAYER_TEST`.
+ */
+export class TransferStore {
+  constructor(private readonly redis: TransferStoreRedis) {}
+
+  /**
+   * `SET NX` on the lock key. The only thing stopping two live consumers both passing the pre-broadcast
+   * checks — `broadcast_pending` cannot, since it is written after a broadcast, not before.
+   *
+   * The token is a uuid generated here, per attempt. Uniqueness is all the release check needs, and a
+   * message id cannot supply it, because Pub/Sub redelivers the same message.
+   *
+   * @returns the lock, or `undefined` when another consumer holds it.
+   */
+  async acquireLock(transferId: string): Promise<TransferLock | undefined> {
+    const token = randomUUID();
+    const acquired = await this.redis.acquireLock(this.lockKey(transferId), token, LOCK_TTL_MS);
+    if (!acquired) {
+      return undefined;
+    }
+
+    // Token-checked, so a lapsed attempt cannot delete the lock a later one now holds.
+    return { transferId, release: () => this.redis.releaseLock(this.lockKey(transferId), token) };
+  }
+
+  /**
+   * Present-but-unparseable throws rather than reading as absent: a record we cannot decode may well
+   * describe a transfer already swept, so the transfer stays blocked until someone looks.
+   */
+  async read(transferId: string): Promise<TransferState | undefined> {
+    const raw = await this.redis.get<string>(this.stateKey(transferId));
+    if (!isDefined(raw)) {
+      return undefined;
+    }
+
+    try {
+      return create(JSON.parse(raw), TransferStateStruct);
+    } catch (err) {
+      throw new CorruptTransferStateError(
+        `transfer state for ${transferId} is unreadable: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  /**
+   * Written the moment a hash exists, before the confirmation wait. Never expires.
+   *
+   * Refuses to overwrite a terminal outcome — the one transition that would lose funds-safety
+   * information. Reaching it means a caller skipped the state read every path begins with.
+   */
+  async recordBroadcast(transferId: string, pending: Omit<BroadcastPendingState, "status">): Promise<void> {
+    const current = await this.read(transferId);
+    if (isDefined(current) && isTerminal(current)) {
+      throw new IllegalStateTransitionError(
+        `refusing to write broadcast_pending over ${current.status} for ${transferId}`
+      );
+    }
+
+    await this.write(transferId, { status: "broadcast_pending", ...pending }, Number.POSITIVE_INFINITY);
+  }
+
+  /** Written once the outcome is known. The polling bot's executed set, per transfer. */
+  async recordTerminal(transferId: string, terminal: TerminalState): Promise<void> {
+    await this.write(transferId, terminal, TERMINAL_TTL_SECONDS);
+  }
+
+  /**
+   * Clears a `broadcast_pending` whose transaction is known to have reverted: nothing moved, so the
+   * transfer may be re-attempted.
+   *
+   * Deletes only if the record is *still* that transaction. A stale reconciliation must not delete a
+   * newer pending hash or a terminal outcome — that would unblock a transfer mid-sweep, which is the
+   * failure this design exists to prevent. Read-then-delete is sufficient because callers hold the lock;
+   * it would need to be atomic only if that stopped being true.
+   *
+   * @returns whether the record was removed.
+   */
+  async clearRevertedBroadcast(transferId: string, expectedTxHash: string): Promise<boolean> {
+    const current = await this.read(transferId);
+    if (!isDefined(current) || isTerminal(current) || current.txHash !== expectedTxHash) {
+      return false;
+    }
+
+    await this.redis.del(this.stateKey(transferId));
+    return true;
+  }
+
+  /**
+   * Every state write goes through here, and an unacknowledged one throws. `set` can answer `undefined`,
+   * and a caller that proceeded to await confirmation would believe a hash was durable when it was not.
+   */
+  private async write(transferId: string, state: TransferState, expirySeconds: number): Promise<void> {
+    const reply = await this.redis.set(this.stateKey(transferId), JSON.stringify(state), expirySeconds);
+    if (reply !== "OK") {
+      throw new StatePersistenceError(
+        `redis did not acknowledge ${state.status} for ${transferId} (replied ${JSON.stringify(reply)})`
+      );
+    }
+  }
+
+  private lockKey(transferId: string): string {
+    return `deposit-address:lock:${transferId}`;
+  }
+
+  private stateKey(transferId: string): string {
+    return `deposit-address:state:${transferId}`;
+  }
+}

--- a/test/DepositAddressService.state.ts
+++ b/test/DepositAddressService.state.ts
@@ -22,7 +22,7 @@ const EXECUTED: TerminalState = {
 };
 
 /** Only the commands the store issues. `satisfies` keeps it honest without a cast. */
-function fakeRedis(seed: Array<[string, string]> = [], opts: { setFails?: boolean } = {}) {
+function fakeRedis(seed: Array<[string, string]> = [], opts: { setFails?: boolean; rejects?: boolean } = {}) {
   const store = new Map<string, string>(seed);
   const ttls = new Map<string, number>();
   const redis = {
@@ -42,6 +42,9 @@ function fakeRedis(seed: Array<[string, string]> = [], opts: { setFails?: boolea
       return true;
     },
     async get<T>(key?: string) {
+      if (opts.rejects) {
+        throw new Error("READONLY You can't write against a read only replica");
+      }
       return (store.get(key ?? "") ?? null) as T | null;
     },
     async set<T>(key: string, val: T, expirySeconds?: number) {
@@ -216,6 +219,86 @@ describe("TransferStore state", function () {
     await store.recordBroadcast(TRANSFER, PENDING);
 
     expect([...backing.keys()].sort()).to.deep.equal([LOCK_KEY, STATE_KEY].sort());
+  });
+});
+
+describe("TransferStore terminal guards", function () {
+  it("records a terminal outcome over the pending record it belongs to", async function () {
+    const store = new TransferStore(fakeRedis().redis);
+    await store.recordBroadcast(TRANSFER, PENDING);
+
+    await store.recordTerminal(TRANSFER, EXECUTED);
+    expect((await store.read(TRANSFER))?.status).to.equal("deposit_executed");
+  });
+
+  it("refuses a terminal outcome for a different transaction than the pending one", async function () {
+    // A worker whose lock lapsed must not write h1's outcome over a newer pending h2.
+    const store = new TransferStore(fakeRedis().redis);
+    await store.recordBroadcast(TRANSFER, { ...PENDING, txHash: "0xh2" });
+
+    await store.recordTerminal(TRANSFER, EXECUTED).then(
+      () => expect.fail("expected a refusal"),
+      (err: Error) => expect(err.message).to.contain("refusing to write deposit_executed over broadcast_pending")
+    );
+    const state = await store.read(TRANSFER);
+    expect(state?.status).to.equal("broadcast_pending");
+    expect(state && "txHash" in state && state.txHash).to.equal("0xh2");
+  });
+
+  it("refuses withdraw_failed over a pending broadcast that may still land", async function () {
+    // It carries no hash, so it can never be the outcome of the transaction on the wire.
+    const store = new TransferStore(fakeRedis().redis);
+    await store.recordBroadcast(TRANSFER, { ...PENDING, operation: "withdraw" });
+
+    await store
+      .recordTerminal(TRANSFER, {
+        status: "withdraw_failed",
+        code: "GAS_EXCEEDS_REFUND",
+        reason: "dust",
+        recordedAtMs: 1,
+      })
+      .then(
+        () => expect.fail("expected a refusal"),
+        (err: Error) => expect(err.message).to.contain("refusing to write withdraw_failed over broadcast_pending")
+      );
+    expect((await store.read(TRANSFER))?.status).to.equal("broadcast_pending");
+  });
+
+  it("refuses to replace one terminal outcome with a different one", async function () {
+    const store = new TransferStore(fakeRedis().redis);
+    await store.recordTerminal(TRANSFER, EXECUTED);
+
+    await store.recordTerminal(TRANSFER, { ...EXECUTED, status: "withdraw_executed" }).then(
+      () => expect.fail("expected a refusal"),
+      (err: Error) => expect(err.message).to.contain("refusing to write withdraw_executed over deposit_executed")
+    );
+  });
+
+  it("records withdraw_failed when nothing was broadcast", async function () {
+    const store = new TransferStore(fakeRedis().redis);
+    await store.recordTerminal(TRANSFER, {
+      status: "withdraw_failed",
+      code: "UNPRICEABLE_REFUND_TOKEN",
+      reason: "no price",
+      recordedAtMs: 1,
+    });
+    expect((await store.read(TRANSFER))?.status).to.equal("withdraw_failed");
+  });
+});
+
+describe("TransferStore redis failures", function () {
+  it("reports a rejected redis command as a transient dependency failure", async function () {
+    // Otherwise the raw client error escapes, and an unrecognised throw alerts — so an ordinary Redis
+    // outage would page on every delivery instead of taking the debug-level retry path.
+    const store = new TransferStore(fakeRedis([], { rejects: true }).redis);
+    await store.read(TRANSFER).then(
+      () => expect.fail("expected a failure"),
+      (err: Error & { code?: string; retriable?: boolean }) => {
+        expect(err.code).to.equal("TRANSIENT_DEPENDENCY_FAILURE");
+        expect(err.retriable).to.equal(true);
+        expect(err.message).to.contain("redis get failed");
+      }
+    );
   });
 });
 

--- a/test/DepositAddressService.state.ts
+++ b/test/DepositAddressService.state.ts
@@ -1,0 +1,251 @@
+import { expect } from "./utils";
+import { TransactionReceipt } from "../src/utils";
+import {
+  TerminalState,
+  TransferStore,
+  TransferStoreRedis,
+  classifyReceipt,
+  isTerminal,
+} from "../src/deposit-address-service/transferState";
+
+const TRANSFER = "42161:0xa3f1c7d40e9b6852f1ad0c3b7e94f628a1d5c09e:7";
+const LOCK_KEY = `deposit-address:lock:${TRANSFER}`;
+const STATE_KEY = `deposit-address:state:${TRANSFER}`;
+
+const PENDING = { operation: "deposit", txHash: "0xh1", chainId: 42161, submittedAtMs: 1_700_000_000_000 } as const;
+const EXECUTED: TerminalState = {
+  status: "deposit_executed",
+  txHash: "0xh1",
+  chainId: 42161,
+  blockNumber: 312884201,
+  completedAtMs: 1_700_000_005_000,
+};
+
+/** Only the commands the store issues. `satisfies` keeps it honest without a cast. */
+function fakeRedis(seed: Array<[string, string]> = [], opts: { setFails?: boolean } = {}) {
+  const store = new Map<string, string>(seed);
+  const ttls = new Map<string, number>();
+  const redis = {
+    async acquireLock(key: string, token: string, ttlMs: number) {
+      if (store.has(key)) {
+        return false;
+      }
+      store.set(key, token);
+      ttls.set(key, ttlMs);
+      return true;
+    },
+    async releaseLock(key: string, token: string) {
+      if (store.get(key) !== token) {
+        return false;
+      }
+      store.delete(key);
+      return true;
+    },
+    async get<T>(key?: string) {
+      return (store.get(key ?? "") ?? null) as T | null;
+    },
+    async set<T>(key: string, val: T, expirySeconds?: number) {
+      if (opts.setFails) {
+        return undefined;
+      }
+      store.set(key, String(val));
+      ttls.set(key, expirySeconds ?? -1);
+      return "OK";
+    },
+    async del(key: string) {
+      return store.delete(key) ? 1 : 0;
+    },
+  } satisfies TransferStoreRedis;
+  return { redis, store, ttls };
+}
+
+function receipt(over: Partial<TransactionReceipt> = {}): TransactionReceipt {
+  return { blockNumber: 312884201, status: 1, ...over } as TransactionReceipt;
+}
+
+describe("classifyReceipt", function () {
+  it("reports a mined transaction as confirmed", function () {
+    expect(classifyReceipt(receipt())).to.equal("confirmed");
+  });
+
+  it("reports only an explicit status of 0 as reverted", function () {
+    expect(classifyReceipt(receipt({ status: 0 }))).to.equal("reverted");
+  });
+
+  it("reads a receipt with no status as confirmed rather than re-broadcasting", function () {
+    // ethers leaves status undefined on some chains. Guessing confirmed can strand a deposit for manual
+    // recovery; guessing reverted would re-broadcast one that already landed. Only the first is reversible.
+    expect(classifyReceipt(receipt({ status: undefined }))).to.equal("confirmed");
+  });
+
+  it("is unresolved without a receipt, so a transaction that may still land is never retried", function () {
+    expect(classifyReceipt(undefined)).to.equal("unresolved");
+    expect(classifyReceipt(null)).to.equal("unresolved");
+    expect(classifyReceipt(receipt({ blockNumber: undefined }))).to.equal("unresolved");
+  });
+});
+
+describe("TransferStore lock", function () {
+  it("admits one holder and refuses the second", async function () {
+    // The only thing stopping two live consumers both passing the pre-broadcast checks.
+    const store = new TransferStore(fakeRedis().redis);
+    expect(await store.acquireLock(TRANSFER)).to.not.equal(undefined);
+    expect(await store.acquireLock(TRANSFER)).to.equal(undefined);
+  });
+
+  it("generates its own token, so no caller can supply or reuse one", async function () {
+    const { redis, store: backing } = fakeRedis();
+    const store = new TransferStore(redis);
+
+    const first = await store.acquireLock(TRANSFER);
+    const firstToken = backing.get(LOCK_KEY);
+    await first?.release();
+    await store.acquireLock(TRANSFER);
+
+    expect(firstToken).to.be.a("string");
+    expect(backing.get(LOCK_KEY)).to.not.equal(firstToken);
+  });
+
+  it("releases only for the holder, so a stale attempt cannot free a live lock", async function () {
+    const { redis, store: backing } = fakeRedis();
+    const store = new TransferStore(redis);
+
+    const stale = await store.acquireLock(TRANSFER);
+    await stale?.release();
+    const live = await store.acquireLock(TRANSFER);
+
+    // The stale handle's token is no longer in Redis, so releasing it again cannot touch the live lock.
+    expect(await stale?.release()).to.equal(false);
+    expect(backing.has(LOCK_KEY)).to.equal(true);
+    expect(await live?.release()).to.equal(true);
+  });
+
+  it("uses a TTL, so a dead consumer does not block the transfer forever", async function () {
+    const { redis, ttls } = fakeRedis();
+    await new TransferStore(redis).acquireLock(TRANSFER);
+    expect(ttls.get(LOCK_KEY)).to.equal(600_000);
+  });
+});
+
+describe("TransferStore state", function () {
+  it("reads back nothing for a transfer never seen", async function () {
+    expect(await new TransferStore(fakeRedis().redis).read(TRANSFER)).to.equal(undefined);
+  });
+
+  it("round-trips a broadcast record and never expires it", async function () {
+    // A pending record must outlive anything that could still land on-chain.
+    const { redis, ttls } = fakeRedis();
+    const store = new TransferStore(redis);
+    await store.recordBroadcast(TRANSFER, PENDING);
+
+    expect(ttls.get(STATE_KEY)).to.equal(Number.POSITIVE_INFINITY);
+    const state = await store.read(TRANSFER);
+    expect(state?.status).to.equal("broadcast_pending");
+    expect(state && isTerminal(state)).to.equal(false);
+  });
+
+  it("round-trips each terminal status with a 90-day TTL", async function () {
+    for (const terminal of [
+      EXECUTED,
+      { ...EXECUTED, status: "withdraw_executed" },
+      { status: "withdraw_failed", code: "GAS_EXCEEDS_REFUND", reason: "dust", recordedAtMs: 5 },
+    ] as TerminalState[]) {
+      const { redis, ttls } = fakeRedis();
+      const store = new TransferStore(redis);
+      await store.recordTerminal(TRANSFER, terminal);
+
+      expect(ttls.get(STATE_KEY)).to.equal(90 * 24 * 60 * 60);
+      const read = await store.read(TRANSFER);
+      expect(read?.status).to.equal(terminal.status);
+      expect(read && isTerminal(read)).to.equal(true);
+    }
+  });
+
+  it("rewrites an identical terminal state without complaint", async function () {
+    const store = new TransferStore(fakeRedis().redis);
+    await store.recordTerminal(TRANSFER, EXECUTED);
+    await store.recordTerminal(TRANSFER, EXECUTED);
+    expect((await store.read(TRANSFER))?.status).to.equal("deposit_executed");
+  });
+
+  it("refuses to write broadcast_pending over a terminal outcome", async function () {
+    // The one transition that loses funds-safety information. Reaching it means a caller skipped the
+    // state read every path begins with.
+    const store = new TransferStore(fakeRedis().redis);
+    await store.recordTerminal(TRANSFER, EXECUTED);
+
+    await store.recordBroadcast(TRANSFER, PENDING).then(
+      () => expect.fail("expected a refusal"),
+      (err: Error) => expect(err.message).to.contain("refusing to write broadcast_pending over deposit_executed")
+    );
+    expect((await store.read(TRANSFER))?.status).to.equal("deposit_executed");
+  });
+
+  it("throws when redis does not acknowledge a write", async function () {
+    // Awaiting confirmation while believing the hash is durable is the unrecoverable direction.
+    const store = new TransferStore(fakeRedis([], { setFails: true }).redis);
+    await store.recordBroadcast(TRANSFER, PENDING).then(
+      () => expect.fail("expected a persistence failure"),
+      (err: Error) => expect(err.message).to.contain("did not acknowledge")
+    );
+  });
+
+  it("throws on a present-but-unreadable record instead of reading it as absent", async function () {
+    // A record we cannot decode may describe a transfer already swept, so it must keep blocking.
+    for (const corrupt of [
+      "not json",
+      '{"status":"nonsense"}',
+      '{"status":"broadcast_pending"}',
+      // Negative and non-integer timestamps must not deserialize.
+      '{"status":"broadcast_pending","operation":"deposit","txHash":"0x1","chainId":1,"submittedAtMs":-1}',
+      '{"status":"broadcast_pending","operation":"deposit","txHash":"0x1","chainId":1,"submittedAtMs":1.5}',
+    ]) {
+      const store = new TransferStore(fakeRedis([[STATE_KEY, corrupt]]).redis);
+      await store.read(TRANSFER).then(
+        () => expect.fail(`expected a throw for ${corrupt}`),
+        (err: Error) => expect(err.message).to.contain("unreadable")
+      );
+    }
+  });
+
+  it("keeps the lock and the state in separate keys", async function () {
+    // Their lifetimes are opposites: the lock must expire, the pending record must not.
+    const { redis, store: backing } = fakeRedis();
+    const store = new TransferStore(redis);
+    await store.acquireLock(TRANSFER);
+    await store.recordBroadcast(TRANSFER, PENDING);
+
+    expect([...backing.keys()].sort()).to.deep.equal([LOCK_KEY, STATE_KEY].sort());
+  });
+});
+
+describe("TransferStore.clearRevertedBroadcast", function () {
+  it("clears the record it was told about, so a reverted broadcast can be re-attempted", async function () {
+    const store = new TransferStore(fakeRedis().redis);
+    await store.recordBroadcast(TRANSFER, PENDING);
+
+    expect(await store.clearRevertedBroadcast(TRANSFER, "0xh1")).to.equal(true);
+    expect(await store.read(TRANSFER)).to.equal(undefined);
+  });
+
+  it("will not delete a newer pending transaction", async function () {
+    // A stale reconciliation of h1 must not unblock a transfer that is mid-sweep on h2.
+    const store = new TransferStore(fakeRedis().redis);
+    await store.recordBroadcast(TRANSFER, { ...PENDING, txHash: "0xh2" });
+
+    expect(await store.clearRevertedBroadcast(TRANSFER, "0xh1")).to.equal(false);
+    expect((await store.read(TRANSFER))?.status).to.equal("broadcast_pending");
+  });
+
+  it("will not delete a terminal outcome", async function () {
+    const store = new TransferStore(fakeRedis().redis);
+    await store.recordTerminal(TRANSFER, EXECUTED);
+
+    expect(await store.clearRevertedBroadcast(TRANSFER, "0xh1")).to.equal(false);
+    expect((await store.read(TRANSFER))?.status).to.equal("deposit_executed");
+  });
+
+  it("is a no-op when there is nothing recorded", async function () {
+    expect(await new TransferStore(fakeRedis().redis).clearRevertedBroadcast(TRANSFER, "0xh1")).to.equal(false);
+  });
+});


### PR DESCRIPTION
Part of #3663 — PR 3 of nine. **Stacked on #3670**, which is stacked on #3668. Bases retarget automatically as each merges.

## What

The two Redis keys the design turns on, plus the receipt classifier. `src/deposit-address-service/transferState.ts`.

```
deposit-address:lock:<transferId>    expiring, SET NX, uuid token generated inside the store
deposit-address:state:<transferId>   broadcast_pending (never expires) | 3 terminal statuses (90d)
```

They are **separate because their lifetimes are opposites**: the lock must expire so a dead consumer does not block a transfer forever; the state must not, because a `broadcast_pending` record has to outlive anything that could still land on-chain. Merging them reintroduces the problem the design exists to remove.

Built entirely on `acquireLock` / `releaseLock` / `get` / `set` / `del`, all already on `RedisCacheInterface` — **no new Redis primitive**, which is what #3648 was criticised for.

## Guards worth reviewing

- **`clearRevertedBroadcast(id, expectedTxHash)`** deletes only if the record is *still* that transaction. A stale reconciliation of `h1` must not delete a newer pending `h2` or a terminal outcome — that would unblock a transfer mid-sweep, which is the exact failure this project exists to prevent. Read-then-check is sufficient because callers hold the lock; it would need to be atomic only if that stopped being true.
- **`recordBroadcast` refuses to overwrite a terminal outcome** — the one transition that loses funds-safety information.
- **Every write throws unless Redis replies `"OK"`.** `set` can answer `undefined`, and awaiting a confirmation while believing a broadcast hash is durable is the unrecoverable direction.
- **A present-but-unparseable record throws** rather than reading as absent: it may describe a transfer already swept, so the transfer stays blocked. `CorruptTransferStateError` is retriable but distinct from a Redis outage — it clears only when an operator repairs or deletes the key.
- **The lock token never crosses the boundary.** `acquireLock(id)` generates a uuid and returns a `TransferLock` handle, so no caller can pass a `messageId` or reuse a token. A message id could not serve anyway: Pub/Sub redelivers the same message.

## `classifyReceipt` returns facts, not actions

`"confirmed" | "reverted" | "unresolved"`. Whether each means ACK, NACK, clear or persist is retry policy and belongs with the orchestration that also holds the lock — so this file has no opinion on it.

A receipt with **no explicit `status === 0` reads as confirmed**. ethers leaves `status` undefined on some chains; guessing confirmed can strand a deposit for manual recovery, whereas guessing reverted would re-broadcast one that already landed. Only the first is reversible.

## Deliberately skipped

- **`schemaVersion`.** Superstruct `type()` already tolerates unknown keys, so today's records stay readable. Add one when there is a second version — a version number does not help with the case it would not cover anyway (a field whose *meaning* changes).
- **A full transition table.** Only the pending-over-terminal row is enforced. Reaching the other six requires a caller to bypass the state read every path begins with.
- **Wiring.** Same reason as PR 2: nothing to lock or record until the execution paths exist, and a handler that ACKed without executing would discard work.

## Testing

`RELAYER_TEST=true yarn hardhat test "test/DepositAddressService*.ts"` → **79 passing** (20 new).

Covers all four `classifyReceipt` branches, `SET NX` exclusivity, token-checked release, internally-generated and differing tokens, the lock TTL, round-trip of every status with its TTL, idempotent terminal rewrite, refusal to downgrade a terminal, unacknowledged writes, corrupt and out-of-range records, and that a stale clear cannot delete either a newer pending hash or a terminal outcome.

`yarn build` reports only the three pre-existing `poolRebalanceLeafCount` errors. `yarn lint` clean.

Note this touches `errors.ts` (three new classes) and the module README, both introduced in #3668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)