### PR TITLE
fix(finalizer): tolerate unrecognised tokens in Arbitrum withdrawal discovery

### DIFF
--- a/src/finalizer/utils/arbStack.ts
+++ b/src/finalizer/utils/arbStack.ts
@@ -158,6 +158,8 @@ export async function arbStackFinalizer(
         unknownTokenWithdrawals.push({
           l1Token: e.args.l1Token,
           to: e.args._to,
+          // @dev Stringified deliberately: the logger stringifies BigNumbers itself, but does so via
+          // Object.fromEntries(), which would collapse this array into an object keyed "0", "1", ...
           amount: e.args._amount.toString(),
           txnRef: e.transactionHash,
         });

--- a/src/finalizer/utils/arbStack.ts
+++ b/src/finalizer/utils/arbStack.ts
@@ -27,6 +27,7 @@ import {
   assert,
   isDefined,
   isEVMSpokePoolClient,
+  Address,
   EvmAddress,
 } from "../../utils";
 import { getRedisCache } from "../../cache/Redis";
@@ -146,14 +147,27 @@ export async function arbStackFinalizer(
       to: latestBlockToFinalize,
     }
   );
+  // @dev Anyone can withdraw an arbitrary token to an address we finalize for, so an unrecognised token must not
+  // stall the queue. The token is only used to label the finalization; it is not an input to the Outbox proof.
+  const unknownTokenWithdrawals: { l1Token: string; to: string; amount: string; txnRef: string }[] = [];
   const _withdrawalEvents = [
     ...withdrawalErc20Events.map((e) => {
+      const l1Token = EvmAddress.from(e.args.l1Token);
       const l2Token = getL2TokenAddresses(e.args.l1Token)?.[chainId];
-      assert(isDefined(l2Token), `Missing L2 token mapping for L1 token ${e.args.l1Token} on chain ${chainId}`);
+      if (!isDefined(l2Token)) {
+        unknownTokenWithdrawals.push({
+          l1Token: e.args.l1Token,
+          to: e.args._to,
+          amount: e.args._amount.toString(),
+          txnRef: e.transactionHash,
+        });
+      }
       return {
         ...e,
         amount: e.args._amount,
-        l2TokenAddress: EvmAddress.from(l2Token),
+        // @dev An unmapped token has no known L2 address, so fall back to the L1 address to keep the withdrawal
+        // identifiable in logs. Nothing downstream reads this to build the finalization.
+        l2TokenAddress: isDefined(l2Token) ? EvmAddress.from(l2Token) : l1Token,
       };
     }),
     ...withdrawalNativeEvents.map((e) => {
@@ -166,30 +180,45 @@ export async function arbStackFinalizer(
       };
     }),
   ];
+  // @dev Deliberately not routed to across-error: anyone can mint this condition on demand, so paging on it would
+  // hand out a notification-spam primitive. It stays a warn so log-based alerting can still key off it if wanted.
+  if (unknownTokenWithdrawals.length > 0) {
+    logger.warn({
+      at: `Finalizer#${networkName}Finalizer`,
+      message: `Finalizing ${unknownTokenWithdrawals.length} ${networkName} withdrawal(s) of unrecognised token(s) 🚩`,
+      unknownTokenWithdrawals,
+    });
+  }
+
   // If there are any found withdrawal initiated events, then add them to the list of TokenBridged events we'll
   // submit proofs and finalizations for.
   _withdrawalEvents.forEach(({ transactionHash, transactionIndex, ...event }) => {
-    try {
-      const tokenBridgedEvent: TokensBridged = {
-        ...event,
-        amountToReturn: event.amount,
-        chainId,
-        leafId: 0,
-        l2TokenAddress: event.l2TokenAddress,
-        txnRef: transactionHash,
-        txnIndex: transactionIndex,
-      };
-      withdrawalEvents.push(tokenBridgedEvent);
-    } catch {
-      logger.debug({
-        at: `Finalizer#${networkName}Finalizer`,
-        message: `Skipping ERC20 withdrawal event for unknown token ${event.l2TokenAddress} on chain ${networkName}`,
-        event: event,
-      });
-    }
+    const tokenBridgedEvent: TokensBridged = {
+      ...event,
+      amountToReturn: event.amount,
+      chainId,
+      leafId: 0,
+      l2TokenAddress: event.l2TokenAddress,
+      txnRef: transactionHash,
+      txnIndex: transactionIndex,
+    };
+    withdrawalEvents.push(tokenBridgedEvent);
   });
 
   return await multicallArbitrumFinalizations(withdrawalEvents, signer, hubPoolClient, logger, chainId);
