### PR TITLE
fix(finalizer): unblock Blast finalization and discover Blast ERC20 withdrawals

### DIFF
--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -337,19 +337,39 @@ async function getOVMStdEvents(
     ethEvents.push(...blastEthEvents);
   }
 
+  // If we're aware of this token, then save the event as one we can finalize.
+  const keepKnownTokens = (events: Log[]) =>
+    events
+      .map((event) => {
+        try {
+          getTokenInfo(EvmAddress.from(event.args.localToken), chainId);
+          return { ...event, l2TokenAddress: event.args.localToken };
+        } catch {
+          logger.debug({ at, message: `Skipping unknown ${chain} token withdrawal: ${event.args.localToken}`, event });
+          return undefined;
+        }
+      })
+      .filter(isDefined);
+
   const erc20filter = bridge.filters.ERC20BridgeInitiated(null, null, fromAddresses);
-  const erc20Events = (await paginatedEventQuery(bridge, erc20filter, searchConfig))
-    .map((event) => {
-      // If we're aware of this token, then save the event as one we can finalize.
-      try {
-        getTokenInfo(EvmAddress.from(event.args.localToken), chainId);
-        return { ...event, l2TokenAddress: event.args.localToken };
-      } catch {
-        logger.debug({ at, message: `Skipping unknown ${chain} token withdrawal: ${event.args.localToken}`, event });
-        return undefined;
-      }
-    })
-    .filter(isDefined);
+  const erc20Events = keepKnownTokens(await paginatedEventQuery(bridge, erc20filter, searchConfig));
+
+  // @dev USDB and other ERC20s leave Blast over the Blast bridge, not the OVM standard bridge, and emit an
+  // identical ERC20BridgeInitiated there. Only that bridge's ETH events were queried above, so ERC20
+  // withdrawals by tracked EOAs were invisible to this finalizer -- a 324.36 USDB withdrawal sat unproven
+  // because of it. Query the Blast bridge for ERC20 events too.
+  if (chainIsBlast(chainId)) {
+    const { address: blastBridgeAddress } = getContractEntry(chainId, "blastBridge");
+    const blastBridge = new Contract(blastBridgeAddress, ovmStandardBridge.abi, provider);
+    const blastErc20Events = keepKnownTokens(
+      await paginatedEventQuery(
+        blastBridge,
+        blastBridge.filters.ERC20BridgeInitiated(null, null, fromAddresses),
+        searchConfig
+      )
+    );
+    erc20Events.push(...blastErc20Events);
+  }
 
   return [...ethEvents, ...erc20Events];
 }
@@ -728,10 +748,28 @@ async function finalizeOptimismMessage(
       crossChainMessenger.l1Provider
     );
 
+    // @dev queryFilter() without an explicit block range defaults to genesis->latest, i.e. one unchunked
+    // eth_getLogs spanning all of mainnet. Providers reject that outright (QuickNode and Chainstack both
+    // cap the range), so with NODE_QUORUM > 1 the call cannot reach quorum and throws. Because the caller
+    // iterates messages without per-message error handling, that aborted every Blast finalization rather
+    // than just this one -- observed erroring on every run from 2026-07-20 onwards.
+    //
+    // A proof cannot predate its own withdrawal, so bound the search below at the L1 block corresponding
+    // to the L2 withdrawal and let paginatedEventQuery() chunk it into provider-safe ranges.
+    const redis = await getRedisCache(logger);
+    const l2WithdrawalBlock = await crossChainMessenger.l2Provider.getBlock(message.event.blockNumber);
+    const [fromBlock, toBlock] = await Promise.all([
+      getBlockForTimestamp(logger, MAINNET, l2WithdrawalBlock.timestamp, undefined, redis),
+      crossChainMessenger.l1Provider.getBlockNumber(),
+    ]);
+
     // @dev The withdrawal hash should be unique for the L2 withdrawal so there should be exactly 1 event for this query.
     // If the withdrawal hasn't been proven yet then this will error.
     const [proofReceipt, latestCheckpointId, lastFinalizedRequestId] = await Promise.all([
-      blastPortal.queryFilter(blastPortal.filters.WithdrawalProven(withdrawalHash)),
+      paginatedEventQuery(blastPortal, blastPortal.filters.WithdrawalProven(withdrawalHash), {
+        from: fromBlock,
+        to: toBlock,
+      }),
       blastEthYield.getLastCheckpointId(),
       blastEthYield.getLastFinalizedRequestId(),
     ]);
