### PR TITLE
fix(cctp-finalizer): select emergencyReceive from on-message deadline

### DIFF
--- a/src/cctp-finalizer/services/cctpService.ts
+++ b/src/cctp-finalizer/services/cctpService.ts
@@ -52,7 +52,6 @@ export class CCTPService {
         attestation: cctpAttestationUnion,
         destinationChainId: providedDestinationChainIdUnion,
         signature: signatureUnion,
-        quoteDeadline: quoteDeadlineUnion,
       } = message;
 
       this.evmPrivateKey = await this.getPrivateKey("evm");
@@ -62,7 +61,6 @@ export class CCTPService {
       const cctpAttestation = cctpAttestationUnion?.string;
       const providedDestinationChainId = providedDestinationChainIdUnion?.long;
       const signature = signatureUnion?.string;
-      const quoteDeadline = quoteDeadlineUnion?.long;
 
       this.logger.info({
         at: "CCTPService#processBurnTransaction",
@@ -177,7 +175,7 @@ export class CCTPService {
       }
 
       // Process the mint
-      return await this.processMint(destinationChainId, sourceChainId, attestation, signature, quoteDeadline);
+      return await this.processMint(destinationChainId, sourceChainId, attestation, signature);
     } catch (error) {
       if (isCCTPError(error)) {
         if (error instanceof AlreadyProcessedError) {
@@ -260,8 +258,7 @@ export class CCTPService {
     originChainId: number,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     attestation: any,
-    signature?: string,
-    quoteDeadline?: number
+    signature?: string
   ): Promise<ProcessBurnTransactionResponse> {
     const chainName = PUBLIC_NETWORKS[destinationChainId]?.name || `Chain ${destinationChainId}`;
     this.logger.info({
@@ -302,8 +299,7 @@ export class CCTPService {
           provider,
           this.evmPrivateKey,
           this.logger,
-          signature,
-          quoteDeadline
+          signature
         );
         return {
           success: true,

--- a/src/cctp-finalizer/utils/evmUtils.ts
+++ b/src/cctp-finalizer/utils/evmUtils.ts
@@ -128,6 +128,31 @@ function getDestination(chainId: number, messageBytes: string, signature?: strin
 }
 
 /**
+ * Whether a sponsored CCTP mint should call emergencyReceiveMessage.
+ * Must use the quote deadline encoded in the CCTP message hookData — never an
+ * untrusted Pub/Sub envelope field. A forged past quoteDeadline would otherwise
+ * force emergencyReceiveMessage and skip sponsorship / custom execution.
+ */
+export function shouldUseEmergencyReceiveMessage(
+  message: string,
+  requiresSignature: boolean,
+  nowSeconds: number = Date.now() / 1000
+): boolean {
+  if (!requiresSignature) {
+    return false;
+  }
+  const hookData = decodeCctpV2HookData(message);
+  if (!isDefined(hookData?.deadline)) {
+    return false;
+  }
+  const deadline = Number(hookData.deadline);
+  if (!Number.isFinite(deadline)) {
+    return false;
+  }
+  return deadline < nowSeconds;
+}
+
+/**
  * Processes a CCTP mint transaction on EVM chain (CCTP V2)
  */
 export async function processMintEvm(
@@ -136,8 +161,7 @@ export async function processMintEvm(
   provider: ethers.providers.JsonRpcProvider,
   privateKey: string,
   logger: winston.Logger,
-  signature?: string,
-  quoteDeadline?: number
+  signature?: string
 ): Promise<{ txHash: string }> {
   const signer = new ethers.Wallet(privateKey, provider);
 
@@ -152,9 +176,9 @@ export async function processMintEvm(
     ? [attestation.message, attestation.attestation, signature]
     : [attestation.message, attestation.attestation];
 
-  // if the quote deadline has expired, we don't need to pass the signature
+  // if the on-message quote deadline has expired, we don't need to pass the signature
   let method = "receiveMessage";
-  if (destination.requiresSignature && isDefined(quoteDeadline) && quoteDeadline < Date.now() / 1000) {
+  if (shouldUseEmergencyReceiveMessage(attestation.message, destination.requiresSignature)) {
     receiveMessageArgs = [attestation.message, attestation.attestation];
     method = "emergencyReceiveMessage";
   }

--- a/test/cctpFinalizer.emergencyReceiveSelection.test.ts
+++ b/test/cctpFinalizer.emergencyReceiveSelection.test.ts
@@ -1,0 +1,53 @@
+import { expect } from "chai";
+import { ethers } from "ethers";
+import { shouldUseEmergencyReceiveMessage } from "../src/cctp-finalizer/utils/evmUtils";
+
+/**
+ * Build a minimal CCTP V2 message whose hookData starts at byte 376 and
+ * encodes a SponsoredCCTP-style quote deadline.
+ */
+function messageWithHookDeadline(deadlineSeconds: number): string {
+  const prefix = Buffer.alloc(376, 0);
+  const recipient = ethers.utils.hexZeroPad("0x1111111111111111111111111111111111111111", 32);
+  const token = ethers.utils.hexZeroPad("0x2222222222222222222222222222222222222222", 32);
+  const hookData = ethers.utils.defaultAbiCoder.encode(
+    ["bytes32", "uint256", "uint256", "uint256", "bytes32", "bytes32", "uint32", "uint8", "uint8", "bytes"],
+    [
+      ethers.constants.HashZero,
+      deadlineSeconds,
+      0,
+      0,
+      recipient,
+      token,
+      0,
+      0,
+      0,
+      "0x",
+    ]
+  );
+  return ethers.utils.hexlify(Buffer.concat([prefix, Buffer.from(ethers.utils.arrayify(hookData))]));
+}
+
+describe("CCTP finalizer emergencyReceiveMessage selection", function () {
+  const now = 1_700_000_000;
+
+  it("does not emergency-receive when on-message deadline is still in the future", function () {
+    const message = messageWithHookDeadline(now + 3600);
+    expect(shouldUseEmergencyReceiveMessage(message, true, now)).to.equal(false);
+  });
+
+  it("emergency-receives only when on-message deadline is expired", function () {
+    const message = messageWithHookDeadline(now - 1);
+    expect(shouldUseEmergencyReceiveMessage(message, true, now)).to.equal(true);
+  });
+
+  it("never emergency-receives when no signature path (standard transmitter)", function () {
+    const message = messageWithHookDeadline(now - 1);
+    expect(shouldUseEmergencyReceiveMessage(message, false, now)).to.equal(false);
+  });
+
+  it("does not emergency-receive when hookData cannot be decoded", function () {
+    const shortMessage = ethers.utils.hexlify(Buffer.alloc(100, 1));
+    expect(shouldUseEmergencyReceiveMessage(shortMessage, true, now)).to.equal(false);
+  });
+});


### PR DESCRIPTION
## Summary

Sponsored CCTP finalization selected `emergencyReceiveMessage` when Pub/Sub `quoteDeadline` was in the past. That field comes from the push envelope (not the CCTP message), so a forged past deadline forced the permissioned bot onto the emergency path and skipped sponsorship / HyperCore/custom `_executeQuote` while the on-message quote was still live.

`SponsoredCCTPDstPeriphery` documents this grief class for invalid signatures with a valid message/attestation; trusting the envelope reintroduces it at the bot layer.

## Change

- Derive emergency vs `receiveMessage` from `decodeCctpV2HookData(message).deadline`.
- Stop using Pub/Sub `quoteDeadline` for method selection.
- Unit tests for future / expired / undecodable / non-sponsored paths.

## Test plan

- [x] `yarn test test/cctpFinalizer.emergencyReceiveSelection.test.ts` → **4/4**
- [ ] CI green

Tip: `741ca9f7d72923f7b13c1c2462ca90eba81e1a87`


Made with [Cursor](https://cursor.com)