### PR TITLE
docs: raise the bar for agent doc updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,11 +12,12 @@ Read docs in this order:
 
 ## Documentation maintenance
 
-Keep all relevant `AGENTS.md` and `README.md` files updated in the same change whenever behavior, configuration, interfaces, or runtime flow changes.
+Document load-bearing things only: significant features, module interfaces, config surfaces, and runtime flows a contributor must understand to make a safe change. Bug fixes, refactors, and routine maintenance normally need no doc change — say so and move on.
 
+- Keep doc edits terse. Prefer amending an existing line over adding a section, and cut anything that wouldn't change what a reader does.
+- When a change does clear the bar, update the affected `AGENTS.md` / `README.md` in the same change, not as a follow-up.
 - Before writing implementation plans, surface material ambiguities first and resolve them with the user.
-- For each new task, propose 0-3 targeted updates to `README.md` and `AGENTS.md` files (or explicitly state why no updates are needed).
-- For deep-dive documentation tasks, prefer cross-module walkthroughs when behavior spans relayer, clients, dataworker, or shared utilities.
+- Write deep-dive docs only when asked, or when a flow spans modules and no single `README.md` covers it. Prefer cross-module walkthroughs over single-file explanations.
 - Write deep-dive docs as "current behavior" references first, then add a concise "contributor recommendations" section.
 
 ## Quick index

--- a/example.CLAUDE.md
+++ b/example.CLAUDE.md
@@ -37,7 +37,7 @@ Before opening a contribution:
 - Preserve current behavior unless the task explicitly asks for behavior changes.
 - Do not silently change risk-sensitive defaults (profitability, finality, rebalancing thresholds).
 - If a change affects money movement logic, include explicit validation steps.
-- Keep docs updated in the same change when behavior changes.
+- Update docs in the same change when a significant feature or load-bearing component changes; skip doc churn for fixes and refactors.
 
 ## Ambiguity and Escalation
 
@@ -53,7 +53,8 @@ Stop and ask for clarification if any of the following are true:
 ## Planning and Documentation Evolution
 
 - Before writing a plan, identify any meaningful ambiguities and ask for clarification first.
-- For every new task, explicitly propose 0-3 concrete updates to `CLAUDE.md` and/or relevant `AGENTS.md` files, or state "no updates needed" with a brief reason.
+- Propose doc updates only when the change adds or materially alters a significant feature or load-bearing component. "No updates needed" is the common case.
+- Keep doc edits concise: amend existing lines before adding new sections, and cut anything that wouldn't change what a reader does.
 - When creating deep-dive docs, include discoverability updates in the same change (relevant `README.md` links and, when useful, `AGENTS.md` quick index entries).
 - Default deep-dive docs to cross-module coverage when behavior spans module boundaries; avoid single-file explanations for multi-module flows.
 - Default deep-dive docs to a "current behavior first" structure with a concise contributor recommendations section at the end.


### PR DESCRIPTION
Requested by @paul in Slack: the doc-maintenance instructions are overkill — agents should document significant features and load-bearing components, concisely, not every change.

### What changed

`AGENTS.md` § Documentation maintenance (`CLAUDE.md` and `.github/instructions/general.instructions.md` both point at this file, so one edit covers all three entrypoints):

- Old opener mandated updates "whenever behavior, configuration, interfaces, or runtime flow changes" → now scoped to significant features, module interfaces, config surfaces, and runtime flows needed to make a safe change. Fixes/refactors explicitly need no doc change.
- Dropped "propose 0-3 targeted updates for each new task" — that bullet is what drove doc churn on every task.
- Added a terseness rule: amend an existing line before adding a section; cut anything that wouldn't change what a reader does.
- Deep-dive docs now gated on "when asked, or when a flow spans modules and no single README covers it" rather than being a standing default.

`example.CLAUDE.md` got the equivalent edits so the template doesn't reintroduce the old wording.

### Notes

- No code or behavior changes; markdown only.
- `example.CLAUDE.md` isn't referenced anywhere in the repo and `CLAUDE.md` is a symlink to `AGENTS.md`, so the template is currently dead weight. Happy to delete it in a follow-up if that's the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)