### PR TITLE
refactor(paxos): carry Paxos Transit token routes as Address, not string

### DIFF
--- a/src/adapter/bridges/PaxosTransitBridge.ts
+++ b/src/adapter/bridges/PaxosTransitBridge.ts
@@ -35,6 +35,7 @@ import ERC20_ABI from "../../common/abi/MinimalERC20.json";
 export class PaxosTransitBridge extends BaseBridgeAdapter {
   protected client: PaxosTransitClient;
   protected l1TokenInfo: TokenInfo;
+  protected l1TokenAddress: EvmAddress;
   protected l2TokenAddress: Address;
 
   constructor(
@@ -59,6 +60,7 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
     this.l2Bridge = new Contract(l2TokenAddress.toNative(), ERC20_ABI, l2SignerOrProvider);
     this.client = createPaxosTransitClient(logger);
     this.l1TokenInfo = getTokenInfo(l1Token, this.hubChainId);
+    this.l1TokenAddress = l1Token;
     this.l2TokenAddress = l2TokenAddress;
   }
 
@@ -70,18 +72,18 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
     _optionalParams?: TransferTokenParams
   ): Promise<BridgeTransactionDetails> {
     assert(l2Token.eq(this.l2TokenAddress), `Attempting to bridge unsupported l2 token ${l2Token}`);
-    assert(l1Token.toNative() === this.l1Bridge?.address, "L1 token mismatch for Paxos Transit bridge");
+    assert(l1Token.eq(this.l1TokenAddress), "L1 token mismatch for Paxos Transit bridge");
 
     if (amount.lt(PAXOS_TRANSIT_MINIMUMS[this.hubChainId]?.[this.l2chainId] ?? bnZero)) {
       throw new Error(`Cannot bridge to ${getNetworkName(this.l2chainId)} due to invalid amount ${amount}`);
     }
 
-    const userAddress = await this.l1Signer.getAddress();
+    const userAddress = EvmAddress.from(await this.l1Signer.getAddress());
     const orderData = await buildPaxosTransitSubmitOrderTxn(this.client, this.l1Signer, {
       userAddress,
       offerAmount: amount,
-      offerAsset: l1Token.toNative(),
-      wantAsset: this.l2TokenAddress.toNative(),
+      offerAsset: l1Token,
+      wantAsset: this.l2TokenAddress,
       sourceChainId: this.hubChainId,
       destinationChainId: this.l2chainId,
       spenderAddress: getPaxosTransitStationAddress(this.hubChainId),
@@ -117,7 +119,7 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
         const tokenContract = new Contract(offerAsset.toNative(), ERC20_ABI, l1Provider);
         const events = await paginatedEventQuery(
           tokenContract,
-          tokenContract.filters.Transfer(fromAddress.toNative(), transitStation),
+          tokenContract.filters.Transfer(fromAddress.toNative(), transitStation.toNative()),
           eventConfig
         );
         return events.map((event) => processEvent(event, "value"));
@@ -141,7 +143,7 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
     const tokenContract = new Contract(this.l2TokenAddress.toNative(), ERC20_ABI, l2Provider);
     const events = await paginatedEventQuery(
       tokenContract,
-      tokenContract.filters.Transfer(boringVault, toAddress.toNative()),
+      tokenContract.filters.Transfer(boringVault.toNative(), toAddress.toNative()),
       eventConfig
     );
     return {
@@ -153,7 +155,7 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
     l1Token: EvmAddress,
     userAddress: EvmAddress
   ): Promise<BridgeEvents> {
-    const orders = await listOutstandingPaxosTransitOrders(this.client, userAddress.toNative());
+    const orders = await listOutstandingPaxosTransitOrders(this.client, userAddress);
     const l2TokenDecimals = getTokenInfo(this.l2TokenAddress, this.l2chainId).decimals;
     const l1TokenDecimals = this.l1TokenInfo.decimals;
     const routeParams = {
@@ -178,7 +180,7 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
     this.logger.debug({
       at: "PaxosTransitBridge#getOutstandingTransfersFromApi",
       message: "Resolved Paxos Transit outstanding orders from API",
-      offerAsset: l1Token.toNative(),
+      offerAsset: l1Token,
       wantAsset: this.l2TokenAddress,
       outstandingOrderCount: bridgeEvents.length,
       outstandingAmount: bridgeEvents.reduce((acc, event) => acc.add(event.amount), bnZero).toString(),

--- a/src/adapter/bridges/PaxosTransitBridge.ts
+++ b/src/adapter/bridges/PaxosTransitBridge.ts
@@ -153,16 +153,16 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
 
   private async buildOutstandingTransfersFromApiOrders(
     l1Token: EvmAddress,
-    userAddress: EvmAddress
+    receiver: EvmAddress
   ): Promise<BridgeEvents> {
-    const orders = await listOutstandingPaxosTransitOrders(this.client, userAddress);
+    const orders = await listOutstandingPaxosTransitOrders(this.client, receiver);
     const l2TokenDecimals = getTokenInfo(this.l2TokenAddress, this.l2chainId).decimals;
     const l1TokenDecimals = this.l1TokenInfo.decimals;
     const routeParams = {
       wantAsset: this.l2TokenAddress,
       sourceChainId: this.hubChainId,
       destinationChainId: this.l2chainId,
-      receiver: userAddress,
+      receiver,
     };
 
     const outstandingOrders = orders.filter(

--- a/src/adapter/bridges/PaxosTransitBridge.ts
+++ b/src/adapter/bridges/PaxosTransitBridge.ts
@@ -157,10 +157,10 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
     const l2TokenDecimals = getTokenInfo(this.l2TokenAddress, this.l2chainId).decimals;
     const l1TokenDecimals = this.l1TokenInfo.decimals;
     const routeParams = {
-      wantAsset: this.l2TokenAddress.toNative(),
+      wantAsset: this.l2TokenAddress,
       sourceChainId: this.hubChainId,
       destinationChainId: this.l2chainId,
-      receiver: userAddress.toNative(),
+      receiver: userAddress,
     };
 
     const outstandingOrders = orders.filter(

--- a/src/adapter/bridges/PaxosTransitBridge.ts
+++ b/src/adapter/bridges/PaxosTransitBridge.ts
@@ -52,7 +52,7 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
     const l2TokenAddress = getPaxosTransitDestinationToken(l2chainId, l1Token);
     assert(
       isDefined(l2TokenAddress),
-      `No Paxos Transit destination token configured for chain ${l2chainId} and L1 token ${l1Token.toNative()}`
+      `No Paxos Transit destination token configured for chain ${l2chainId} and L1 token ${l1Token}`
     );
 
     this.l1Bridge = new Contract(l1Token.toNative(), ERC20_ABI, l1Signer);
@@ -69,7 +69,7 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
     amount: BigNumber,
     _optionalParams?: TransferTokenParams
   ): Promise<BridgeTransactionDetails> {
-    assert(l2Token.eq(this.l2TokenAddress), `Attempting to bridge unsupported l2 token ${l2Token.toNative()}`);
+    assert(l2Token.eq(this.l2TokenAddress), `Attempting to bridge unsupported l2 token ${l2Token}`);
     assert(l1Token.toNative() === this.l1Bridge?.address, "L1 token mismatch for Paxos Transit bridge");
 
     if (amount.lt(PAXOS_TRANSIT_MINIMUMS[this.hubChainId]?.[this.l2chainId] ?? bnZero)) {

--- a/src/adapter/bridges/PaxosTransitBridge.ts
+++ b/src/adapter/bridges/PaxosTransitBridge.ts
@@ -23,7 +23,6 @@ import {
   PaxosTransitClient,
   bnZero,
   mapAsync,
-  toAddressType,
   listOutstandingPaxosTransitOrders,
   isPaxosTransitOrderOutstanding,
   paxosTransitOrderMatchesRoute,
@@ -36,7 +35,7 @@ import ERC20_ABI from "../../common/abi/MinimalERC20.json";
 export class PaxosTransitBridge extends BaseBridgeAdapter {
   protected client: PaxosTransitClient;
   protected l1TokenInfo: TokenInfo;
-  protected l2TokenAddress: string;
+  protected l2TokenAddress: Address;
 
   constructor(
     l2chainId: number,
@@ -57,7 +56,7 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
     );
 
     this.l1Bridge = new Contract(l1Token.toNative(), ERC20_ABI, l1Signer);
-    this.l2Bridge = new Contract(l2TokenAddress, ERC20_ABI, l2SignerOrProvider);
+    this.l2Bridge = new Contract(l2TokenAddress.toNative(), ERC20_ABI, l2SignerOrProvider);
     this.client = createPaxosTransitClient(logger);
     this.l1TokenInfo = getTokenInfo(l1Token, this.hubChainId);
     this.l2TokenAddress = l2TokenAddress;
@@ -70,10 +69,7 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
     amount: BigNumber,
     _optionalParams?: TransferTokenParams
   ): Promise<BridgeTransactionDetails> {
-    assert(
-      l2Token.toNative() === this.l2TokenAddress,
-      `Attempting to bridge unsupported l2 token ${l2Token.toNative()}`
-    );
+    assert(l2Token.eq(this.l2TokenAddress), `Attempting to bridge unsupported l2 token ${l2Token.toNative()}`);
     assert(l1Token.toNative() === this.l1Bridge?.address, "L1 token mismatch for Paxos Transit bridge");
 
     if (amount.lt(PAXOS_TRANSIT_MINIMUMS[this.hubChainId]?.[this.l2chainId] ?? bnZero)) {
@@ -85,7 +81,7 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
       userAddress,
       offerAmount: amount,
       offerAsset: l1Token.toNative(),
-      wantAsset: this.l2TokenAddress,
+      wantAsset: this.l2TokenAddress.toNative(),
       sourceChainId: this.hubChainId,
       destinationChainId: this.l2chainId,
       spenderAddress: getPaxosTransitStationAddress(this.hubChainId),
@@ -118,7 +114,7 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
     const offerAssets = getPaxosTransitOfferAssetsForWantAsset(this.l2chainId, this.l2TokenAddress);
     const processedEvents = (
       await mapAsync(offerAssets, async (offerAsset) => {
-        const tokenContract = new Contract(offerAsset, ERC20_ABI, l1Provider);
+        const tokenContract = new Contract(offerAsset.toNative(), ERC20_ABI, l1Provider);
         const events = await paginatedEventQuery(
           tokenContract,
           tokenContract.filters.Transfer(fromAddress.toNative(), transitStation),
@@ -128,7 +124,7 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
       })
     ).flat();
     return {
-      [this.l2TokenAddress]: processedEvents,
+      [this.l2TokenAddress.toNative()]: processedEvents,
     };
   }
 
@@ -142,14 +138,14 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
     const l2Provider = this.l2Bridge?.provider;
     assert(isDefined(l2Provider), "PaxosTransitBridge: l2 provider is required");
     const boringVault = getPaxosTransitBoringVaultAddress(this.l2chainId);
-    const tokenContract = new Contract(this.l2TokenAddress, ERC20_ABI, l2Provider);
+    const tokenContract = new Contract(this.l2TokenAddress.toNative(), ERC20_ABI, l2Provider);
     const events = await paginatedEventQuery(
       tokenContract,
       tokenContract.filters.Transfer(boringVault, toAddress.toNative()),
       eventConfig
     );
     return {
-      [this.l2TokenAddress]: events.map((event) => processEvent(event, "value")),
+      [this.l2TokenAddress.toNative()]: events.map((event) => processEvent(event, "value")),
     };
   }
 
@@ -158,10 +154,10 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
     userAddress: EvmAddress
   ): Promise<BridgeEvents> {
     const orders = await listOutstandingPaxosTransitOrders(this.client, userAddress.toNative());
-    const l2TokenDecimals = getTokenInfo(toAddressType(this.l2TokenAddress, this.l2chainId), this.l2chainId).decimals;
+    const l2TokenDecimals = getTokenInfo(this.l2TokenAddress, this.l2chainId).decimals;
     const l1TokenDecimals = this.l1TokenInfo.decimals;
     const routeParams = {
-      wantAsset: this.l2TokenAddress,
+      wantAsset: this.l2TokenAddress.toNative(),
       sourceChainId: this.hubChainId,
       destinationChainId: this.l2chainId,
       receiver: userAddress.toNative(),
@@ -189,7 +185,7 @@ export class PaxosTransitBridge extends BaseBridgeAdapter {
     });
 
     return {
-      [this.l2TokenAddress]: bridgeEvents,
+      [this.l2TokenAddress.toNative()]: bridgeEvents,
     };
   }
 }

--- a/src/adapter/l2Bridges/PaxosTransitL2Bridge.ts
+++ b/src/adapter/l2Bridges/PaxosTransitL2Bridge.ts
@@ -71,12 +71,12 @@ export class PaxosTransitL2Bridge extends BaseL2BridgeAdapter {
 
     const { l2Signer } = this;
     assert(isDefined(l2Signer), "PaxosTransitL2Bridge: l2Signer is required");
-    const userAddress = await l2Signer.getAddress();
+    const userAddress = EvmAddress.from(await l2Signer.getAddress());
     const orderData = await buildPaxosTransitSubmitOrderTxn(this.client, l2Signer, {
       userAddress,
       offerAmount: amount,
-      offerAsset: this.l2TokenAddress.toNative(),
-      wantAsset: this.l1Token.toNative(),
+      offerAsset: this.l2TokenAddress,
+      wantAsset: this.l1Token,
       sourceChainId: this.l2chainId,
       destinationChainId: this.hubChainId,
       spenderAddress: getPaxosTransitStationAddress(this.l2chainId),
@@ -114,7 +114,7 @@ export class PaxosTransitL2Bridge extends BaseL2BridgeAdapter {
     const tokenContract = new Contract(this.l2TokenAddress.toNative(), ERC20_ABI, l2Provider);
     const events = await paginatedEventQuery(
       tokenContract,
-      tokenContract.filters.Transfer(fromAddress.toNative(), transitStation),
+      tokenContract.filters.Transfer(fromAddress.toNative(), transitStation.toNative()),
       l2EventConfig
     );
     return events.map((event) => processEvent(event, "value")).reduce((acc, event) => acc.add(event.amount), bnZero);

--- a/src/adapter/l2Bridges/PaxosTransitL2Bridge.ts
+++ b/src/adapter/l2Bridges/PaxosTransitL2Bridge.ts
@@ -18,7 +18,6 @@ import {
   getPaxosTransitStationAddress,
   buildPaxosTransitSubmitOrderTxn,
   paginatedEventQuery,
-  toAddressType,
   PaxosTransitClient,
 } from "../../utils";
 import { BaseL2BridgeAdapter } from "./BaseL2BridgeAdapter";
@@ -31,7 +30,7 @@ export class PaxosTransitL2Bridge extends BaseL2BridgeAdapter {
   protected client: PaxosTransitClient;
   protected l1TokenInfo: TokenInfo;
   protected l2TokenInfo: TokenInfo;
-  protected l2TokenAddress: string;
+  protected l2TokenAddress: Address;
 
   constructor(l2chainId: number, hubChainId: number, l2Signer: Signer, l1Signer: Signer, l1Token: EvmAddress) {
     if (hubChainId !== CHAIN_IDs.MAINNET) {
@@ -48,13 +47,13 @@ export class PaxosTransitL2Bridge extends BaseL2BridgeAdapter {
     this.client = createPaxosTransitClient();
     this.l1TokenInfo = getTokenInfo(l1Token, this.hubChainId);
     this.l2TokenAddress = l2TokenAddress;
-    this.l2TokenInfo = getTokenInfo(toAddressType(l2TokenAddress, this.l2chainId), this.l2chainId);
-    this.l2Bridge = new Contract(l2TokenAddress, ERC20_ABI, l2Signer);
+    this.l2TokenInfo = getTokenInfo(l2TokenAddress, this.l2chainId);
+    this.l2Bridge = new Contract(l2TokenAddress.toNative(), ERC20_ABI, l2Signer);
     this.l1Bridge = new Contract(l1Token.toNative(), ERC20_ABI, l1Signer);
   }
 
   override getL2Token(): Address {
-    return toAddressType(this.l2TokenAddress, this.l2chainId);
+    return this.l2TokenAddress;
   }
 
   async constructWithdrawToL1Txns(
@@ -63,7 +62,7 @@ export class PaxosTransitL2Bridge extends BaseL2BridgeAdapter {
     l1Token: EvmAddress,
     amount: BigNumber
   ): Promise<AugmentedTransaction[]> {
-    assert(l2Token.toNative() === this.l2TokenAddress, `Unsupported L2 token ${l2Token.toNative()}`);
+    assert(l2Token.eq(this.l2TokenAddress), `Unsupported L2 token ${l2Token.toNative()}`);
     assert(l1Token.eq(this.l1Token), `Unsupported L1 token ${l1Token.toNative()}`);
 
     if (amount.lt(PAXOS_TRANSIT_MINIMUMS[this.l2chainId]?.[this.hubChainId] ?? toBN(Number.MAX_SAFE_INTEGER))) {
@@ -76,7 +75,7 @@ export class PaxosTransitL2Bridge extends BaseL2BridgeAdapter {
     const orderData = await buildPaxosTransitSubmitOrderTxn(this.client, l2Signer, {
       userAddress,
       offerAmount: amount,
-      offerAsset: this.l2TokenAddress,
+      offerAsset: this.l2TokenAddress.toNative(),
       wantAsset: this.l1Token.toNative(),
       sourceChainId: this.l2chainId,
       destinationChainId: this.hubChainId,
@@ -107,12 +106,12 @@ export class PaxosTransitL2Bridge extends BaseL2BridgeAdapter {
   ): Promise<BigNumber> {
     const { l2Signer } = this;
     assert(isDefined(l2Signer), "PaxosTransitL2Bridge: l2Signer is required");
-    assert(l2Token.toNative() === this.l2TokenAddress, `Unsupported L2 token ${l2Token.toNative()}`);
+    assert(l2Token.eq(this.l2TokenAddress), `Unsupported L2 token ${l2Token.toNative()}`);
 
     const l2Provider = l2Signer.provider;
     assert(isDefined(l2Provider), "PaxosTransitL2Bridge: l2Signer must have a provider");
     const transitStation = getPaxosTransitStationAddress(this.l2chainId);
-    const tokenContract = new Contract(this.l2TokenAddress, ERC20_ABI, l2Provider);
+    const tokenContract = new Contract(this.l2TokenAddress.toNative(), ERC20_ABI, l2Provider);
     const events = await paginatedEventQuery(
       tokenContract,
       tokenContract.filters.Transfer(fromAddress.toNative(), transitStation),

--- a/src/adapter/l2Bridges/PaxosTransitL2Bridge.ts
+++ b/src/adapter/l2Bridges/PaxosTransitL2Bridge.ts
@@ -41,7 +41,7 @@ export class PaxosTransitL2Bridge extends BaseL2BridgeAdapter {
     const l2TokenAddress = getPaxosTransitDestinationToken(l2chainId, l1Token);
     assert(
       isDefined(l2TokenAddress),
-      `No Paxos Transit destination token configured for chain ${l2chainId} and L1 token ${l1Token.toNative()}`
+      `No Paxos Transit destination token configured for chain ${l2chainId} and L1 token ${l1Token}`
     );
 
     this.client = createPaxosTransitClient();
@@ -62,8 +62,8 @@ export class PaxosTransitL2Bridge extends BaseL2BridgeAdapter {
     l1Token: EvmAddress,
     amount: BigNumber
   ): Promise<AugmentedTransaction[]> {
-    assert(l2Token.eq(this.l2TokenAddress), `Unsupported L2 token ${l2Token.toNative()}`);
-    assert(l1Token.eq(this.l1Token), `Unsupported L1 token ${l1Token.toNative()}`);
+    assert(l2Token.eq(this.l2TokenAddress), `Unsupported L2 token ${l2Token}`);
+    assert(l1Token.eq(this.l1Token), `Unsupported L1 token ${l1Token}`);
 
     if (amount.lt(PAXOS_TRANSIT_MINIMUMS[this.l2chainId]?.[this.hubChainId] ?? toBN(Number.MAX_SAFE_INTEGER))) {
       throw new Error(`Cannot bridge to ${getNetworkName(this.hubChainId)} due to invalid amount ${amount}`);
@@ -106,7 +106,7 @@ export class PaxosTransitL2Bridge extends BaseL2BridgeAdapter {
   ): Promise<BigNumber> {
     const { l2Signer } = this;
     assert(isDefined(l2Signer), "PaxosTransitL2Bridge: l2Signer is required");
-    assert(l2Token.eq(this.l2TokenAddress), `Unsupported L2 token ${l2Token.toNative()}`);
+    assert(l2Token.eq(this.l2TokenAddress), `Unsupported L2 token ${l2Token}`);
 
     const l2Provider = l2Signer.provider;
     assert(isDefined(l2Provider), "PaxosTransitL2Bridge: l2Signer must have a provider");

--- a/src/refiller/Refiller.ts
+++ b/src/refiller/Refiller.ts
@@ -115,7 +115,7 @@ export class Refiller {
   private _hasMainnetUsdgSweepConfigured(): boolean {
     const mainnetUsdgAddress = getMainnetUsdgAddress();
     return this.config.refillEnabledBalances.some(
-      ({ chainId, token }) => chainId === CHAIN_IDs.MAINNET && token.toNative() === mainnetUsdgAddress
+      ({ chainId, token }) => chainId === CHAIN_IDs.MAINNET && token.eq(mainnetUsdgAddress)
     );
   }
 
@@ -151,7 +151,7 @@ export class Refiller {
         case TOKEN_SYMBOLS_MAP.USDH.addresses[CHAIN_IDs.HYPEREVM]:
           refillHandler = this.refillUsdh;
           break;
-        case getMainnetUsdgAddress():
+        case getMainnetUsdgAddress().toNative():
           assert(chainId === CHAIN_IDs.MAINNET, "Mainnet USDG sweep must be configured on mainnet");
           refillHandler = this.sweepMainnetUsdgToRobinhood;
           break;
@@ -616,14 +616,14 @@ export class Refiller {
       return;
     }
 
-    const mainnetUsdgAddress = getMainnetUsdgAddress();
+    const l1Token = getMainnetUsdgAddress();
     const rhUsdgAddress = TOKEN_SYMBOLS_MAP.USDG.addresses[CHAIN_IDs.ROBINHOOD];
     const mainnetProvider = this.clients.balanceAllocator.providers[CHAIN_IDs.MAINNET];
     const rhProvider = this.clients.balanceAllocator.providers[CHAIN_IDs.ROBINHOOD];
     assert(isDefined(mainnetProvider), "No mainnet provider found for USDG sweep");
     assert(isDefined(rhProvider), "No Robinhood provider found for USDG sweep");
 
-    const usdg = new Contract(mainnetUsdgAddress, ERC20_ABI, this.baseSigner.connect(mainnetProvider));
+    const usdg = new Contract(l1Token.toNative(), ERC20_ABI, this.baseSigner.connect(mainnetProvider));
     const amountToTransfer = await usdg.balanceOf(this.baseSignerAddress.toNative());
     if (amountToTransfer.lte(this.config.minUsdgSweepAmount)) {
       this.logger.debug({
@@ -635,7 +635,6 @@ export class Refiller {
       return;
     }
 
-    const l1Token = EvmAddress.from(mainnetUsdgAddress);
     const tokenBridge = new PaxosTransitBridge(
       CHAIN_IDs.ROBINHOOD,
       CHAIN_IDs.MAINNET,

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -87,7 +87,7 @@ export function isUnmeteredFastRebalance(chainId: number, token: Address, hubCha
     chainId !== CHAIN_IDs.HYPEREVM;
   // Paxos Transit withdrawals settle in ~7-11 min and cap at $50mm/order, so they're fast and
   // effectively unmetered at relayer size.
-  const paxosTransit = getPaxosTransitOfferAssetsForWantAsset(chainId, token.toNative()).length > 0;
+  const paxosTransit = getPaxosTransitOfferAssetsForWantAsset(chainId, token).length > 0;
   return cctp || oft || paxosTransit || chainId === hubChainId;
 }
 

--- a/src/utils/PaxosTransitUtils.ts
+++ b/src/utils/PaxosTransitUtils.ts
@@ -17,6 +17,8 @@ import {
   toBN,
   winston,
   Address,
+  EvmAddress,
+  toAddressType,
 } from "./";
 
 export function getMainnetUsdgAddress(): string {
@@ -128,14 +130,18 @@ export function isPaxosTransitOrderOutstanding(order: PaxosTransitOrder): boolea
   return PAXOS_TRANSIT_OUTSTANDING_ORDER_STATUSES.has(order.status);
 }
 
-export function getPaxosTransitOfferAssetsForWantAsset(dstChainId: number, wantAsset: string): string[] {
+/**
+ * Resolve the mainnet offer assets that Paxos Transit will bridge into `wantAsset` on `dstChainId`.
+ * Offer assets are always keyed on mainnet, hence the EvmAddress return type.
+ */
+export function getPaxosTransitOfferAssetsForWantAsset(dstChainId: number, wantAsset: Address): EvmAddress[] {
   const destinations = PAXOS_TRANSIT_DESTINATION_TOKENS[dstChainId];
   if (!isDefined(destinations)) {
     return [];
   }
   return Object.entries(destinations)
-    .filter(([, destinationWantAsset]) => destinationWantAsset.toLowerCase() === wantAsset.toLowerCase())
-    .map(([offerAsset]) => offerAsset);
+    .filter(([, destinationWantAsset]) => toAddressType(destinationWantAsset, dstChainId).eq(wantAsset))
+    .map(([offerAsset]) => EvmAddress.from(offerAsset));
 }
 
 export function paxosTransitOrderMatchesRoute(
@@ -220,8 +226,9 @@ export function getPaxosTransitBoringVaultAddress(chainId: number): string {
   return getContractAddress(chainId, "paxosTransitBoringVault");
 }
 
-export function getPaxosTransitDestinationToken(dstChainId: number, l1Token: Address): string | undefined {
-  return PAXOS_TRANSIT_DESTINATION_TOKENS[dstChainId]?.[l1Token.toNative()];
+export function getPaxosTransitDestinationToken(dstChainId: number, l1Token: Address): Address | undefined {
+  const destinationToken = PAXOS_TRANSIT_DESTINATION_TOKENS[dstChainId]?.[l1Token.toNative()];
+  return isDefined(destinationToken) ? toAddressType(destinationToken, dstChainId) : undefined;
 }
 
 export class PaxosTransitClient {

--- a/src/utils/PaxosTransitUtils.ts
+++ b/src/utils/PaxosTransitUtils.ts
@@ -17,6 +17,7 @@ import {
   toBN,
   winston,
   Address,
+  compareAddressesSimple,
   EvmAddress,
   toAddressType,
 } from "./";
@@ -147,17 +148,20 @@ export function getPaxosTransitOfferAssetsForWantAsset(dstChainId: number, wantA
 export function paxosTransitOrderMatchesRoute(
   order: PaxosTransitOrder,
   params: {
-    wantAsset: string;
+    wantAsset: Address;
     sourceChainId: number;
     destinationChainId: number;
-    receiver: string;
+    receiver: Address;
   }
 ): boolean {
+  // order.wantAsset and order.receiver arrive as raw strings from the Paxos API, so compare them
+  // case-insensitively rather than parsing into an Address — a malformed field should fail to match,
+  // not throw.
   return (
-    order.wantAsset.toLowerCase() === params.wantAsset.toLowerCase() &&
+    compareAddressesSimple(order.wantAsset, params.wantAsset.toNative()) &&
     order.sourceChainId === params.sourceChainId &&
     order.destinationChainId === params.destinationChainId &&
-    order.receiver.toLowerCase() === params.receiver.toLowerCase()
+    compareAddressesSimple(order.receiver, params.receiver.toNative())
   );
 }
 

--- a/src/utils/PaxosTransitUtils.ts
+++ b/src/utils/PaxosTransitUtils.ts
@@ -22,10 +22,10 @@ import {
   toAddressType,
 } from "./";
 
-export function getMainnetUsdgAddress(): string {
+export function getMainnetUsdgAddress(): EvmAddress {
   const address = TOKEN_SYMBOLS_MAP["USDG-MAINNET"].addresses[CHAIN_IDs.MAINNET];
   assert(isDefined(address), "USDG-MAINNET is not configured on mainnet");
-  return address;
+  return EvmAddress.from(address);
 }
 
 export const PAXOS_TRANSIT_DESTINATION_TOKENS: { [dstChainId: number]: { [l1TokenAddress: string]: string } } = {
@@ -167,7 +167,7 @@ export function paxosTransitOrderMatchesRoute(
 
 export async function listPaxosTransitOrders(
   client: PaxosTransitClient,
-  userAddress: string,
+  userAddress: Address,
   filter?: string
 ): Promise<PaxosTransitOrder[]> {
   const orders: PaxosTransitOrder[] = [];
@@ -188,7 +188,7 @@ export async function listPaxosTransitOrders(
 /** @deprecated Use listPaxosTransitOrders or listOutstandingPaxosTransitOrders */
 export async function listAllPaxosTransitOrders(
   client: PaxosTransitClient,
-  userAddress: string
+  userAddress: Address
 ): Promise<PaxosTransitOrder[]> {
   return listPaxosTransitOrders(client, userAddress);
 }
@@ -199,7 +199,7 @@ export async function listAllPaxosTransitOrders(
  */
 export async function listOutstandingPaxosTransitOrders(
   client: PaxosTransitClient,
-  userAddress: string
+  userAddress: Address
 ): Promise<PaxosTransitOrder[]> {
   return listPaxosTransitOrders(client, userAddress, PAXOS_TRANSIT_OUTSTANDING_ORDERS_FILTER);
 }
@@ -212,22 +212,22 @@ export function getPaxosTransitOutstandingOrderAmountInL1Decimals(
   return ConvertDecimals(wantAssetDecimals, offerAssetDecimals)(getPaxosTransitOrderOutstandingWantAmount(order));
 }
 
-export function getPaxosTransitStationAddress(chainId: number): string {
+export function getPaxosTransitStationAddress(chainId: number): Address {
   const envKey = `PAXOS_TRANSIT_STATION_${chainId}`;
   const envAddress = process.env[envKey];
-  if (isDefined(envAddress) && envAddress.length > 0) {
-    return envAddress;
-  }
-  return getContractAddress(chainId, "paxosTransitStation");
+  const address =
+    isDefined(envAddress) && envAddress.length > 0 ? envAddress : getContractAddress(chainId, "paxosTransitStation");
+  return toAddressType(address, chainId);
 }
 
-export function getPaxosTransitBoringVaultAddress(chainId: number): string {
+export function getPaxosTransitBoringVaultAddress(chainId: number): Address {
   const envKey = `PAXOS_TRANSIT_BORING_VAULT_${chainId}`;
   const envAddress = process.env[envKey];
-  if (isDefined(envAddress) && envAddress.length > 0) {
-    return envAddress;
-  }
-  return getContractAddress(chainId, "paxosTransitBoringVault");
+  const address =
+    isDefined(envAddress) && envAddress.length > 0
+      ? envAddress
+      : getContractAddress(chainId, "paxosTransitBoringVault");
+  return toAddressType(address, chainId);
 }
 
 export function getPaxosTransitDestinationToken(dstChainId: number, l1Token: Address): Address | undefined {
@@ -235,6 +235,11 @@ export function getPaxosTransitDestinationToken(dstChainId: number, l1Token: Add
   return isDefined(destinationToken) ? toAddressType(destinationToken, dstChainId) : undefined;
 }
 
+/**
+ * Request params are `Address` and are serialised to strings here, at the wire boundary. Response
+ * types stay string-typed: they are deserialised JSON, and `toAddressType()` throws on a malformed
+ * value where a string compare merely fails to match.
+ */
 export class PaxosTransitClient {
   constructor(
     readonly baseUrl: string,
@@ -244,40 +249,40 @@ export class PaxosTransitClient {
   ) {}
 
   async getAuthorization(params: {
-    spenderAddress: string;
-    tokenAddress: string;
+    spenderAddress: Address;
+    tokenAddress: Address;
     amount: BigNumber;
-    userAddress: string;
+    userAddress: Address;
     chainId: number;
   }): Promise<PaxosTransitAuthorizationResponse> {
     const query = new URLSearchParams({
-      spenderAddress: params.spenderAddress,
-      tokenAddress: params.tokenAddress,
+      spenderAddress: params.spenderAddress.toNative(),
+      tokenAddress: params.tokenAddress.toNative(),
       amount: params.amount.toString(),
-      userAddress: params.userAddress,
+      userAddress: params.userAddress.toNative(),
       chainId: String(params.chainId),
     });
     return this.getWithRetry<PaxosTransitAuthorizationResponse>(`v3/core/authorization?${query.toString()}`);
   }
 
   async getOrderQuote(params: {
-    userAddress: string;
+    userAddress: Address;
     offerAmount: BigNumber;
-    offerAsset: string;
-    wantAsset: string;
+    offerAsset: Address;
+    wantAsset: Address;
     sourceChainId: number;
     destinationChainId: number;
     permitSignature?: string;
     permitDeadline?: string;
     integratorFee?: string;
-    integratorFeeReceiver?: string;
+    integratorFeeReceiver?: Address;
     responseFormat?: "default" | "full" | "structured";
   }): Promise<PaxosTransitOrderQuoteResponse> {
     const query = new URLSearchParams({
-      userAddress: params.userAddress,
+      userAddress: params.userAddress.toNative(),
       offerAmount: params.offerAmount.toString(),
-      offerAsset: params.offerAsset,
-      wantAsset: params.wantAsset,
+      offerAsset: params.offerAsset.toNative(),
+      wantAsset: params.wantAsset.toNative(),
       sourceChainId: String(params.sourceChainId),
       destinationChainId: String(params.destinationChainId),
     });
@@ -291,7 +296,7 @@ export class PaxosTransitClient {
       query.set("integratorFee", params.integratorFee);
     }
     if (isDefined(params.integratorFeeReceiver)) {
-      query.set("integratorFeeReceiver", params.integratorFeeReceiver);
+      query.set("integratorFeeReceiver", params.integratorFeeReceiver.toNative());
     }
     if (isDefined(params.responseFormat)) {
       query.set("responseFormat", params.responseFormat);
@@ -311,13 +316,13 @@ export class PaxosTransitClient {
   }
 
   async listOrders(params: {
-    userAddress: string;
+    userAddress: Address;
     filter?: string;
     pageSize?: number;
     pageToken?: string;
   }): Promise<{ orders: PaxosTransitOrder[]; nextPageToken: string | null }> {
     const query = new URLSearchParams({
-      userAddress: params.userAddress,
+      userAddress: params.userAddress.toNative(),
     });
     if (isDefined(params.filter)) {
       query.set("filter", params.filter);
@@ -377,13 +382,13 @@ function permitTypesForSigning(
 
 async function submitPaxosTransitApproval(
   signer: Signer,
-  tokenAddress: string,
+  tokenAddress: Address,
   approvalCalldata: string
 ): Promise<void> {
   const provider = signer.provider;
   assert(isDefined(provider), "Signer must have a provider to submit Paxos Transit approval transaction");
   const tx = await signer.sendTransaction({
-    to: tokenAddress,
+    to: tokenAddress.toNative(),
     data: approvalCalldata,
   });
   await provider.waitForTransaction(tx.hash);
@@ -393,9 +398,9 @@ export async function resolvePaxosTransitAuthorization(
   client: PaxosTransitClient,
   signer: Signer,
   params: {
-    spenderAddress: string;
-    tokenAddress: string;
-    userAddress: string;
+    spenderAddress: Address;
+    tokenAddress: Address;
+    userAddress: Address;
     chainId: number;
     amount: BigNumber;
   }
@@ -436,13 +441,13 @@ export async function buildPaxosTransitSubmitOrderTxn(
   client: PaxosTransitClient,
   signer: Signer,
   params: {
-    userAddress: string;
+    userAddress: Address;
     offerAmount: BigNumber;
-    offerAsset: string;
-    wantAsset: string;
+    offerAsset: Address;
+    wantAsset: Address;
     sourceChainId: number;
     destinationChainId: number;
-    spenderAddress: string;
+    spenderAddress: Address;
   }
 ): Promise<PaxosTransitOrderQuoteResponse> {
   const authorization = await resolvePaxosTransitAuthorization(client, signer, {

--- a/test/generic-adapters/PaxosTransitBridge.ts
+++ b/test/generic-adapters/PaxosTransitBridge.ts
@@ -4,6 +4,7 @@ import { BigNumber } from "ethers";
 import { PaxosTransitBridge } from "../../src/adapter/bridges/PaxosTransitBridge";
 import { expect, createSpyLogger, sinon, toBNWei, randomAddress, assert } from "../utils";
 import {
+  Address,
   EvmAddress,
   isDefined,
   PAXOS_TRANSIT_DESTINATION_TOKENS,
@@ -57,10 +58,10 @@ class MockPaxosTransitClient extends PaxosTransitClient {
   }
 
   async getAuthorization(params: {
-    spenderAddress: string;
-    tokenAddress: string;
+    spenderAddress: Address;
+    tokenAddress: Address;
     amount: BigNumber;
-    userAddress: string;
+    userAddress: Address;
     chainId: number;
   }) {
     if (params.amount.toString() !== MAX_SAFE_ALLOWANCE) {
@@ -73,7 +74,7 @@ class MockPaxosTransitClient extends PaxosTransitClient {
     return this.orderQuote;
   }
 
-  async listOrders(params: { userAddress: string; filter?: string; pageSize?: number; pageToken?: string }) {
+  async listOrders(params: { userAddress: Address; filter?: string; pageSize?: number; pageToken?: string }) {
     const { filter } = params;
     const filteredOrders = isDefined(filter)
       ? this.orders.filter((order) => {
@@ -164,19 +165,19 @@ describe("Cross Chain Adapter: PaxosTransitBridge", function () {
       delete process.env.PAXOS_TRANSIT_BORING_VAULT_1;
       delete process.env.PAXOS_TRANSIT_BORING_VAULT_4663;
 
-      expect(getPaxosTransitStationAddress(CHAIN_IDs.MAINNET)).to.equal("0x49AAA987b1a7e9E4AE091dcD8332c39F322D7d28");
-      expect(getPaxosTransitStationAddress(CHAIN_IDs.ROBINHOOD)).to.equal("0x49AAA987b1a7e9E4AE091dcD8332c39F322D7d28");
-      expect(getPaxosTransitBoringVaultAddress(CHAIN_IDs.MAINNET)).to.equal(
-        "0x91fe06c6e9f97e7de4580a280e03046155f8e1e3"
-      );
-      expect(getPaxosTransitBoringVaultAddress(CHAIN_IDs.ROBINHOOD)).to.equal(
-        "0x91fe06c6e9f97e7de4580a280e03046155f8e1e3"
-      );
+      const station = toAddress("0x49AAA987b1a7e9E4AE091dcD8332c39F322D7d28");
+      const boringVault = toAddress("0x91fe06c6e9f97e7de4580a280e03046155f8e1e3");
+      expect(getPaxosTransitStationAddress(CHAIN_IDs.MAINNET).eq(station)).to.be.true;
+      expect(getPaxosTransitStationAddress(CHAIN_IDs.ROBINHOOD).eq(station)).to.be.true;
+      expect(getPaxosTransitBoringVaultAddress(CHAIN_IDs.MAINNET).eq(boringVault)).to.be.true;
+      expect(getPaxosTransitBoringVaultAddress(CHAIN_IDs.ROBINHOOD).eq(boringVault)).to.be.true;
     });
 
     it("prefers env override over ContractAddresses default", function () {
       process.env.PAXOS_TRANSIT_STATION_1 = "0x2222222222222222222222222222222222222222";
-      expect(getPaxosTransitStationAddress(CHAIN_IDs.MAINNET)).to.equal("0x2222222222222222222222222222222222222222");
+      expect(
+        getPaxosTransitStationAddress(CHAIN_IDs.MAINNET).eq(toAddress("0x2222222222222222222222222222222222222222"))
+      ).to.be.true;
     });
 
     it("throws when l2Token does not match expected destination token", async function () {
@@ -419,14 +420,12 @@ describe("Cross Chain Adapter: PaxosTransitBridge", function () {
 
     it("routes mainnet USDG-MAINNET to Robinhood USDG", function () {
       const mainnetUsdgAddress = getMainnetUsdgAddress();
-      expect(getPaxosTransitDestinationToken(l2ChainId, toAddress(mainnetUsdgAddress))?.toNative()).to.equal(
-        l2UsdgAddress
-      );
+      expect(getPaxosTransitDestinationToken(l2ChainId, mainnetUsdgAddress)?.toNative()).to.equal(l2UsdgAddress);
       expect(
         getPaxosTransitOfferAssetsForWantAsset(l2ChainId, toAddressType(l2UsdgAddress, l2ChainId))
           .map((offerAsset) => offerAsset.toNative())
           .sort()
-      ).to.deep.equal([l1UsdcAddress, mainnetUsdgAddress].sort());
+      ).to.deep.equal([l1UsdcAddress, mainnetUsdgAddress.toNative()].sort());
     });
 
     it("does not match a token without a Paxos Transit route", function () {

--- a/test/generic-adapters/PaxosTransitBridge.ts
+++ b/test/generic-adapters/PaxosTransitBridge.ts
@@ -398,14 +398,23 @@ describe("Cross Chain Adapter: PaxosTransitBridge", function () {
     it("identifies outstanding Paxos orders and matching routes", function () {
       const order = buildOrder({ status: "PROCESSING", remainingAmountDue: "1000" });
       const routeParams = {
-        wantAsset: l2UsdgAddress,
+        wantAsset: toAddress(l2UsdgAddress),
         sourceChainId: hubChainId,
         destinationChainId: l2ChainId,
-        receiver: relayerAddress,
+        receiver: toAddress(relayerAddress),
       };
       expect(isPaxosTransitOrderOutstanding(order)).to.be.true;
       expect(paxosTransitOrderMatchesRoute(order, routeParams)).to.be.true;
       expect(isPaxosTransitOrderOutstanding(buildOrder({ status: "PROCESSED", remainingAmountDue: "0" }))).to.be.false;
+
+      // Order fields come from the Paxos API: casing must not matter, and a malformed address must
+      // fail to match rather than throw.
+      const lowercased = buildOrder({
+        wantAsset: l2UsdgAddress.toLowerCase(),
+        receiver: relayerAddress.toLowerCase(),
+      });
+      expect(paxosTransitOrderMatchesRoute(lowercased, routeParams)).to.be.true;
+      expect(paxosTransitOrderMatchesRoute(buildOrder({ wantAsset: "not-an-address" }), routeParams)).to.be.false;
     });
 
     it("routes mainnet USDG-MAINNET to Robinhood USDG", function () {

--- a/test/generic-adapters/PaxosTransitBridge.ts
+++ b/test/generic-adapters/PaxosTransitBridge.ts
@@ -19,6 +19,7 @@ import {
   getPaxosTransitOfferAssetsForWantAsset,
   isPaxosTransitOrderOutstanding,
   paxosTransitOrderMatchesRoute,
+  toAddressType,
 } from "../../src/utils";
 import * as contractUtils from "../../src/utils/ContractUtils";
 import * as eventUtils from "../../src/utils/EventUtils";
@@ -409,9 +410,19 @@ describe("Cross Chain Adapter: PaxosTransitBridge", function () {
 
     it("routes mainnet USDG-MAINNET to Robinhood USDG", function () {
       const mainnetUsdgAddress = getMainnetUsdgAddress();
-      expect(getPaxosTransitDestinationToken(l2ChainId, toAddress(mainnetUsdgAddress))).to.equal(l2UsdgAddress);
-      expect(getPaxosTransitOfferAssetsForWantAsset(l2ChainId, l2UsdgAddress).sort()).to.deep.equal(
-        [l1UsdcAddress, mainnetUsdgAddress].sort()
+      expect(getPaxosTransitDestinationToken(l2ChainId, toAddress(mainnetUsdgAddress))?.toNative()).to.equal(
+        l2UsdgAddress
+      );
+      expect(
+        getPaxosTransitOfferAssetsForWantAsset(l2ChainId, toAddressType(l2UsdgAddress, l2ChainId))
+          .map((offerAsset) => offerAsset.toNative())
+          .sort()
+      ).to.deep.equal([l1UsdcAddress, mainnetUsdgAddress].sort());
+    });
+
+    it("does not match a token without a Paxos Transit route", function () {
+      expect(getPaxosTransitOfferAssetsForWantAsset(l2ChainId, toAddressType(l1UsdcAddress, l2ChainId))).to.deep.equal(
+        []
       );
     });
   });


### PR DESCRIPTION
Follow-up to #3676, requested by @pxrl in Slack. **Stacked on #3676** — base is that branch, so the diff here is just the refactor. #3676 has since squash-merged as c62814933fbf310ee334f673bfc9eacb712fcd66, so retargeting to `master` now needs a rebase to drop those commits — say the word and I'll do it.

## Why

`getPaxosTransitOfferAssetsForWantAsset()` took a raw `string` and compared it case-insensitively against `PAXOS_TRANSIT_DESTINATION_TOKENS`, so callers holding an `Address` had to unwrap first — #3676 added `getPaxosTransitOfferAssetsForWantAsset(chainId, token.toNative())` in `isUnmeteredFastRebalance()`, which is what prompted this.

The end state, after @pxrl asked whether the pattern applied elsewhere: **no address-typed parameter or return value on the Paxos interface is a bare `string` any more.**

## What

### Route resolution

- `getPaxosTransitOfferAssetsForWantAsset(dstChainId, wantAsset: Address): EvmAddress[]`. Offer assets are always keyed on mainnet, hence `EvmAddress` rather than `Address`. Matching is `Address.eq()` against `toAddressType(registryValue, dstChainId)` instead of `toLowerCase()` string equality.
- `getPaxosTransitDestinationToken()` returns `Address | undefined` for the same reason: its result is what feeds the function above, and both Paxos adapters were re-wrapping it with `toAddressType()` at each use.
- `paxosTransitOrderMatchesRoute()` takes `Address` for `wantAsset`/`receiver`, so the caller stops unwrapping two `Address`es to build `routeParams`.

### Address resolvers

`getMainnetUsdgAddress()` → `EvmAddress`; `getPaxosTransitStationAddress()` and `getPaxosTransitBoringVaultAddress()` → `Address`. These three were the only `get*Address()` helpers in `src/` returning a bare string — `getSpokePoolAddress`, `getHubPoolAddress`, `getNativeTokenAddressForChain` and `getWrappedNativeTokenAddress` all return `Address`/`EvmAddress`.

### Request surfaces

`listPaxosTransitOrders`, `listOutstandingPaxosTransitOrders`, `resolvePaxosTransitAuthorization`, `buildPaxosTransitSubmitOrderTxn`, `submitPaxosTransitApproval` and the three `PaxosTransitClient` request-param objects all take `Address`. The client serialises with `toNative()` into `URLSearchParams`, so strings are produced at the wire boundary and nowhere earlier.

### Adapters

- `PaxosTransitBridge.l2TokenAddress` and `PaxosTransitL2Bridge.l2TokenAddress` become `Address`, letting the three `l2Token` identity checks use `eq()` rather than `===` on `toNative()`.
- Both adapters wrap the signer address as `EvmAddress.from(await signer.getAddress())`, matching the eleven other sites in `src/` that do this.
- `PaxosTransitBridge` holds `l1Token`, so the L1-token assert uses `eq()` instead of comparing `toNative()` against the ethers `Contract` address.
- The `offerAsset` log field passes the `Address` directly — `Address.toJSON()` delegates to `toNative()`.

### Deliberately still `string`

- Response types (`PaxosTransitOrder`, `PaxosTransitAuthorizationResponse`, `PaxosTransitOrderQuoteResponse`, `PaxosTransitPermitData`) are deserialised JSON. `toAddressType()` throws on a malformed value where a string compare merely fails to match, so `paxosTransitOrderMatchesRoute` keeps using `compareAddressesSimple` on the order side.
- `PAXOS_TRANSIT_DESTINATION_TOKENS` is built from `TOKEN_SYMBOLS_MAP` literals; the conversion belongs in the accessors.
- Remaining `toNative()` calls are the real boundaries: ethers `Contract` constructors and event filters, `BridgeEvents` record keys (`{ [l2Token: string]: BridgeEvent[] }`), the `switch` on `token.toNative()` in `Refiller#refillBalances`, and the Paxos HTTP params.

## Behaviour

None intended. The comparison is equivalent for these routes: registry values and callers' tokens are both EVM addresses on the same chain, so `toAddressType()` yields `EvmAddress` on both sides and `eq()` compares checksummed forms where the old code compared lowercased ones.

## Testing

- `yarn typecheck`, `yarn lint` clean.
- `test/generic-adapters/*`, `test/generic-l2-adapters/*`, `test/Refiller.ts`, `test/FillUtils.isUnmeteredFastRebalance.ts` — 113 passing.
- `test/InventoryClient.RefundChain.ts`, `test/ProfitClient.ConsiderProfitability.ts` — 57 passing.
- `test/generic-adapters/PaxosTransitBridge.ts` updated for the new types, plus a case asserting a token with no Paxos route returns `[]`.

Note `tsconfig.json` scopes `typecheck` to `./src`, `index.ts` and `./scripts` — test files are only type-checked when the suite runs, so the suites above are what covers the test-side changes.

No `README.md`/`AGENTS.md` updates: the two docs that mention Paxos (`src/refiller/README.md`, `src/clients/README.md`) describe behaviour and env config, neither of which changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