+}
+
+/**
+ * Resolve token metadata for the finalization log line. The Outbox proof is built from the L2 message alone, so a
+ * token we can't describe must degrade the label rather than abort the batch. The fallback decimals only keep the
+ * logged amount readable; treat it as indicative for an unrecognised token.
+ */
+function describeToken(l2TokenAddress: Address, chainId: number): { symbol: string; decimals: number } {
+  try {
+    return getTokenInfo(l2TokenAddress, chainId);
+  } catch {
+    return { symbol: "UNKNOWN", decimals: 18 };
+  }
 }
 
 async function multicallArbitrumFinalizations(
@@ -202,7 +231,7 @@ async function multicallArbitrumFinalizations(
   const finalizableMessages = await getFinalizableMessages(logger, tokensBridged, hubSigner, chainId);
   const callData = await Promise.all(finalizableMessages.map((message) => finalizeArbitrum(message.message, chainId)));
   const crossChainTransfers = finalizableMessages.map(({ info: { l2TokenAddress, amountToReturn } }) => {
-    const { symbol, decimals } = getTokenInfo(l2TokenAddress, chainId);
+    const { symbol, decimals } = describeToken(l2TokenAddress, chainId);
     const amountFromWei = convertFromWei(amountToReturn.toString(), decimals);
     const withdrawal: CrossChainMessage = {
       originationChainId: chainId,


### PR DESCRIPTION
## Problem

`arbStackFinalizer` discovers withdrawals by querying the canonical Arbitrum gateways, then resolves each event's L1 token to an L2 address before it can build any finalization:

```ts
const l2Token = getL2TokenAddresses(e.args.l1Token)?.[chainId];
assert(isDefined(l2Token), `Missing L2 token mapping ...`);
```

`getL2TokenAddresses` returns `undefined` for any token absent from `TOKEN_SYMBOLS_MAP`, so the assert throws inside the `.map()` — before `multicallArbitrumFinalizations` is reached. The finalizer returns nothing, and `finalize()` catches it per-chain, so *every* Arbitrum → Ethereum withdrawal in that run is skipped rather than just the one unrecognised token. Because the input is recomputed each loop, the condition persists until the event ages out of the lookback window.

The `try/catch` a few lines below, whose `catch` logs `"Skipping ERC20 withdrawal event for unknown token"`, was intended to cover this — but it wraps only object construction and an `Array.push`, neither of which can throw, so that path was unreachable.

## Why finalize rather than skip

The token is not an input to the finalization. `finalizeArbitrum` builds the Outbox `executeTransaction` calldata entirely from the Arbitrum SDK message (`getOutboxProof()` plus `nitroWriter.event`); `getUniqueLogIndex` keys on `txnRef`. The only real consumer is `getTokenInfo` in `multicallArbitrumFinalizations`, which supplies `symbol`/`decimals` for the log line.

So an unrecognised token is a labelling gap, not a reason to withhold a withdrawal — and skipping would drop a legitimate withdrawal whenever a real token is missing from `constants` (removed or renamed while a withdrawal sits mid-challenge-period). These withdrawals are already destined for an address we finalize for; the gateway queries filter on `to ∈ {HubPool, SpokePool, AtomicDepositor, userAddresses}`.

## Changes

- Discovery no longer treats token resolution as a precondition. An unmapped token falls back to the L1 address so the withdrawal stays identifiable in logs.
- One aggregated `logger.warn` per run listing the unrecognised withdrawals (`l1Token`, `to`, `amount`, `txnRef`), so these stay visible.
- `getTokenInfo` at the log-line site is wrapped in `describeToken()`, degrading to `UNKNOWN`/18. This was a second throw site — fixing only the assert would have relocated the failure, not removed it.
- Removed the dead `try/catch`.

`zkSync.ts` already carries the equivalent guard ("a single unknown token would otherwise abort finalization for every withdrawal on this chain"); `arbStack` was the gap. Polygon and Linea source their events from the SpokePool and sender-filtered queries respectively, so neither is affected.

## Testing

`yarn build`, `eslint` and `prettier` pass. No automated regression test — exercising the discovery path needs Arbitrum SDK receipts, Redis and block-time mocking. Happy to add one by extracting the event → `TokensBridged` mapping into an exported pure helper (the way `buildFinalizationBatches` is exported for its test) if reviewers want it.

## Note for reviewers

The warn is deliberately **not** routed to `notificationPath: "across-error"`. Reasoning in the code comment; easy to flip if you disagree.

## Credit

Reported by Jagdish, who also offered to help test the fix. Thanks!

🤖 Generated with [Claude Code](https://claude.com/claude-code)
