### PR TITLE
feat(deposit-address-service): announce settled withdrawals

### DIFF
--- a/src/deposit-address-service/README.md
+++ b/src/deposit-address-service/README.md
@@ -5,11 +5,10 @@ and executes them, replacing the polling bot in [`../deposit-address`](../deposi
 left untouched until cutover. Why a service rather than a poller:
 [#3663](https://github.com/across-protocol/relayer/issues/3663).
 
-> **v3 deposits and refund withdrawals execute.** A withdrawal's `withdraw_executed` is recorded but not
-> yet announced — lifecycle publishing and its recovery land next, before execution is enabled anywhere.
-> With no handler configured, or `EXECUTION_ENABLED` unset, the service NACKs every delivery and `/ready`
-> stays `503`, so nothing is discarded if a subscription is attached early. v1 messages stay with the
-> polling bot.
+> **v3 deposits and refund withdrawals execute**, and a withdrawal is announced over Pub/Sub. With no
+> handler configured, or `EXECUTION_ENABLED` unset, the service NACKs every delivery and `/ready` stays
+> `503`, so nothing is discarded if a subscription is attached early. v1 messages stay with the polling
+> bot.
 
 ## Contracts
 
@@ -112,6 +111,37 @@ optional and unset. Every other sign-withdraw failure NACKs. The refund is gas-d
 are the deposit path's, with `operation: "withdraw"` on the pending record — a confirmed withdraw is not
 expected to carry the provenance event, so it does not warn about its absence.
 
+### Announcing a settled withdrawal
+
+A withdrawal leaves **no on-chain provenance event**, so unlike a deposit it has to be announced: the
+Pub/Sub `withdraw_executed` message is the only way the indexer learns the refund settled.
+[`withdrawLifecycle.ts`](./withdrawLifecycle.ts) reuses `buildWithdrawExecutedPayload` from the polling
+bot verbatim, and the `{ type, data }` envelope is locked by the consumer.
+
+The announcement is **durable state, not a step of the request that made it** —
+`withdrawLifecyclePublishedAt` on the `withdraw_executed` record. That is what makes a dropped one
+recoverable, and it is why the terminal short-circuit is pierced in **both** places (the pre-lock read and
+the post-lock re-read): a settled-but-unannounced withdrawal takes the lock and publishes instead of
+acknowledging. Piercing one alone would ACK before the retry could happen. Recovery keys on the recorded
+state, never on the message's classification — a `correct_transfer` refunded below the minimum owes the
+same announcement — and it re-fetches the receipt, because the payload's `logIndex` comes from scanning
+`receipt.logs` for the settlement log and cannot be rebuilt from the record.
+
+**Publish, then stamp.** The reverse order loses the announcement for good on any failure between the two;
+this order can at worst announce twice, which at-least-once delivery already implies. A fresh withdrawal
+publishes from what `TransferStore` durably holds rather than from what the request believes it just did,
+so the happy path runs the same code a redelivery does — the recovery path being the one that cannot be
+exercised in production.
+
+| Outcome | Disposition |
+| --- | --- |
+| Published | stamp the record, ACK |
+| Publish threw | preserve `withdraw_executed` **unstamped**, NACK; the redelivery retries the publication only |
+| Receipt carries no settlement log | ACK + `warn`, record left unstamped — the funds moved correctly and no redelivery can conjure a log that is not there |
+
+**No path here re-executes the withdrawal.** The polling bot instead catches, logs at `error` and never
+throws, so a dropped publish is never replayed; closing that is the point of publishing from state.
+
 ### Broadcasting — why not `sendAndConfirmTransaction`
 
 That helper submits **and** confirms in one call and returns `undefined` with no hash on every failure
@@ -209,6 +239,7 @@ for as long as the message is retained. That drives every mapping:
 | Handler threw a terminal error | `204` | Redelivery can't help; a non-2xx would retry forever. |
 | Lock held by another consumer | `500` | It finishes or its lock expires; either way a later delivery proceeds. |
 | Sign-withdraw answered 422 | `204` | Terminal per product decision; recorded as `withdraw_failed` first. |
+| Withdrawal settled but its announcement failed | `500` | The refund is done; the redelivery retries the publication alone. |
 | Fails the transport contract (no decodable `data`, no `messageId`) | `204` | Same reasoning. |
 | Unparseable JSON, or body over the 1mb cap | `204` | Body-parser errors only; anything else NACKs. |
 | Execution disabled, or no handler configured | `500` | Preserves the message; never discards silently. |
@@ -291,6 +322,9 @@ the config cannot tell whether it actually was.
 | `CONFIRMATION_TRIES` | `4` | `AugmentedTransaction.maxTries`. Capped at the client's own default of 10, which would be ~22 min. |
 | `CONFIRM_BUDGET_MS` | `300000` | Time reserved for the confirmation after the deadline check; only used to assert the lock-TTL relation above. |
 | `RELAYER_ORIGIN_CHAINS` | `[]` | Origin chains to execute on. **The same variable the polling bot reads**, so both can run during migration without new config. |
+| `ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER` | `false` | Gates announcing settled withdrawals. **The polling bot's variable.** Off leaves records unstamped, so turning it on lets a redelivery announce after the fact. `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER` is dead config here. |
+| `PUBSUB_GCP_PROJECT_ID` | — | Project hosting the topic. Required when the publisher gate is on; startup fails otherwise. |
+| `PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC` | — | Short topic name. Required when the publisher gate is on. |
 | `SWAP_API_KEY` | — | Required; startup fails without it. |
 | `API_TIMEOUT_OVERRIDE` | `3000` | quote-api timeout, ms. |
 

--- a/src/deposit-address-service/README.md
+++ b/src/deposit-address-service/README.md
@@ -127,6 +127,12 @@ state, never on the message's classification — a `correct_transfer` refunded b
 same announcement — and it re-fetches the receipt, because the payload's `logIndex` comes from scanning
 `receipt.logs` for the settlement log and cannot be rebuilt from the record.
 
+Resolution and announcement are therefore **one function**, `resolveAndAnnounce`, and no caller invokes the
+resolver directly. `resolvePendingTransaction` is the only place `withdraw_executed` is written and its
+caller ACKs immediately after, so a resolution that did not announce would be the last delivery that could
+ever announce — the same permanent loss, reached from a redelivery that resolves a broadcast whose original
+request died rather than from one that found the terminal state already written.
+
 **Publish, then stamp.** The reverse order loses the announcement for good on any failure between the two;
 this order can at worst announce twice, which at-least-once delivery already implies. A fresh withdrawal
 publishes from what `TransferStore` durably holds rather than from what the request believes it just did,

--- a/src/deposit-address-service/config.ts
+++ b/src/deposit-address-service/config.ts
@@ -101,6 +101,22 @@ export class DepositAddressServiceConfig {
 
   readonly confirmBudgetMs: number;
 
+  /**
+   * Gates announcing `withdraw_executed` over Pub/Sub. Reuses `ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER`,
+   * the variable the polling bot already reads, so both can run during migration without new config.
+   *
+   * Off means a settled withdrawal is recorded but never announced, and the record says so — the timestamp
+   * stays unset, so turning the gate on later lets a redelivery announce it after the fact.
+   * `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER` is dead config here: the service never publishes deposits.
+   */
+  readonly withdrawPublisherEnabled: boolean;
+
+  /** GCP project hosting the lifecycle topic. Required when {@link withdrawPublisherEnabled}. */
+  readonly pubSubGcpProjectId: string;
+
+  /** Short topic name, e.g. `topic-deposit-address-execution`. Required when {@link withdrawPublisherEnabled}. */
+  readonly pubSubWithdrawTopic: string;
+
   constructor(env: ProcessEnv) {
     this.port = readInteger("PORT", env.PORT, DEFAULT_PORT, MAX_PORT);
     this.executionEnabled = readBoolean(env.EXECUTION_ENABLED);
@@ -136,6 +152,23 @@ export class DepositAddressServiceConfig {
       DEFAULT_CONFIRM_BUDGET_MS,
       LOCK_TTL_MS - 1
     );
+
+    this.withdrawPublisherEnabled = readBoolean(env.ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER);
+    this.pubSubGcpProjectId = env.PUBSUB_GCP_PROJECT_ID?.trim() ?? "";
+    this.pubSubWithdrawTopic = env.PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC?.trim() ?? "";
+    // A gate that is on with nothing to publish to is the "running with something other than what was
+    // configured" case this file refuses everywhere else — and here it would be invisible until a refund
+    // settled and went unannounced.
+    if (this.withdrawPublisherEnabled) {
+      for (const [name, value] of [
+        ["PUBSUB_GCP_PROJECT_ID", this.pubSubGcpProjectId],
+        ["PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC", this.pubSubWithdrawTopic],
+      ] as const) {
+        if (value.length === 0) {
+          throw new Error(`${name} is required when ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER is set`);
+        }
+      }
+    }
 
     // The load-bearing relation, asserted rather than left as a comment.
     //

--- a/src/deposit-address-service/depositHandler.ts
+++ b/src/deposit-address-service/depositHandler.ts
@@ -7,6 +7,7 @@ import {
 import { AugmentedTransaction, TransactionClient } from "../clients/TransactionClient";
 import ERC20_ABI from "../common/abi/MinimalERC20.json";
 import { DepositAddressMessageV3 } from "../interfaces/DepositAddress";
+import { GcpPubSubPublisher } from "../messaging/gcp";
 import {
   BigNumber,
   Contract,
@@ -48,6 +49,7 @@ import { HandlerResult, MessageHandler, RequestContext, assertBeforeDeadline } f
 import { ParsedTransfer, parseTransfer } from "./message";
 import { resolvePendingTransaction } from "./pendingTransaction";
 import { BroadcastPendingState, TerminalState, TransferLock, TransferStore } from "./transferState";
+import { WithdrawLifecycleDeps, awaitsWithdrawPublication, publishWithdrawExecuted } from "./withdrawLifecycle";
 
 /** The API's stable discriminator for an amount under the minimum deposit; a 422 with any other code is not this. */
 const AMOUNT_BELOW_MINIMUM_ERROR_CODE = "AMOUNT_BELOW_MINIMUM";
@@ -78,6 +80,11 @@ export interface DepositHandlerDeps {
   signerAddress: EvmAddress;
   /** Non-empty enables `dispatch()`'s signer rotation, matching the polling bot's `depositAddressSigners`. */
   dispatcherSigners: Signer[];
+  /**
+   * Announces settled withdrawals. Absent when the publisher gate is off — and under `RELAYER_TEST`, which is
+   * why it is injected. Deposits are never published: the indexer ingests their on-chain provenance event.
+   */
+  publisher?: GcpPubSubPublisher;
   /** Defaults to the repo's memoized `getProvider`, so nothing is built per request or at startup. */
   getProvider?: (chainId: number) => Promise<Provider>;
 }
@@ -97,8 +104,18 @@ export function createDepositHandler(deps: DepositHandlerDeps): MessageHandler {
 
     // A cheap short-circuit before taking a lock: a transfer that is already done needs no exclusion. Only
     // terminal states qualify — resolving a pending record may clear it, so that needs the lock.
+    //
+    // A withdrawal that settled but was never announced is **not** done, however cheap acknowledging it would
+    // be: the indexer still has to be told, and this is the only delivery that can do it. So it falls through
+    // and takes the lock. Piercing here is half the job — `processUnderLock` re-reads and would acknowledge
+    // it there instead.
+    const lifecycle = withdrawLifecycleDeps(deps);
     const existing = await deps.store.read(parsed.transferId);
-    if (isDefined(existing) && existing.status !== "broadcast_pending") {
+    if (
+      isDefined(existing) &&
+      existing.status !== "broadcast_pending" &&
+      !(isDefined(lifecycle) && awaitsWithdrawPublication(existing))
+    ) {
       return { outcome: `already_${existing.status}`, fields: { transferId: parsed.transferId, ...existing } };
     }
 
@@ -129,9 +146,28 @@ async function processUnderLock(
   const originChainId = Number(chainId);
   const getProvider = deps.getProvider ?? getProviderDefault;
 
+  const lifecycle = withdrawLifecycleDeps(deps);
   const current = await store.read(transferId);
   if (isDefined(current)) {
     if (current.status !== "broadcast_pending") {
+      // The other half of piercing the terminal short-circuit. A withdrawal that settled but was never
+      // announced takes the lock — this is where the retry actually happens, and acknowledging here would
+      // make the pre-lock pierce pointless.
+      //
+      // The provider is built from the **record's** chain, which is where the transaction we are looking up
+      // is (the same chain the message names, since a refund settles where the funds landed). Built before
+      // the chain guards, as the pending branch below is, and for the same reason: a settled withdrawal on a
+      // since-disabled chain still owes its announcement.
+      if (isDefined(lifecycle) && awaitsWithdrawPublication(current)) {
+        const published = await publishWithdrawExecuted(
+          lifecycle,
+          await getProvider(current.chainId),
+          transferId,
+          message,
+          current
+        );
+        return { outcome: `already_${current.status}`, fields: { transferId, ...current, ...published } };
+      }
       return { outcome: `already_${current.status}`, fields: { transferId, ...current } };
     }
     // A transaction may still land, so never re-execute: resolve the recorded one instead. The chain guards
@@ -238,8 +274,8 @@ async function executeDeposit(
  * sign-withdraw rejection is *recorded* as `withdraw_failed` and ACKed rather than retried. The refund is
  * gas-deducted (`deductGasFromRefund: true`) — deliberate, and different from v1's full-amount refund.
  *
- * `withdraw_executed` is recorded but not yet announced; lifecycle publishing and its recovery follow in a
- * later change, before execution is enabled anywhere.
+ * A settled withdrawal is then announced over Pub/Sub, since it leaves no on-chain provenance event for the
+ * indexer to read. See {@link publishWithdrawExecuted}.
  */
 async function executeWithdraw(
   deps: DepositHandlerDeps,
@@ -335,16 +371,35 @@ async function executeWithdraw(
       `bundledDeploy: ${signed.bundledDeploy})`,
   });
   const result = await resolvePendingTransaction({ logger, store, provider }, transferId, pending);
+
+  // Announced from what Redis durably holds, not from what this request believes it just did — so a
+  // withdrawal is never announced unless its terminal state landed, and this path is the same code a
+  // redelivery runs to finish an announcement that failed. A publish failure throws, leaving
+  // `withdraw_executed` in place for that redelivery to retry; nothing here re-signs or re-broadcasts.
+  const lifecycle = withdrawLifecycleDeps(deps);
+  const recorded = await store.read(transferId);
+  const published =
+    isDefined(lifecycle) && awaitsWithdrawPublication(recorded)
+      ? await publishWithdrawExecuted(lifecycle, provider, transferId, message, recorded)
+      : {};
+
   return {
     outcome: result.outcome,
     fields: {
       ...result.fields,
+      ...published,
       quoteMs: Date.now() - quotedAtMs,
       requestedAmount: signed.requestedAmount,
       appliedGasFee: signed.appliedGasFee,
       netAmount: signed.netAmount,
     },
   };
+}
+
+/** The publication dependencies, or `undefined` when the publisher gate is off and nothing is announced. */
+function withdrawLifecycleDeps(deps: DepositHandlerDeps): WithdrawLifecycleDeps | undefined {
+  const { logger, store, config, publisher } = deps;
+  return isDefined(publisher) ? { logger, store, publisher, topic: config.pubSubWithdrawTopic } : undefined;
 }
 
 /** Raw calldata for one broadcast, plus the Slack-facing lines the shared client logs on success. */

--- a/src/deposit-address-service/depositHandler.ts
+++ b/src/deposit-address-service/depositHandler.ts
@@ -173,8 +173,11 @@ async function processUnderLock(
     // A transaction may still land, so never re-execute: resolve the recorded one instead. The chain guards
     // below deliberately do **not** gate this — a transfer on a since-disabled chain still has a transaction
     // on the wire, and abandoning it unresolved is the one unrecoverable direction.
-    const deps_ = { logger: deps.logger, store, provider: await getProvider(originChainId) };
-    return resolvePendingTransaction(deps_, transferId, current);
+    //
+    // Announcing here is not optional. This is the branch that first observes a withdrawal broadcast by a
+    // request that died before it could resolve, so it is where `withdraw_executed` gets written — and it
+    // then ACKs, which is the last delivery that could ever announce it.
+    return resolveAndAnnounce(deps, transferId, message, await getProvider(originChainId), current);
   }
 
   // Both guards run **before** the provider is built. `getProvider` throws a bare `No RPC providers defined`
@@ -204,7 +207,6 @@ async function executeDeposit(
   provider: Provider,
   originChainId: number
 ): Promise<HandlerResult> {
-  const { store, logger } = deps;
   const { transferId, message } = parsed;
   const { depositAddress, erc20Transfer } = message;
 
@@ -260,7 +262,7 @@ async function executeDeposit(
       `${getNetworkName(destinationChainId)}, using deposit address ` +
       `${blockExplorerLink(message.depositAddress, originChainId)}`,
   });
-  const result = await resolvePendingTransaction({ logger, store, provider }, transferId, pending);
+  const result = await resolveAndAnnounce(deps, transferId, message, provider, pending);
   return { outcome: result.outcome, fields: { ...result.fields, quoteMs: Date.now() - quotedAtMs, integratorId } };
 }
 
@@ -285,7 +287,7 @@ async function executeWithdraw(
   provider: Provider,
   refundChainId: number
 ): Promise<HandlerResult> {
-  const { config, store, logger } = deps;
+  const { config, store } = deps;
   const { transferId, message } = parsed;
   const { depositAddress, erc20Transfer } = message;
 
@@ -370,30 +372,51 @@ async function executeWithdraw(
       `appliedGasFee: ${signed.appliedGasFee}, netAmount: ${signed.netAmount}, ` +
       `bundledDeploy: ${signed.bundledDeploy})`,
   });
-  const result = await resolvePendingTransaction({ logger, store, provider }, transferId, pending);
-
-  // Announced from what Redis durably holds, not from what this request believes it just did — so a
-  // withdrawal is never announced unless its terminal state landed, and this path is the same code a
-  // redelivery runs to finish an announcement that failed. A publish failure throws, leaving
-  // `withdraw_executed` in place for that redelivery to retry; nothing here re-signs or re-broadcasts.
-  const lifecycle = withdrawLifecycleDeps(deps);
-  const recorded = await store.read(transferId);
-  const published =
-    isDefined(lifecycle) && awaitsWithdrawPublication(recorded)
-      ? await publishWithdrawExecuted(lifecycle, provider, transferId, message, recorded)
-      : {};
-
+  const result = await resolveAndAnnounce(deps, transferId, message, provider, pending);
   return {
     outcome: result.outcome,
     fields: {
       ...result.fields,
-      ...published,
       quoteMs: Date.now() - quotedAtMs,
       requestedAmount: signed.requestedAmount,
       appliedGasFee: signed.appliedGasFee,
       netAmount: signed.netAmount,
     },
   };
+}
+
+/**
+ * Resolves a broadcast against the chain and then announces the withdrawal it settled, if one is owed.
+ *
+ * **The two steps belong together**, which is why every caller goes through here rather than calling the
+ * resolver directly. This is the only place `withdraw_executed` is written, and the request ACKs immediately
+ * after — so an announcement skipped here is never made, whether the record was written by this request or
+ * by an earlier one that died before it could announce. A caller that resolved without announcing would
+ * reopen the gap this whole path exists to close.
+ *
+ * The announcement is built from what Redis durably holds, not from what the resolution believes it just
+ * did, so a withdrawal is never announced unless its terminal state landed. A publish failure throws,
+ * leaving `withdraw_executed` in place for a redelivery to retry; nothing here re-signs or re-broadcasts.
+ * The deposit path pays only an extra read for this: `deposit_executed` never awaits an announcement.
+ */
+async function resolveAndAnnounce(
+  deps: DepositHandlerDeps,
+  transferId: string,
+  message: DepositAddressMessageV3,
+  provider: Provider,
+  pending: BroadcastPendingState
+): Promise<HandlerResult> {
+  const { logger, store } = deps;
+  const result = await resolvePendingTransaction({ logger, store, provider }, transferId, pending);
+
+  const lifecycle = withdrawLifecycleDeps(deps);
+  const recorded = await store.read(transferId);
+  if (!isDefined(lifecycle) || !awaitsWithdrawPublication(recorded)) {
+    return result;
+  }
+
+  const published = await publishWithdrawExecuted(lifecycle, provider, transferId, message, recorded);
+  return { outcome: result.outcome, fields: { ...result.fields, ...published } };
 }
 
 /** The publication dependencies, or `undefined` when the publisher gate is off and nothing is announced. */

--- a/src/deposit-address-service/errors.ts
+++ b/src/deposit-address-service/errors.ts
@@ -149,6 +149,20 @@ export class InvalidWithdrawResponseError extends DepositAddressServiceError {
 }
 
 /**
+ * The withdrawal settled on-chain but its `withdraw_executed` announcement could not be published. NACK, and
+ * the redelivery retries **the publication only** — `withdraw_executed` is preserved, so no path re-withdraws.
+ *
+ * Its own code rather than {@link TransientDependencyError}'s: the dispositions coincide, but the conditions
+ * do not. This one means the funds have already moved and the indexer has not been told, which is the state an
+ * operator needs to be able to find on the outcome line. The polling bot instead swallows this failure and
+ * logs it, so a dropped publish is never replayed; that is the gap this service closes.
+ */
+export class WithdrawPublicationError extends DepositAddressServiceError {
+  readonly retriable = true;
+  readonly code = "WITHDRAW_PUBLICATION_FAILED";
+}
+
+/**
  * The origin chain's family has no v3 execute path at all — not EVM, not TVM. ACK: this is a property of the
  * code, not of configuration, so no redelivery can change it while this build is deployed.
  */

--- a/src/deposit-address-service/index.ts
+++ b/src/deposit-address-service/index.ts
@@ -3,6 +3,7 @@ import minimist from "minimist";
 import { getRedisCache } from "../cache/Redis";
 import { AcrossSwapApiClient } from "../clients/AcrossSwapApiClient";
 import { TransactionClient } from "../clients/TransactionClient";
+import { getGcpPubSubPublisher } from "../messaging/gcp";
 import { EvmAddress, assert, config, getDispatcherKeys, getSigner, isDefined, Logger, waitForLogger } from "../utils";
 import { safeStringifyThrownValue } from "./errors";
 import { createApp } from "./app";
@@ -80,6 +81,16 @@ async function buildHandler(
   const swapApiKey = SWAP_API_KEY?.trim();
   assert(isDefined(swapApiKey) && swapApiKey.length > 0, "DepositAddressService: SWAP_API_KEY is required");
 
+  // Asserted rather than degraded, like Redis above: a gate that is on with no publisher behind it announces
+  // nothing, and that is invisible until a refund settles and the indexer is never told.
+  const publisher = serviceConfig.withdrawPublisherEnabled
+    ? getGcpPubSubPublisher(logger, serviceConfig.pubSubGcpProjectId)
+    : undefined;
+  assert(
+    !serviceConfig.withdrawPublisherEnabled || isDefined(publisher),
+    "DepositAddressService: the withdraw publisher is enabled but no Pub/Sub publisher could be built"
+  );
+
   return createDepositHandler({
     logger,
     config: serviceConfig,
@@ -89,6 +100,7 @@ async function buildHandler(
     baseSigner,
     signerAddress,
     dispatcherSigners,
+    publisher,
   });
 }
 

--- a/src/deposit-address-service/transferState.ts
+++ b/src/deposit-address-service/transferState.ts
@@ -56,13 +56,20 @@ const DepositExecuted = type({
   completedAtMs: timestampMs(),
 });
 
-/** Separate from `DepositExecuted` because only this one gains lifecycle-publication state (PR 6). */
+/**
+ * Separate from `DepositExecuted` because only this one carries lifecycle-publication state.
+ *
+ * Withdrawals have no on-chain provenance event, so the indexer only learns of one from the Pub/Sub
+ * announcement — which makes "did we announce it" durable state rather than a detail of the request that
+ * made it. Absent means the announcement is still owed, and a redelivery retries **the publication only**.
+ */
 const WithdrawExecuted = type({
   status: literal("withdraw_executed"),
   txHash: string(),
   chainId: min(integer(), 1),
   blockNumber: min(integer(), 0),
   completedAtMs: timestampMs(),
+  withdrawLifecyclePublishedAt: optional(timestampMs()),
 });
 
 /**
@@ -81,6 +88,7 @@ const TerminalStateStruct = union([DepositExecuted, WithdrawExecuted, WithdrawFa
 const TransferStateStruct = union([BroadcastPending, TerminalStateStruct]);
 
 export type BroadcastPendingState = Infer<typeof BroadcastPending>;
+export type WithdrawExecutedState = Infer<typeof WithdrawExecuted>;
 export type TerminalState = Infer<typeof TerminalStateStruct>;
 export type TransferState = Infer<typeof TransferStateStruct>;
 

--- a/src/deposit-address-service/withdrawLifecycle.ts
+++ b/src/deposit-address-service/withdrawLifecycle.ts
@@ -1,0 +1,118 @@
+import { buildWithdrawExecutedPayload } from "../deposit-address/withdrawPayload";
+import { DepositAddressMessageV3 } from "../interfaces/DepositAddress";
+import { GcpPubSubPublisher } from "../messaging/gcp";
+import { Provider, TransactionReceipt, winston } from "../utils";
+import { isDefined } from "../utils/TypeGuards";
+import { TransientDependencyError, WithdrawPublicationError } from "./errors";
+import { receiptLookupHash } from "./pendingTransaction";
+import { TransferState, TransferStore, WithdrawExecutedState, classifyReceipt } from "./transferState";
+
+export interface WithdrawLifecycleDeps {
+  logger: winston.Logger;
+  store: TransferStore;
+  publisher: GcpPubSubPublisher;
+  topic: string;
+}
+
+/**
+ * Whether this transfer still owes the indexer a `withdraw_executed` announcement.
+ *
+ * A deposit never does — the indexer ingests its on-chain provenance event, so the service publishes none. A
+ * withdrawal has no such event, which is why the announcement is durable state rather than a step of the
+ * request that made it: a publish that failed leaves `withdraw_executed` in place with no timestamp, and the
+ * next delivery finishes the job. A withdrawal settled while the publisher gate was off is likewise unstamped,
+ * so turning the gate on lets a later delivery announce it after the fact.
+ *
+ * Deliberately a statement about the **state**, never about the message's classification: a `correct_transfer`
+ * the execute endpoint rejected as below the minimum was refunded too, and owes the same announcement.
+ */
+export function awaitsWithdrawPublication(state: TransferState | undefined): state is WithdrawExecutedState {
+  return isDefined(state) && state.status === "withdraw_executed" && !isDefined(state.withdrawLifecyclePublishedAt);
+}
+
+/**
+ * Announces a settled withdrawal, then records that it was announced.
+ *
+ * Called from two places with the same meaning, and deliberately the same code in both: by a fresh withdrawal
+ * once its terminal state is durable, and by a redelivery that found a `withdraw_executed` carrying no
+ * timestamp. The recovery path is the one that cannot be exercised in production, so it is the path the happy
+ * path runs every time rather than a second implementation of it.
+ *
+ * **Publish before stamping.** Stamping first and publishing after would lose the announcement for good on
+ * any failure between the two; this order can at worst announce twice, which at-least-once delivery already
+ * implies. Nothing here re-executes the withdrawal — the funds have moved, and only the announcement is owed.
+ *
+ * @returns fields for the outcome line. Not `messageId`: the app spreads delivery identity last, so a handler
+ * field of that name would be silently overwritten by the Pub/Sub one.
+ */
+export async function publishWithdrawExecuted(
+  deps: WithdrawLifecycleDeps,
+  provider: Provider,
+  transferId: string,
+  message: DepositAddressMessageV3,
+  state: WithdrawExecutedState
+): Promise<Record<string, unknown>> {
+  const { logger, store, publisher, topic } = deps;
+
+  // The receipt is re-fetched rather than carried over from whoever confirmed the transaction: the payload's
+  // `logIndex` comes from scanning `receipt.logs` for the settlement log, so it cannot be rebuilt from the
+  // state record, which holds only the hash, chain and block.
+  const receipt = await fetchReceipt(provider, state);
+  const payload = buildWithdrawExecutedPayload(receipt, message);
+  if (!isDefined(payload)) {
+    // The withdrawal happened; no redelivery can conjure a settlement log that is not in the receipt. So this
+    // acknowledges and leaves `withdraw_executed` **unstamped** — the timestamp means "announced", and
+    // recording one here would claim something untrue rather than merely repeat this warning.
+    logger.warn({
+      at: "DepositAddressService#publishWithdrawExecuted",
+      message: "Withdrawal settled but its receipt carries no settlement log; the indexer will not be told.",
+      transferId,
+      txHash: state.txHash,
+      chainId: state.chainId,
+      depositAddress: message.depositAddress,
+      refundAddress: message.refundAddress.address,
+      token: message.erc20Transfer.contractAddress,
+    });
+    return { withdrawLifecyclePublished: false };
+  }
+
+  let lifecycleMessageId: string;
+  try {
+    lifecycleMessageId = await publisher.publishJson(topic, payload);
+  } catch (err) {
+    throw new WithdrawPublicationError(
+      `failed to publish withdraw_executed for ${transferId} to ${topic}: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
+
+  await store.recordTerminal(transferId, { ...state, withdrawLifecyclePublishedAt: Date.now() });
+  return { withdrawLifecyclePublished: true, lifecycleMessageId };
+}
+
+/**
+ * A receipt the payload can be built from, or a retriable failure.
+ *
+ * The record says this transaction confirmed, so a missing receipt now is our provider disagreeing with what
+ * we already observed — transient, and a later delivery looks again. A receipt that reads as reverted is not
+ * treated separately: it carries no settlement log either, so it falls through to the warn above.
+ */
+async function fetchReceipt(provider: Provider, state: WithdrawExecutedState): Promise<TransactionReceipt> {
+  let receipt: TransactionReceipt;
+  try {
+    receipt = await provider.getTransactionReceipt(receiptLookupHash(state.txHash));
+  } catch (err) {
+    throw new TransientDependencyError(
+      `failed to fetch receipt for ${state.txHash}: ${err instanceof Error ? err.message : String(err)}`,
+      err
+    );
+  }
+
+  if (classifyReceipt(receipt) === "unresolved") {
+    throw new TransientDependencyError(
+      `receipt for ${state.txHash} on chain ${state.chainId} is no longer visible; cannot announce the withdrawal`
+    );
+  }
+  return receipt;
+}

--- a/test/DepositAddressService.config.ts
+++ b/test/DepositAddressService.config.ts
@@ -49,6 +49,26 @@ describe("DepositAddressServiceConfig", function () {
     );
   });
 
+  it("refuses a withdraw-publisher gate with nothing behind it", function () {
+    // A settled withdrawal has no on-chain provenance event, so an enabled-but-unwired publisher is only
+    // discovered when a refund goes unannounced. Off, the two are irrelevant and unvalidated.
+    expect(new DepositAddressServiceConfig({}).withdrawPublisherEnabled).to.equal(false);
+    for (const env of [
+      { ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER: "true" },
+      { ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER: "true", PUBSUB_GCP_PROJECT_ID: "p" },
+      { ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER: "true", PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC: "t" },
+    ]) {
+      expect(() => new DepositAddressServiceConfig(env), JSON.stringify(env)).to.throw(/is required when/);
+    }
+
+    const config = new DepositAddressServiceConfig({
+      ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER: "true",
+      PUBSUB_GCP_PROJECT_ID: "p",
+      PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC: "t",
+    });
+    expect(config.pubSubWithdrawTopic).to.equal("t");
+  });
+
   it("requires the drain timeout strictly below Cloud Run's SIGKILL grace period", function () {
     // A drain running until the SIGKILL instant races the kill, so 10s is as useless as 25s.
     expect(new DepositAddressServiceConfig({}).shutdownDrainTimeoutMs).to.equal(8_000);

--- a/test/DepositAddressService.deposit.ts
+++ b/test/DepositAddressService.deposit.ts
@@ -19,6 +19,7 @@ import {
   ethers,
   toBN,
 } from "../src/utils";
+import { GcpPubSubPublisher } from "../src/messaging/gcp";
 import { createApp } from "../src/deposit-address-service/app";
 import { DepositAddressServiceConfig } from "../src/deposit-address-service/config";
 import { createDepositHandler } from "../src/deposit-address-service/depositHandler";
@@ -45,6 +46,11 @@ describe("DepositAddressService v3 execution", function () {
   const ORIGINAL_HASH = "0xaa22c7d40e9b6852f1ad0c3b7e94f628a1d5c09e3b7a2d8f4c6e1b0a9d8c7f611";
   const SIGNER_NONCE = 41;
   const METADATA_TOPIC = ethers.utils.id("MetadataEmitted(bytes)");
+  const TRANSFER_TOPIC = ethers.utils.id("Transfer(address,address,uint256)");
+  const REFUND_ADDRESS = "0x9A6e5F1B8C7D0E3a2b4c5D6e7F8A9b0c1D2E3f40";
+  const LIFECYCLE_TOPIC = "topic-deposit-address-execution-test";
+  const LIFECYCLE_MESSAGE_ID = "pubsub-99123";
+  const SETTLEMENT_LOG_INDEX = 3;
   const WITHDRAW_LEAF = {
     kind: "withdraw",
     implementationAddress: "0x00000000000000000000000000000000000000e1",
@@ -80,6 +86,9 @@ describe("DepositAddressService v3 execution", function () {
   /** What the quote-api answers. */
   let quote: { response?: Partial<DepositAddressExecuteResponse>; error?: Error };
 
+  /** Every lifecycle announcement the handler published, and an optional failure to inject. */
+  let lifecycle: { published: { topic: string; payload: unknown }[]; error?: Error };
+
   /** What the sign-withdraw endpoint answers, plus every request it received. */
   let withdraw: {
     response?: Partial<DepositAddressSignWithdrawResponse>;
@@ -106,7 +115,7 @@ describe("DepositAddressService v3 execution", function () {
       shouldSponsorAccountCreation: false,
       counterfactualMaterials: [WITHDRAW_LEAF],
       depositAddressNamespace: "evm",
-      refundAddress: { namespace: "evm", address: "0x9A6e5F1B8C7D0E3a2b4c5D6e7F8A9b0c1D2E3f40" },
+      refundAddress: { namespace: "evm", address: REFUND_ADDRESS },
       routeParams: {
         outputToken: USDC,
         destinationChainId: "8453",
@@ -130,6 +139,24 @@ describe("DepositAddressService v3 execution", function () {
 
   function receipt(over: Partial<TransactionReceipt> = {}): TransactionReceipt {
     return { blockNumber: FUNDING_BLOCK, status: 1, logs: [], ...over } as TransactionReceipt;
+  }
+
+  /**
+   * The ERC20 `Transfer` a settled refund leaves behind — token contract, `from` the deposit address, `to` the
+   * refund address. `buildWithdrawExecutedPayload` matches on all three and takes its `logIndex` from the log,
+   * which is why the announcement needs the receipt and cannot be rebuilt from the state record.
+   */
+  function settlementLog(over: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      address: USDC,
+      topics: [
+        TRANSFER_TOPIC,
+        ethers.utils.hexZeroPad(DEPOSIT_ADDRESS.toLowerCase(), 32),
+        ethers.utils.hexZeroPad(REFUND_ADDRESS.toLowerCase(), 32),
+      ],
+      logIndex: SETTLEMENT_LOG_INDEX,
+      ...over,
+    };
   }
 
   function recordingLogger(): winston.Logger {
@@ -292,6 +319,22 @@ describe("DepositAddressService v3 execution", function () {
     } as unknown as AcrossSwapApiClient;
   }
 
+  /**
+   * Stands in for `GcpPubSubPublisher`, which `getGcpPubSubPublisher` refuses to build under `RELAYER_TEST`.
+   * Records what was announced and where, so a test can assert the envelope the indexer consumer is keyed on.
+   */
+  function fakePublisher(): GcpPubSubPublisher {
+    return {
+      async publishJson(topic: string, payload: unknown) {
+        if (lifecycle.error) {
+          throw lifecycle.error;
+        }
+        lifecycle.published.push({ topic, payload });
+        return LIFECYCLE_MESSAGE_ID;
+      },
+    } as unknown as GcpPubSubPublisher;
+  }
+
   function pushBody(payload: Record<string, unknown>): string {
     return JSON.stringify({
       message: {
@@ -342,12 +385,22 @@ describe("DepositAddressService v3 execution", function () {
     quote = {};
     withdraw = { requests: [] };
     lockSeen = {};
+    lifecycle = { published: [] };
 
-    await startServer({ ENABLE_V3_WITHDRAWALS: "true" });
+    await startServer({
+      ENABLE_V3_WITHDRAWALS: "true",
+      ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER: "true",
+      PUBSUB_GCP_PROJECT_ID: "test-project",
+      PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC: LIFECYCLE_TOPIC,
+    });
   });
 
-  /** Builds the handler and binds the app. Re-callable inside a test that needs different env, e.g. the withdraw gate off. */
-  async function startServer(env: Record<string, string>): Promise<void> {
+  /**
+   * Builds the handler and binds the app. Re-callable inside a test that needs different env, e.g. the
+   * withdraw gate off. `publisher` defaults on so every withdraw test exercises the announcement rather than
+   * passing because publishing happened to be disabled; pass `false` for the unconfigured case.
+   */
+  async function startServer(env: Record<string, string>, publisher = true): Promise<void> {
     const baseSigner = Wallet.createRandom();
     signerAddress = await baseSigner.getAddress();
 
@@ -367,6 +420,7 @@ describe("DepositAddressService v3 execution", function () {
       baseSigner,
       signerAddress: EvmAddress.from(signerAddress),
       dispatcherSigners: [],
+      publisher: publisher ? fakePublisher() : undefined,
       // Throws for any chain but the configured one, because the real `getProvider` throws
       // `No RPC providers defined` for a chain with no RPC configuration. A fake that answered for every
       // chain would be more forgiving than production and would mask a guard running *after* the provider
@@ -755,8 +809,13 @@ describe("DepositAddressService v3 execution", function () {
 
     beforeEach(function () {
       // Withdraw transactions carry no provenance event — only executes do — so the default receipt here has
-      // no metadata topic, and the tests assert that never produces a warning.
-      chain.executeReceipt = receipt({ blockNumber: FUNDING_BLOCK + 10 });
+      // no metadata topic, and the tests assert that never produces a warning. It does carry the settlement
+      // log the lifecycle announcement is built from, as a real refund's receipt would.
+      chain.executeReceipt = receipt({
+        blockNumber: FUNDING_BLOCK + 10,
+        transactionHash: EXECUTE_HASH,
+        logs: [settlementLog()] as never,
+      });
     });
 
     it("refunds a mis_route, records withdraw_executed and ACKs", async function () {
@@ -988,6 +1047,172 @@ describe("DepositAddressService v3 execution", function () {
       expect(response.status).to.equal(204);
       expect(state()).to.include({ status: "withdraw_executed", txHash: EXECUTE_HASH });
       expect(withdraw.requests).to.have.length(0);
+    });
+
+    /**
+     * A withdrawal leaves no on-chain provenance event, so the Pub/Sub announcement is the only way the
+     * indexer learns it settled — which is why a dropped one is retried rather than logged and forgotten, as
+     * the polling bot does. Every case here asserts both halves: what was announced, and what the state record
+     * says was announced.
+     */
+    describe("the lifecycle announcement", function () {
+      /** Seeds a settled withdrawal, optionally already announced. */
+      function settled(over: Record<string, unknown> = {}): void {
+        redisStore.set(
+          STATE_KEY,
+          JSON.stringify({
+            status: "withdraw_executed",
+            txHash: EXECUTE_HASH,
+            chainId: ARBITRUM,
+            blockNumber: FUNDING_BLOCK + 10,
+            completedAtMs: 1_700_000_000_000,
+            ...over,
+          })
+        );
+      }
+
+      it("announces the settled withdrawal and records that it did", async function () {
+        const response = await post(misRoute());
+
+        expect(response.status).to.equal(204);
+        expect(lifecycle.published).to.have.length(1);
+        expect(lifecycle.published[0].topic).to.equal(LIFECYCLE_TOPIC);
+        // The envelope is locked by the indexer consumer, which keys on `type` and validates `data`. The
+        // logIndex is the settlement log's, which is why the receipt has to be read rather than the record.
+        expect(lifecycle.published[0].payload).to.deep.equal({
+          type: "withdraw_executed",
+          data: {
+            chainId: ARBITRUM,
+            blockNumber: FUNDING_BLOCK + 10,
+            txHash: EXECUTE_HASH,
+            logIndex: SETTLEMENT_LOG_INDEX,
+            erc20Transfer: {
+              chainId: ARBITRUM,
+              blockNumber: FUNDING_BLOCK,
+              txHash: FUNDING_TX,
+              logIndex: 7,
+            },
+          },
+        });
+        expect(state()).to.have.property("withdrawLifecyclePublishedAt").that.is.a("number");
+        expect(lastLine()).to.include({ withdrawLifecyclePublished: true, lifecycleMessageId: LIFECYCLE_MESSAGE_ID });
+      });
+
+      // The point of the whole change. A dropped announcement must survive as work still owed, which means
+      // the timestamp is written only *after* the publish returns — the reverse order would discard the
+      // evidence that it never happened.
+      it("preserves the unannounced withdrawal and NACKs when the publish fails", async function () {
+        lifecycle.error = new Error("Total timeout of API google.pubsub.v1.Publisher exceeded");
+
+        const response = await post(misRoute());
+
+        expect(response.status).to.equal(500);
+        expect(state()).to.include({ status: "withdraw_executed", txHash: EXECUTE_HASH });
+        expect(state()).to.not.have.property("withdrawLifecyclePublishedAt");
+        expect(failure()).to.include({ code: "WITHDRAW_PUBLICATION_FAILED" });
+      });
+
+      // Retries the announcement and *only* the announcement: the funds already moved, so re-signing or
+      // re-broadcasting would be the double-sweep this service exists to prevent.
+      it("announces on redelivery without re-withdrawing", async function () {
+        settled();
+
+        const response = await post(misRoute());
+
+        expect(response.status).to.equal(204);
+        expect(lifecycle.published).to.have.length(1);
+        expect(withdraw.requests).to.have.length(0);
+        expect(state()).to.have.property("withdrawLifecyclePublishedAt").that.is.a("number");
+        // Taken and given back: the announcement runs under the transfer's lock, like everything else.
+        expect(redisStore.has(LOCK_KEY)).to.equal(false);
+        expect(lastLine()).to.include({ outcome: "already_withdraw_executed" });
+      });
+
+      // A `correct_transfer` the execute endpoint rejected below the minimum was refunded too, so recovery
+      // has to key on the recorded state rather than on the message's classification.
+      it("announces a below-minimum refund's withdrawal, not just a mis_route's", async function () {
+        settled();
+
+        const response = await post(message());
+
+        expect(response.status).to.equal(204);
+        expect(lifecycle.published).to.have.length(1);
+        expect(withdraw.requests).to.have.length(0);
+      });
+
+      it("ACKs a redelivery of an already-announced withdrawal without announcing again", async function () {
+        settled({ withdrawLifecyclePublishedAt: 1_700_000_001_000 });
+        // Would fail every guard if any path beyond the short-circuit were re-entered.
+        chain.fundingReceipt = null;
+        chain.balance = "0";
+
+        const response = await post(misRoute());
+
+        expect(response.status).to.equal(204);
+        expect(lifecycle.published).to.have.length(0);
+        expect(withdraw.requests).to.have.length(0);
+      });
+
+      // The funds moved correctly and no redelivery can conjure a log that is not in the receipt, so this
+      // acknowledges. It stays unstamped: the timestamp means "announced", and claiming one here would be a
+      // lie, where repeating the warning is merely noise.
+      it("warns and ACKs when the receipt carries no settlement log", async function () {
+        chain.executeReceipt = receipt({
+          blockNumber: FUNDING_BLOCK + 10,
+          transactionHash: EXECUTE_HASH,
+          logs: [settlementLog({ topics: [TRANSFER_TOPIC] })] as never,
+        });
+
+        const response = await post(misRoute());
+
+        expect(response.status).to.equal(204);
+        expect(lifecycle.published).to.have.length(0);
+        expect(state()).to.not.have.property("withdrawLifecyclePublishedAt");
+        expect(logs.some((l) => l.level === "warn")).to.equal(true);
+      });
+
+      // Announcing something Redis does not hold would tell the indexer a refund is done while every later
+      // delivery still believes it is owed one.
+      it("announces nothing when the terminal write itself failed", async function () {
+        // set #1 = broadcast_pending from the hook, #2 = the terminal write.
+        redisFaults.failSetCalls = [2];
+
+        const response = await post(misRoute());
+
+        expect(response.status).to.equal(500);
+        expect(lifecycle.published).to.have.length(0);
+      });
+
+      // With the gate off nothing is announced and nothing claims to have been, so turning it on later lets a
+      // redelivery finish the job.
+      it("records no announcement when no publisher is configured", async function () {
+        server.close();
+        await startServer({ ENABLE_V3_WITHDRAWALS: "true" }, false);
+
+        expect((await post(misRoute())).status).to.equal(204);
+        expect(state()).to.include({ status: "withdraw_executed" });
+        expect(state()).to.not.have.property("withdrawLifecyclePublishedAt");
+
+        // And the terminal short-circuit still ACKs it rather than taking the lock every time.
+        expect((await post(misRoute())).status).to.equal(204);
+        expect(lastLine()).to.include({ outcome: "already_withdraw_executed" });
+      });
+
+      it("never announces a deposit, whose provenance the indexer reads on-chain", async function () {
+        redisStore.set(
+          STATE_KEY,
+          JSON.stringify({
+            status: "deposit_executed",
+            txHash: EXECUTE_HASH,
+            chainId: ARBITRUM,
+            blockNumber: FUNDING_BLOCK + 10,
+            completedAtMs: 1_700_000_000_000,
+          })
+        );
+
+        expect((await post(message())).status).to.equal(204);
+        expect(lifecycle.published).to.have.length(0);
+      });
     });
   });
 });

--- a/test/DepositAddressService.deposit.ts
+++ b/test/DepositAddressService.deposit.ts
@@ -676,6 +676,9 @@ describe("DepositAddressService v3 execution", function () {
 
       expect(response.status).to.equal(204);
       expect(state()).to.include({ status: "deposit_executed", txHash: EXECUTE_HASH });
+      // Resolving a pending record announces a settled withdrawal, but never a deposit: the indexer reads
+      // the deposit's provenance event on-chain.
+      expect(lifecycle.published).to.have.length(0);
     });
 
     it("NACKs while another consumer holds the lock", async function () {
@@ -1126,6 +1129,29 @@ describe("DepositAddressService v3 execution", function () {
         // Taken and given back: the announcement runs under the transfer's lock, like everything else.
         expect(redisStore.has(LOCK_KEY)).to.equal(false);
         expect(lastLine()).to.include({ outcome: "already_withdraw_executed" });
+      });
+
+      // The other way a withdrawal reaches `withdraw_executed`: an earlier request broadcast it and died
+      // before the receipt landed. This delivery is the one that resolves the record — and it ACKs, so it is
+      // also the last one that could ever announce it.
+      it("announces a withdrawal it resolved from a pending record", async function () {
+        redisStore.set(
+          STATE_KEY,
+          JSON.stringify({
+            status: "broadcast_pending",
+            operation: "withdraw",
+            txHash: EXECUTE_HASH,
+            chainId: ARBITRUM,
+            submittedAtMs: 1_700_000_000_000,
+          })
+        );
+
+        const response = await post(misRoute());
+
+        expect(response.status).to.equal(204);
+        expect(lifecycle.published).to.have.length(1);
+        expect(state()).to.have.property("withdrawLifecyclePublishedAt").that.is.a("number");
+        expect(withdraw.requests).to.have.length(0);
       });
 
       // A `correct_transfer` the execute endpoint rejected below the minimum was refunded too, so recovery


### PR DESCRIPTION
Part of #3663 — PR 6 of the standalone deposit-address service. Stacked on #3709.

A withdrawal leaves **no on-chain provenance event**, so unlike a deposit it has to be announced: the
Pub/Sub `withdraw_executed` message is the only way the indexer learns the refund settled. PR 5 records
`withdraw_executed` and announces nothing, so every refund it makes today leaves the indexer row pending.

`buildWithdrawExecutedPayload` and the `{ type, data }` envelope locked by
`DepositAddressWithdrawConsumer` are reused verbatim. `buildDepositExecutedPayload` is not — the service
never publishes deposits.

## The structural change

The announcement is **durable state, not a step of the request that made it** —
`withdrawLifecyclePublishedAt` on the `withdraw_executed` record. That is what makes a dropped one
recoverable, and it is why the terminal short-circuit is pierced in **both** places (the pre-lock read in
`createDepositHandler` and the post-lock re-read in `processUnderLock`): a settled-but-unannounced
withdrawal takes the lock and publishes instead of acknowledging. Piercing one alone would ACK before the
retry could happen.

Recovery keys on the **recorded state**, never on the message's classification — a `correct_transfer`
refunded below the minimum owes the same announcement — and it re-fetches the receipt, because the
payload's `logIndex` comes from scanning `receipt.logs` for the settlement log and cannot be rebuilt from
the record.

## Ordering

**Publish, then stamp.** The reverse order loses the announcement for good on any failure between the
two; this order can at worst announce twice, which at-least-once delivery already implies. A fresh
withdrawal publishes from what `TransferStore` durably holds rather than from what the request believes
it just did, so the happy path runs the same code a redelivery does — the recovery path being the one
that cannot be exercised in production.

| Outcome | Disposition |
| --- | --- |
| Published | stamp the record, ACK |
| Publish threw | preserve `withdraw_executed` **unstamped**, NACK; the redelivery retries the publication only |
| Receipt carries no settlement log | ACK + `warn`, left unstamped — the funds moved correctly and no redelivery can conjure a log that is not there |

**No path here re-executes the withdrawal.** The polling bot instead catches, logs at `error` and never
throws, so a dropped publish is never replayed; closing that is the point of this change, so its swallow
is deliberately not copied.

## Config

Mirrors the polling bot, reusing its variable names so both can run during migration:
`ENABLE_DEPOSIT_ADDRESS_WITHDRAW_PUBLISHER`, `PUBSUB_GCP_PROJECT_ID`,
`PUBSUB_DEPOSIT_ADDRESS_WITHDRAW_TOPIC`. The gate on with either of the other two empty **fails startup**,
as does a gate with no publisher behind it — announcing nothing is otherwise invisible until a refund
goes unannounced. `ENABLE_DEPOSIT_ADDRESS_DEPOSIT_PUBLISHER` stays dead config. The publisher is injected
like Redis, since `getGcpPubSubPublisher` answers `undefined` under `RELAYER_TEST`.

## Testing

`DepositAddressService.deposit.ts` gains the publisher in its **default** harness, so every pre-existing
withdraw test now exercises the announcement rather than passing because publishing was off. New cases
cover: the envelope and the stamp; publish throws ⇒ state preserved unstamped + NACK; redelivery of a
published withdrawal ACKs without republishing; redelivery of an unpublished one republishes and never
re-withdraws; the same for a below-minimum `correct_transfer`; missing settlement log ⇒ ACK + warn; a
failed terminal write announces nothing; no publisher configured; and a deposit is never announced.

Each new branch was verified red-first — the bug reintroduced and the test confirmed failing — for the
stamp/publish swap, both short-circuit pierces individually, gating recovery on classification, stamping
on the missing-log path, and announcing before the durable terminal write.

```
yarn tsc --build --force && yarn lint
RELAYER_TEST=true yarn hardhat test test/DepositAddressService.*.ts test/TransactionClient.ts   # 200 passing
```

*Review focus: the envelope still matches the locked consumer contract; a publication retry can never
re-withdraw.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)