### PR TITLE
fix(dataworker): dispute proposals that move a disabled chain's end block

### DIFF
--- a/docs/bundle-construction.md
+++ b/docs/bundle-construction.md
@@ -112,6 +112,8 @@ The bundle block range for each chain is therefore `[A, B]`, where disabled chai
 
 Note that a disabled chain's zero length range is not self-certifying. [UMIP-157](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-157.md#determining-block-range-for-root-bundle-proposal) requires that a chain in `DISABLED_CHAINS` re-uses its end block from the latest executed bundle, so `A` is a fixed historical value rather than whatever the proposal published. Deriving `A` from `B` — as `getImpliedBundleBlockRanges` does — produces a zero length range for any `B` the proposer chose, which rebuilds identical roots even when the proposal silently moved the chain's end block. `Dataworker.validateRootBundle` therefore compares a disabled chain's end block against the latest executed bundle directly.
 
+That comparison resolves `DISABLED_CHAINS` at the bundle's mainnet **start** block, matching the proposer (`getWidestPossibleExpectedBlockRange` is called with `getEnabledChains(mainnetBundleStartBlock)`). UMIP-157 words the rule against the mainnet **end** block, so the two disagree for the single bundle in which a chain is disabled partway through: the proposer still advances that chain's end block, and the validator still accepts it. Realigning both sides onto the end block is a protocol-level change to the proposer and the validator together, not to the validator alone.
+
 ## Finding bridge events in block ranges
 
 Now that we have `R = [A, B]`, we need to agree on all deposits and fills that occurred in the block range. We'll use these events to construct the resultant running balance for the bundle.

--- a/docs/bundle-construction.md
+++ b/docs/bundle-construction.md
@@ -110,6 +110,8 @@ flowchart LR
 
 The bundle block range for each chain is therefore `[A, B]`, where disabled chains have zero length ranges (i.e. A = B).
 
