### PR TITLE
fix(clients): let on-chain CHAIN_ID_INDICES override the injected chain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -356,6 +356,10 @@ ARWEAVE_GATEWAYS='[{"host":"arweave.org", "port": 443, "protocol":"https"}]'
 # Note: This logic does apply sanitizations so it is not possible to inject
 #       a new change prior to the most previous chain ID update within the
 #       Config Store.
+# Note: CHAIN_ID_INDICES is append-only on-chain, so a chain can never be added
+#       to it twice. Once the injected chain is genuinely onboarded on-chain, the
+#       on-chain update takes precedence over this variable and a warning is
+#       logged; unset this variable at that point.
 #INJECT_CHAIN_ID_INCLUSION='{"blockNumber":17876743,"chainId":8453}'
 
 # Used to force a proposal to be attempted regardless of whether there is a

--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -11,6 +11,10 @@ export class ConfigStoreClient extends clients.AcrossConfigStoreClient {
       }
     | undefined;
 
+  // Set once an on-chain CHAIN_ID_INDICES update supersedes the injected chain, so that the
+  // override is logged loudly but only once per process rather than on every update cycle.
+  private injectionSuperseded = false;
+
   constructor(
     readonly logger: winston.Logger,
     readonly configStore: Contract,
@@ -48,11 +52,13 @@ export class ConfigStoreClient extends clients.AcrossConfigStoreClient {
     if (isDefined(injectedChain)) {
       // Track the initial length of the chain id indices updates
       const initialLength = this.chainIdIndicesUpdates.length;
-      // Because this chain is `injected` we know that it doesn't occur
-      // on-chain, and therefore we just need to remove it altogether
-      // wherever an instance of it appears.
+      // Identify the synthetic entry by the marker this class stamps on it below (an empty txnRef at
+      // the injected block number), not by chain ID membership. CHAIN_ID_INDICES is append-only, so
+      // once the chain is genuinely onboarded a real on-chain update will also contain
+      // injectedChain.chainId; a membership test would delete that real event, and super.update()
+      // cannot restore it because its search window has already advanced past that block.
       this.chainIdIndicesUpdates = this.chainIdIndicesUpdates.filter(
-        ({ value }) => !value.includes(injectedChain.chainId)
+        ({ txnRef, blockNumber }) => !(txnRef === "" && blockNumber === injectedChain.blockNumber)
       );
       if (this.chainIdIndicesUpdates.length !== initialLength) {
         this.logger.debug({
@@ -74,12 +80,22 @@ export class ConfigStoreClient extends clients.AcrossConfigStoreClient {
         });
         return;
       }
-      // Sanity check to ensure that the injected chain id is not already included
+      // The injected chain is already present in an on-chain CHAIN_ID_INDICES update. That key is
+      // append-only, so a chain can never be appended to it twice: the on-chain event is authoritative
+      // and supersedes the locally-configured injection. Leave the real update in place and stop
+      // injecting. Log this loudly (once) because it means INJECT_CHAIN_ID_INCLUSION is now stale.
       if (this.chainIdIndicesUpdates.some(({ value }) => value.includes(injectedChainId))) {
-        this.logger.debug({
-          at: "ConfigStore[Relayer]#update",
-          message: `Injected chain id ${injectedChainId} is already included`,
-        });
+        if (!this.injectionSuperseded) {
+          this.injectionSuperseded = true;
+          this.logger.warn({
+            at: "ConfigStore[Relayer]#update",
+            message:
+              `On-chain CHAIN_ID_INDICES update already includes injected chain ${injectedChainId}; ` +
+              "the on-chain config overrides INJECT_CHAIN_ID_INCLUSION, which should now be unset. " +
+              "This variable is for testing only and must not be set in production.",
+            injectedChain: this.injectedChain,
+          });
+        }
         return;
       }
 

--- a/src/clients/README.md
+++ b/src/clients/README.md
@@ -15,6 +15,25 @@ EVM and SVM subscribe over websockets and apply quorum in the application layer:
 - After a one-time historical backfill of the look-back-only events (`RequestedSpeedUpDeposit`, `RelayedRootBundle`, `ExecutedRelayerRefundRoot`) up to the startup head, it loops every ~2s (just under TRON's ~3s block time). On each new head it issues one `--blockrange`-paginated `eth_getLogs` for the live events (`FundsDeposited`, `FilledRelay`) over the last `REORG_WINDOW` (64) blocks and diffs the result against what it has posted: events that vanished (re-orged out) are removed, new or re-org-replacement events are added. A re-org is reflected within one poll once quorum converges; a failed query skips the pass and retries on the next poll.
 - On TRON the RPC URL must target QuikNode's eth-JSON-RPC path (`…/jsonrpc`); the bare token URL is the TronGrid API and 404s for `eth_*` calls.
 
+## Config Store Client
+
+The ConfigStoreClient wraps the SDK's `AcrossConfigStoreClient` to add support for `INJECT_CHAIN_ID_INCLUSION` — a testing-only variable that pretends a chain was added to the Config Store's `CHAIN_ID_INDICES` before it actually was, so a bot can be exercised against a chain that isn't onboarded yet. It must not be set in production.
+
+The variable is `{"blockNumber":<n>,"chainId":<n>}`, parsed once at construction. Each `update()` then:
+
+1. Drops the synthetic entry from `chainIdIndicesUpdates` before calling `super.update()`, which would otherwise reject an entry that now predates its search window.
+2. Re-appends it afterwards, as the most recent genuine `CHAIN_ID_INDICES` value plus `chainId` (or the protocol defaults plus `chainId` when there is no genuine update), stamped at `blockNumber` with an empty `txnRef`.
+
+Injection is skipped — at debug level — when `blockNumber` is ahead of the latest searched height, or behind the last genuine update, since neither can be reconciled into the update history.
+
+### On-chain updates override the injection
+
+`CHAIN_ID_INDICES` is append-only on-chain, so a chain can never be appended to it twice. Once the injected chain is genuinely onboarded, the real on-chain update is authoritative: the client leaves it in place, stops injecting, and logs a warning (once per process, not once per update cycle) that `INJECT_CHAIN_ID_INCLUSION` is stale and should be unset.
+
+This is why step 1 identifies the synthetic entry by its marker — an empty `txnRef` at the injected block number — rather than by testing whether the entry contains the injected chain ID. Genuine events always derive `txnRef` from their transaction hash, so the marker distinguishes the two; a membership test does not, and would delete the real on-chain update. `super.update()` cannot restore it, because its search window has already advanced past that block, so the entry would be lost for the lifetime of the process: any chain onboarded in the same update as the injected one would be silently dropped, and the injected chain back-dated to the injected block.
+
+`test/ConfigStoreClient.ts` pins the injection lifecycle, the on-chain override, and the once-per-process warning.
+
 ## Inventory Client
 
 The InventoryClient has several important functions that all use its `InventoryConfig` as input

--- a/test/ConfigStoreClient.ts
+++ b/test/ConfigStoreClient.ts
@@ -1,0 +1,111 @@
+import { ConfigStoreClient, GLOBAL_CONFIG_STORE_KEYS } from "../src/clients/ConfigStoreClient";
+import {
+  Contract,
+  createSpyLogger,
+  deployConfigStore,
+  ethers,
+  expect,
+  hubPoolFixture,
+  sinon,
+  utf8ToHex,
+  winston,
+} from "./utils";
+
+// Chain onboarded via INJECT_CHAIN_ID_INCLUSION, matching the example in .env.example.
+const injectedChainId = 8453;
+// A second chain onboarded in the same genuine on-chain transaction as the injected one.
+const coOnboardedChainId = 59144;
+
+describe("ConfigStoreClient: injected chain ID inclusion", function () {
+  let spy: sinon.SinonSpy;
+  let spyLogger: winston.Logger;
+  let configStore: Contract;
+  // CHAIN_ID_INDICES is append-only against an implicit [hubChainId] baseline, so every update must
+  // begin with the local hub chain ID rather than the protocol's mainnet defaults.
+  let baseline: number[];
+
+  const overrideLogCount = () =>
+    spy.getCalls().filter((call) => JSON.stringify(call.lastArg ?? "").includes("overrides INJECT_CHAIN_ID_INCLUSION"))
+      .length;
+
+  const setChainIdIndices = async (chainIds: number[]): Promise<number> => {
+    const txn = await configStore.updateGlobalConfig(
+      utf8ToHex(GLOBAL_CONFIG_STORE_KEYS.CHAIN_ID_INDICES),
+      JSON.stringify(chainIds)
+    );
+    const { blockNumber } = await txn.wait();
+    return blockNumber;
+  };
+
+  beforeEach(async function () {
+    const [owner] = await ethers.getSigners();
+    ({ spy, spyLogger } = createSpyLogger());
+
+    const { dai: l1Token } = await hubPoolFixture();
+    ({ configStore } = await deployConfigStore(owner, [l1Token]));
+
+    const { chainId: hubChainId } = await configStore.provider.getNetwork();
+    baseline = [hubChainId, 10, 137, 288, 42161];
+
+    // Seed a genuine CHAIN_ID_INDICES update so there is a real "last update" to append to. Inject at
+    // a strictly later block: the injection must not predate the last genuine update, and sharing a
+    // block with it would leave the synthetic entry shadowed by the real one when sorting.
+    await setChainIdIndices(baseline);
+    await ethers.provider.send("evm_mine", []);
+    process.env.INJECT_CHAIN_ID_INCLUSION = JSON.stringify({
+      chainId: injectedChainId,
+      blockNumber: await configStore.provider.getBlockNumber(),
+    });
+  });
+
+  afterEach(function () {
+    delete process.env.INJECT_CHAIN_ID_INCLUSION;
+  });
+
+  it("injects the configured chain before it is onboarded on-chain", async function () {
+    const configStoreClient = new ConfigStoreClient(spyLogger, configStore);
+    await configStoreClient.update();
+
+    expect(configStoreClient.getChainIdIndicesForBlock()).to.deep.equal([...baseline, injectedChainId]);
+    expect(overrideLogCount()).to.equal(0);
+  });
+
+  it("retains a genuine on-chain update that includes the injected chain, across repeated update() calls", async function () {
+    const configStoreClient = new ConfigStoreClient(spyLogger, configStore);
+    await configStoreClient.update();
+
+    // The chain is genuinely onboarded on-chain, together with a second chain in the same update.
+    await setChainIdIndices([...baseline, injectedChainId, coOnboardedChainId]);
+    const expected = [...baseline, injectedChainId, coOnboardedChainId];
+
+    // Cycle N: the real update is fetched and the injection is correctly skipped.
+    await configStoreClient.update();
+    expect(configStoreClient.getChainIdIndicesForBlock()).to.deep.equal(expected);
+
+    // Cycle N+1 is the regression: the pre-filter used to delete the real update by chain-ID
+    // membership, and super.update() could not re-fetch it because the search window had advanced.
+    // That dropped coOnboardedChainId entirely and back-dated injectedChainId to the injected block.
+    await configStoreClient.update();
+    expect(configStoreClient.getChainIdIndicesForBlock()).to.deep.equal(expected);
+
+    // Further cycles must remain stable.
+    await configStoreClient.update();
+    expect(configStoreClient.getChainIdIndicesForBlock()).to.deep.equal(expected);
+  });
+
+  it("logs the on-chain override loudly, but only once per process", async function () {
+    const configStoreClient = new ConfigStoreClient(spyLogger, configStore);
+    await configStoreClient.update();
+    expect(overrideLogCount()).to.equal(0);
+
+    await setChainIdIndices([...baseline, injectedChainId]);
+
+    await configStoreClient.update();
+    expect(overrideLogCount()).to.equal(1);
+
+    // The guard is re-evaluated every cycle; the warning must not be repeated on each one.
+    await configStoreClient.update();
+    await configStoreClient.update();
+    expect(overrideLogCount()).to.equal(1);
+  });
+});


### PR DESCRIPTION
Closes BOU-66.

## Problem

`ConfigStoreClient.update()` pre-filtered the injected chain out of `chainIdIndicesUpdates` by testing **chain-ID membership**:

```ts
this.chainIdIndicesUpdates = this.chainIdIndicesUpdates.filter(
  ({ value }) => !value.includes(injectedChain.chainId)
);
```

`CHAIN_ID_INDICES` is append-only, so once the injected chain is genuinely onboarded, a *real* on-chain update also contains that chain ID — and the predicate deleted the real event. `super.update()` cannot restore it, because `firstHeightToSearch` has already advanced past that block (`AcrossConfigStoreClient.ts:557`), so the loss is permanent for the process lifetime.

Sequence: on cycle N the real update is fetched and the existing L78 guard correctly skips injecting. On cycle N+1 the pre-filter deletes that real entry, the guard can no longer see it, and a synthetic entry rebuilt from the stale pre-onboarding list is pushed at the injected block — dropping any chain onboarded alongside the injected one and back-dating the injected chain.

## Fix

Identify the synthetic entry by the marker this class stamps on it (an empty `txnRef` at the injected block) rather than by chain-ID membership. Genuine events always derive `txnRef` from the transaction hash (`EventUtils.ts:183`), so the real update now survives, the existing "already included" guard fires, and **the on-chain config takes precedence over `INJECT_CHAIN_ID_INCLUSION`** — logged at `warn` once per process, since it means the variable is stale.

The pre-filter still does its original job of keeping the synthetic entry out of the SDK's append-only superset check (`AcrossConfigStoreClient.ts:502-510`).

## Not production-facing

`INJECT_CHAIN_ID_INCLUSION` is testing-only and is not set in any committed config; `.env.example` states this emphatically. Nothing here is reachable in a production configuration. Per discussion on BOU-66 the chosen behaviour is deliberately *not* graceful: on-chain wins, loudly.

## Notes for review

- **Log level / cadence:** `warn`, once per process. `warn` matches this feature's existing `Invalid injected chain id inclusion` log and demonstrably reaches Slack. It's one-shot because the guard is re-evaluated every cycle and would otherwise fire on every hub-chain block. Trivial to change to `error` or to re-log periodically if preferred.
- **Test:** `test/ConfigStoreClient.ts` is new — this client had no coverage, which is how the bug survived. Verified it *fails* against the previous code (drops the co-onboarded chain, logs nothing) and passes with the fix.
- **`.env.example`:** documents the new precedence.
- **Not addressed here:** `fireAndForget(updateHub)` at `src/relayer/index.ts:107` is called with no `onError`, so any failure in `configStoreClient`/`hubPoolClient`/`tokenClient` update on the onBlock path is silently discarded. Probably worth its own issue.

## Testing

- `yarn typecheck` clean; `eslint` + `prettier` clean on changed files.
- New tests: 3 passing; confirmed failing against the pre-fix code.
- Full suite: 995 passing, 3 failing. All 3 are unrelated to this change — each passes in isolation, and each passes when run directly after the new test file (ruling out env-var leakage from its `beforeEach`): `Filters expired deposits`, `Disputer::mintBond`, and `finalizeCCTPV1Messages` (`spawn solana-test-validator ENOENT`, environmental).

🤖 Generated with [Claude Code](https://claude.com/claude-code)