### PR TITLE
feat(deposit-address-service): execute v3 refund withdrawals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ The main bot types in `src/`:
 - `monitor`: Runs monitoring and reporting checks.
 - `gasless`: Handles gasless relay flows.
 - `deposit-address`: Polls the across-indexer for counterfactual deposit-address transfers and executes the resulting deposits or refund withdraws.
-- `deposit-address-service`: Standalone Express service doing the same work driven by GCP Pub/Sub push instead of polling. Not part of the `index.ts` CLI dispatch — it runs as its own entrypoint, like `cctp-finalizer`. Intended to replace `deposit-address`. Executes v3 deposits; v3 withdrawals and v1 are not ported yet, and both NACK so nothing is discarded.
+- `deposit-address-service`: Standalone Express service doing the same work driven by GCP Pub/Sub push instead of polling. Not part of the `index.ts` CLI dispatch — it runs as its own entrypoint, like `cctp-finalizer`. Intended to replace `deposit-address`. Executes v3 deposits and refund withdrawals; v1 is not ported yet and stays with the polling bot.
 
 ## Directory tree
 

--- a/src/deposit-address-service/README.md
+++ b/src/deposit-address-service/README.md
@@ -5,11 +5,11 @@ and executes them, replacing the polling bot in [`../deposit-address`](../deposi
 left untouched until cutover. Why a service rather than a poller:
 [#3663](https://github.com/across-protocol/relayer/issues/3663).
 
-> **v3 deposits execute; v3 withdrawals do not yet.** A `mis_route` transfer, and a `correct_transfer`
-> the execute endpoint rejects as below the minimum, both **NACK** until the withdraw path lands — they
-> are preserved, not discarded. With no handler configured, or `EXECUTION_ENABLED` unset, the service
-> NACKs every delivery and `/ready` stays `503`, so nothing is discarded if a subscription is attached
-> early. v1 messages stay with the polling bot.
+> **v3 deposits and refund withdrawals execute.** A withdrawal's `withdraw_executed` is recorded but not
+> yet announced — lifecycle publishing and its recovery land next, before execution is enabled anywhere.
+> With no handler configured, or `EXECUTION_ENABLED` unset, the service NACKs every delivery and `/ready`
+> stays `503`, so nothing is discarded if a subscription is attached early. v1 messages stay with the
+> polling bot.
 
 ## Contracts
 
@@ -85,6 +85,32 @@ transfer's money — so `null` is transient. Ordering it first is what lets the 
 This guard is **new**, not parity. The polling bot's balance check claims to cover reorgs
 (`DepositAddressHandler.ts:1165`) but cannot distinguish "this funding transfer is real" from "there
 happens to be money at this address" — the shared-pot failure this service exists to close.
+
+### The v3 refund withdrawal
+
+`executeWithdraw` serves a `mis_route`, and a `correct_transfer` the execute endpoint rejected as
+`AMOUNT_BELOW_MINIMUM` — that rejection is terminal at the API, so the fallback runs immediately, **under
+the same lock**, as the polling bot holds its in-flight lock across `initiateWithdrawV3`. No `refund_only`
+marker is recorded: a redelivery re-calls `/execute`, gets the same rejection, and falls through again.
+
+Not the deposit path with a different verb, ported guard-for-guard from `initiateWithdrawV3`:
+
+| Guard | Disposition on failure |
+| --- | --- |
+| `ENABLE_V3_WITHDRAWALS` set | NACK — an operator switch, like a disabled chain |
+| `depositAddressNamespace` **and** `refundAddress.namespace` exactly `evm` | ACK — **stricter than the deposit path**; there is no TVM withdraw route |
+| withdraw leaf present in `counterfactualMaterials` | ACK — the leaves were fixed at address creation |
+| funding transfer canonical, then balance ≥ amount | as the deposit path, same order, same reasons |
+| signed `chainId` matches the **refund** chain (`erc20Transfer.chainId` — for a `mis_route` not the route's origin) | NACK |
+| signature deadline ≥ now + 60s | NACK |
+| sign-withdraw answered **422** | persist `withdraw_failed`, ACK |
+
+The 422 is classified on the HTTP status alone, exactly as production's `_getSignedWithdrawV3` does — the
+client posts through `_postOrThrow`, which discards the API's error code, so `withdraw_failed.code` is
+optional and unset. Every other sign-withdraw failure NACKs. The refund is gas-deducted
+(`deductGasFromRefund: true`), deliberately unlike v1's full-amount refund. Broadcast and reconciliation
+are the deposit path's, with `operation: "withdraw"` on the pending record — a confirmed withdraw is not
+expected to carry the provenance event, so it does not warn about its absence.
 
 ### Broadcasting — why not `sendAndConfirmTransaction`
 
@@ -182,7 +208,7 @@ for as long as the message is retained. That drives every mapping:
 | Handler threw a `retriable` error | `500` | May clear; let the subscription back off. |
 | Handler threw a terminal error | `204` | Redelivery can't help; a non-2xx would retry forever. |
 | Lock held by another consumer | `500` | It finishes or its lock expires; either way a later delivery proceeds. |
-| `mis_route`, or `AMOUNT_BELOW_MINIMUM` | `500` | Both want the withdraw path, which is not built yet. Permanently-retriable would normally be the no-DLQ trap, but it is unreachable while `EXECUTION_ENABLED` is false. |
+| Sign-withdraw answered 422 | `204` | Terminal per product decision; recorded as `withdraw_failed` first. |
 | Fails the transport contract (no decodable `data`, no `messageId`) | `204` | Same reasoning. |
 | Unparseable JSON, or body over the 1mb cap | `204` | Body-parser errors only; anything else NACKs. |
 | Execution disabled, or no handler configured | `500` | Preserves the message; never discards silently. |
@@ -259,6 +285,7 @@ the config cannot tell whether it actually was.
 | --- | --- | --- |
 | `PORT` | `8080` | HTTP port. |
 | `EXECUTION_ENABLED` | `false` | Master switch for fund-moving work. Must be exactly `"true"`. |
+| `ENABLE_V3_WITHDRAWALS` | `false` | Gates the refund-withdraw path independently. **The same variable the polling bot reads.** Disabled withdraws NACK. |
 | `APPLICATION_DEADLINE_MS` | `480000` | See above. Must be < 540s. |
 | `SHUTDOWN_DRAIN_TIMEOUT_MS` | `8000` | Must be < 10s: Cloud Run SIGKILLs that long after SIGTERM. |
 | `CONFIRMATION_TRIES` | `4` | `AugmentedTransaction.maxTries`. Capped at the client's own default of 10, which would be ~22 min. |

--- a/src/deposit-address-service/config.ts
+++ b/src/deposit-address-service/config.ts
@@ -74,6 +74,14 @@ export class DepositAddressServiceConfig {
   readonly executionEnabled: boolean;
 
   /**
+   * Gates the v3 refund-withdraw path independently of {@link executionEnabled}, defaulting **false**.
+   * Reuses `ENABLE_V3_WITHDRAWALS`, the same variable the polling bot reads, so both can run during
+   * migration without new config. Disabled withdraws NACK — the funds are still on the deposit address,
+   * and an ACK would discard the only delivery that could ever refund them.
+   */
+  readonly v3WithdrawalsEnabled: boolean;
+
+  /**
    * Why the Redis lock needs no renewal. A Cloud Run 504 does **not** stop handler code, so the
    * guarantee comes from the application: bound every outbound call, and never broadcast past this.
    */
@@ -96,6 +104,7 @@ export class DepositAddressServiceConfig {
   constructor(env: ProcessEnv) {
     this.port = readInteger("PORT", env.PORT, DEFAULT_PORT, MAX_PORT);
     this.executionEnabled = readBoolean(env.EXECUTION_ENABLED);
+    this.v3WithdrawalsEnabled = readBoolean(env.ENABLE_V3_WITHDRAWALS);
     this.originChains = parseJson.numberArray(env.RELAYER_ORIGIN_CHAINS);
 
     this.applicationDeadlineMs = readInteger(

--- a/src/deposit-address-service/depositHandler.ts
+++ b/src/deposit-address-service/depositHandler.ts
@@ -1,5 +1,9 @@
 import { AcrossApiHttpError } from "../clients/AcrossApiBaseClient";
-import { AcrossSwapApiClient, DepositAddressExecuteResponse } from "../clients/AcrossSwapApiClient";
+import {
+  AcrossSwapApiClient,
+  DepositAddressExecuteResponse,
+  DepositAddressSignWithdrawResponse,
+} from "../clients/AcrossSwapApiClient";
 import { AugmentedTransaction, TransactionClient } from "../clients/TransactionClient";
 import ERC20_ABI from "../common/abi/MinimalERC20.json";
 import { DepositAddressMessageV3 } from "../interfaces/DepositAddress";
@@ -15,6 +19,7 @@ import {
   getEthersCompatibleAddress,
   getNetworkName,
   getProvider as getProviderDefault,
+  isHttpError,
   isNativeTokenSentinel,
   submitTransaction,
   toAddressType,
@@ -24,23 +29,25 @@ import {
 import { isDefined } from "../utils/TypeGuards";
 import { DepositAddressServiceConfig } from "./config";
 import {
-  BelowMinimumDepositError,
   InsufficientBalanceError,
   LockContentionError,
   NonCanonicalTransferError,
   TransientDependencyError,
-  WithdrawRouteNotImplementedError,
+  WithdrawalsDisabledError,
 } from "./errors";
 import {
+  assertEvmWithdrawNamespaces,
   assertIntegratorId,
   assertSupportedNamespace,
   assertSupportedOriginChain,
   assertValidExecuteResponse,
+  assertValidWithdrawResponse,
+  assertWithdrawMaterials,
 } from "./guards";
 import { HandlerResult, MessageHandler, RequestContext, assertBeforeDeadline } from "./handler";
 import { ParsedTransfer, parseTransfer } from "./message";
 import { resolvePendingTransaction } from "./pendingTransaction";
-import { BroadcastPendingState, TransferLock, TransferStore } from "./transferState";
+import { BroadcastPendingState, TerminalState, TransferLock, TransferStore } from "./transferState";
 
 /** The API's stable discriminator for an amount under the minimum deposit; a 422 with any other code is not this. */
 const AMOUNT_BELOW_MINIMUM_ERROR_CODE = "AMOUNT_BELOW_MINIMUM";
@@ -143,11 +150,11 @@ async function processUnderLock(
   // Switched on the indexer's own classification rather than a deposit/withdraw label decided at parse time:
   // a `correct_transfer` the execute endpoint rejects as below the minimum becomes a refund withdraw too, so
   // the action is not knowable here. `intent_refund` was already rejected by `parseTransfer`.
+  //
+  // Note `originChainId` is `erc20Transfer.chainId` — where the funds landed — which is the refund chain the
+  // withdraw path needs. For a `mis_route` that is *not* the route's origin chain, which is the whole point.
   if (transferClassification === "mis_route") {
-    throw new WithdrawRouteNotImplementedError(
-      `transfer ${transferId} is a ${transferClassification} and needs a refund withdraw, which is not ` +
-        "implemented in this build"
-    );
+    return executeWithdraw(deps, context, parsed, lock, await getProvider(originChainId), originChainId);
   }
 
   return executeDeposit(deps, context, parsed, lock, await getProvider(originChainId), originChainId);
@@ -189,6 +196,13 @@ async function executeDeposit(
 
   const quotedAtMs = Date.now();
   const response = await requestExecuteTx(deps, message, originChainId, integratorId);
+  if (response === "below_minimum") {
+    // Terminal at the API — the amount is whatever landed on the address, so no retry changes it. The
+    // correct handling is a refund withdraw, run under the **same lock**, exactly as the polling bot holds
+    // its in-flight lock across `initiateWithdrawV3`. No `refund_only` marker is recorded: a redelivery
+    // re-calls `/execute`, gets the same rejection, and falls through here again.
+    return executeWithdraw(deps, context, parsed, lock, provider, originChainId);
+  }
   assertValidExecuteResponse(response, message, originChainId, Math.floor(Date.now() / 1000));
 
   // The point of no return. The deadline check is what makes an un-renewed lock safe against a Cloud Run 504,
@@ -198,13 +212,155 @@ async function executeDeposit(
     throw new LockContentionError(`lock for ${transferId} is no longer held; refusing to broadcast`);
   }
 
-  const pending = await broadcast(deps, context, parsed, response, originChainId, provider);
+  const destinationChainId = Number(message.routeParams.destinationChainId);
+  const pending = await broadcast(deps, context, transferId, originChainId, provider, {
+    operation: "deposit",
+    to: response.executeTx.to,
+    data: response.executeTx.data,
+    value: response.executeTx.value,
+    message: "Completed Deposit Execution Successfully 🎯",
+    mrkdwn:
+      `Completed execution of v3 Deposit on ${getNetworkName(originChainId)} to ` +
+      `${getNetworkName(destinationChainId)}, using deposit address ` +
+      `${blockExplorerLink(message.depositAddress, originChainId)}`,
+  });
   const result = await resolvePendingTransaction({ logger, store, provider }, transferId, pending);
   return { outcome: result.outcome, fields: { ...result.fields, quoteMs: Date.now() - quotedAtMs, integratorId } };
 }
 
 /**
- * Broadcasts the execute and returns the `broadcast_pending` record that was persisted for it.
+ * v3 refund withdrawal — the path for a `mis_route`, and for a `correct_transfer` the execute endpoint
+ * rejected as below the minimum. Both callers already hold the transfer's lock, and it is held across the
+ * whole withdraw, so the two actions can never interleave with another consumer.
+ *
+ * Not the deposit path with a different verb. Withdrawals are **EVM-only** (stricter than the deposit
+ * path's chain-native namespaces), they need the message's withdraw leaf materials, and a terminal
+ * sign-withdraw rejection is *recorded* as `withdraw_failed` and ACKed rather than retried. The refund is
+ * gas-deducted (`deductGasFromRefund: true`) — deliberate, and different from v1's full-amount refund.
+ *
+ * `withdraw_executed` is recorded but not yet announced; lifecycle publishing and its recovery follow in a
+ * later change, before execution is enabled anywhere.
+ */
+async function executeWithdraw(
+  deps: DepositHandlerDeps,
+  context: RequestContext,
+  parsed: ParsedTransfer,
+  lock: TransferLock,
+  provider: Provider,
+  refundChainId: number
+): Promise<HandlerResult> {
+  const { config, store, logger } = deps;
+  const { transferId, message } = parsed;
+  const { depositAddress, erc20Transfer } = message;
+
+  if (!config.v3WithdrawalsEnabled) {
+    throw new WithdrawalsDisabledError(`refund withdraw for ${transferId} refused: ENABLE_V3_WITHDRAWALS is not set`);
+  }
+
+  assertEvmWithdrawNamespaces(message);
+  const withdrawLeaf = assertWithdrawMaterials(message);
+
+  // Canonicality before balance, for the deposit path's reason: only this ordering lets the balance guard's
+  // ACK mean "the funds genuinely left" rather than "possibly our node is behind". Re-run even when the
+  // below-minimum fallback already passed both — the guards are cheap reads, and the polling bot's withdraw
+  // path re-checks its balance too.
+  await assertCanonicalFundingTransfer(provider, message, refundChainId);
+  const onchainBalance = await readDepositAddressBalance(
+    provider,
+    refundChainId,
+    erc20Transfer.contractAddress,
+    depositAddress
+  );
+  if (onchainBalance.lt(toBN(erc20Transfer.amount))) {
+    throw new InsufficientBalanceError(
+      `deposit address ${depositAddress} holds ${onchainBalance.toString()} of ${erc20Transfer.contractAddress}, ` +
+        `below the transfer amount ${erc20Transfer.amount}`
+    );
+  }
+
+  const quotedAtMs = Date.now();
+  let signed: DepositAddressSignWithdrawResponse;
+  try {
+    signed = await deps.api.signWithdrawDepositAddressV3({
+      chainId: refundChainId,
+      depositAddress,
+      initialRoot: message.initialRoot,
+      salt: message.salt,
+      token: erc20Transfer.contractAddress,
+      amount: erc20Transfer.amount,
+      user: message.refundAddress.address,
+      proof: withdrawLeaf.merkleProof,
+      counterfactualDepositFactory: message.counterfactualFactoryContractAddress,
+      counterfactualBeacon: message.counterfactualBeaconContractAddress,
+      adminWithdrawManager: message.adminWithdrawManagerContractAddress,
+      withdrawImplementation: withdrawLeaf.implementationAddress,
+      // Deliberate, and different from v1: the v3 refund is net of execution gas, and the response reports
+      // requestedAmount / appliedGasFee / netAmount. Do not unify with v1's full-amount refund.
+      deductGasFromRefund: true,
+    });
+  } catch (err) {
+    // Terminal per product decision — gas exceeds the refund, or the refund token is unpriceable — and
+    // classified on the HTTP status alone, exactly as the polling bot does. The client posts through
+    // `_postOrThrow`, which discards the API's error code, so none is recorded.
+    if (isHttpError(err) && err.status === 422) {
+      const failed: TerminalState = { status: "withdraw_failed", reason: err.message, recordedAtMs: Date.now() };
+      await store.recordTerminal(transferId, failed);
+      return { outcome: "withdraw_failed", fields: { transferId, chainId: refundChainId, reason: err.message } };
+    }
+    throw new TransientDependencyError(
+      `sign-withdraw request failed for ${depositAddress} on chain ${refundChainId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      err
+    );
+  }
+  assertValidWithdrawResponse(signed, refundChainId, Math.floor(Date.now() / 1000));
+
+  // The point of no return, same as the deposit path: deadline first, then lock ownership.
+  assertBeforeDeadline(context);
+  if (!(await lock.isHeld())) {
+    throw new LockContentionError(`lock for ${transferId} is no longer held; refusing to broadcast`);
+  }
+
+  const pending = await broadcast(deps, context, transferId, refundChainId, provider, {
+    operation: "withdraw",
+    to: signed.signedWithdrawTx.to,
+    data: signed.signedWithdrawTx.data,
+    value: signed.signedWithdrawTx.value,
+    message: "Completed Refund Withdraw 💸",
+    mrkdwn:
+      `v3 refund withdraw on ${getNetworkName(refundChainId)} for deposit address ` +
+      `${blockExplorerLink(depositAddress, refundChainId)} (requestedAmount: ${signed.requestedAmount}, ` +
+      `appliedGasFee: ${signed.appliedGasFee}, netAmount: ${signed.netAmount}, ` +
+      `bundledDeploy: ${signed.bundledDeploy})`,
+  });
+  const result = await resolvePendingTransaction({ logger, store, provider }, transferId, pending);
+  return {
+    outcome: result.outcome,
+    fields: {
+      ...result.fields,
+      quoteMs: Date.now() - quotedAtMs,
+      requestedAmount: signed.requestedAmount,
+      appliedGasFee: signed.appliedGasFee,
+      netAmount: signed.netAmount,
+    },
+  };
+}
+
+/** Raw calldata for one broadcast, plus the Slack-facing lines the shared client logs on success. */
+interface BroadcastRequest {
+  operation: BroadcastPendingState["operation"];
+  to: string;
+  data: string;
+  value: string;
+  message: string;
+  mrkdwn: string;
+}
+
+/**
+ * Broadcasts a transaction and returns the `broadcast_pending` record that was persisted for it. Shared by
+ * the execute and refund-withdraw paths — the record-keeping is identical, only the calldata and the
+ * `operation` it records differ.
  *
  * `sendAndConfirmTransaction` is deliberately not used: it submits *and* confirms in one call and returns
  * `undefined` with no hash on every failure path, so the earliest a caller could see a hash is *after* the wait
@@ -218,16 +374,13 @@ async function executeDeposit(
 async function broadcast(
   deps: DepositHandlerDeps,
   context: RequestContext,
-  parsed: ParsedTransfer,
-  response: DepositAddressExecuteResponse,
-  originChainId: number,
-  provider: Provider
+  transferId: string,
+  chainId: number,
+  provider: Provider,
+  request: BroadcastRequest
 ): Promise<BroadcastPendingState> {
   const { store, transactionClient, config, logger } = deps;
-  const { transferId, message } = parsed;
-  const { executeTx } = response;
   const useDispatcher = deps.dispatcherSigners.length > 0;
-  const destinationChainId = Number(message.routeParams.destinationChainId);
 
   // Assigned **before** the Redis write, not after. The hook's rejection is swallowed by
   // `TransactionClient`, so a write failure that also lost the hash would leave a confirmed transaction with
@@ -239,27 +392,24 @@ async function broadcast(
   // the stale variant makes the terminal write unacceptable to `canReplace`.
   let recordedTxHash: string | undefined;
   const txn: AugmentedTransaction = {
-    contract: executeContract(deps.baseSigner, provider, executeTx.to, originChainId, useDispatcher),
+    contract: executeContract(deps.baseSigner, provider, request.to, chainId, useDispatcher),
     method: "",
-    args: [executeTx.data],
-    value: toBN(executeTx.value),
-    chainId: originChainId,
+    args: [request.data],
+    value: toBN(request.value),
+    chainId,
     ensureConfirmation: true,
     maxTries: config.confirmationTries,
-    message: "Completed Deposit Execution Successfully 🎯",
-    mrkdwn:
-      `Completed execution of v3 Deposit on ${getNetworkName(originChainId)} to ` +
-      `${getNetworkName(destinationChainId)}, using deposit address ` +
-      `${blockExplorerLink(message.depositAddress, originChainId)}`,
+    message: request.message,
+    mrkdwn: request.mrkdwn,
     onBroadcast: async (tx) => {
       // Re-entered on every hash change, so the record always names the transaction `TransactionClient` is
       // currently tracking rather than one it replaced. `persisted` resets per entry: a hash that persisted
       // does not vouch for the replacement that followed it.
       pending = {
         status: "broadcast_pending",
-        operation: "deposit",
+        operation: request.operation,
         txHash: tx.hash,
-        chainId: originChainId,
+        chainId,
         submittedAtMs: Date.now(),
       };
       await store.recordBroadcast(transferId, pending);
@@ -275,7 +425,7 @@ async function broadcast(
     // there is nothing to classify — if a hash exists the chain is asked, and if not, nothing was broadcast.
     if (!isDefined(pending)) {
       throw new TransientDependencyError(
-        `execute submission for ${transferId} failed before any transaction was broadcast: ${
+        `${request.operation} submission for ${transferId} failed before any transaction was broadcast: ${
           err instanceof Error ? err.message : String(err)
         }`,
         err
@@ -293,7 +443,7 @@ async function broadcast(
   if (!isDefined(pending)) {
     // A hash-less success should be impossible — `submitTransaction` throws on an empty response — but the
     // record is what makes a broadcast recoverable, so treat its absence as "did not happen" rather than assume.
-    throw new TransientDependencyError(`execute for ${transferId} produced no transaction hash`);
+    throw new TransientDependencyError(`${request.operation} for ${transferId} produced no transaction hash`);
   }
 
   if (recordedTxHash !== pending.txHash) {
@@ -439,13 +589,18 @@ async function readDepositAddressBalance(
  * `erc20Transfer` is **always** sent. The service relies on the resulting on-chain provenance event — it never
  * publishes `deposit_executed` itself, the indexer ingests the event — so this is a service requirement, not
  * the optional flag it is in the polling bot. An API without the schema change would reject the whole request.
+ *
+ * Answers `"below_minimum"` rather than throwing for an `AMOUNT_BELOW_MINIMUM` rejection: that outcome is not
+ * a failure to propagate but the signal to fall through to the refund withdraw, under the lock the caller
+ * already holds. Matched on the error **code**, not the bare 422 — `executeDepositAddress` posts through
+ * `_postOrThrowWithErrorCode` precisely so several 422s stay distinguishable.
  */
 async function requestExecuteTx(
   deps: DepositHandlerDeps,
   message: DepositAddressMessageV3,
   originChainId: number,
   integratorId: string
-): Promise<DepositAddressExecuteResponse> {
+): Promise<DepositAddressExecuteResponse | "below_minimum"> {
   const { routeParams, refundAddress, erc20Transfer, depositAddress } = message;
 
   try {
@@ -473,12 +628,8 @@ async function requestExecuteTx(
       },
     });
   } catch (err) {
-    // Terminal at the API: the amount is whatever landed on the address, so no retry changes it. The correct
-    // handling is a refund withdraw, which is not implemented yet, so NACK to preserve the transfer.
     if (err instanceof AcrossApiHttpError && err.code === AMOUNT_BELOW_MINIMUM_ERROR_CODE) {
-      throw new BelowMinimumDepositError(
-        `execute rejected amount ${erc20Transfer.amount} as below the minimum deposit: ${err.message}`
-      );
+      return "below_minimum";
     }
     throw new TransientDependencyError(
       `execute request failed for ${depositAddress} on chain ${originChainId}: ${

--- a/src/deposit-address-service/errors.ts
+++ b/src/deposit-address-service/errors.ts
@@ -120,14 +120,32 @@ export class LockContentionError extends DepositAddressServiceError {
 }
 
 /**
- * A `mis_route` transfer, which routes to a refund withdraw that does not exist yet.
- *
- * NACK rather than ACK so the transfer is not discarded. Permanently-retriable would normally be the no-DLQ
- * trap; it is unreachable while `EXECUTION_ENABLED` is false, and the withdrawal PR removes this branch.
+ * The v3 refund-withdraw path is off (`ENABLE_V3_WITHDRAWALS` unset). NACK, same shape as
+ * {@link ExecutionDisabledError}: the gate is an operator switch, the funds are still on the deposit
+ * address, and an ACK would discard the only delivery that could ever refund them.
  */
-export class WithdrawRouteNotImplementedError extends DepositAddressServiceError {
+export class WithdrawalsDisabledError extends DepositAddressServiceError {
   readonly retriable = true;
-  readonly code = "WITHDRAW_ROUTE_NOT_IMPLEMENTED";
+  readonly code = "V3_WITHDRAWALS_DISABLED";
+}
+
+/**
+ * The message carries no usable withdraw leaf in `counterfactualMaterials`. Deterministic — the leaves
+ * were fixed when the deposit address was created — so ACK; no redelivery can grow one.
+ */
+export class MissingWithdrawMaterialsError extends DepositAddressServiceError {
+  readonly retriable = false;
+  readonly code = "MISSING_WITHDRAW_MATERIALS";
+}
+
+/**
+ * The sign-withdraw response failed validation — signed for a different chain than the refund chain, or a
+ * signature deadline too close to expiry. NACK, like {@link InvalidExecuteResponseError}: the calldata is
+ * perishable, so a fresh response on the next delivery may well pass.
+ */
+export class InvalidWithdrawResponseError extends DepositAddressServiceError {
+  readonly retriable = true;
+  readonly code = "INVALID_WITHDRAW_RESPONSE";
 }
 
 /**
@@ -157,7 +175,8 @@ export class OriginChainDisabledError extends DepositAddressServiceError {
 /**
  * A namespace that is not native to the origin chain's family (e.g. `tron` on an EVM chain). A data
  * anomaly, deterministic, so ACK. Note zkSync-family chains are EVM here, so a `zksync`-namespaced message
- * is dropped — the same outcome the polling bot produces.
+ * is dropped — the same outcome the polling bot produces. The withdraw path raises this more strictly:
+ * v3 withdrawals are EVM-only, so even a chain-native `tron` namespace fails there.
  */
 export class UnsupportedNamespaceError extends DepositAddressServiceError {
   readonly retriable = false;
@@ -207,20 +226,6 @@ export class InsufficientBalanceError extends DepositAddressServiceError {
 export class InvalidExecuteResponseError extends DepositAddressServiceError {
   readonly retriable = true;
   readonly code = "INVALID_EXECUTE_RESPONSE";
-}
-
-/**
- * The execute endpoint rejected the amount as below the minimum deposit.
- *
- * Terminal at the API — the amount is whatever landed on the address, so no retry changes it — but NACK
- * here rather than ACK, because the correct handling is a refund withdraw and that path does not exist yet.
- * A permanently-retriable condition would normally be the no-DLQ trap; it is unreachable while
- * `EXECUTION_ENABLED` is false, and the withdrawal PR replaces this throw with the fallback at its call
- * site.
- */
-export class BelowMinimumDepositError extends DepositAddressServiceError {
-  readonly retriable = true;
-  readonly code = "AMOUNT_BELOW_MINIMUM";
 }
 
 /**

--- a/src/deposit-address-service/guards.ts
+++ b/src/deposit-address-service/guards.ts
@@ -1,10 +1,12 @@
-import { DepositAddressExecuteResponse } from "../clients/AcrossSwapApiClient";
-import { DepositAddressMessageV3 } from "../interfaces/DepositAddress";
+import { DepositAddressExecuteResponse, DepositAddressSignWithdrawResponse } from "../clients/AcrossSwapApiClient";
+import { CounterfactualMaterialV3, DepositAddressMessageV3 } from "../interfaces/DepositAddress";
 import { chainIsEvm, chainIsTvm, getEthersCompatibleAddress } from "../utils";
 import { isDefined } from "../utils/TypeGuards";
 import {
   InvalidExecuteResponseError,
   InvalidIntegratorIdError,
+  InvalidWithdrawResponseError,
+  MissingWithdrawMaterialsError,
   OriginChainDisabledError,
   UnsupportedChainFamilyError,
   UnsupportedNamespaceError,
@@ -132,6 +134,68 @@ export function assertValidExecuteResponse(
   if (signatureDeadline < nowSeconds + SIGNATURE_DEADLINE_BUFFER_SECONDS) {
     throw new InvalidExecuteResponseError(
       `signature deadline ${signatureDeadline} is within ${SIGNATURE_DEADLINE_BUFFER_SECONDS}s of expiry`
+    );
+  }
+}
+
+/**
+ * v3 withdrawals are **EVM-only — stricter than the deposit path**, which accepts any namespace native to
+ * the chain family. The polling bot requires both namespaces to be exactly `evm`, and the sign-withdraw
+ * response's `ecosystem` is the type-level literal `"evm"`, so a Tron-native message that the deposit path
+ * would execute still has no withdraw route. Deterministic, so ACK.
+ */
+export function assertEvmWithdrawNamespaces(message: DepositAddressMessageV3): void {
+  const { depositAddressNamespace, refundAddress } = message;
+  if (depositAddressNamespace !== "evm" || refundAddress.namespace !== "evm") {
+    throw new UnsupportedNamespaceError(
+      `v3 withdrawals are EVM-only; got depositAddress=${depositAddressNamespace} ` +
+        `refundAddress=${refundAddress.namespace}`
+    );
+  }
+}
+
+/**
+ * Returns the withdraw leaf the sign-withdraw request is built from. The `merkleProof` and
+ * `implementationAddress` checks are subsumed by the message schema today; they stay because the polling
+ * bot checks them and a schema loosening must not silently reach the request builder.
+ */
+export function assertWithdrawMaterials(message: DepositAddressMessageV3): CounterfactualMaterialV3 {
+  const withdrawLeaf = message.counterfactualMaterials.find((leaf) => leaf.kind === "withdraw");
+  if (
+    !isDefined(withdrawLeaf) ||
+    !isDefined(withdrawLeaf.merkleProof) ||
+    !isDefined(withdrawLeaf.implementationAddress)
+  ) {
+    throw new MissingWithdrawMaterialsError(
+      `message for ${message.depositAddress} carries no usable withdraw leaf in counterfactualMaterials`
+    );
+  }
+  return withdrawLeaf;
+}
+
+/**
+ * Sanity-checks a sign-withdraw response before submission. Deliberately **not** `assertValidExecuteResponse`
+ * with a different verb: there is no `isPlaceholder`, no API-re-derived address to compare (the request
+ * *supplies* the address), and `ecosystem` is a type-level literal — only the chain and deadline checks apply.
+ *
+ * The chain to match is the **refund** chain, `erc20Transfer.chainId` — where the funds landed. For a
+ * `mis_route` that differs from the route's origin chain, which is exactly the case this path exists for.
+ *
+ * @param nowSeconds Unix seconds, passed in so this stays pure and the deadline check is testable.
+ */
+export function assertValidWithdrawResponse(
+  response: DepositAddressSignWithdrawResponse,
+  refundChainId: number,
+  nowSeconds: number
+): void {
+  if (response.signedWithdrawTx.chainId !== refundChainId) {
+    throw new InvalidWithdrawResponseError(
+      `signed withdraw chainId ${response.signedWithdrawTx.chainId} does not match refund chain ${refundChainId}`
+    );
+  }
+  if (response.deadline < nowSeconds + SIGNATURE_DEADLINE_BUFFER_SECONDS) {
+    throw new InvalidWithdrawResponseError(
+      `signature deadline ${response.deadline} is within ${SIGNATURE_DEADLINE_BUFFER_SECONDS}s of expiry`
     );
   }
 }

--- a/src/deposit-address-service/pendingTransaction.ts
+++ b/src/deposit-address-service/pendingTransaction.ts
@@ -76,8 +76,10 @@ export async function resolvePendingTransaction(
     case "confirmed": {
       // Has a blockNumber by construction: classifyReceipt only answers "confirmed" when one is present.
       const confirmed = receipt;
-      const metadataEmitted = hasMetadataEvent(confirmed);
-      if (!metadataEmitted) {
+      // Only an execute carries the provenance event. Withdrawals have no on-chain metadata — they are
+      // announced over Pub/Sub instead — so checking them here would warn on every successful refund.
+      const metadataEmitted = operation === "deposit" ? hasMetadataEvent(confirmed) : undefined;
+      if (metadataEmitted === false) {
         logger.warn({
           at: "DepositAddressService#resolvePendingTransaction",
           message: "Execute confirmed without the expected provenance metadata event.",
@@ -94,7 +96,14 @@ export async function resolvePendingTransaction(
         completedAtMs: Date.now(),
       };
       await store.recordTerminal(transferId, terminal);
-      return { outcome: terminal.status, fields: { ...fields, blockNumber: confirmed.blockNumber, metadataEmitted } };
+      return {
+        outcome: terminal.status,
+        fields: {
+          ...fields,
+          blockNumber: confirmed.blockNumber,
+          ...(operation === "deposit" && { metadataEmitted }),
+        },
+      };
     }
 
     case "reverted":

--- a/src/deposit-address-service/transferState.ts
+++ b/src/deposit-address-service/transferState.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { Infer, create, enums, integer, literal, min, string, type, union } from "superstruct";
+import { Infer, create, enums, integer, literal, min, optional, string, type, union } from "superstruct";
 import { RedisCacheInterface } from "../cache/Redis";
 import { TransactionReceipt } from "../utils";
 import { isDefined } from "../utils/TypeGuards";
@@ -65,9 +65,14 @@ const WithdrawExecuted = type({
   completedAtMs: timestampMs(),
 });
 
+/**
+ * `code` is optional because the sign-withdraw client posts through `_postOrThrow`, which discards the API's
+ * error code — the handler classifies on the HTTP status alone, exactly as the polling bot does, and records
+ * no code. The enum stays for the day that call is switched to `_postOrThrowWithErrorCode` for diagnostics.
+ */
 const WithdrawFailed = type({
   status: literal("withdraw_failed"),
-  code: enums(["GAS_EXCEEDS_REFUND", "UNPRICEABLE_REFUND_TOKEN"]),
+  code: optional(enums(["GAS_EXCEEDS_REFUND", "UNPRICEABLE_REFUND_TOKEN"])),
   reason: string(),
   recordedAtMs: timestampMs(),
 });

--- a/test/DepositAddressService.deposit.ts
+++ b/test/DepositAddressService.deposit.ts
@@ -2,7 +2,12 @@ import { AddressInfo } from "net";
 import { Server } from "http";
 import { expect, winston } from "./utils";
 import { AcrossApiHttpError } from "../src/clients/AcrossApiBaseClient";
-import { AcrossSwapApiClient, DepositAddressExecuteResponse } from "../src/clients/AcrossSwapApiClient";
+import {
+  AcrossSwapApiClient,
+  DepositAddressExecuteResponse,
+  DepositAddressSignWithdrawRequest,
+  DepositAddressSignWithdrawResponse,
+} from "../src/clients/AcrossSwapApiClient";
 import { AugmentedTransaction, TransactionClient } from "../src/clients/TransactionClient";
 import {
   CHAIN_IDs,
@@ -21,12 +26,12 @@ import { RequestLifecycle } from "../src/deposit-address-service/lifecycle";
 import { TransferStore, TransferStoreRedis } from "../src/deposit-address-service/transferState";
 
 /**
- * The v3 deposit execute path over the real Express boundary and the real store, with only the chain, the
- * quote-api and the submission client faked. Every case below is a failure point from the plan's verification
- * list, and each asserts the **queue disposition** as well as the state left in Redis, because those two
- * together are what stop a transfer being swept twice.
+ * The v3 deposit execute and refund-withdraw paths over the real Express boundary and the real store, with
+ * only the chain, the quote-api and the submission client faked. Every case below is a failure point from the
+ * plan's verification list, and each asserts the **queue disposition** as well as the state left in Redis,
+ * because those two together are what stop a transfer being swept — or refunded — twice.
  */
-describe("DepositAddressService v3 deposit execution", function () {
+describe("DepositAddressService v3 execution", function () {
   const ARBITRUM = CHAIN_IDs.ARBITRUM;
   const FUNDING_TX = "0xa3f1c7d40e9b6852f1ad0c3b7e94f628a1d5c09e3b7a2d8f4c6e1b0a9d8c7f6e5";
   const FUNDING_BLOCK = 312884201;
@@ -40,6 +45,13 @@ describe("DepositAddressService v3 deposit execution", function () {
   const ORIGINAL_HASH = "0xaa22c7d40e9b6852f1ad0c3b7e94f628a1d5c09e3b7a2d8f4c6e1b0a9d8c7f611";
   const SIGNER_NONCE = 41;
   const METADATA_TOPIC = ethers.utils.id("MetadataEmitted(bytes)");
+  const WITHDRAW_LEAF = {
+    kind: "withdraw",
+    implementationAddress: "0x00000000000000000000000000000000000000e1",
+    encodedParams: "0x",
+    leafHash: "0x01",
+    merkleProof: ["0x0000000000000000000000000000000000000000000000000000000000000002"],
+  };
 
   let server: Server;
   let baseUrl: string;
@@ -68,6 +80,20 @@ describe("DepositAddressService v3 deposit execution", function () {
   /** What the quote-api answers. */
   let quote: { response?: Partial<DepositAddressExecuteResponse>; error?: Error };
 
+  /** What the sign-withdraw endpoint answers, plus every request it received. */
+  let withdraw: {
+    response?: Partial<DepositAddressSignWithdrawResponse>;
+    error?: Error;
+    requests: DepositAddressSignWithdrawRequest[];
+  };
+
+  /**
+   * The lock value observed inside each quote-api call. Asserting the two are the same defined token is what
+   * pins "one lock held across both actions" for the below-minimum fallback — a release-and-reacquire (or a
+   * release-then-withdraw) would be invisible to the state assertions alone.
+   */
+  let lockSeen: { atExecute?: string; atSignWithdraw?: string };
+
   function message(over: Record<string, unknown> = {}): Record<string, unknown> {
     return {
       depositAddress: DEPOSIT_ADDRESS,
@@ -78,7 +104,7 @@ describe("DepositAddressService v3 deposit execution", function () {
       counterfactualFactoryContractAddress: "0x00000000000000000000000000000000000000f1",
       adminWithdrawManagerContractAddress: "0x00000000000000000000000000000000000000a1",
       shouldSponsorAccountCreation: false,
-      counterfactualMaterials: [],
+      counterfactualMaterials: [WITHDRAW_LEAF],
       depositAddressNamespace: "evm",
       refundAddress: { namespace: "evm", address: "0x9A6e5F1B8C7D0E3a2b4c5D6e7F8A9b0c1D2E3f40" },
       routeParams: {
@@ -219,6 +245,7 @@ describe("DepositAddressService v3 deposit execution", function () {
   function fakeApi(): AcrossSwapApiClient {
     return {
       async executeDepositAddress(): Promise<DepositAddressExecuteResponse> {
+        lockSeen.atExecute = redisStore.get(LOCK_KEY);
         if (quote.error) {
           throw quote.error;
         }
@@ -235,6 +262,31 @@ describe("DepositAddressService v3 deposit execution", function () {
           signatureDeadline: Math.floor(Date.now() / 1000) + 600,
           isPlaceholder: false,
           ...quote.response,
+        };
+      },
+      async signWithdrawDepositAddressV3(
+        request: DepositAddressSignWithdrawRequest
+      ): Promise<DepositAddressSignWithdrawResponse> {
+        withdraw.requests.push(request);
+        lockSeen.atSignWithdraw = redisStore.get(LOCK_KEY);
+        if (withdraw.error) {
+          throw withdraw.error;
+        }
+        return {
+          signedWithdrawTx: {
+            ecosystem: "evm",
+            chainId: ARBITRUM,
+            to: "0x0000000000000000000000000000000000000ca1",
+            data: "0xfeedface",
+            value: "0",
+          },
+          bundledDeploy: false,
+          signer: signerAddress,
+          deadline: Math.floor(Date.now() / 1000) + 600,
+          requestedAmount: AMOUNT,
+          appliedGasFee: "2000",
+          netAmount: "9998000",
+          ...withdraw.response,
         };
       },
     } as unknown as AcrossSwapApiClient;
@@ -288,7 +340,14 @@ describe("DepositAddressService v3 deposit execution", function () {
     };
     submission = { mode: "broadcast", hash: EXECUTE_HASH };
     quote = {};
+    withdraw = { requests: [] };
+    lockSeen = {};
 
+    await startServer({ ENABLE_V3_WITHDRAWALS: "true" });
+  });
+
+  /** Builds the handler and binds the app. Re-callable inside a test that needs different env, e.g. the withdraw gate off. */
+  async function startServer(env: Record<string, string>): Promise<void> {
     const baseSigner = Wallet.createRandom();
     signerAddress = await baseSigner.getAddress();
 
@@ -296,6 +355,7 @@ describe("DepositAddressService v3 deposit execution", function () {
     const config = new DepositAddressServiceConfig({
       EXECUTION_ENABLED: "true",
       RELAYER_ORIGIN_CHAINS: `[${ARBITRUM}]`,
+      ...env,
     } as never);
 
     const handler = createDepositHandler({
@@ -323,7 +383,7 @@ describe("DepositAddressService v3 deposit execution", function () {
     server = app.listen(0, "127.0.0.1");
     await new Promise((resolve) => server.once("listening", resolve));
     baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}/`;
-  });
+  }
 
   afterEach(function () {
     server?.close();
@@ -622,16 +682,6 @@ describe("DepositAddressService v3 deposit execution", function () {
   });
 
   describe("quote-api outcomes", function () {
-    it("NACKs a below-minimum rejection until the withdraw fallback exists", async function () {
-      quote.error = new AcrossApiHttpError("amount below minimum", 422, "AMOUNT_BELOW_MINIMUM");
-
-      const response = await post(message());
-
-      expect(response.status).to.equal(500);
-      expect(state()).to.equal(undefined);
-      expect(failure()).to.include({ code: "AMOUNT_BELOW_MINIMUM" });
-    });
-
     it("NACKs any other quote failure", async function () {
       quote.error = new Error("gateway timeout");
 
@@ -653,18 +703,6 @@ describe("DepositAddressService v3 deposit execution", function () {
   });
 
   describe("routing", function () {
-    it("NACKs a mis_route until the withdraw path exists", async function () {
-      const misRoute = message({
-        erc20Transfer: { ...(message().erc20Transfer as object), transferClassification: "mis_route" },
-      });
-
-      const response = await post(misRoute);
-
-      expect(response.status).to.equal(500);
-      expect(state()).to.equal(undefined);
-      expect(failure()).to.include({ code: "WITHDRAW_ROUTE_NOT_IMPLEMENTED" });
-    });
-
     // NACK, not ACK. The chain may be re-enabled and the funds are still on the deposit address, so ACKing
     // would destroy the only delivery that could ever sweep them — the polling bot skipped and revisited.
     it("NACKs an origin chain that is not enabled", async function () {
@@ -704,6 +742,252 @@ describe("DepositAddressService v3 deposit execution", function () {
       expect(response.status).to.equal(204);
       expect(failure()).to.include({ code: "MESSAGE_VALIDATION_FAILED" });
       expect(redisStore.size).to.equal(0);
+    });
+  });
+
+  describe("the v3 refund withdrawal", function () {
+    function misRoute(over: Record<string, unknown> = {}): Record<string, unknown> {
+      return message({
+        erc20Transfer: { ...(message().erc20Transfer as object), transferClassification: "mis_route" },
+        ...over,
+      });
+    }
+
+    beforeEach(function () {
+      // Withdraw transactions carry no provenance event — only executes do — so the default receipt here has
+      // no metadata topic, and the tests assert that never produces a warning.
+      chain.executeReceipt = receipt({ blockNumber: FUNDING_BLOCK + 10 });
+    });
+
+    it("refunds a mis_route, records withdraw_executed and ACKs", async function () {
+      const response = await post(misRoute());
+
+      expect(response.status).to.equal(204);
+      expect(state()).to.deep.include({
+        status: "withdraw_executed",
+        txHash: EXECUTE_HASH,
+        chainId: ARBITRUM,
+        blockNumber: FUNDING_BLOCK + 10,
+      });
+      expect(redisStore.has(LOCK_KEY)).to.equal(false);
+      expect(lastLine()).to.include({ outcome: "withdraw_executed" });
+    });
+
+    it("relays the funding context and deducts gas from the refund", async function () {
+      await post(misRoute());
+
+      expect(withdraw.requests).to.have.length(1);
+      // The refund chain is erc20Transfer.chainId — where the funds landed — and the amount, token and user
+      // are the funded ones. `deductGasFromRefund: true` is deliberate and differs from v1's full refund.
+      expect(withdraw.requests[0]).to.deep.include({
+        chainId: ARBITRUM,
+        depositAddress: DEPOSIT_ADDRESS,
+        token: USDC,
+        amount: AMOUNT,
+        user: (message().refundAddress as { address: string }).address,
+        proof: WITHDRAW_LEAF.merkleProof,
+        withdrawImplementation: WITHDRAW_LEAF.implementationAddress,
+        deductGasFromRefund: true,
+      });
+    });
+
+    // A confirmed withdraw never carries the MetadataEmitted event, so warning about its absence — as the
+    // deposit path must — would fire on every successful refund.
+    it("does not warn about missing provenance metadata on a confirmed withdraw", async function () {
+      const response = await post(misRoute());
+
+      expect(response.status).to.equal(204);
+      expect(logs.some((l) => l.level === "warn")).to.equal(false);
+      expect(lastLine()).to.not.have.property("metadataEmitted");
+    });
+
+    it("falls through to the withdraw when the execute endpoint rejects the amount as below minimum", async function () {
+      quote.error = new AcrossApiHttpError(422, "amount below minimum", "AMOUNT_BELOW_MINIMUM");
+
+      const response = await post(message());
+
+      expect(response.status).to.equal(204);
+      expect(state()).to.include({ status: "withdraw_executed", txHash: EXECUTE_HASH });
+    });
+
+    // The review focus: one lock held across both actions. The fake API records the lock value it observed
+    // inside each call — a release between the execute rejection and the withdraw would show up here as a
+    // missing or different token, invisible to the state assertions alone.
+    it("holds the same lock across the execute rejection and the withdraw", async function () {
+      quote.error = new AcrossApiHttpError(422, "amount below minimum", "AMOUNT_BELOW_MINIMUM");
+
+      await post(message());
+
+      expect(lockSeen.atExecute, "execute ran without the lock").to.not.equal(undefined);
+      expect(lockSeen.atSignWithdraw, "sign-withdraw ran without the lock").to.not.equal(undefined);
+      expect(lockSeen.atSignWithdraw).to.equal(lockSeen.atExecute);
+    });
+
+    // Only the AMOUNT_BELOW_MINIMUM code falls through — any other 422 from /execute stays a NACK, since
+    // nothing says a refund is the right handling for it.
+    it("does not fall through on a 422 with a different code", async function () {
+      quote.error = new AcrossApiHttpError(422, "unprocessable", "SOMETHING_ELSE");
+
+      const response = await post(message());
+
+      expect(response.status).to.equal(500);
+      expect(withdraw.requests).to.have.length(0);
+      expect(failure()).to.include({ code: "TRANSIENT_DEPENDENCY_FAILURE" });
+    });
+
+    it("NACKs while v3 withdrawals are disabled", async function () {
+      server.close();
+      await startServer({});
+
+      const response = await post(misRoute());
+
+      // NACK: the gate is an operator switch and the funds are still on the deposit address, so an ACK
+      // would discard the only delivery that could ever refund them.
+      expect(response.status).to.equal(500);
+      expect(state()).to.equal(undefined);
+      expect(withdraw.requests).to.have.length(0);
+      expect(failure()).to.include({ code: "V3_WITHDRAWALS_DISABLED" });
+    });
+
+    // Stricter than the deposit path: withdrawals are EVM-only, so even a namespace the deposit path would
+    // accept as chain-native has no route here. Deterministic, so ACK.
+    it("ACKs a non-EVM refund namespace", async function () {
+      const tron = misRoute({ refundAddress: { namespace: "tron", address: "TQ5NMqJjW8sSjhWkrGheJHnWvpJPMdKMzn" } });
+
+      const response = await post(tron);
+
+      expect(response.status).to.equal(204);
+      expect(state()).to.equal(undefined);
+      expect(failure()).to.include({ code: "UNSUPPORTED_NAMESPACE" });
+    });
+
+    it("ACKs a message carrying no withdraw leaf", async function () {
+      const response = await post(misRoute({ counterfactualMaterials: [] }));
+
+      expect(response.status).to.equal(204);
+      expect(state()).to.equal(undefined);
+      expect(failure()).to.include({ code: "MISSING_WITHDRAW_MATERIALS" });
+    });
+
+    // Same order as the deposit path, for the same reason: only canonicality can tell "this funding
+    // transfer is real" from "there happens to be money at this address".
+    it("does not reach the balance check when canonicality fails", async function () {
+      chain.fundingReceipt = receipt({ blockNumber: FUNDING_BLOCK + 1 });
+      chain.balance = "0";
+
+      const response = await post(misRoute());
+
+      expect(response.status).to.equal(204);
+      expect(failure()).to.include({ code: "NON_CANONICAL_TRANSFER" });
+    });
+
+    it("NACKs when the funding transaction is not yet visible", async function () {
+      chain.fundingReceipt = null;
+
+      const response = await post(misRoute());
+
+      expect(response.status).to.equal(500);
+      expect(failure()).to.include({ code: "TRANSIENT_DEPENDENCY_FAILURE" });
+    });
+
+    it("ACKs and writes no state when the balance is short", async function () {
+      chain.balance = "9999999";
+
+      const response = await post(misRoute());
+
+      expect(response.status).to.equal(204);
+      expect(state()).to.equal(undefined);
+      expect(failure()).to.include({ code: "INSUFFICIENT_BALANCE" });
+    });
+
+    describe("the sign-withdraw response decides on the HTTP status alone", function () {
+      it("records withdraw_failed and ACKs on a terminal 422", async function () {
+        withdraw.error = new AcrossApiHttpError(422, "gas exceeds refund");
+
+        const response = await post(misRoute());
+
+        expect(response.status).to.equal(204);
+        // No `code`: the client posts through `_postOrThrow`, which discards the API's discriminator.
+        expect(state()).to.include({ status: "withdraw_failed", reason: "gas exceeds refund" });
+        expect(state()).to.not.have.property("code");
+        expect(lastLine()).to.include({ outcome: "withdraw_failed" });
+      });
+
+      it("NACKs any non-422 failure without writing state", async function () {
+        for (const error of [new Error("gateway timeout"), new AcrossApiHttpError(500, "upstream error")]) {
+          withdraw.error = error;
+
+          const response = await post(misRoute());
+
+          expect(response.status, error.message).to.equal(500);
+          expect(state(), error.message).to.equal(undefined);
+          expect(failure()).to.include({ code: "TRANSIENT_DEPENDENCY_FAILURE" });
+        }
+      });
+
+      it("ACKs a redelivery after withdraw_failed without calling the API again", async function () {
+        redisStore.set(
+          STATE_KEY,
+          JSON.stringify({ status: "withdraw_failed", reason: "gas exceeds refund", recordedAtMs: 1_700_000_000_000 })
+        );
+
+        const response = await post(misRoute());
+
+        expect(response.status).to.equal(204);
+        expect(withdraw.requests).to.have.length(0);
+        expect(lastLine()).to.include({ outcome: "already_withdraw_failed" });
+      });
+    });
+
+    it("NACKs a response signed for a different chain than the refund chain", async function () {
+      withdraw.response = {
+        signedWithdrawTx: {
+          ecosystem: "evm",
+          chainId: CHAIN_IDs.BASE,
+          to: "0x0000000000000000000000000000000000000ca1",
+          data: "0xfeedface",
+          value: "0",
+        },
+      };
+
+      const response = await post(misRoute());
+
+      expect(response.status).to.equal(500);
+      expect(state()).to.equal(undefined);
+      expect(failure()).to.include({ code: "INVALID_WITHDRAW_RESPONSE" });
+    });
+
+    it("records broadcast_pending with the withdraw operation before the confirmation wait", async function () {
+      chain.executeReceipt = null;
+
+      const response = await post(misRoute());
+
+      expect(response.status).to.equal(500);
+      expect(state()).to.deep.include({
+        status: "broadcast_pending",
+        operation: "withdraw",
+        txHash: EXECUTE_HASH,
+        chainId: ARBITRUM,
+      });
+    });
+
+    it("resolves a pending withdraw on redelivery instead of re-signing", async function () {
+      redisStore.set(
+        STATE_KEY,
+        JSON.stringify({
+          status: "broadcast_pending",
+          operation: "withdraw",
+          txHash: EXECUTE_HASH,
+          chainId: ARBITRUM,
+          submittedAtMs: 1_700_000_000_000,
+        })
+      );
+
+      const response = await post(misRoute());
+
+      expect(response.status).to.equal(204);
+      expect(state()).to.include({ status: "withdraw_executed", txHash: EXECUTE_HASH });
+      expect(withdraw.requests).to.have.length(0);
     });
   });
 });

--- a/test/DepositAddressService.guards.ts
+++ b/test/DepositAddressService.guards.ts
@@ -1,16 +1,21 @@
 import { expect } from "./utils";
 import { CHAIN_IDs } from "../src/utils";
-import { DepositAddressExecuteResponse } from "../src/clients/AcrossSwapApiClient";
+import { DepositAddressExecuteResponse, DepositAddressSignWithdrawResponse } from "../src/clients/AcrossSwapApiClient";
 import { DepositAddressMessageV3 } from "../src/interfaces/DepositAddress";
 import {
+  assertEvmWithdrawNamespaces,
   assertIntegratorId,
   assertSupportedNamespace,
   assertSupportedOriginChain,
   assertValidExecuteResponse,
+  assertValidWithdrawResponse,
+  assertWithdrawMaterials,
 } from "../src/deposit-address-service/guards";
 import {
   InvalidExecuteResponseError,
   InvalidIntegratorIdError,
+  InvalidWithdrawResponseError,
+  MissingWithdrawMaterialsError,
   OriginChainDisabledError,
   UnsupportedChainFamilyError,
   UnsupportedNamespaceError,
@@ -200,11 +205,120 @@ describe("DepositAddressService guards", function () {
     });
   });
 
+  describe("assertEvmWithdrawNamespaces", function () {
+    it("passes matching evm namespaces", function () {
+      expect(() => assertEvmWithdrawNamespaces(message())).to.not.throw();
+    });
+
+    it("rejects a non-evm namespace on either side", function () {
+      const tronDeposit = message({ depositAddressNamespace: "tron" });
+      const tronRefund = message({
+        refundAddress: { namespace: "tron", address: "TQ5NMqJjW8sSjhWkrGheJHnWvpJPMdKMzn" },
+      } as Partial<DepositAddressMessageV3>);
+      expect(() => assertEvmWithdrawNamespaces(tronDeposit)).to.throw(UnsupportedNamespaceError);
+      expect(() => assertEvmWithdrawNamespaces(tronRefund)).to.throw(UnsupportedNamespaceError);
+    });
+
+    // The withdraw path is stricter than the deposit path, deliberately: a Tron-native message that
+    // `assertSupportedNamespace` would execute as a deposit still has no v3 withdraw route.
+    it("rejects a Tron-native message the deposit path would accept", function () {
+      const tronNative = message({
+        depositAddressNamespace: "tron",
+        refundAddress: { namespace: "tron", address: "TQ5NMqJjW8sSjhWkrGheJHnWvpJPMdKMzn" },
+      } as Partial<DepositAddressMessageV3>);
+      expect(() => assertSupportedNamespace(tronNative, CHAIN_IDs.TRON)).to.not.throw();
+      expect(() => assertEvmWithdrawNamespaces(tronNative)).to.throw(UnsupportedNamespaceError);
+    });
+  });
+
+  describe("assertWithdrawMaterials", function () {
+    const withdrawLeaf = {
+      kind: "withdraw",
+      implementationAddress: "0x00000000000000000000000000000000000000e1",
+      encodedParams: "0x",
+      leafHash: "0x01",
+      merkleProof: ["0x02"],
+    };
+    const cctpLeaf = { ...withdrawLeaf, kind: "cctp" };
+
+    it("returns the withdraw leaf from among the message's materials", function () {
+      const found = assertWithdrawMaterials(message({ counterfactualMaterials: [cctpLeaf, withdrawLeaf] }));
+      expect(found).to.deep.equal(withdrawLeaf);
+    });
+
+    it("rejects a message with no materials at all", function () {
+      expect(() => assertWithdrawMaterials(message({ counterfactualMaterials: [] }))).to.throw(
+        MissingWithdrawMaterialsError
+      );
+    });
+
+    // `find` must select by kind, not take whatever leaf comes first.
+    it("rejects a message whose materials carry no withdraw leaf", function () {
+      expect(() => assertWithdrawMaterials(message({ counterfactualMaterials: [cctpLeaf] }))).to.throw(
+        MissingWithdrawMaterialsError
+      );
+    });
+
+    // ACK: the leaves were fixed when the deposit address was created, so no redelivery can grow one.
+    it("is terminal", function () {
+      expect(new MissingWithdrawMaterialsError("x").retriable).to.equal(false);
+    });
+  });
+
+  describe("assertValidWithdrawResponse", function () {
+    function signed(over: Partial<DepositAddressSignWithdrawResponse> = {}): DepositAddressSignWithdrawResponse {
+      return {
+        signedWithdrawTx: {
+          ecosystem: "evm",
+          chainId: ARBITRUM,
+          to: "0x0000000000000000000000000000000000000ca1",
+          data: "0xdeadbeef",
+          value: "0",
+        },
+        bundledDeploy: false,
+        signer: "0x9A6e5F1B8C7D0E3a2b4c5D6e7F8A9b0c1D2E3f40",
+        deadline: NOW_SECONDS + 600,
+        requestedAmount: "10000000",
+        appliedGasFee: "2000",
+        netAmount: "9998000",
+        ...over,
+      };
+    }
+
+    it("passes a well-formed response", function () {
+      expect(() => assertValidWithdrawResponse(signed(), ARBITRUM, NOW_SECONDS)).to.not.throw();
+    });
+
+    // The refund chain is `erc20Transfer.chainId` — where the funds landed — so a response signed for any
+    // other chain must not be broadcast.
+    it("rejects a response signed for a different chain", function () {
+      const wrongChain = signed({ signedWithdrawTx: { ...signed().signedWithdrawTx, chainId: CHAIN_IDs.BASE } });
+      expect(() => assertValidWithdrawResponse(wrongChain, ARBITRUM, NOW_SECONDS)).to.throw(
+        InvalidWithdrawResponseError
+      );
+    });
+
+    it("rejects a signature deadline inside the buffer, accepts one exactly at it", function () {
+      expect(() => assertValidWithdrawResponse(signed({ deadline: NOW_SECONDS + 59 }), ARBITRUM, NOW_SECONDS)).to.throw(
+        InvalidWithdrawResponseError
+      );
+      expect(() =>
+        assertValidWithdrawResponse(signed({ deadline: NOW_SECONDS + 60 }), ARBITRUM, NOW_SECONDS)
+      ).to.not.throw();
+    });
+
+    // A perishable response must NACK, not ACK: a fresh one next delivery may well pass.
+    it("makes withdraw-response failures retriable", function () {
+      expect(new InvalidWithdrawResponseError("x").retriable).to.equal(true);
+    });
+  });
+
   describe("disposition of the deterministic guards", function () {
     it("ACKs every guard whose outcome a retry cannot change", function () {
       expect(new UnsupportedChainFamilyError("x").retriable).to.equal(false);
       expect(new UnsupportedNamespaceError("x").retriable).to.equal(false);
       expect(new InvalidIntegratorIdError("x").retriable).to.equal(false);
+      expect(new MissingWithdrawMaterialsError("x").retriable).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
Part of #3663 — PR 5 of the standalone deposit-address service. Stacked on #3701.

Executes the v3 refund withdrawal: the path for a `mis_route`, and for a `correct_transfer` the execute endpoint rejected as `AMOUNT_BELOW_MINIMUM`. Replaces PR 4's two placeholder throws at the lines they sat on, so the deposit lock is held across both actions via `processUnderLock`'s existing `try/finally`. `WithdrawRouteNotImplementedError` disappears with them, taking the last identifier carrying the removed `route` vocabulary.

**Review focus: one lock held across both actions; terminal 422 handling.**

## What is genuinely new

- `executeWithdraw` in `depositHandler.ts`, ported guard-for-guard from `initiateWithdrawV3` per the issue's parity matrix: the `ENABLE_V3_WITHDRAWALS` gate (same env var the polling bot reads, NACK while off), **EVM-only** namespaces (stricter than the deposit path — `assertSupportedNamespace` allows `tron` on TVM chains, so it could not be reused), the withdraw leaf materials check, and a smaller response assertion (`assertValidWithdrawResponse`: signed `chainId` against the **refund** chain `erc20Transfer.chainId`, and the now+60s signature deadline — `assertValidExecuteResponse` deliberately does not carry over).
- Terminal classification of a sign-withdraw failure **on the HTTP status alone**, exactly as production's `_getSignedWithdrawV3` does (`isHttpError(err) && err.status === 422`): persist `withdraw_failed`, ACK. Everything else NACKs. No client change; `_postOrThrow` discards the API's error code, so `withdraw_failed.code` becomes `optional(...)` and is unset — every existing PR 3 state test passes unchanged.
- `deductGasFromRefund: true`, deliberately unlike v1's full-amount refund — not to be unified in the v1 PR.

## Reused unchanged

The lock, both state reads, `assertSupportedOriginChain` (already runs on `erc20Transfer.chainId` before routing), canonicality-then-balance in that order and for the same reason, `onBroadcast` + `maxTries`, the pending-write retry, and `resolvePendingTransaction` (whose `operation: "withdraw"` mapping already existed). `broadcast()` is parameterised over `{operation, to, data, value, message, mrkdwn}` rather than duplicated. One adjustment there: a confirmed **withdraw** is not expected to carry the `MetadataEmitted` provenance event, so the missing-metadata warning is now gated to deposits.

## Not in this PR

`withdraw_executed` is recorded but **not published** — lifecycle publishing and its recovery are PR 6, which lands before PR 7 enables execution anywhere.

## Verification

- `yarn tsc --build --force` clean; `yarn lint` clean.
- 190 passing across the service suites + `TransactionClient` (163 on the base branch; +27 here).
- Every new guard and branch was red-checked by reintroducing the bug: the metadata gate, `deductGasFromRefund`, the signed-chainId check, the `operation` label, 422-only terminal classification, the code-gated below-minimum fallthrough, the lock held across both actions (the fake API records the lock token it observed inside each call), the withdraw gate, the leaf `kind` filter, EVM-only strictness, and canonicality-before-balance ordering — each failed exactly the expected tests, then passed on revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)