+Note that a disabled chain's zero length range is not self-certifying. [UMIP-157](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-157.md#determining-block-range-for-root-bundle-proposal) requires that a chain in `DISABLED_CHAINS` re-uses its end block from the latest executed bundle, so `A` is a fixed historical value rather than whatever the proposal published. Deriving `A` from `B` — as `getImpliedBundleBlockRanges` does — produces a zero length range for any `B` the proposer chose, which rebuilds identical roots even when the proposal silently moved the chain's end block. `Dataworker.validateRootBundle` therefore compares a disabled chain's end block against the latest executed bundle directly.
+
 ## Finding bridge events in block ranges
 
 Now that we have `R = [A, B]`, we need to agree on all deposits and fills that occurred in the block range. We'll use these events to construct the resultant running balance for the bundle.

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -899,6 +899,51 @@ export class Dataworker {
     const chainIds = this.clients.configStoreClient.getChainIdIndicesForBlock(mainnetBundleStartBlock);
     const endBlockBuffers = getEndBlockBuffers(chainIds, this.blockRangeEndBlockBuffer);
 
+    // UMIP-157 requires that a chain listed in DISABLED_CHAINS re-uses its end block from the latest executed
+    // bundle. This is checked explicitly against the latest executed bundle rather than being inferred from
+    // `widestPossibleExpectedBlockRange`, because callers are free to derive that range from the proposal itself.
+    // `scripts/validateRootBundle.ts` does exactly that via `getImpliedBundleBlockRanges`, which resolves a disabled
+    // chain to [proposedEndBlock, proposedEndBlock]. The end block comparisons below would then compare the proposal
+    // against itself and accept any end block the proposer picked, including one that walks the chain backwards over
+    // a range that a previous bundle already settled.
+    const { proposalBlockNumber } = rootBundle;
+    assert(isDefined(proposalBlockNumber), "validateRootBundle: rootBundle.proposalBlockNumber is required");
+    const enabledChains = this.clients.configStoreClient.getEnabledChains(mainnetBundleStartBlock);
+    // @dev Skip this check if the HubPoolClient's lookback is too short to see the preceding bundle, otherwise
+    // `getLatestBundleEndBlockForChain` returns 0 for every chain and we would dispute a valid proposal. The block
+    // ranges rebuilt below are unusable in that case anyway, so `_validateBlockRanges` reports it as a lookback error.
+    const previousBundleIsKnown = isDefined(
+      this.clients.hubPoolClient.getLatestFullyExecutedRootBundle(proposalBlockNumber)
+    );
+    const invalidDisabledChainEndBlocks = chainIds
+      .map((chainId, index) => {
+        if (!previousBundleIsKnown || enabledChains.includes(chainId)) {
+          return undefined;
+        }
+        // @dev This resolves the same bundle that `getImpliedBundleBlockRanges` uses as the previous bundle, so the
+        // expected end block is consistent with the block ranges the roots are rebuilt over.
+        const expectedEndBlock = this.clients.hubPoolClient.getLatestBundleEndBlockForChain(
+          chainIds,
+          proposalBlockNumber,
+          chainId
+        );
+        const proposedEndBlock = rootBundle.bundleEvaluationBlockNumbers[index];
+        return proposedEndBlock === expectedEndBlock ? undefined : { chainId, proposedEndBlock, expectedEndBlock };
+      })
+      .filter(isDefined);
+    if (invalidDisabledChainEndBlocks.length > 0) {
+      this.logger.debug({
+        at: "Dataworker#validate",
+        message: "A disabled chain's end block does not match the latest executed bundle, submitting dispute",
+        invalidDisabledChainEndBlocks,
+      });
+      return {
+        valid: false,
+        reason:
+          PoolRebalanceUtils.generateMarkdownForDisputeInvalidDisabledChainEndBlocks(invalidDisabledChainEndBlocks),
+      };
+    }
+
     // Make sure that all end blocks are >= expected start blocks. Allow for situation where chain was halted
     // and bundle end blocks hadn't advanced at time of proposal, meaning that the end blocks were equal to the
     // previous end blocks. So, even if by the time the disputer runs, the chain has started advancing again, then
@@ -1029,12 +1074,11 @@ export class Dataworker {
       );
     }
 
-    assert(isDefined(rootBundle.proposalBlockNumber), "validateRootBundle: rootBundle.proposalBlockNumber is required");
     const logData = true;
     const rootBundleData = await this._proposeRootBundle(
       blockRangesImpliedByBundleEndBlocks,
       spokePoolClients,
-      rootBundle.proposalBlockNumber,
+      proposalBlockNumber,
       loadDataFromArweave,
       logData
     );

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -908,6 +908,12 @@ export class Dataworker {
     // a range that a previous bundle already settled.
     const { proposalBlockNumber } = rootBundle;
     assert(isDefined(proposalBlockNumber), "validateRootBundle: rootBundle.proposalBlockNumber is required");
+    // @dev The disabled chain list is resolved at the bundle's mainnet *start* block to stay in step with the
+    // proposer, which derives its block ranges from `getEnabledChains(mainnetBundleStartBlock)` -- see
+    // `_getWidestPossibleBlockRangeForNextBundle`. UMIP-157 words the rule against the mainnet *end* block instead,
+    // so a chain that enters DISABLED_CHAINS partway through a bundle is skipped here for that one transition
+    // bundle. Tightening this side alone to the end block would dispute the proposals our own proposer builds, so
+    // the proposer and the validator have to move together; that is a separate change.
     const enabledChains = this.clients.configStoreClient.getEnabledChains(mainnetBundleStartBlock);
     // @dev Skip this check if the HubPoolClient's lookback is too short to see the preceding bundle, otherwise
     // `getLatestBundleEndBlockForChain` returns 0 for every chain and we would dispute a valid proposal. The block

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -38,6 +38,21 @@ export function generateMarkdownForDisputeInvalidBundleBlocks(
   );
 }
 