@@ -809,22 +847,34 @@ async function multicallOptimismFinalizations(
   const withdrawals: CrossChainMessage[] = [];
 
   await forEachAsync(finalizableMessages, async (message) => {
-    const _callData = await finalizeOptimismMessage(logger, chainId, crossChainMessenger, message, message.logIndex);
-    if (!isDefined(_callData)) {
-      return;
-    }
-    const { symbol, decimals } = getTokenInfo(message.event.l2TokenAddress, chainId);
-    const amountFromWei = convertFromWei(message.event.amountToReturn.toString(), decimals);
-    const withdrawal: CrossChainMessage = {
-      originationChainId: chainId,
-      l1TokenSymbol: symbol,
-      amount: amountFromWei,
-      type: "withdrawal",
-      destinationChainId: hubPoolClient.chainId,
-    };
+    // @dev Isolate per-message failures. Without this, one message that throws -- an RPC quorum failure, a
+    // missing proof receipt, an unknown token -- rejects the whole forEachAsync and drops every other
+    // finalization for this chain, including ones that would have succeeded.
+    try {
+      const _callData = await finalizeOptimismMessage(logger, chainId, crossChainMessenger, message, message.logIndex);
+      if (!isDefined(_callData)) {
+        return;
+      }
+      const { symbol, decimals } = getTokenInfo(message.event.l2TokenAddress, chainId);
+      const amountFromWei = convertFromWei(message.event.amountToReturn.toString(), decimals);
+      const withdrawal: CrossChainMessage = {
+        originationChainId: chainId,
+        l1TokenSymbol: symbol,
+        amount: amountFromWei,
+        type: "withdrawal",
+        destinationChainId: hubPoolClient.chainId,
+      };
 
-    callData.push(_callData);
-    withdrawals.push(withdrawal);
+      callData.push(_callData);
+      withdrawals.push(withdrawal);
+    } catch (error) {
+      logger.warn({
+        at: `${getNetworkName(chainId)}Finalizer`,
+        message: `Failed to build finalization for withdrawal ${message.event.txnRef}; skipping it.`,
+        txnRef: message.event.txnRef,
+        error,
+      });
+    }
   });
 
   // Blast USDB withdrawals have a two step withdrawal process involving a separate claim that can be made

--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -755,7 +755,10 @@ async function finalizeOptimismMessage(
     // than just this one -- observed erroring on every run from 2026-07-20 onwards.
     //
     // A proof cannot predate its own withdrawal, so bound the search below at the L1 block corresponding
-    // to the L2 withdrawal and let paginatedEventQuery() chunk it into provider-safe ranges.
+    // to the L2 withdrawal. That alone is not enough: any message reaching this path has cleared the 7-day
+    // challenge period, so the bounded range is still ~50k mainnet blocks. paginatedEventQuery() only splits
+    // a range when maxLookBack is set -- otherwise it issues the same single oversized eth_getLogs -- so pass
+    // the L1 lookback to get provider-safe chunks.
     const redis = await getRedisCache(logger);
     const l2WithdrawalBlock = await crossChainMessenger.l2Provider.getBlock(message.event.blockNumber);
     const [fromBlock, toBlock] = await Promise.all([
@@ -769,6 +772,7 @@ async function finalizeOptimismMessage(
       paginatedEventQuery(blastPortal, blastPortal.filters.WithdrawalProven(withdrawalHash), {
         from: fromBlock,
         to: toBlock,
+        maxLookBack: CHAIN_MAX_BLOCK_LOOKBACK[MAINNET],
       }),
       blastEthYield.getLastCheckpointId(),
       blastEthYield.getLastFinalizedRequestId(),


### PR DESCRIPTION
## Motivation

Three related defects, all observed in production. Blast has finalized nothing since **2026-07-20T21:31Z**.

### 1. Unbounded `queryFilter` aborts every Blast finalization

`finalizeOptimismMessage()` called:

```ts
blastPortal.queryFilter(blastPortal.filters.WithdrawalProven(withdrawalHash))
```

No block range, so ethers resolves it to `genesis -> latest`: one unchunked `eth_getLogs` across all of mainnet. Both non-Alchemy providers reject it:

```
Error: Not enough providers succeeded. Errors:
Provider https://proud-clean-dust.quiknode.pro failed with error: eth_getLogs is limited to a 10,000 range
Provider https://ethereum-mainnet.core.chainstack.com failed with error: Block range limit exceeded.
Successful Providers:
https://eth-mainnet.g.alchemy.com
```

`NODE_QUORUM=2` cannot be met, so it throws. `Something errored in a finalizer for chain 81457` appeared on **every** run — 354 error lines in 14 days, starting 2026-07-20T21:31:25Z. (Sweeper logs go back to 07-12 and are clean before that date, so it is a real start, not a retention edge.)

Fixed by bounding the search below at the L1 block corresponding to the L2 withdrawal — a proof cannot predate its own withdrawal — and using `paginatedEventQuery()`, which chunks into provider-safe ranges.

### 2. One bad message dropped all the others

```ts
await forEachAsync(finalizableMessages, async (message) => {
  const _callData = await finalizeOptimismMessage(...);   // throws -> whole loop rejects
```

No per-message error handling, so any throw rejected the entire loop. **This is what escalated defect 1** from "one stuck ETH withdrawal" into "no Blast withdrawal is ever finalized". Now wrapped: log and skip.

### 3. Blast ERC20 withdrawals were undiscoverable

`getOVMStdEvents()` queries `ERC20BridgeInitiated` on the OVM standard bridge (`0x42..10`) only. USDB and other ERC20s leave Blast over the **Blast bridge** (`0x43..05`), which emits an identical event — the existing Blast branch already queries it, but only for `ETHBridgeInitiated`.

Confirmed on-chain: a 324.358513 USDB withdrawal by a tracked EOA (L2 tx `0xe77e912c…`) emits `ERC20BridgeInitiated` on `0x4300000000000000000000000000000000000005`. It sat unproven and invisible to the finalizer. Now both bridges are queried.

## Current impact

| item | amount | state |
|---|---|---|
| SpokePool → HubPool | 4.4103 USDB | proven 08-05, finalizable 08-12 12:36Z |
| SpokePool → HubPool | 0.05161 WBTC | proven 08-05, finalizable 08-12 12:36Z |
| EOA | 324.3585 USDB | was unproven (defect 3); proven manually 08-11 |

The first two are discovered via `TokensBridged` and should finalize automatically once defects 1+2 land.

## Risk

- Defect 2's fix changes failure granularity only — a message that previously killed the batch now logs `warn` and is retried next run.
- Defect 3 strictly widens discovery; it cannot cause a withdrawal to be missed relative to today.
- Defect 1's bound is derived per-message rather than from a constant, so it does not need revisiting if Blast's timings change.
- Costs one `eth_getBlockByHash` (L2) and one cached `getBlockForTimestamp` per Blast ETH message.

## Testing

`yarn lint` and `yarn typecheck` clean.

No unit coverage added — there is no existing `opStack`/Blast finalizer test to extend, and this needs a mocked portal, yield manager, and dual providers. Flagging rather than implying coverage. Each defect was instead verified directly: the quorum error and its 07-20 start from GCP logs, the `forEachAsync` blast radius by reading the call path, and the missing ERC20 discovery by decoding the L2 receipt of the stuck USDB withdrawal.

Per `AGENTS.md`: no `README.md` / `AGENTS.md` updates proposed — `src/finalizer/` has no module doc and this is a bug fix with no config, interface, or runtime-flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)