### PR TITLE
chore(adapter): name the chain and venue in Binance L2 withdrawal alerts

### DIFF
--- a/src/adapter/l2Bridges/BinanceCEXBridge.ts
+++ b/src/adapter/l2Bridges/BinanceCEXBridge.ts
@@ -77,6 +77,7 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
       network: this.depositNetwork,
     });
     const formatter = createFormatFunction(2, 4, false, l2TokenInfo.decimals);
+    const network = getNetworkName(this.l2chainId);
     const transferTxn: AugmentedTransaction = {
       contract: this.getL2Bridge(),
       chainId: this.l2chainId,
@@ -88,10 +89,8 @@ export class BinanceCEXBridge extends BaseL2BridgeAdapter {
       nonMulticall: true,
       canFailInSimulation: false,
       value: bnZero,
-      message: `🎰 Withdrew BNB ${l2TokenInfo.symbol} to L1`,
-      mrkdwn: `Withdrew ${formatter(amount.toString())} ${l2TokenInfo.symbol} from ${getNetworkName(
-        this.l2chainId
-      )} to L1`,
+      message: `🎰 Withdrew ${network} ${l2TokenInfo.symbol} to L1 via Binance`,
+      mrkdwn: `Withdrew ${formatter(amount.toString())} ${l2TokenInfo.symbol} from ${network} to L1 via Binance`,
     };
     return [transferTxn];
   }


### PR DESCRIPTION
## Motivation

A zkSync USDC.e rebalance surfaced in Slack as:

> 🎰 Withdrew **BNB** USDC.e to L1 — Withdrew 21,160.83 USDC.e from zkSync to L1

The `BNB` is a hardcoded literal in `BinanceCEXBridge.constructWithdrawToL1Txns`, not the chain the withdrawal came from. It reads as a BSC withdrawal, and it hides the thing an operator actually wants to know from the alert: that the funds left via Binance rather than the canonical bridge. It prompted a "was this via Binance?" investigation in Slack that the alert should have answered on its own.

## Change

```diff
-      message: `🎰 Withdrew BNB ${l2TokenInfo.symbol} to L1`,
+      message: `🎰 Withdrew ${network} ${l2TokenInfo.symbol} to L1 via Binance`,
```

`mrkdwn` gets the same `via Binance` suffix, and the existing inline `getNetworkName(this.l2chainId)` is hoisted to a `network` const — same pattern `BinanceCEXNativeBridge` already uses a few lines over.

The zkSync example now reads: `🎰 Withdrew zkSync USDC.e to L1 via Binance`.

## Scope / risk

Log-string only — no behavior change. `AugmentedTransaction.message` is consumed solely by `TransactionClient`'s Slack mrkdwn line (`TransactionClient.ts:331`); nothing keys off it and no test asserts on it.

Deliberately left alone, happy to fold in if you'd prefer:
- `BinanceCEXNativeBridge` (WETH path) already prints the real chain name, so it isn't misleading — but it also doesn't name the venue. Aligning it would make the pair consistent.

## Docs

No `README.md` / `AGENTS.md` updates proposed — no config, interface, or runtime-flow change, and neither doc quotes these alert strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)