+export function generateMarkdownForDisputeInvalidDisabledChainEndBlocks(
+  invalidDisabledChainEndBlocks: { chainId: number; proposedEndBlock: number; expectedEndBlock: number }[]
+): string {
+  return (
+    "Disputed pending root bundle because a chain in DISABLED_CHAINS did not re-use its end block from the latest " +
+    "executed bundle:" +
+    invalidDisabledChainEndBlocks
+      .map(
+        ({ chainId, proposedEndBlock, expectedEndBlock }) =>
+          `\n\t\t${getNetworkName(chainId)} (${chainId}): proposed ${proposedEndBlock}, expected ${expectedEndBlock}`
+      )
+      .join("")
+  );
+}
+
 export function generateMarkdownForDispute(pendingRootBundle: PendingRootBundle): string {
   return (
     "Disputed pending root bundle:" +

--- a/test/Dataworker.validateRootBundle.ts
+++ b/test/Dataworker.validateRootBundle.ts
@@ -7,6 +7,7 @@ import {
   MAX_REFUNDS_PER_RELAYER_REFUND_LEAF,
   amountToDeposit,
   destinationChainId,
+  repaymentChainId,
 } from "./constants";
 import { setupDataworker } from "./fixtures/Dataworker.Fixture";
 import {
@@ -371,6 +372,116 @@ describe("Dataworker: Validate pending root bundle", function () {
     await updateAllClients();
     await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal("Unexpected pool rebalance root, submitting dispute");
+    await multiCallerClient.executeTxnQueues();
+  });
+  it("Disputes a proposal that moves a disabled chain's end block", async function () {
+    // Regression test: UMIP-157 requires a chain listed in DISABLED_CHAINS to re-use its end block from the latest
+    // executed bundle. A disabled chain's implied block range is [proposedEndBlock, proposedEndBlock], so a
+    // validator that derives its expected range from the proposal itself (as scripts/validateRootBundle.ts does via
+    // getImpliedBundleBlockRanges) rebuilds identical roots and accepts whatever end block the proposer picked,
+    // including one that walks the chain backwards over a range a previously executed bundle already settled.
+    await updateAllClients();
+
+    const deposit = await depositV3(
+      spokePool_1,
+      destinationChainId,
+      depositor,
+      erc20_1.address,
+      amountToDeposit,
+      erc20_2.address,
+      amountToDeposit
+    );
+    await updateAllClients();
+    await fillV3Relay(spokePool_2, deposit, depositor, destinationChainId);
+    for (let i = 0; i < BUNDLE_END_BLOCK_BUFFER; i++) {
+      await hre.network.provider.send("evm_mine");
+    }
+    await updateAllClients();
+
+    // Propose a first bundle and execute all of its leaves so that it becomes the latest executed bundle.
+    const latestBlock = await hubPool.provider.getBlockNumber();
+    const blockRange = Object.keys(spokePoolClients).map(() => [0, latestBlock]);
+    const poolRebalanceRoot = await dataworkerInstance.buildPoolRebalanceRoot(blockRange, spokePoolClients);
+    await l1Token_1.approve(hubPool.address, MAX_UINT_VAL);
+    await dataworkerInstance.proposeRootBundle(spokePoolClients);
+    await multiCallerClient.executeTxnQueues();
+    await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
+    for (const leaf of poolRebalanceRoot.leaves) {
+      await hubPool.executeRootBundle(
+        leaf.chainId,
+        leaf.groupIndex,
+        leaf.bundleLpFees,
+        leaf.netSendAmounts,
+        leaf.runningBalances,
+        leaf.leafId,
+        leaf.l1Tokens.map((l1Token) => l1Token.toEvmAddress()),
+        poolRebalanceRoot.tree.getHexProof(leaf)
+      );
+    }
+    await updateAllClients();
+
+    // The executed bundle pinned an end block for every chain. Disable one of them from the very first block so
+    // that it is disabled at the next bundle's mainnet start block.
+    const executedEndBlocks = hubPoolClient
+      .getLatestProposedRootBundle()
+      .bundleEvaluationBlockNumbers.map((blockNumber) => blockNumber.toNumber());
+    const disabledChainIndex = dataworkerInstance.chainIdListForBundleEvaluationBlockNumbers.indexOf(repaymentChainId);
+    configStoreClient._updateDisabledChains([repaymentChainId], 0);
+
+    // Give the next bundle something to propose.
+    const deposit2 = await depositV3(
+      spokePool_1,
+      destinationChainId,
+      depositor,
+      erc20_1.address,
+      amountToDeposit,
+      erc20_2.address,
+      amountToDeposit
+    );
+    await updateAllClients();
+    await fillV3Relay(spokePool_2, deposit2, depositor, destinationChainId);
+    for (let i = 0; i < BUNDLE_END_BLOCK_BUFFER; i++) {
+      await hre.network.provider.send("evm_mine");
+    }
+    await updateAllClients();
+
+    // The proposer freezes the disabled chain at the executed bundle's end block, and the proposal validates.
+    await dataworkerInstance.proposeRootBundle(spokePoolClients);
+    await multiCallerClient.executeTxnQueues();
+    await updateAllClients();
+    const proposal = hubPoolClient.getLatestProposedRootBundle();
+    const proposedEndBlocks = proposal.bundleEvaluationBlockNumbers.map((blockNumber) => blockNumber.toNumber());
+    expect(proposedEndBlocks[disabledChainIndex]).to.equal(executedEndBlocks[disabledChainIndex]);
+    await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
+    expect(lastSpyLogIncludes(spy, "Pending root bundle matches with expected")).to.be.true;
+
+    // Re-propose the identical roots, but roll the disabled chain's end block backwards. The disabled chain
+    // contributes a zero-length range either way, so the roots are unchanged and the proposal is only detectable by
+    // comparing its end block against the latest executed bundle.
+    await hubPool.emergencyDeleteProposal();
+    await updateAllClients();
+    const rolledBackEndBlocks = [...proposedEndBlocks];
+    rolledBackEndBlocks[disabledChainIndex] -= 1;
+    expect(rolledBackEndBlocks[disabledChainIndex]).to.be.greaterThan(0);
+    await hubPool.proposeRootBundle(
+      rolledBackEndBlocks,
+      proposal.poolRebalanceLeafCount,
+      proposal.poolRebalanceRoot,
+      proposal.relayerRefundRoot,
+      proposal.slowRelayRoot
+    );
+    await updateAllClients();
+    await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
+    expect(spy.getCall(-2).lastArg.message).to.equal(
+      "A disabled chain's end block does not match the latest executed bundle, submitting dispute"
+    );
+    expect(spy.getCall(-2).lastArg.invalidDisabledChainEndBlocks).to.deep.equal([
+      {
+        chainId: repaymentChainId,
+        proposedEndBlock: executedEndBlocks[disabledChainIndex] - 1,
+        expectedEndBlock: executedEndBlocks[disabledChainIndex],
+      },
+    ]);
     await multiCallerClient.executeTxnQueues();
   });
   it("Validates root bundle with large bundleEvaluationBlockNumbers", async function () {


### PR DESCRIPTION
## Motivation

[UMIP-157](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-157.md#determining-block-range-for-root-bundle-proposal) requires that a chain listed in `DISABLED_CHAINS` re-uses its end block from the latest executed bundle:

> if a chain exists in DISABLED_CHAINS at the "mainnet" end block (chain ID 1) for a particular proposal, the end block for that chain should be identical to its value in the latest executed bundle.

Nothing in `validateRootBundle` checked that directly. It was only caught incidentally, by comparing the proposed end blocks against `widestPossibleExpectedBlockRange` — which is only meaningful when the caller derived that range independently.

`scripts/validateRootBundle.ts` does not. It passes `getImpliedBundleBlockRanges()`, which resolves a disabled chain to `[proposedEndBlock, proposedEndBlock]`. Both end block checks then compare the proposal against itself:

- `block + 1 < widest[i][0]` → `end + 1 < end` → always false
- `block > widest[i][1]` → `end > end` → always false

`start === end` also makes `blockRangesAreInvalidForSpokeClients` skip the chain. The chain contributes a zero length range, the rebuilt roots match, and the script reports `valid: true` for **any** end block the proposer picked.

### This is not hypothetical

Bundle `0xf0c6265a` (proposed at mainnet block 25690323, disputed at `REQUEST_TIME=1785952403`) rolled Blast's end block back from **38,570,088 → 38,567,388**, 2,700 blocks below the latest executed bundle, after Blast was added to `DISABLED_CHAINS` at mainnet block 25,689,824. `yarn validate-root-bundle` reported `valid: true`. The four other disabled chains in that same proposal (288, 534352, 690, 41455) were all correctly frozen — Blast was the only entry that moved, and it moved backwards.

Left unchecked, this re-opens an already-settled window: blocks 38,567,389–38,570,088 were covered by the executed bundle, and would be re-evaluated if Blast were re-enabled. (There happened to be no Blast SpokePool events in that range, so there was no double-refund exposure in this specific instance.)

## Change

Check the rule explicitly against the latest executed bundle in `Dataworker.validateRootBundle`, so it holds regardless of how the caller sourced its expected range.

This also closes two gaps in the **live disputer**, which reaches the right answer today only via inequalities against `[lastEnd, lastEnd]`:

| proposed end block | before | after |
| --- | --- | --- |
| `lastEnd - 1` | accepted (`end + 1 < lastEnd` is false) | disputed |
| `lastEnd + 1..buffer` | deferred as `bundle-end-block-buffer` | disputed |

Deferring is correct for an enabled chain whose head we may not have observed yet, but a disabled chain's expected end block is a fixed historical value — there is no head-of-chain race to wait out.

The check is skipped when the `HubPoolClient`'s lookback cannot see the preceding bundle, since `getLatestBundleEndBlockForChain` then returns `0` for every chain and we would dispute a valid proposal. `_validateBlockRanges` already reports that case as `insufficient-dataworker-lookback`.

Enabled-chain behaviour is unchanged: with no `DISABLED_CHAINS` entry the new loop yields nothing.

## Testing

New regression test `Disputes a proposal that moves a disabled chain's end block` executes a bundle, disables a chain, has the dataworker propose legitimately (asserting it freezes the disabled chain), then re-proposes **identical roots** with that chain's end block rolled back one block.

Verified it fails without the fix — and fails in the way that matters: the unpatched validator does not dispute at all, it accepts the proposal and proceeds to build roots.

- `Dataworker.validateRootBundle`, `Dataworker.blockRangeUtils`, `Dataworker.proposeRootBundle`, `Dataworker.buildRoots` — 20 passing
- `Dataworker.executePoolRebalances`, `Dataworker.executePoolRebalanceUtils`, `Dataworker.customSpokePoolClients`, `DataworkerUtils`, `Dataworker.executeRelayerRefunds`, `Dataworker.executeSlowRelay` — 54 passing
- `yarn typecheck`, `yarn lint` clean

The full `yarn test` suite was not run to completion locally (exceeded the sandbox time limit); leaving that to CI.

## Follow-up, not addressed here

The implementation decides enabled/disabled at the bundle's mainnet **start** block (`getEnabledChains(mainnetBundleStartBlock)`), while UMIP-157 keys on the mainnet **end** block. In the incident above, the preceding bundle (proposed at 25690167, mainnet end block 25690148) advanced Blast even though the disable had already landed at 25689824 — legal under the implementation, not under a literal reading of the UMIP. This PR deliberately keeps the existing start-block semantics so it does not retroactively invalidate bundles the current code considers valid. Worth resolving separately, likely in the SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)